### PR TITLE
ci: skip attestation in pull requests

### DIFF
--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -269,6 +269,7 @@ jobs:
 
       - &generate-attestation
         name: Generate artifact attestation
+        if: github.event_name != 'pull_request'
         uses: actions/attest-build-provenance@v3
         with:
           subject-path: |


### PR DESCRIPTION
Skip generating build attestation for pull request events to avoid permission issues when the GitHub token has limited permissions in external PRs.

- Add conditional check to skip attestation step for pull requests
- Uses github.event_name != 'pull_request' condition

Change-Id: 4c3e6d1f3ea80218af65036af9babd98
Change-Id-Short: vnwltmykwlpr