### PR TITLE
fix: Kobo build scripts

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -8,60 +8,59 @@ method=${1:-"fast"}
 [ -e libs -a "$1" = "slow" ] && method=skip
 
 case "$method" in
-	fast)
-		./download.sh 'libs/*'
-		cd libs
+fast)
+	./download.sh 'libs/*'
+	cd libs
 
-		ln -s libz.so.1 libz.so
-		ln -s libbz2.so.1.0 libbz2.so
+	ln -s libz.so.1 libz.so
+	ln -s libbz2.so.1.0 libbz2.so
 
-		ln -s libpng16.so.16 libpng16.so
-		ln -s libjpeg.so.9 libjpeg.so
-		ln -s libopenjp2.so.7 libopenjp2.so
-		ln -s libjbig2dec.so.0 libjbig2dec.so
+	ln -s libpng16.so.16 libpng16.so
+	ln -s libjpeg.so.9 libjpeg.so
+	ln -s libopenjp2.so.7 libopenjp2.so
+	ln -s libjbig2dec.so.0 libjbig2dec.so
 
-		ln -s libfreetype.so.6 libfreetype.so
-		ln -s libharfbuzz.so.0 libharfbuzz.so
+	ln -s libfreetype.so.6 libfreetype.so
+	ln -s libharfbuzz.so.0 libharfbuzz.so
 
-		ln -s libgumbo.so.2 libgumbo.so
-		ln -s libdjvulibre.so.21 libdjvulibre.so
+	ln -s libgumbo.so.1 libgumbo.so
+	ln -s libdjvulibre.so.21 libdjvulibre.so
 
-		cd ../thirdparty
-		./download.sh mupdf
-		cd ..
-		;;
+	cd ../thirdparty
+	./download.sh mupdf
+	cd ..
+	;;
 
-	slow)
-		shift
-		cd thirdparty
-		./download.sh "$@"
-		./build.sh "$@"
-		cd ..
+slow)
+	shift
+	cd thirdparty
+	./download.sh "$@"
+	./build.sh "$@"
+	cd ..
 
-		[ -e libs ] || mkdir libs
+	[ -e libs ] || mkdir libs
 
-		cp thirdparty/zlib/libz.so libs
-		cp thirdparty/bzip2/libbz2.so libs
+	cp thirdparty/zlib/libz.so libs
+	cp thirdparty/bzip2/libbz2.so libs
 
-		cp thirdparty/libpng/.libs/libpng16.so libs
-		cp thirdparty/libjpeg/.libs/libjpeg.so libs
-		cp thirdparty/openjpeg/build/bin/libopenjp2.so libs
-		cp thirdparty/jbig2dec/.libs/libjbig2dec.so libs
+	cp thirdparty/libpng/.libs/libpng16.so libs
+	cp thirdparty/libjpeg/.libs/libjpeg.so libs
+	cp thirdparty/openjpeg/build/bin/libopenjp2.so libs
+	cp thirdparty/jbig2dec/.libs/libjbig2dec.so libs
 
-		cp thirdparty/freetype2/objs/.libs/libfreetype.so libs
-		cp thirdparty/harfbuzz/build/src/libharfbuzz.so libs
+	cp thirdparty/freetype2/objs/.libs/libfreetype.so libs
+	cp thirdparty/harfbuzz/build/src/libharfbuzz.so libs
 
-		cp thirdparty/gumbo/.libs/libgumbo.so libs
-		cp thirdparty/djvulibre/libdjvu/.libs/libdjvulibre.so libs
-		cp thirdparty/mupdf/build/release/libmupdf.so libs
-		;;
+	cp thirdparty/gumbo/.libs/libgumbo.so libs
+	cp thirdparty/djvulibre/libdjvu/.libs/libdjvulibre.so libs
+	cp thirdparty/mupdf/build/release/libmupdf.so libs
+	;;
 
-	skip)
-		;;
-	*)
-		printf "Unknown build method: %s.\n" "$method" 1>&2
-		exit 1
-		;;
+skip) ;;
+*)
+	printf "Unknown build method: %s.\n" "$method" 1>&2
+	exit 1
+	;;
 esac
 
 cd mupdf_wrapper

--- a/dist.sh
+++ b/dist.sh
@@ -21,7 +21,7 @@ cp libs/libjbig2dec.so dist/libs/libjbig2dec.so.0
 cp libs/libfreetype.so dist/libs/libfreetype.so.6
 cp libs/libharfbuzz.so dist/libs/libharfbuzz.so.0
 
-cp libs/libgumbo.so dist/libs/libgumbo.so.2
+cp libs/libgumbo.so dist/libs/libgumbo.so.1
 cp libs/libdjvulibre.so dist/libs/libdjvulibre.so.21
 cp libs/libmupdf.so dist/libs
 

--- a/download.sh
+++ b/download.sh
@@ -2,7 +2,7 @@
 
 version=$(cargo pkgid -p plato | cut -d '#' -f 2)
 archive="plato-${version}.zip"
-if ! [ -e "$archive" ] ; then
+if ! [ -e "$archive" ]; then
 	info_url="https://api.github.com/repos/baskerville/plato/releases/tags/${version}"
 	echo "Downloading ${archive}."
 	release_url=$(wget -q -O - "$info_url" | jq -r ".assets[] | select(.name == \"$archive\").browser_download_url")

--- a/thirdparty/djvulibre/build-kobo.sh
+++ b/thirdparty/djvulibre/build-kobo.sh
@@ -2,6 +2,7 @@
 
 TRIPLE=arm-linux-gnueabihf
 JPEG_DIR=$(realpath ../libjpeg)
+export CC=${TRIPLE}-gcc
 export CFLAGS="-O2 -mcpu=cortex-a9 -mfpu=neon"
 export CXXFLAGS="$CFLAGS"
 export CXX=${TRIPLE}-g++

--- a/thirdparty/freetype2/build-kobo.sh
+++ b/thirdparty/freetype2/build-kobo.sh
@@ -1,6 +1,8 @@
 #! /bin/sh
 
 export TRIPLE=arm-linux-gnueabihf
+export CC=${TRIPLE}-gcc
+export CXX=${TRIPLE}-g++
 export CFLAGS="-O2 -mcpu=cortex-a9 -mfpu=neon"
 export CXXFLAGS="$CFLAGS"
 export ZLIB_CFLAGS="-I../zlib"
@@ -11,5 +13,5 @@ export LIBPNG_CFLAGS="-I../libpng"
 export LIBPNG_LIBS="-L../libpng/.libs -lpng16"
 
 ./configure --host=${TRIPLE} --with-zlib=yes --with-png=yes \
-            --with-bzip2=yes --with-harfbuzz=no --with-brotli=no \
-            --disable-static && make
+	--with-bzip2=yes --with-harfbuzz=no --with-brotli=no \
+	--disable-static && make

--- a/thirdparty/gumbo/build-kobo.sh
+++ b/thirdparty/gumbo/build-kobo.sh
@@ -1,6 +1,8 @@
 #! /bin/sh
 
 export TRIPLE=arm-linux-gnueabihf
+export CC=${TRIPLE}-gcc
+export CXX=${TRIPLE}-g++
 
 [ -x configure ] || ./autogen.sh
 ./configure --host="$TRIPLE" && make

--- a/thirdparty/jbig2dec/build-kobo.sh
+++ b/thirdparty/jbig2dec/build-kobo.sh
@@ -1,6 +1,8 @@
 #! /bin/sh
 
 TRIPLE=arm-linux-gnueabihf
+export CC=${TRIPLE}-gcc
+export CXX=${TRIPLE}-g++
 export CFLAGS='-O2 -mcpu=cortex-a9 -mfpu=neon'
 export CXXFLAGS="$CFLAGS"
 export AS=${TRIPLE}-as

--- a/thirdparty/libjpeg/build-kobo.sh
+++ b/thirdparty/libjpeg/build-kobo.sh
@@ -1,6 +1,8 @@
 #! /bin/sh
 
 TRIPLE=arm-linux-gnueabihf
+export CC=${TRIPLE}-gcc
+export CXX=${TRIPLE}-g++
 export CFLAGS="-O2 -mcpu=cortex-a9 -mfpu=neon"
 
 ./configure --host=${TRIPLE} && make

--- a/thirdparty/libpng/build-kobo.sh
+++ b/thirdparty/libpng/build-kobo.sh
@@ -2,6 +2,8 @@
 
 TRIPLE=arm-linux-gnueabihf
 ZLIB_DIR=../zlib
+export CC=${TRIPLE}-gcc
+export CXX=${TRIPLE}-g++
 export CFLAGS="-O2 -mcpu=cortex-a9 -mfpu=neon"
 export CXXFLAGS="$CFLAGS"
 export CPPFLAGS="-I${ZLIB_DIR}"

--- a/thirdparty/zlib/build-kobo.sh
+++ b/thirdparty/zlib/build-kobo.sh
@@ -1,6 +1,8 @@
 #! /bin/sh
 
 export CHOST=arm-linux-gnueabihf
+export CC=arm-linux-gnueabihf-gcc
+export CXX=arm-linux-gnueabihf-g++
 export CFLAGS="-O2 -mcpu=cortex-a9 -mfpu=neon"
 export CXXFLAGS="$CFLAGS"
 


### PR DESCRIPTION
Consolidate cross-compiler environment setup and
improve code formatting for consistency.

- Add explicit CC/CXX compiler exports to build scripts
- Fix gumbo library version from 2 to 1

Change-Id: 4a8494406510cd628b29bddd77cb9b44
Change-Id-Short: vprvqvvztuyz

<!--
BEGIN_COMMIT_OVERRIDE
chore: Kobo build scripts (#61)
END_COMMIT_OVERRIDE
-->