### PR TITLE
ci: expand cache key to include build scripts

### DIFF
--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -77,7 +77,7 @@ jobs:
             libs/
             thirdparty/
             mupdf_wrapper/
-          key: ${{ runner.os }}-thirdparty-libs-kobo-${{ hashFiles('thirdparty/download.sh') }}
+          key: ${{ runner.os }}-thirdparty-libs-kobo-${{ hashFiles('thirdparty/download.sh', 'thirdparty/**/build-kobo.sh', 'thirdparty/**/*.patch') }}
 
       - uses: awalsh128/cache-apt-pkgs-action@latest
         with:


### PR DESCRIPTION
Include thirdparty build scripts and patches in the cache key to ensure the cache is invalidated when build configuration changes:

- Add 'thirdparty/**/build-kobo.sh' to cache key
- Add 'thirdparty/**/*.patch' to cache key

Change-Id: 707e78a6bcb3ba5181d4c8b549b3c2e6
Change-Id-Short: szslsrptonow