### PR TITLE
ci: configure release-please for single release

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -4,27 +4,31 @@
   "bump-minor-pre-major": true,
   "bump-patch-for-minor-pre-major": true,
   "changelog-path": "CHANGELOG.md",
+  "include-component-in-tag": false,
   "packages": {
     "crates/core": {
-      "component": "plato-core"
+      "component": "plato-core",
+      "skip-github-release": true
     },
     "crates/plato": {
       "component": "plato"
     },
     "crates/emulator": {
-      "component": "emulator"
+      "component": "emulator",
+      "skip-github-release": true
     },
     "crates/importer": {
-      "component": "importer"
+      "component": "importer",
+      "skip-github-release": true
     },
     "crates/fetcher": {
-      "component": "fetcher"
+      "component": "fetcher",
+      "skip-github-release": true
     }
   },
   "plugins": [
     {
-      "type": "cargo-workspace",
-      "merge": false
+      "type": "cargo-workspace"
     },
     {
       "type": "linked-versions",


### PR DESCRIPTION
Update release-please configuration to simplify the release process by consolidating releases under a single tag.

- Add include-component-in-tag: false to use simple version tags
- Add skip-github-release: true to non-main crates
- Remove merge: false from cargo-workspace plugin

Change-Id: 02f76e4986d8f311961931f3e1438cd2
Change-Id-Short: zxkstlvqrtmr