### PR TITLE
ci: simplify release-please to single package attempt 2 

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -6,40 +6,18 @@
   "changelog-path": "CHANGELOG.md",
   "include-component-in-tag": false,
   "packages": {
-    "crates/core": {
-      "component": "plato-core",
-      "skip-github-release": true
-    },
-    "crates/plato": {
-      "component": "plato"
-    },
-    "crates/emulator": {
-      "component": "emulator",
-      "skip-github-release": true
-    },
-    "crates/importer": {
-      "component": "importer",
-      "skip-github-release": true
-    },
-    "crates/fetcher": {
-      "component": "fetcher",
-      "skip-github-release": true
+    ".": {
+      "component": "plato",
+      "extra-files": [
+        {"type": "toml", "path": "crates/core/Cargo.toml", "jsonpath": "$.package.version"},
+        {"type": "toml", "path": "crates/plato/Cargo.toml", "jsonpath": "$.package.version"},
+        {"type": "toml", "path": "crates/emulator/Cargo.toml", "jsonpath": "$.package.version"},
+        {"type": "toml", "path": "crates/importer/Cargo.toml", "jsonpath": "$.package.version"},
+        {"type": "toml", "path": "crates/fetcher/Cargo.toml", "jsonpath": "$.package.version"}
+      ]
     }
   },
   "plugins": [
-    {
-      "type": "cargo-workspace"
-    },
-    {
-      "type": "linked-versions",
-      "groupName": "plato",
-      "components": [
-        "plato-core",
-        "plato",
-        "emulator",
-        "importer",
-        "fetcher"
-      ]
-    }
+    "cargo-workspace"
   ]
 }


### PR DESCRIPTION
Consolidate multi-package release-please configuration to a single root-level package with unified versioning.

- Replace per-crate packages with single root package
- Add extra-files to update all crate Cargo.toml versions
- Remove linked-versions plugin (no longer needed)
- Add include-component-in-tag: false for cleaner tags
- Simplify plugins array to just cargo-workspace

Change-Id: 2a97e49a61ec5cce4757026f4a65b146
Change-Id-Short: xpqslvqptyln