### PR TITLE
chore: add git version detection to build 

### DIFF
--- a/crates/core/build.rs
+++ b/crates/core/build.rs
@@ -1,7 +1,25 @@
 use std::env;
+use std::process::Command;
 
 fn main() {
     let target = env::var("TARGET").unwrap();
+
+    println!("cargo:rerun-if-changed=.git/HEAD");
+
+    let git_version = Command::new("git")
+        .args(&["describe", "--tags", "--always", "--dirty"])
+        .output()
+        .ok()
+        .and_then(|output| {
+            if output.status.success() {
+                Some(String::from_utf8_lossy(&output.stdout).trim().to_string())
+            } else {
+                None
+            }
+        })
+        .unwrap_or_else(|| "unknown".to_string());
+
+    println!("cargo:rustc-env=GIT_VERSION={}", git_version);
 
     // Cross-compiling for Kobo.
     if target == "arm-unknown-linux-gnueabihf" {

--- a/crates/emulator/build.rs
+++ b/crates/emulator/build.rs
@@ -1,0 +1,20 @@
+use std::process::Command;
+
+fn main() {
+    println!("cargo:rerun-if-changed=.git/HEAD");
+
+    let git_version = Command::new("git")
+        .args(&["describe", "--tags", "--always", "--dirty"])
+        .output()
+        .ok()
+        .and_then(|output| {
+            if output.status.success() {
+                Some(String::from_utf8_lossy(&output.stdout).trim().to_string())
+            } else {
+                None
+            }
+        })
+        .unwrap_or_else(|| "unknown".to_string());
+
+    println!("cargo:rustc-env=GIT_VERSION={}", git_version);
+}

--- a/crates/emulator/src/main.rs
+++ b/crates/emulator/src/main.rs
@@ -661,7 +661,7 @@ fn main() -> Result<(), Error> {
                     let dialog = Dialog::new(
                         ViewId::AboutDialog,
                         None,
-                        format!("Plato {}", env!("CARGO_PKG_VERSION")),
+                        format!("Plato {}", env!("GIT_VERSION")),
                         &mut context,
                     );
                     rq.add(RenderData::new(

--- a/crates/plato/build.rs
+++ b/crates/plato/build.rs
@@ -1,0 +1,20 @@
+use std::process::Command;
+
+fn main() {
+    println!("cargo:rerun-if-changed=.git/HEAD");
+
+    let git_version = Command::new("git")
+        .args(&["describe", "--tags", "--always", "--dirty"])
+        .output()
+        .ok()
+        .and_then(|output| {
+            if output.status.success() {
+                Some(String::from_utf8_lossy(&output.stdout).trim().to_string())
+            } else {
+                None
+            }
+        })
+        .unwrap_or_else(|| "unknown".to_string());
+
+    println!("cargo:rustc-env=GIT_VERSION={}", git_version);
+}

--- a/crates/plato/src/app.rs
+++ b/crates/plato/src/app.rs
@@ -1008,7 +1008,7 @@ pub fn run() -> Result<(), Error> {
                 let dialog = Dialog::new(
                     ViewId::AboutDialog,
                     None,
-                    format!("Plato {}", env!("CARGO_PKG_VERSION")),
+                    format!("Plato {}", env!("GIT_VERSION")),
                     &mut context,
                 );
                 rq.add(RenderData::new(


### PR DESCRIPTION
Add git version detection via build scripts to all crates, using 'git describe --tags --always --dirty' to get accurate version information. Update about dialogs to display the git version instead of the package version.

- Add build.rs to emulator and plato crates with git version detection logic
- Update core/build.rs to capture and export GIT_VERSION env var
- Replace CARGO_PKG_VERSION with GIT_VERSION in about dialogs
- Clean up trailing commas in core/build.rs match arms

Change-Id: dc62fadc16f6e26da54acdc0ba4bd59e
Change-Id-Short: mntxkpmnytkt