### PR TITLE
ci: configure multi-crate release management

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,3 +1,7 @@
 {
-  ".": "0.9.44"
+  "crates/core": "0.9.44",
+  "crates/plato": "0.9.44",
+  "crates/emulator": "0.9.44",
+  "crates/importer": "0.9.44",
+  "crates/fetcher": "0.9.44"
 }

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -4,12 +4,38 @@
   "bump-minor-pre-major": true,
   "bump-patch-for-minor-pre-major": true,
   "changelog-path": "CHANGELOG.md",
+  "packages": {
+    "crates/core": {
+      "component": "plato-core"
+    },
+    "crates/plato": {
+      "component": "plato"
+    },
+    "crates/emulator": {
+      "component": "emulator"
+    },
+    "crates/importer": {
+      "component": "importer"
+    },
+    "crates/fetcher": {
+      "component": "fetcher"
+    }
+  },
   "plugins": [
     {
-      "type": "cargo-workspace"
+      "type": "cargo-workspace",
+      "merge": false
+    },
+    {
+      "type": "linked-versions",
+      "groupName": "plato",
+      "components": [
+        "plato-core",
+        "plato",
+        "emulator",
+        "importer",
+        "fetcher"
+      ]
     }
-  ],
-  "packages": {
-    ".": {}
-  }
+  ]
 }


### PR DESCRIPTION
Configure Release Please to manage versions and releases
for individual workspace crates. Updates manifest to track
crate versions separately and adds linked-versions plugin
to keep all crates synchronized during releases.

- Update manifest to track each crate version
- Add package configuration for all crates
- Add linked-versions plugin for sync releases
- Disable cargo-workspace merge

Change-Id: bae46d543a2eaabfe91a4372e90e33f7
Change-Id-Short: oplvtmuvwpxl
