### PR TITLE
dev: add ui-dev crate for component development

### DIFF
--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -24,6 +24,8 @@ jobs:
             ~/.cargo/git/db/
             target/
           key: ${{ runner.os }}-cargo-${{ steps.rust-toolchain.outputs.cachekey }}-${{ hashFiles('**/Cargo.lock') }}
+      - name: copy ui-dev template
+        run: cp crates/ui-dev/src/view.rs.template crates/ui-dev/src/view.rs
       - name: Check formatting
         run: cargo fmt --all --check
 
@@ -56,6 +58,8 @@ jobs:
           tool: cargo-diff-tools
       - name: Fetch base ref
         run: git fetch origin ${{ github.base_ref }}
+      - name: copy ui-dev template
+        run: cp crates/ui-dev/src/view.rs.template crates/ui-dev/src/view.rs
       - name: Run cargo clippy
         run: cargo-clippy-diff -o GitHub origin/${{ github.base_ref }} -- -q --workspace --all-targets --all-features
 
@@ -133,6 +137,8 @@ jobs:
             ar cr thirdparty/mupdf/build/release/libmupdf-third.a
           fi
           ln -sf "$(pwd)/thirdparty/mupdf/build/release/libmupdf-third.a" target/mupdf_wrapper/Linux/
+      - name: copy ui-dev template
+        run: cp crates/ui-dev/src/view.rs.template crates/ui-dev/src/view.rs
       - name: Run cargo test
         run: cargo test --workspace
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -200,7 +200,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "titlecase",
  "toml",
  "unicode-normalization",
@@ -212,9 +212,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.53"
+version = "1.2.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "755d2fce177175ffca841e9a06afdb2c4ab0f593d53b4dee48147dfaade85932"
+checksum = "6354c81bbfd62d9cfa9cb3c773c2b7b2a3a482d569de977fd0e961f6e7c00583"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -457,13 +457,13 @@ checksum = "8591b0bcc8a98a64310a2fae1bb3e9b8564dd10e381e6e28010fde8e8e8568db"
 
 [[package]]
 name = "flate2"
-version = "1.1.5"
+version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfe33edd8e85a12a67454e37f8c75e730830d83e313556ab9ebf9ee7fbeb3bfb"
+checksum = "b375d6465b98090a5f25b1c7703f3859783755aa9a80433b36e0379a3ec2f369"
 dependencies = [
  "crc32fast",
- "libz-rs-sys",
  "miniz_oxide",
+ "zlib-rs",
 ]
 
 [[package]]
@@ -986,15 +986,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
 
 [[package]]
-name = "libz-rs-sys"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c10501e7805cee23da17c7790e59df2870c0d4043ec6d03f67d31e2b53e77415"
-dependencies = [
- "zlib-rs",
-]
-
-[[package]]
 name = "linux-raw-sys"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1090,9 +1081,9 @@ checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "openssl-probe"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f50d9b3dabb09ecd771ad0aa242ca6894994c130308ca3d7684634df8037391"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "paragraph-breaker"
@@ -1179,9 +1170,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.105"
+version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "535d180e0ecab6268a3e718bb9fd44db66bbbc256257165fc699dadf70d16fe7"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
@@ -1200,7 +1191,7 @@ dependencies = [
  "rustc-hash",
  "rustls",
  "socket2",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "web-time",
@@ -1222,7 +1213,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tinyvec",
  "tracing",
  "web-time",
@@ -1244,9 +1235,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.43"
+version = "1.0.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc74d9a594b72ae6656596548f56f667211f8a97b3d4c3d467150794690dc40a"
+checksum = "21b2ebcf727b7760c461f091f9f0f539b77b8e87f2fd88131e7f1b433b3cece4"
 dependencies = [
  "proc-macro2",
 ]
@@ -1773,11 +1764,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.17"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f63587ca0f12b72a0600bcba1d40081f830876000bb46dd2337a3051618f4fc8"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl 2.0.17",
+ "thiserror-impl 2.0.18",
 ]
 
 [[package]]
@@ -1793,9 +1784,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.17"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1809,6 +1800,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9e442fc33d7fdb45aa9bfeb312c095964abdf596f7567261062b2a7107aaabd"
 dependencies = [
  "deranged",
+ "js-sys",
  "num-conv",
  "powerfmt",
  "serde_core",
@@ -1989,10 +1981,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "typed-path"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e43ffa54726cdc9ea78392023ffe9fe9cf9ac779e1c6fcb0d23f9862e3879d20"
+
+[[package]]
 name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+
+[[package]]
+name = "ui-dev"
+version = "0.9.45"
+dependencies = [
+ "cadmus-core",
+ "sdl2",
+]
 
 [[package]]
 name = "unicode-ident"
@@ -2615,9 +2621,9 @@ dependencies = [
 
 [[package]]
 name = "zip"
-version = "7.1.0"
+version = "7.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9013f1222db8a6d680f13a7ccdc60a781199cd09c2fa4eff58e728bb181757fc"
+checksum = "c42e33efc22a0650c311c2ef19115ce232583abbe80850bc8b66509ebef02de0"
 dependencies = [
  "aes",
  "bzip2",
@@ -2635,6 +2641,7 @@ dependencies = [
  "ppmd-rust",
  "sha1",
  "time",
+ "typed-path",
  "zeroize",
  "zopfli",
  "zstd",
@@ -2648,9 +2655,9 @@ checksum = "40990edd51aae2c2b6907af74ffb635029d5788228222c4bb811e9351c0caad3"
 
 [[package]]
 name = "zmij"
-version = "1.0.14"
+version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd8f3f50b848df28f887acb68e41201b5aea6bc8a8dacc00fb40635ff9a72fea"
+checksum = "dfcd145825aace48cff44a8844de64bf75feec3080e0aa5cdbde72961ae51a65"
 
 [[package]]
 name = "zopfli"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
   "crates/core",
   "crates/cadmus",
   "crates/emulator",
+  "crates/ui-dev",
   "crates/importer",
   "crates/fetcher",
 ]

--- a/crates/ui-dev/.gitignore
+++ b/crates/ui-dev/.gitignore
@@ -1,0 +1,1 @@
+src/view.rs

--- a/crates/ui-dev/Cargo.toml
+++ b/crates/ui-dev/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "ui-dev"
+version = "0.9.45"
+edition = "2024"
+
+[[bin]]
+name = "plato-ui-dev"
+path = "src/main.rs"
+
+[dependencies]
+cadmus-core = { path = "../core" }
+sdl2 = "0.38.0"

--- a/crates/ui-dev/README.md
+++ b/crates/ui-dev/README.md
@@ -1,0 +1,25 @@
+# UI Dev
+
+A lightweight development environment for creating and testing individual Plato UI components in isolation.
+
+## Overview
+
+`ui-dev` is a specialized emulator crate that spins up a single-view SDL2 window, making it easy to develop, test, and iterate on UI components without the overhead of the full Plato application.
+
+## Getting Started
+
+### Initial Setup
+
+1. Copy the template to create your view implementation:
+
+```bash
+cp crates/ui-dev/src/view.rs.template crates/ui-dev/src/view.rs
+```
+
+2. Edit `crates/ui-dev/src/view.rs` to render your component
+
+3. Run the emulator:
+
+```bash
+cargo run -p ui-dev
+```

--- a/crates/ui-dev/build.rs
+++ b/crates/ui-dev/build.rs
@@ -1,0 +1,20 @@
+use std::process::Command;
+
+fn main() {
+    println!("cargo:rerun-if-changed=.git/HEAD");
+
+    let git_version = Command::new("git")
+        .args(&["describe", "--tags", "--always", "--dirty"])
+        .output()
+        .ok()
+        .and_then(|output| {
+            if output.status.success() {
+                Some(String::from_utf8_lossy(&output.stdout).trim().to_string())
+            } else {
+                None
+            }
+        })
+        .unwrap_or_else(|| "unknown".to_string());
+
+    println!("cargo:rustc-env=GIT_VERSION={}", git_version);
+}

--- a/crates/ui-dev/src/main.rs
+++ b/crates/ui-dev/src/main.rs
@@ -1,0 +1,310 @@
+mod view;
+
+use cadmus_core::anyhow::{Context as ResultExt, Error};
+use cadmus_core::battery::{Battery, FakeBattery};
+use cadmus_core::chrono::Local;
+use cadmus_core::color::Color;
+use cadmus_core::context::Context;
+use cadmus_core::device::CURRENT_DEVICE;
+use cadmus_core::font::Fonts;
+use cadmus_core::framebuffer::{Framebuffer, UpdateMode};
+use cadmus_core::frontlight::{Frontlight, LightLevels};
+use cadmus_core::geom::Rectangle;
+use cadmus_core::gesture::gesture_events;
+use cadmus_core::input::{ButtonCode, ButtonStatus, DeviceEvent, FingerStatus};
+use cadmus_core::library::Library;
+use cadmus_core::lightsensor::LightSensor;
+use cadmus_core::png;
+use cadmus_core::pt;
+use cadmus_core::settings::{IntermKind, Settings};
+use cadmus_core::view::common::locate;
+use cadmus_core::view::intermission::Intermission;
+use cadmus_core::view::notification::Notification;
+use cadmus_core::view::{Event, RenderData, RenderQueue, View, handle_event, process_render_queue};
+use sdl2::event::Event as SdlEvent;
+use sdl2::keyboard::{Keycode, Mod, Scancode};
+use sdl2::pixels::{Color as SdlColor, PixelFormatEnum};
+use sdl2::rect::Point as SdlPoint;
+use sdl2::rect::Rect as SdlRect;
+use sdl2::render::{BlendMode, WindowCanvas};
+use std::collections::VecDeque;
+use std::fs::File;
+use std::mem;
+use std::path::PathBuf;
+use std::sync::mpsc;
+use std::thread;
+use std::time::Duration;
+
+pub const APP_NAME: &str = "Plato UI Dev";
+const DEFAULT_ROTATION: i8 = 1;
+
+#[inline]
+fn seconds(timestamp: u32) -> f64 {
+    timestamp as f64 / 1000.0
+}
+
+#[inline]
+pub fn device_event(event: SdlEvent) -> Option<DeviceEvent> {
+    match event {
+        SdlEvent::MouseButtonDown {
+            timestamp, x, y, ..
+        } => Some(DeviceEvent::Finger {
+            id: 0,
+            status: FingerStatus::Down,
+            position: pt!(x, y),
+            time: seconds(timestamp),
+        }),
+        SdlEvent::MouseButtonUp {
+            timestamp, x, y, ..
+        } => Some(DeviceEvent::Finger {
+            id: 0,
+            status: FingerStatus::Up,
+            position: pt!(x, y),
+            time: seconds(timestamp),
+        }),
+        SdlEvent::MouseMotion {
+            timestamp, x, y, ..
+        } => Some(DeviceEvent::Finger {
+            id: 0,
+            status: FingerStatus::Motion,
+            position: pt!(x, y),
+            time: seconds(timestamp),
+        }),
+        _ => None,
+    }
+}
+
+struct FBCanvas(WindowCanvas);
+
+impl Framebuffer for FBCanvas {
+    fn set_pixel(&mut self, x: u32, y: u32, color: Color) {
+        let [red, green, blue] = color.rgb();
+        self.0.set_draw_color(SdlColor::RGB(red, green, blue));
+        self.0
+            .draw_point(SdlPoint::new(x as i32, y as i32))
+            .unwrap();
+    }
+
+    fn set_blended_pixel(&mut self, x: u32, y: u32, color: Color, alpha: f32) {
+        let [red, green, blue] = color.rgb();
+        self.0
+            .set_draw_color(SdlColor::RGBA(red, green, blue, (alpha * 255.0) as u8));
+        self.0
+            .draw_point(SdlPoint::new(x as i32, y as i32))
+            .unwrap();
+    }
+
+    fn invert_region(&mut self, rect: &Rectangle) {
+        let width = rect.width();
+        let s_rect = Some(SdlRect::new(rect.min.x, rect.min.y, width, rect.height()));
+        if let Ok(data) = self.0.read_pixels(s_rect, PixelFormatEnum::RGB24) {
+            for y in rect.min.y..rect.max.y {
+                let v = (y - rect.min.y) as u32;
+                for x in rect.min.x..rect.max.x {
+                    let u = (x - rect.min.x) as u32;
+                    let addr = 3 * (v * width + u);
+                    let red = data[addr as usize];
+                    let green = data[(addr + 1) as usize];
+                    let blue = data[(addr + 2) as usize];
+                    let mut color = Color::Rgb(red, green, blue);
+                    color.invert();
+                    self.set_pixel(x as u32, y as u32, color);
+                }
+            }
+        }
+    }
+
+    fn shift_region(&mut self, rect: &Rectangle, drift: u8) {
+        let width = rect.width();
+        let s_rect = Some(SdlRect::new(rect.min.x, rect.min.y, width, rect.height()));
+        if let Ok(data) = self.0.read_pixels(s_rect, PixelFormatEnum::RGB24) {
+            for y in rect.min.y..rect.max.y {
+                let v = (y - rect.min.y) as u32;
+                for x in rect.min.x..rect.max.x {
+                    let u = (x - rect.min.x) as u32;
+                    let addr = 3 * (v * width + u);
+                    let red = data[addr as usize];
+                    let green = data[(addr + 1) as usize];
+                    let blue = data[(addr + 2) as usize];
+                    let mut color = Color::Rgb(red, green, blue);
+                    color.shift(drift);
+                    self.set_pixel(x as u32, y as u32, color);
+                }
+            }
+        }
+    }
+
+    fn update(&mut self, _rect: &Rectangle, _mode: UpdateMode) -> Result<u32, Error> {
+        self.0.present();
+        Ok(Local::now().timestamp_subsec_millis())
+    }
+
+    fn wait(&self, _tok: u32) -> Result<i32, Error> {
+        Ok(1)
+    }
+
+    fn save(&self, _path: &str) -> Result<(), Error> {
+        unimplemented!()
+    }
+
+    fn rotation(&self) -> i8 {
+        DEFAULT_ROTATION
+    }
+
+    fn set_rotation(&mut self, _n: i8) -> Result<(u32, u32), Error> {
+        unimplemented!()
+    }
+
+    fn set_monochrome(&mut self, _enable: bool) {}
+
+    fn set_dithered(&mut self, _enable: bool) {}
+
+    fn set_inverted(&mut self, _enable: bool) {}
+
+    fn monochrome(&self) -> bool {
+        false
+    }
+
+    fn dithered(&self) -> bool {
+        false
+    }
+
+    fn inverted(&self) -> bool {
+        false
+    }
+
+    fn width(&self) -> u32 {
+        self.0.window().size().0
+    }
+
+    fn height(&self) -> u32 {
+        self.0.window().size().1
+    }
+}
+
+pub fn build_context(fb: Box<dyn Framebuffer>) -> Result<Context, Error> {
+    let mut settings = Settings::default();
+
+    settings.libraries[0].path = PathBuf::from(".");
+
+    let library_settings = &settings.libraries[settings.selected_library];
+    let library = Library::new(&library_settings.path, library_settings.mode)?;
+
+    let battery = Box::new(FakeBattery::new()) as Box<dyn Battery>;
+    let frontlight = Box::new(LightLevels::default()) as Box<dyn Frontlight>;
+    let lightsensor = Box::new(0u16) as Box<dyn LightSensor>;
+    let fonts = Fonts::load()?;
+
+    Ok(Context::new(
+        fb,
+        None,
+        library,
+        settings,
+        fonts,
+        battery,
+        frontlight,
+        lightsensor,
+    ))
+}
+
+fn main() -> Result<(), Error> {
+    let sdl_context = sdl2::init().unwrap();
+    let video_subsystem = sdl_context.video().unwrap();
+    let (width, height) = CURRENT_DEVICE.dims;
+    let window = video_subsystem
+        .window("Plato UI Dev", width, height)
+        .position_centered()
+        .build()
+        .unwrap();
+
+    let mut fb = window.into_canvas().software().build().unwrap();
+    fb.set_blend_mode(BlendMode::Blend);
+
+    let mut context = build_context(Box::new(FBCanvas(fb)))?;
+
+    let (tx, rx) = mpsc::channel();
+    let (ty, ry) = mpsc::channel();
+    let touch_screen = gesture_events(ry);
+
+    let tx2 = tx.clone();
+    thread::spawn(move || {
+        while let Ok(evt) = touch_screen.recv() {
+            tx2.send(evt).ok();
+        }
+    });
+
+    let mut rq = RenderQueue::new();
+    let mut view: Box<dyn View> =
+        view::create_root_view(context.fb.rect(), &tx, &mut rq, &mut context);
+
+    rq.add(RenderData::new(view.id(), *view.rect(), UpdateMode::Full));
+
+    let mut updating = Vec::new();
+
+    if context.settings.frontlight {
+        let levels = context.settings.frontlight_levels;
+        context.frontlight.set_intensity(levels.intensity);
+        context.frontlight.set_warmth(levels.warmth);
+    } else {
+        context.frontlight.set_warmth(0.0);
+        context.frontlight.set_intensity(0.0);
+    }
+
+    println!(
+        "{} is running on a Kobo {}.",
+        APP_NAME, CURRENT_DEVICE.model
+    );
+    println!(
+        "The framebuffer resolution is {} by {}.",
+        context.fb.rect().width(),
+        context.fb.rect().height()
+    );
+
+    let mut bus = VecDeque::with_capacity(4);
+
+    process_render_queue(view.as_ref(), &mut rq, &mut context, &mut updating);
+
+    'outer: loop {
+        let mut event_pump = sdl_context.event_pump().unwrap();
+        while let Some(sdl_evt) = event_pump.poll_event() {
+            match sdl_evt {
+                SdlEvent::Quit { .. } => {
+                    break 'outer;
+                }
+                _ => {
+                    if let Some(dev_evt) = device_event(sdl_evt) {
+                        ty.send(dev_evt).ok();
+                    }
+                }
+            }
+        }
+
+        while let Ok(evt) = rx.recv_timeout(Duration::from_millis(20)) {
+            match evt {
+                Event::Device(DeviceEvent::RotateScreen(n)) => {
+                    if n != context.display.rotation {
+                        if let Ok(dims) = context.fb.set_rotation(n) {
+                            context.display.rotation = n;
+                            let fb_rect = Rectangle::from(dims);
+                            if context.display.dims != dims {
+                                context.display.dims = dims;
+                                view.resize(fb_rect, &tx, &mut rq, &mut context);
+                            }
+                        }
+                    }
+                }
+                _ => {
+                    handle_event(view.as_mut(), &evt, &tx, &mut bus, &mut rq, &mut context);
+                }
+            }
+        }
+
+        process_render_queue(view.as_ref(), &mut rq, &mut context, &mut updating);
+
+        while let Some(ce) = bus.pop_front() {
+            tx.send(ce).ok();
+        }
+    }
+
+    Ok(())
+}

--- a/crates/ui-dev/src/view.rs.template
+++ b/crates/ui-dev/src/view.rs.template
@@ -1,0 +1,49 @@
+use plato_core::context::Context;
+use plato_core::geom::Rectangle;
+use plato_core::view::label::Label;
+use plato_core::view::{Align, Hub, RenderQueue, View};
+
+/// Create the root view to be rendered in the UI development emulator.
+///
+/// This function is called once at startup. Modify it to test your own components.
+///
+/// # Example: Creating a simple label
+///
+/// ```no_run
+/// Box::new(Label::new(
+///     rect,
+///     "Hello, Plato UI Dev!".to_string(),
+///     Align::Center,
+/// ))
+/// ```
+///
+/// # Example: Creating a container with children
+///
+/// ```no_run
+/// let mut container = Filler::new(rect, Color::White);
+/// // Add children to container.children_mut()
+/// Box::new(container)
+/// ```
+///
+/// # Available View Components
+///
+/// Some commonly used view components you can import and use:
+/// - `Label`: Simple text label
+/// - `Button`: Clickable button
+/// - `Filler`: Colored rectangle container
+/// - `Icon`: Icon display
+/// - `Slider`: Value slider
+///
+/// Check `crates/core/src/view/` for more components.
+pub fn create_root_view(
+    rect: Rectangle,
+    _hub: &Hub,
+    _rq: &mut RenderQueue,
+    _context: &mut Context,
+) -> Box<dyn View> {
+    Box::new(Label::new(
+        rect,
+        "Hello, Plato UI Dev!".to_string(),
+        Align::Center,
+    ))
+}

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -23,6 +23,18 @@
       "skip-github-release": true,
       "skip-changelog": true
     },
+    "crates/ui-dev": {
+      "release-type": "rust",
+      "component": "ui-dev",
+      "skip-github-release": true,
+      "skip-changelog": true
+    },
+    "crates/ui-dev": {
+      "release-type": "rust",
+      "component": "ui-dev",
+      "skip-github-release": true,
+      "skip-changelog": true
+    },
     "crates/emulator": {
       "release-type": "rust",
       "component": "emulator",
@@ -52,8 +64,9 @@
         "cadmus-core",
         "cadmus-bin",
         "emulator",
+        "fetcher",
         "importer",
-        "fetcher"
+        "ui-dev"
       ]
     }
   ]


### PR DESCRIPTION
Add a new ui-dev crate that provides a lightweight development environment for creating and testing individual Plato UI components in isolation. The crate spins up a single-view SDL2 window, enabling rapid iteration on UI components without the overhead of the full application.

- Implement FBCanvas SDL2 framebuffer adapter
- Build context setup with fake battery/frontlight/lightsensor
- Event mapping from SDL2 to Plato device events
- Include view template for rapid component development

Change-Id: 6becdc42944f538935529531f50d47de
Change-Id-Short: tolnmnvxqvvk
Relates-To: #2 