### PR TITLE
refactor: use INTERNAL_CARD_ROOT for deployment path

### DIFF
--- a/crates/core/src/ota/client.rs
+++ b/crates/core/src/ota/client.rs
@@ -8,6 +8,9 @@ use std::path::PathBuf;
 use std::time::Duration;
 use zip::ZipArchive;
 
+#[cfg(not(test))]
+use crate::settings::INTERNAL_CARD_ROOT;
+
 /// Size of each download chunk in bytes (10 MB)
 const CHUNK_SIZE: usize = 10 * 1024 * 1024;
 
@@ -430,7 +433,7 @@ impl OtaClient {
         );
 
         #[cfg(not(test))]
-        let deploy_path = PathBuf::from("/mnt/onboard/.kobo/KoboRoot.tgz");
+        let deploy_path = PathBuf::from(format!("{}/.kobo/KoboRoot.tgz", INTERNAL_CARD_ROOT));
 
         #[cfg(test)]
         let deploy_path = {


### PR DESCRIPTION
Replace hardcoded deployment path with configurable constant.

- Import INTERNAL_CARD_ROOT constant conditionally
- Update deploy_path to use format string with INTERNAL_CARD_ROOT

Change-Id: 62e1c05883de474d628edff8863d2274
Change-Id-Short: txlynzurrwml