### PR TITLE
chore: configure release-plz for plato workspace

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,12 +1,17 @@
 [workspace]
 # Automatically update all workspace dependencies
 allow_dirty = false
-# Use conventional commits
-# conventional_commits = "error"
-# Create a single PR for all workspace members
-git_release_enable = true
+git_release_enable = false
 publish = false
 semver_check = true
+
+[[plato]]
+name = "plato"
+changelog_include = ["core"]
+changelog_path = "CHANGELOG.md"
+changelog_update = true
+git_release_enable = true
+publish = false
 
 # Changelog configuration
 [changelog]


### PR DESCRIPTION
Update release-plz configuration to properly handle the plato
workspace with specific changelog settings and release behavior.

- Add explicit workspace-level git_release_enable and publish flags
- Add plato crate-specific configuration with changelog settings
- Enable semver_check for workspace dependencies
- Set changelog_include to track core crate changes


Change-Id: 52c7a0aead73727b2590a26c1de5feac
Change-Id-Short: uxnspzplpmsw
