### PR TITLE
ci: add shell scripts and bin to code signing 

### DIFF
--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -111,8 +111,10 @@ jobs:
         with:
           subject-path: |
             dist/plato
+            dist/*.sh
             dist/scripts/*
             dist/libs/*
+            dist/bin/*
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
Extend code signing subject paths to include shell scripts and binaries in the dist directory. This ensures all executable artifacts are properly signed.

- Add dist/*.sh to subject-path for shell scripts
- Add dist/bin/* to subject-path for binaries


Change-Id: b0398e83e0c619f3a2a126399f739ccf
Change-Id-Short: ozwqrlrwlznt