### PR TITLE
ci: add Kobo build workflow to cargo.yml

### DIFF
--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -26,3 +26,97 @@ jobs:
           key: ${{ runner.os }}-cargo-${{ steps.rust-toolchain.outputs.cachekey }}-${{ hashFiles('**/Cargo.lock') }}
       - name: Check formatting
         run: cargo fmt --all --check
+
+  build-kobo:
+    runs-on: ubuntu-latest
+
+    permissions:
+      id-token: write
+      contents: read
+      attestations: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+        id: rust-toolchain
+        with:
+          targets: arm-unknown-linux-gnueabihf
+
+      - name: Cache Cargo registry
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-${{ steps.rust-toolchain.outputs.cachekey }}-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Cache Linaro toolchain
+        id: cache-linaro
+        uses: actions/cache@v4
+        with:
+          path: ~/linaro-toolchain
+          key: linaro-gcc-4.9.4-2017.01
+
+      - name: Download Linaro toolchain
+        if: steps.cache-linaro.outputs.cache-hit != 'true'
+        run: |
+          mkdir -p ~/linaro-toolchain
+          cd ~/linaro-toolchain
+          wget -q https://releases.linaro.org/components/toolchain/binaries/4.9-2017.01/arm-linux-gnueabihf/gcc-linaro-4.9.4-2017.01-x86_64_arm-linux-gnueabihf.tar.xz
+          tar xf gcc-linaro-4.9.4-2017.01-x86_64_arm-linux-gnueabihf.tar.xz --strip-components=1
+          rm gcc-linaro-4.9.4-2017.01-x86_64_arm-linux-gnueabihf.tar.xz
+
+      - name: Cache thirdparty libraries
+        uses: actions/cache@v4
+        with:
+          path: |
+            libs/
+            thirdparty/
+            mupdf_wrapper/
+          key: ${{ runner.os }}-thirdparty-libs-kobo-${{ hashFiles('thirdparty/download.sh') }}
+
+      - uses: awalsh128/cache-apt-pkgs-action@latest
+        with:
+          packages: git wget curl pkg-config unzip jq patchelf gcc g++ make cmake meson ninja-build autoconf automake libtool gperf python3 zlib1g-dev libbz2-dev libpng-dev libjpeg-dev libopenjp2-7-dev libjbig2dec0-dev libgumbo-dev libfreetype6-dev libharfbuzz-dev libdjvulibre-dev
+          version: 1.0
+
+      - name: Setup Linaro toolchain
+        run: |
+          echo "$HOME/linaro-toolchain/bin" >> $GITHUB_PATH
+
+      - name: Build for Kobo
+        env:
+          CC: arm-linux-gnueabihf-gcc
+          CXX: arm-linux-gnueabihf-g++
+          AR: arm-linux-gnueabihf-ar
+          LD: arm-linux-gnueabihf-ld
+          RANLIB: arm-linux-gnueabihf-ranlib
+          STRIP: arm-linux-gnueabihf-strip
+          PKG_CONFIG_ALLOW_CROSS: "1"
+          CARGO_TARGET_ARM_UNKNOWN_LINUX_GNUEABIHF_LINKER: arm-linux-gnueabihf-gcc
+          CC_arm_unknown_linux_gnueabihf: arm-linux-gnueabihf-gcc
+          AR_arm_unknown_linux_gnueabihf: arm-linux-gnueabihf-ar
+        run: |
+          ./build.sh slow
+
+      - name: Create distribution
+        run: ./dist.sh
+
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@v3
+        with:
+          subject-path: |
+            dist/plato
+            dist/scripts/*
+            dist/libs/*
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: plato-kobo
+          path: dist/
+          retention-days: 7

--- a/build.sh
+++ b/build.sh
@@ -5,6 +5,7 @@ set -e
 method=${1:-"fast"}
 
 [ -e libs -a $# -eq 0 ] && method=skip
+[ -e libs -a "$1" = "slow" ] && method=skip
 
 case "$method" in
 	fast)

--- a/thirdparty/download.sh
+++ b/thirdparty/download.sh
@@ -1,5 +1,7 @@
 #! /usr/bin/env bash
 
+set -e
+
 declare -A urls=(
 	# Compression
 	["zlib"]="https://www.zlib.net/zlib-1.3.1.tar.gz"
@@ -30,6 +32,6 @@ for name in "${@:-${!urls[@]}}" ; do
 	else
 		mkdir "$name"
 	fi
-	wget -q --show-progress -O "${name}.tgz" "$url"
+	wget -q --show-progress --retry-connrefused --waitretry=1 --read-timeout=20 --timeout=15 --tries=3 -O "${name}.tgz" "$url"
 	tar -xz --strip-components 1 -C "$name" -f "${name}.tgz" && rm "${name}.tgz"
 done


### PR DESCRIPTION
Add a new 'build-kobo' CI job to automate building the for Kobo devices. The workflow includes toolchain setup,
caching of dependencies, and artifact generation.

- Download and cache Linaro GCC toolchain for ARM compilation
- Setup cross-compilation environment variables
- Build distribution packages using build.sh and dist.sh
- Upload build artifacts with 7-day retention policy
- Cache Cargo dependencies and third-party sources

Change-Id: 9fc5ccb8f7c50902f83259b38b7432f3
Change-Id-Short: qknunnorksnu