### PR TITLE
chore: configure release-plz for proper package releases

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -5,16 +5,21 @@ git_release_enable = false
 publish = false
 semver_check = true
 git_tag_enable = false
+changelog_update = false
+release = false
+release_always = false
 
 [[package]]
 name = "plato"
-changelog_include = ["core"]
+changelog_include = ["plato-core", "importer", "fetcher"]
 changelog_path = "CHANGELOG.md"
 changelog_update = true
 git_release_enable = true
 publish = false
 git_tag_enable = true
-git_release_name = "v{version}"
+git_release_name = "v{{version}}"
+git_tag_name = "v{{version}}"
+release = true
 
 # Changelog configuration
 [changelog]


### PR DESCRIPTION
Update release-plz configuration to properly handle multi-crate
releases with correct changelog includes and version templating.

- Add global settings to disable changelog and release by default
- Update changelog_include to reference all packages as 'plato-core',
  'importer', and 'fetcher'
- Fix version template syntax using double braces for templating
- Add git_tag_name and release settings to plato package config

Change-Id: 3809c9fea51e71199075e6c699684621
Change-Id-Short: wrzqnqklpuyl
