### PR TITLE
ci: update release-plz config and trigger

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,7 @@ on:
   pull_request:
     paths:
       - .github/workflows/release.yml
+      - release-plz.toml
 
 permissions:
   contents: write

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -5,7 +5,7 @@ git_release_enable = false
 publish = false
 semver_check = true
 
-[[plato]]
+[[package]]
 name = "plato"
 changelog_include = ["core"]
 changelog_path = "CHANGELOG.md"


### PR DESCRIPTION
Fix deprecated plato section in release-plz.toml by
changing to correct 'package' format. Also update
release.yml to include release-plz.toml in paths that
trigger the workflow.

- Change [[plato]] to [[package]] in release-plz.toml
- Add release-plz.toml to release workflow trigger paths

Change-Id: 887acbd13a3185ba4609fb354507bec5
Change-Id-Short: rrspnomywpwy
