### PR TITLE
ci(pages): it never works one first try

### DIFF
--- a/.github/workflows/mdbook-pages.yml
+++ b/.github/workflows/mdbook-pages.yml
@@ -57,7 +57,7 @@ jobs:
           echo "$HOME/.local/bin" >> $GITHUB_PATH
       - name: Build book
         working-directory: docs
-        run: mdbook build .
+        run: mdbook build
       - name: rm epub files
         run: rm docs/book/*.epub
       - name: Upload Pages artifact

--- a/.github/workflows/mdbook-pr.yml
+++ b/.github/workflows/mdbook-pr.yml
@@ -8,6 +8,7 @@ on:
   pull_request:
     paths:
       - "docs/**"
+      - ".github/workflows/mdbook-pr.yml"
 
 jobs:
   build:
@@ -44,4 +45,4 @@ jobs:
           echo "$HOME/.local/bin" >> $GITHUB_PATH
       - name: Build book
         working-directory: docs
-        run: mdbook build .
+        run: mdbook build


### PR DESCRIPTION
Replace `mdbook build .` with `mdbook build` in GitHub Actions.

- .github/workflows/mdbook-pages.yml: remove trailing dot from build command
- .github/workflows/mdbook-pr.yml: remove trailing dot from build command

Change-Id: a2ac0b11c4a7926e3453e85b1f5dc6cd
Change-Id-Short: pxpnzoyynvps