### PR TITLE
ci: fix gh pr view JSON query in workflow

### DIFF
--- a/.github/workflows/build-release-candidate.yml
+++ b/.github/workflows/build-release-candidate.yml
@@ -30,9 +30,9 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          pr_data=$(gh pr view ${{ inputs.pr_number }} --repo ${{ github.repository }} --json headRefName,headRepository)
+          pr_data=$(gh pr view ${{ inputs.pr_number }} --repo ${{ github.repository }} --json headRefName,headRepository,headRepositoryOwner)
           echo "branch=$(echo $pr_data | jq -r '.headRefName')" >> $GITHUB_OUTPUT
-          echo "repo=$(echo $pr_data | jq -r '.headRepository.owner.login + "/" + .headRepository.name')" >> $GITHUB_OUTPUT
+          echo "repo=$(echo $pr_data | jq -r '.headRepositoryOwner.login + "/" + .headRepository.name')" >> $GITHUB_OUTPUT
 
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
Modify the build-release-candidate workflow to query the
headRepositoryOwner field.

- Add headRepositoryOwner to the gh pr view JSON fields

Change-Id: eec6f1ad7c9f47b9a06acbe97337db05
Change-Id-Short: llntkypmsnqk
