### PR TITLE
ci: remove unnecessary escapes in jq filter

### DIFF
--- a/.github/workflows/build-release-candidate.yml
+++ b/.github/workflows/build-release-candidate.yml
@@ -32,7 +32,7 @@ jobs:
         run: |
           pr_data=$(gh pr view ${{ inputs.pr_number }} --repo ${{ github.repository }} --json headRefName,headRepository)
           echo "branch=$(echo $pr_data | jq -r '.headRefName')" >> $GITHUB_OUTPUT
-          echo "repo=$(echo $pr_data | jq -r '.headRepository.owner.login + \"/\" + .headRepository.name')" >> $GITHUB_OUTPUT
+          echo "repo=$(echo $pr_data | jq -r '.headRepository.owner.login + "/" + .headRepository.name')" >> $GITHUB_OUTPUT
 
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
The forward slash in the jq string concatenation does not require
escaping. This change simplifies the filter syntax without changing
behavior.

- Remove escaped quotes around forward slash in jq filter

Change-Id: 9ccc92e214272361581096f518adb838
Change-Id-Short: qnnnqxlxyvxs
