### PR TITLE
feat: add restart application menu option

### DIFF
--- a/contrib/plato.sh
+++ b/contrib/plato.sh
@@ -105,7 +105,15 @@ fi
 
 [ "$ORIG_BPP" ] && ./bin/utils/fbdepth -q -d 8
 
-LIBC_FATAL_STDERR_=1 ./plato >> info.log 2>&1
+while true; do
+	LIBC_FATAL_STDERR_=1 ./plato >> info.log 2>&1
+
+	if [ -f /tmp/restart ]; then
+		rm /tmp/restart
+	else
+		break
+	fi
+done
 
 [ "$ORIG_BPP" ] && ./bin/utils/fbdepth -q -d "$ORIG_BPP"
 

--- a/crates/core/src/view/common.rs
+++ b/crates/core/src/view/common.rs
@@ -144,6 +144,7 @@ pub fn toggle_main_menu(
             EntryKind::Separator,
         ];
 
+        entries.push(EntryKind::Command("Restart".to_string(), EntryId::Restart));
         entries.push(EntryKind::Command("Reboot".to_string(), EntryId::Reboot));
         entries.push(EntryKind::Command("Quit".to_string(), EntryId::Quit));
 

--- a/crates/core/src/view/mod.rs
+++ b/crates/core/src/view/mod.rs
@@ -633,6 +633,7 @@ pub enum EntryId {
     New,
     Refresh,
     TakeScreenshot,
+    Restart,
     Reboot,
     Quit,
 }

--- a/crates/core/src/view/reader/mod.rs
+++ b/crates/core/src/view/reader/mod.rs
@@ -5134,6 +5134,7 @@ impl View for Reader {
             }
             Event::Select(EntryId::Quit)
             | Event::Select(EntryId::Reboot)
+            | Event::Select(EntryId::Restart)
             | Event::Back
             | Event::Suspend => {
                 self.quit(context);

--- a/crates/plato/src/app.rs
+++ b/crates/plato/src/app.rs
@@ -256,6 +256,7 @@ fn set_wifi(enable: bool, context: &mut Context) {
 #[derive(PartialEq)]
 enum ExitStatus {
     Quit,
+    Restart,
     Reboot,
     PowerOff,
 }
@@ -1267,6 +1268,10 @@ pub fn run() -> Result<(), Error> {
                 let notif = Notification::new(msg, &tx, &mut rq, &mut context);
                 view.children_mut().push(Box::new(notif) as Box<dyn View>);
             }
+            Event::Select(EntryId::Restart) => {
+                exit_status = ExitStatus::Restart;
+                break;
+            }
             Event::Select(EntryId::Reboot) => {
                 exit_status = ExitStatus::Reboot;
                 break;
@@ -1334,6 +1339,9 @@ pub fn run() -> Result<(), Error> {
     save_toml(&context.settings, path).context("can't save settings")?;
 
     match exit_status {
+        ExitStatus::Restart => {
+            File::create("/tmp/restart").ok();
+        }
         ExitStatus::Reboot => {
             File::create("/tmp/reboot").ok();
         }


### PR DESCRIPTION
Add restart functionality to gracefully restart the application without rebooting the device.

- Add Restart variant to ExitStatus enum in app.rs
- Add Restart variant to EntryId enum in view/mod.rs
- Add restart command to entry menu in view/common.rs
- Handle restart exit event in reader view
- Wrap plato startup in loop that checks for restart signal file
- Application creates /tmp/restart file on restart to signal the shell script to restart instead of exiting

Change-Id: 409a638622da6c57b281eed6378cad92
Change-Id-Short: vzqptwrtxxmp