### PR TITLE
chore: correct release workflow and plato config

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -154,6 +154,6 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh release upload ${{ steps.extract-tag.outputs.releases[0].tag }} \
+          gh release upload ${{ steps.extract-tag.outputs.tag }} \
             plato-kobo.tar.gz \
             --repo ${{ github.repository }}

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -4,6 +4,7 @@ allow_dirty = false
 git_release_enable = false
 publish = false
 semver_check = true
+git_tag_enable = false
 
 [[package]]
 name = "plato"
@@ -12,6 +13,8 @@ changelog_path = "CHANGELOG.md"
 changelog_update = true
 git_release_enable = true
 publish = false
+git_tag_enable = true
+git_release_name = "v{version}"
 
 # Changelog configuration
 [changelog]


### PR DESCRIPTION
Fix incorrect variable reference in GitHub release upload step
and configure release-plz git tagging and naming settings.

- Replace releases[0].tag with tag in release workflow
- Disable global git_tag_enable in release-plz config
- Enable git_tag_enable for plato package specifically
- Add git_release_name pattern for plato releases


Change-Id: dc976b72f7fc24c0a67ea6f1a9acc5d6
Change-Id-Short: mnqstosxkskn
