### PR TITLE
ci: remove component from root package config

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -10,8 +10,6 @@
     }
   ],
   "packages": {
-    ".": {
-      "component": "plato"
-    }
+    ".": {}
   }
 }


### PR DESCRIPTION
Remove the component field from the root package in the
release-please configuration. This simplifies the release
configuration by using default component naming.

- Remove 'component: plato' from root package config
- Retain empty package object for root path

Change-Id: fcca98fa0a68d70850aa9b3b6fdfb9b4
Change-Id-Short: knnpqrkpzptr
