### PR TITLE
ci: bundle KoboRoot as part of (release) artifacts

### DIFF
--- a/.github/workflows/build-release-candidate.yml
+++ b/.github/workflows/build-release-candidate.yml
@@ -85,6 +85,12 @@ jobs:
           packages: git wget curl pkg-config unzip jq patchelf gcc g++ make cmake meson ninja-build autoconf automake libtool gperf python3 zlib1g-dev libbz2-dev libpng-dev libjpeg-dev libopenjp2-7-dev libjbig2dec0-dev libgumbo-dev libfreetype6-dev libharfbuzz-dev libdjvulibre-dev
           version: 1.0
 
+      - name: Cache NickelMenu
+        uses: actions/cache@v5
+        with:
+          path: .cache/
+          key: ${{ runner.os }}-nickelmenu-${{ hashFiles('bundle.sh') }}
+
       - name: Setup Linaro toolchain
         run: |
           echo "$HOME/linaro-toolchain/bin" >> $GITHUB_PATH
@@ -107,6 +113,28 @@ jobs:
       - name: Create distribution
         run: ./dist.sh
 
+      - name: Get commit hash
+        id: commit
+        run: echo "short_sha=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+
+      - name: Build release artifacts
+        run: |
+          mkdir -p release-artifacts
+
+          # Raw dist folder
+          cd dist
+          tar czf ../release-artifacts/plato-kobo.tar.gz .
+          cd ..
+
+          # KoboRoot without NickelMenu
+          ./bundle.sh --no-nickel
+          cp bundle/KoboRoot.tgz release-artifacts/KoboRoot.tgz
+
+          # KoboRoot with NickelMenu
+          rm -rf bundle
+          ./bundle.sh
+          cp bundle/KoboRoot-nm.tgz release-artifacts/KoboRoot-nm.tgz
+
       - name: Generate artifact attestation
         uses: actions/attest-build-provenance@v3
         with:
@@ -114,15 +142,16 @@ jobs:
             dist/plato
             dist/*.sh
             dist/scripts/*
-            dist/libs/*
+            dist/libs/*.so*
             dist/bin/*
+            release-artifacts/*.tgz
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v6
         with:
-          name: plato-kobo-pr${{ inputs.pr_number }}
-          path: dist/
-          retention-days: 30
+          name: plato-kobo-pr${{ inputs.pr_number }}-${{ steps.commit.outputs.short_sha }}
+          path: release-artifacts/*
+          retention-days: 14
 
       - name: Comment on PR or Issue
         env:

--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -178,6 +178,12 @@ jobs:
             mupdf_wrapper/
           key: ${{ runner.os }}-thirdparty-libs-kobo-${{ hashFiles('thirdparty/download.sh', 'thirdparty/**/build-kobo.sh', 'thirdparty/**/*.patch') }}
 
+      - name: Cache NickelMenu downloads
+        uses: actions/cache@v5
+        with:
+          path: .cache/
+          key: ${{ runner.os }}-nickelmenu-${{ hashFiles('bundle.sh') }}
+
       - uses: awalsh128/cache-apt-pkgs-action@latest
         with:
           packages: git wget curl pkg-config unzip jq patchelf gcc g++ make cmake meson ninja-build autoconf automake libtool gperf python3 zlib1g-dev libbz2-dev libpng-dev libjpeg-dev libopenjp2-7-dev libjbig2dec0-dev libgumbo-dev libfreetype6-dev libharfbuzz-dev libdjvulibre-dev libsdl2-dev
@@ -205,6 +211,37 @@ jobs:
       - name: Create distribution
         run: ./dist.sh
 
+      - name: Get commit hash
+        id: commit
+        run: echo "short_sha=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+
+      - name: Determine artifact suffix
+        id: artifact
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            echo "suffix=pr${{ github.event.pull_request.number }}-${{ steps.commit.outputs.short_sha }}" >> $GITHUB_OUTPUT
+          else
+            echo "suffix=${{ steps.commit.outputs.short_sha }}" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Build release artifacts
+        run: |
+          mkdir -p release-artifacts
+
+          # Raw dist folder
+          cd dist
+          tar czf ../release-artifacts/plato-kobo.tar.gz .
+          cd ..
+
+          # KoboRoot without NickelMenu
+          ./bundle.sh --no-nickel
+          cp bundle/KoboRoot.tgz release-artifacts/KoboRoot.tgz
+
+          # KoboRoot with NickelMenu
+          rm -rf bundle
+          ./bundle.sh
+          cp bundle/KoboRoot-nm.tgz release-artifacts/KoboRoot-nm.tgz
+
       - name: Generate artifact attestation
         uses: actions/attest-build-provenance@v3
         with:
@@ -212,12 +249,13 @@ jobs:
             dist/plato
             dist/*.sh
             dist/scripts/*
-            dist/libs/*
+            dist/libs/*.so*
             dist/bin/*
+            release-artifacts/*.tgz
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v6
         with:
-          name: plato-kobo
-          path: dist/
+          name: plato-kobo-${{ steps.artifact.outputs.suffix }}
+          path: release-artifacts/*
           retention-days: 7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,6 +90,12 @@ jobs:
           packages: git wget curl pkg-config unzip jq patchelf gcc g++ make cmake meson ninja-build autoconf automake libtool gperf python3 zlib1g-dev libbz2-dev libpng-dev libjpeg-dev libopenjp2-7-dev libjbig2dec0-dev libgumbo-dev libfreetype6-dev libharfbuzz-dev libdjvulibre-dev
           version: 1.0
 
+      - name: Cache NickelMenu
+        uses: actions/cache@v5
+        with:
+          path: .cache/
+          key: ${{ runner.os }}-nickelmenu-${{ hashFiles('bundle.sh') }}
+
       - name: Setup Linaro toolchain
         run: |
           echo "$HOME/linaro-toolchain/bin" >> $GITHUB_PATH
@@ -112,6 +118,22 @@ jobs:
       - name: Create distribution
         run: ./dist.sh
 
+      - name: Build release artifacts
+        run: |
+          # Raw dist folder
+          cd dist
+          tar czf ../plato-kobo.tar.gz .
+          cd ..
+          
+          # KoboRoot without NickelMenu
+          ./bundle.sh --no-nickel
+          cp bundle/KoboRoot.tgz KoboRoot.tgz
+          
+          # KoboRoot with NickelMenu
+          rm -rf bundle
+          ./bundle.sh
+          cp bundle/KoboRoot-nm.tgz KoboRoot-nm.tgz
+
       - name: Generate artifact attestation
         uses: actions/attest-build-provenance@v3
         with:
@@ -121,11 +143,8 @@ jobs:
             dist/scripts/*
             dist/libs/*.so*
             dist/bin/*
-
-      - name: Create distribution archive
-        run: |
-          cd dist
-          tar czf ../plato-kobo.tar.gz .
+            KoboRoot.tgz
+            KoboRoot-nm.tgz
 
       - name: Upload release assets
         env:
@@ -133,4 +152,6 @@ jobs:
         run: |
           gh release upload ${{ needs.release-please.outputs.tag_name }} \
             plato-kobo.tar.gz \
+            KoboRoot.tgz \
+            KoboRoot-nm.tgz \
             --repo ${{ github.repository }}

--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@
 /dictionaries
 /dist
 /bundle
+/.cache
 /plato-*.zip
 /thirdparty/*/*
 !/thirdparty/*/*kobo*

--- a/bundle.sh
+++ b/bundle.sh
@@ -1,39 +1,208 @@
 #! /bin/sh
+#
+# Bundle Plato for Kobo devices (with or without NickelMenu)
+#
+# Usage:
+#   bundle.sh [--skip-download] [--no-nickel]
+#
+# Examples:
+#   bundle.sh                          Auto-download NickelMenu and bundle
+#   bundle.sh --skip-download          Use cached NickelMenu archive
+#   bundle.sh --no-nickel              Create KoboRoot without NickelMenu
+#   NICKEL_VERSION=0.7.0 bundle.sh     Download NickelMenu v0.7.0
+#
+# Environment Variables:
+#   NICKEL_VERSION    NickelMenu version to download (default: 0.6.0). Ensure this
+#                     version exists at https://github.com/pgaskin/NickelMenu/releases
 
-if [ "$#" -lt 1 ] ; then
-	printf "Usage: %s NICKEL_MENU_ARCHIVE\n" "${0##*/}" >&2
-	exit 1
-fi
+set -e
+
+NICKEL_VERSION=${NICKEL_VERSION:-0.6.0}
+CACHE_DIR=".cache"
+NICKEL_MENU_REPO="pgaskin/NickelMenu"
+NICKEL_MENU_ARCHIVE="${CACHE_DIR}/NickelMenu-${NICKEL_VERSION}-KoboRoot.tgz"
+
+check_dependencies() {
+	missing=""
+	for cmd in curl wget jq sha256sum tar; do
+		if ! command -v "$cmd" >/dev/null 2>&1; then
+			missing="${missing} $cmd"
+		fi
+	done
+
+	if [ -n "$missing" ]; then
+		echo "Error: Missing required commands:$missing" >&2
+		echo "Please install them and try again" >&2
+		exit 5
+	fi
+}
+
+download_nickel_menu() {
+	mkdir -p "$CACHE_DIR"
+
+	if [ -f "$NICKEL_MENU_ARCHIVE" ]; then
+		echo "Using cached NickelMenu v${NICKEL_VERSION}"
+		return 0
+	fi
+
+	echo "Downloading NickelMenu v${NICKEL_VERSION}..."
+
+	info_url="https://api.github.com/repos/${NICKEL_MENU_REPO}/releases/tags/v${NICKEL_VERSION}"
+	echo "Fetching release info from: $info_url" >&2
+
+	temp_file="${CACHE_DIR}/release_info.json"
+	if ! curl -f "$info_url" >"$temp_file"; then
+		curl_exit=$?
+		echo "Error: Failed to fetch GitHub API (curl exit code: $curl_exit)" >&2
+		echo "Possible causes:" >&2
+		echo "  - Network connectivity issues" >&2
+		echo "  - GitHub API rate limiting" >&2
+		echo "  - Invalid release version: v${NICKEL_VERSION}" >&2
+		echo "Check: https://github.com/${NICKEL_MENU_REPO}/releases" >&2
+		rm -f "$temp_file"
+		exit 1
+	fi
+
+	if ! jq empty "$temp_file"; then
+		echo "Error: GitHub API returned invalid JSON" >&2
+		echo "Response:" >&2
+		cat "$temp_file" >&2
+		exit 1
+	fi
+
+	download_url=$(jq -r '.assets[] | select(.name | endswith("KoboRoot.tgz")).browser_download_url' "$temp_file" 2>/dev/null)
+	expected_sha256=$(jq -r '.assets[] | select(.name | endswith("KoboRoot.tgz")).digest' "$temp_file" 2>/dev/null | cut -d: -f2)
+
+	if [ -z "$download_url" ] || [ "$download_url" = "null" ]; then
+		echo "Error: Could not find NickelMenu v${NICKEL_VERSION} KoboRoot.tgz asset" >&2
+		echo "Release info:" >&2
+		jq '.assets[].name' "$temp_file" 2>/dev/null || cat "$temp_file"
+		echo "" >&2
+		echo "Check: https://github.com/${NICKEL_MENU_REPO}/releases/tag/v${NICKEL_VERSION}" >&2
+		exit 1
+	fi
+
+	echo "Downloading from: $download_url" >&2
+	if ! wget -q "$download_url" -O "$NICKEL_MENU_ARCHIVE"; then
+		wget_exit=$?
+		echo "Error: Failed to download NickelMenu (wget exit code: $wget_exit)" >&2
+		rm -f "$NICKEL_MENU_ARCHIVE"
+		exit 1
+	fi
+
+	if [ -n "$expected_sha256" ] && [ "$expected_sha256" != "null" ]; then
+		echo "Verifying SHA256 checksum..."
+		actual_sha256=$(sha256sum "$NICKEL_MENU_ARCHIVE" | cut -d' ' -f1)
+
+		if [ "$actual_sha256" != "$expected_sha256" ]; then
+			echo "Error: SHA256 checksum mismatch" >&2
+			echo "Expected: $expected_sha256" >&2
+			echo "Got:      $actual_sha256" >&2
+			rm -f "$NICKEL_MENU_ARCHIVE"
+			exit 1
+		fi
+		echo "Checksum verified successfully"
+	fi
+
+	echo "Downloaded NickelMenu to $NICKEL_MENU_ARCHIVE"
+}
+
+validate_archive() {
+	archive="$1"
+
+	if ! tar -tzf "$archive" >/dev/null 2>&1; then
+		echo "Error: Invalid or corrupted archive: $archive" >&2
+		exit 1
+	fi
+}
+
+extract_and_merge() {
+	archive="$1"
+
+	mkdir bundle
+	cd bundle || exit 1
+
+	tar -xzf "../$archive"
+	mv mnt/onboard/.adds .
+	rm -Rf mnt
+
+	mv ../dist .adds/plato
+	cp ../contrib/NickelMenu/* .adds/nm
+
+	cd ..
+}
+
+create_bundle_plato_only() {
+	mkdir -p bundle/mnt/onboard/.adds/plato
+	cp -r dist/* bundle/mnt/onboard/.adds/plato/
+
+	cd bundle || exit 1
+
+	echo "Creating KoboRoot.tgz (Plato only)..."
+	tar -czf "KoboRoot.tgz" mnt
+
+	rm -Rf mnt
+	cd ..
+
+	echo "Bundle created: bundle/KoboRoot.tgz"
+	echo "Place this file in the .kobo directory on your Kobo device"
+}
+
+create_bundle_with_nickel() {
+	cd bundle || exit 1
+
+	mkdir -p mnt/onboard
+	mv .adds mnt/onboard/.adds
+
+	echo "Creating KoboRoot-nm.tgz (with NickelMenu)..."
+	tar -czf "KoboRoot-nm.tgz" usr mnt
+
+	rm -Rf usr mnt
+	cd ..
+
+	echo "Bundle created: bundle/KoboRoot-nm.tgz"
+	echo "Place this file in the .kobo directory on your Kobo device"
+}
+
+skip_download=false
+no_nickel=false
+
+for arg in "$@"; do
+	case "$arg" in
+	--skip-download)
+		skip_download=true
+		;;
+	--no-nickel)
+		no_nickel=true
+		;;
+	*)
+		echo "Unknown option: $arg" >&2
+		echo "Usage: bundle.sh [--skip-download] [--no-nickel]" >&2
+		exit 1
+		;;
+	esac
+done
+
+check_dependencies
 
 [ -d dist ] || ./dist.sh
 [ -d bundle ] && rm -Rf bundle
 
-NICKEL_MENU_ARCHIVE=$1
-
-mkdir bundle
-cd bundle || exit 1
-
-if gzip -tq "$NICKEL_MENU_ARCHIVE"; then
-	ln -s "$NICKEL_MENU_ARCHIVE" KoboRoot.tgz
+if [ "$no_nickel" = true ]; then
+	create_bundle_plato_only
 else
-	unzip "$NICKEL_MENU_ARCHIVE" KoboRoot.tgz
+	if [ "$skip_download" = false ]; then
+		download_nickel_menu
+	else
+		if [ ! -f "$NICKEL_MENU_ARCHIVE" ]; then
+			echo "Error: NickelMenu archive not found at $NICKEL_MENU_ARCHIVE" >&2
+			echo "Remove --skip-download flag to auto-download" >&2
+			exit 1
+		fi
+		echo "Using cached NickelMenu v${NICKEL_VERSION}"
+	fi
+
+	validate_archive "$NICKEL_MENU_ARCHIVE"
+	extract_and_merge "$NICKEL_MENU_ARCHIVE"
+	create_bundle_with_nickel
 fi
-
-tar -xzvf KoboRoot.tgz
-rm KoboRoot.tgz
-mv mnt/onboard/.adds .
-rm -Rf mnt
-
-mv ../dist .adds/plato
-cp ../contrib/NickelMenu/* .adds/nm
-
-mkdir .kobo
-tar -czvf .kobo/KoboRoot.tgz usr
-rm -Rf usr
-
-FIRMWARE_VERSION=$(basename "$FIRMWARE_ARCHIVE" .zip)
-FIRMWARE_VERSION=${FIRMWARE_VERSION##*-}
-PLATO_VERSION=$(cargo pkgid -p plato | cut -d '#' -f 2)
-
-zip -r plato-bundle-"$PLATO_VERSION".zip .adds .kobo
-rm -Rf .adds .kobo

--- a/devenv.nix
+++ b/devenv.nix
@@ -220,4 +220,10 @@ in
     echo "Running Plato tests"
     cargo test --workspace
   '';
+
+  git-hooks.hooks = {
+    actionlint.enable = true;
+    shellcheck.enable = true;
+    shfmt.enable = true;
+  };
 }


### PR DESCRIPTION
Refactor bundle.sh to automate NickelMenu downloads with checksum
verification and support building Plato-only releases. Update CI
workflows to generate versioned release artifacts.

- Add automatic NickelMenu v0.6.0 download with SHA256 validation
- Support --no-nickel flag for Plato-only KoboRoot builds
- Generate separate KoboRoot.tgz and KoboRoot-nm.tgz artifacts
- Version artifacts with commit SHA in all CI workflows
- Create release-artifacts directory for organized output
- Add .cache to .gitignore for NickelMenu download cache
- Update attestation and upload steps in all workflows

Change-Id: 4eac857e7a18e6eb2a8b721098fb8b32
Change-Id-Short: vlpnruslspyr
