### PR TITLE
feat: add JSON logging with OTLP export

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,6 @@
+# Cadmus
+
+## Emulator vs App
+
+The code path for the emulator, we prefer to panic on errors to catch issues early during development. In contrast, the app code path should handle errors gracefully to ensure a smooth user experience.
+

--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ devenv.local.yaml
 .pre-commit-config.yaml
 
 .tmp
+logs

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -44,6 +44,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
 
 [[package]]
+name = "async-stream"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "atlatl"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -86,6 +119,53 @@ dependencies = [
  "cmake",
  "dunce",
  "fs_extra",
+]
+
+[[package]]
+name = "axum"
+version = "0.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
+dependencies = [
+ "async-trait",
+ "axum-core",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustversion",
+ "serde",
+ "sync_wrapper",
+ "tower 0.5.3",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09f2bd6146b97ae3359fa0cc6d6b376d9539582c7b4220f041a33ec24c226199"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "rustversion",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
 ]
 
 [[package]]
@@ -166,6 +246,7 @@ name = "cadmus"
 version = "0.9.45"
 dependencies = [
  "cadmus-core",
+ "tracing",
 ]
 
 [[package]]
@@ -180,20 +261,27 @@ dependencies = [
  "entities",
  "flate2",
  "fxhash",
+ "gethostname",
  "globset",
- "indexmap",
+ "indexmap 2.13.0",
  "kl-hyphenate",
  "lazy_static",
  "levenshtein",
  "libc",
+ "log",
  "nix",
+ "opentelemetry",
+ "opentelemetry-appender-tracing",
+ "opentelemetry-otlp",
+ "opentelemetry-semantic-conventions",
+ "opentelemetry_sdk",
  "paragraph-breaker",
  "percent-encoding",
  "png",
- "rand_core",
+ "rand_core 0.9.5",
  "rand_xoshiro",
  "regex",
- "reqwest",
+ "reqwest 0.13.1",
  "rustls",
  "secrecy",
  "septem",
@@ -203,7 +291,12 @@ dependencies = [
  "thiserror 2.0.17",
  "titlecase",
  "toml",
+ "tracing",
+ "tracing-appender",
+ "tracing-opentelemetry",
+ "tracing-subscriber",
  "unicode-normalization",
+ "uuid",
  "walkdir",
  "webpki-roots",
  "xi-unicode",
@@ -337,6 +430,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-channel"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
 name = "crypto-common"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -396,11 +504,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
 name = "emulator"
 version = "0.9.45"
 dependencies = [
  "cadmus-core",
  "sdl2",
+ "tracing",
 ]
 
 [[package]]
@@ -445,7 +560,7 @@ name = "fetcher"
 version = "0.9.45"
 dependencies = [
  "cadmus-core",
- "reqwest",
+ "reqwest 0.13.1",
  "signal-hook",
 ]
 
@@ -457,13 +572,13 @@ checksum = "8591b0bcc8a98a64310a2fae1bb3e9b8564dd10e381e6e28010fde8e8e8568db"
 
 [[package]]
 name = "flate2"
-version = "1.1.5"
+version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfe33edd8e85a12a67454e37f8c75e730830d83e313556ab9ebf9ee7fbeb3bfb"
+checksum = "b375d6465b98090a5f25b1c7703f3859783755aa9a80433b36e0379a3ec2f369"
 dependencies = [
  "crc32fast",
- "libz-rs-sys",
  "miniz_oxide",
+ "zlib-rs",
 ]
 
 [[package]]
@@ -504,10 +619,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
 
 [[package]]
+name = "futures-executor"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-io"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "futures-sink"
@@ -529,6 +666,7 @@ checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
  "futures-core",
  "futures-io",
+ "futures-macro",
  "futures-sink",
  "futures-task",
  "memchr",
@@ -554,6 +692,16 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+]
+
+[[package]]
+name = "gethostname"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bd49230192a3797a9a4d6abe9b3eed6f7fa4c8a8a4947977c6f80025f92cbd8"
+dependencies = [
+ "rustix",
+ "windows-link",
 ]
 
 [[package]]
@@ -593,6 +741,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "glob"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
 name = "globset"
 version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -604,6 +758,31 @@ dependencies = [
  "regex-automata",
  "regex-syntax",
 ]
+
+[[package]]
+name = "h2"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap 2.13.0",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
@@ -660,6 +839,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
 name = "hyper"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -669,9 +854,11 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
+ "h2",
  "http",
  "http-body",
  "httparse",
+ "httpdate",
  "itoa",
  "pin-project-lite",
  "pin-utils",
@@ -697,6 +884,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-timeout"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
+dependencies = [
+ "hyper",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
+]
+
+[[package]]
 name = "hyper-util"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -714,7 +914,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2",
+ "socket2 0.6.1",
  "tokio",
  "tower-service",
  "tracing",
@@ -856,12 +1056,22 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+dependencies = [
+ "autocfg",
+ "hashbrown 0.12.3",
+]
+
+[[package]]
+name = "indexmap"
 version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.16.1",
  "serde",
  "serde_core",
 ]
@@ -889,6 +1099,15 @@ checksum = "c91338f0783edbd6195decb37bae672fd3b165faffb89bf7b9e6942f8b1a731a"
 dependencies = [
  "memchr",
  "serde",
+]
+
+[[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
 ]
 
 [[package]]
@@ -986,15 +1205,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
 
 [[package]]
-name = "libz-rs-sys"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c10501e7805cee23da17c7790e59df2870c0d4043ec6d03f67d31e2b53e77415"
-dependencies = [
- "zlib-rs",
-]
-
-[[package]]
 name = "linux-raw-sys"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1029,10 +1239,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
+name = "matchit"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
+
+[[package]]
 name = "memchr"
 version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
+
+[[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "miniz_oxide"
@@ -1068,6 +1299,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1095,6 +1335,104 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f50d9b3dabb09ecd771ad0aa242ca6894994c130308ca3d7684634df8037391"
 
 [[package]]
+name = "opentelemetry"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "570074cc999d1a58184080966e5bd3bf3a9a4af650c3b05047c2621e7405cd17"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "js-sys",
+ "once_cell",
+ "pin-project-lite",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "opentelemetry-appender-tracing"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14f62d9a23c680ab91c74605f5006110768eb67600bb654937fef5c852fb8ec7"
+dependencies = [
+ "opentelemetry",
+ "tracing",
+ "tracing-core",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "opentelemetry-http"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6351496aeaa49d7c267fb480678d85d1cd30c5edb20b497c48c56f62a8c14b99"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "http",
+ "opentelemetry",
+ "reqwest 0.12.28",
+]
+
+[[package]]
+name = "opentelemetry-otlp"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29e1f9c8b032d4f635c730c0efcf731d5e2530ea13fa8bef7939ddc8420696bd"
+dependencies = [
+ "async-trait",
+ "futures-core",
+ "http",
+ "opentelemetry",
+ "opentelemetry-http",
+ "opentelemetry-proto",
+ "opentelemetry_sdk",
+ "prost",
+ "reqwest 0.12.28",
+ "thiserror 1.0.69",
+ "tokio",
+ "tonic",
+]
+
+[[package]]
+name = "opentelemetry-proto"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9d3968ce3aefdcca5c27e3c4ea4391b37547726a70893aab52d3de95d5f8b34"
+dependencies = [
+ "opentelemetry",
+ "opentelemetry_sdk",
+ "prost",
+ "tonic",
+]
+
+[[package]]
+name = "opentelemetry-semantic-conventions"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db945c1eaea8ac6a9677185357480d215bb6999faa9f691d0c4d4d641eab7a09"
+
+[[package]]
+name = "opentelemetry_sdk"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2c627d9f4c9cdc1f21a29ee4bfbd6028fcb8bcf2a857b43f3abdf72c9c862f3"
+dependencies = [
+ "async-trait",
+ "futures-channel",
+ "futures-executor",
+ "futures-util",
+ "glob",
+ "once_cell",
+ "opentelemetry",
+ "percent-encoding",
+ "rand 0.8.5",
+ "serde_json",
+ "thiserror 1.0.69",
+ "tokio",
+ "tokio-stream",
+]
+
+[[package]]
 name = "paragraph-breaker"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1115,6 +1453,26 @@ name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "pin-project"
+version = "1.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677f1add503faace112b9f1373e43e9e054bfdd22ff1a63c1bc485eaec6a6a8a"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "pin-project-lite"
@@ -1187,6 +1545,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "prost"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
+dependencies = [
+ "anyhow",
+ "itertools",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "quinn"
 version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1199,7 +1580,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2",
+ "socket2 0.6.1",
  "thiserror 2.0.17",
  "tokio",
  "tracing",
@@ -1216,7 +1597,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand",
+ "rand 0.9.2",
  "ring",
  "rustc-hash",
  "rustls",
@@ -1237,7 +1618,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2",
+ "socket2 0.6.1",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -1259,12 +1640,33 @@ checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -1274,7 +1676,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
 ]
 
 [[package]]
@@ -1292,7 +1703,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f703f4665700daf5512dcca5f43afa6af89f09db47fb56be587f80636bda2d41"
 dependencies = [
- "rand_core",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -1326,6 +1737,40 @@ checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 
 [[package]]
 name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tower 0.5.3",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
+name = "reqwest"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04e9018c9d814e5f30cc16a0f03271aeab3571e609612d9fe78c1aa8d11c2f62"
@@ -1355,7 +1800,7 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-rustls",
- "tower",
+ "tower 0.5.3",
  "tower-http",
  "tower-service",
  "url",
@@ -1653,6 +2098,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1695,6 +2149,16 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "socket2"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "socket2"
@@ -1803,16 +2267,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "time"
 version = "0.3.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9e442fc33d7fdb45aa9bfeb312c095964abdf596f7567261062b2a7107aaabd"
 dependencies = [
  "deranged",
+ "itoa",
  "num-conv",
  "powerfmt",
  "serde_core",
  "time-core",
+ "time-macros",
 ]
 
 [[package]]
@@ -1820,6 +2295,16 @@ name = "time-core"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b36ee98fd31ec7426d599183e8fe26932a8dc1fb76ddb6214d05493377d34ca"
+
+[[package]]
+name = "time-macros"
+version = "0.2.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71e552d1249bf61ac2a52db88179fd0673def1e1ad8243a00d9ec9ed71fee3dd"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
 
 [[package]]
 name = "tinystr"
@@ -1865,8 +2350,20 @@ dependencies = [
  "libc",
  "mio",
  "pin-project-lite",
- "socket2",
+ "socket2 0.6.1",
+ "tokio-macros",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1880,12 +2377,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-stream"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "toml"
 version = "0.9.11+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3afc9a848309fe1aaffaed6e1546a7a14de1f935dc9d89d32afd9a44bab7c46"
 dependencies = [
- "indexmap",
+ "indexmap 2.13.0",
  "serde_core",
  "serde_spanned",
  "toml_datetime",
@@ -1919,6 +2440,56 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab16f14aed21ee8bfd8ec22513f7287cd4a91aa92e44edfe2c17ddd004e92607"
 
 [[package]]
+name = "tonic"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877c5b330756d856ffcc4553ab34a5684481ade925ecc54bcd1bf02b1d0d4d52"
+dependencies = [
+ "async-stream",
+ "async-trait",
+ "axum",
+ "base64",
+ "bytes",
+ "h2",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-timeout",
+ "hyper-util",
+ "percent-encoding",
+ "pin-project",
+ "prost",
+ "socket2 0.5.10",
+ "tokio",
+ "tokio-stream",
+ "tower 0.4.13",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "indexmap 1.9.3",
+ "pin-project",
+ "pin-project-lite",
+ "rand 0.8.5",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
 name = "tower"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1946,7 +2517,7 @@ dependencies = [
  "http-body",
  "iri-string",
  "pin-project-lite",
- "tower",
+ "tower 0.5.3",
  "tower-layer",
  "tower-service",
 ]
@@ -1970,7 +2541,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-appender"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "786d480bce6247ab75f005b14ae1624ad978d3029d9113f0a22fa1ac773faeaf"
+dependencies = [
+ "crossbeam-channel",
+ "thiserror 2.0.17",
+ "time",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1980,6 +2575,67 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-opentelemetry"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc58af5d3f6c5811462cabb3289aec0093f7338e367e5a33d28c0433b3c7360b"
+dependencies = [
+ "js-sys",
+ "once_cell",
+ "opentelemetry",
+ "opentelemetry_sdk",
+ "smallvec",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+ "tracing-subscriber",
+ "web-time",
+]
+
+[[package]]
+name = "tracing-serde"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f30143827ddab0d256fd843b7a66d164e9f271cfa0dde49142c5ca0ca291f1e"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "serde",
+ "serde_json",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]
@@ -2038,6 +2694,23 @@ name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "uuid"
+version = "1.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee48d38b119b0cd71fe4141b30f5ba9c7c5d9f4e7a3a8b4a674e4b6ef789976f"
+dependencies = [
+ "getrandom 0.3.4",
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "version-compare"
@@ -2628,7 +3301,7 @@ dependencies = [
  "generic-array",
  "getrandom 0.3.4",
  "hmac",
- "indexmap",
+ "indexmap 2.13.0",
  "lzma-rust2",
  "memchr",
  "pbkdf2",

--- a/contrib/Settings-sample.toml
+++ b/contrib/Settings-sample.toml
@@ -27,6 +27,18 @@ date-format = "%A, %B %-d, %Y"
 # Appends the tapped external URLs to this file.
 external-urls-queue = "bin/article_fetcher/urls.txt"
 
+[logging]
+# Enable or disable structured JSON logging.
+enabled = true
+# Possible values: "trace", "debug", "info", "warn", "error".
+level = "info"
+# The number of rotated log files to keep. Use 0 to keep all files.
+max-files = 3
+# Directory for log files (relative to the installation directory).
+directory = "logs"
+# Optional OTLP endpoint for exporting logs when the build enables the otel feature.
+# otlp-endpoint = "https://otel.example.com:4318"
+
 # You can create libraries by adding further [[libraries]] entries.
 [[libraries]]
 name = "On Board"

--- a/crates/cadmus/Cargo.toml
+++ b/crates/cadmus/Cargo.toml
@@ -10,6 +10,8 @@ path = "src/main.rs"
 
 [features]
 test = ["cadmus-core/test"]
+otel = ["cadmus-core/otel"]
 
 [dependencies]
 cadmus-core = { path = "../core" }
+tracing = "0.1"

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -55,9 +55,31 @@ reqwest = { version = "0.13.1", default-features = false, features = [
 rustls = { workspace = true }
 webpki-roots = "1.0.5"
 
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["json", "env-filter"] }
+tracing-appender = "0.2"
+tracing-opentelemetry = { version = "0.27", optional = true }
+opentelemetry-appender-tracing = { version = "0.26", optional = true }
+opentelemetry = { version = "0.26", features = ["trace", "logs"], optional = true }
+opentelemetry-otlp = { version = "0.26", features = ["trace", "logs", "http-proto", "reqwest-client"], optional = true }
+opentelemetry_sdk = { version = "0.26", features = ["trace", "logs", "rt-tokio-current-thread"], optional = true }
+opentelemetry-semantic-conventions = { version = "0.26", optional = true }
+log = "0.4.29"
+uuid = { version = "1.20.0", features = ["v7"] }
+gethostname = {version = "1.1.0", optional = true }
+
 [dev-dependencies]
 tempfile = "3.14"
 
 [features]
 default = []
 test = []
+otel = [
+    "tracing-opentelemetry",
+    "opentelemetry",
+    "opentelemetry-otlp",
+    "opentelemetry-appender-tracing",
+    "opentelemetry_sdk",
+    "opentelemetry-semantic-conventions",
+    "gethostname",
+]

--- a/crates/core/src/context.rs
+++ b/crates/core/src/context.rs
@@ -21,6 +21,7 @@ use std::collections::{BTreeMap, VecDeque};
 #[cfg(test)]
 use std::env;
 use std::path::Path;
+use tracing::error;
 
 use walkdir::WalkDir;
 
@@ -95,7 +96,7 @@ impl Context {
                 continue;
             }
             if let Ok(mut library) = Library::new(&library_settings.path, library_settings.mode)
-                .map_err(|e| eprintln!("{:#?}", e))
+                .map_err(|e| error!("{:#?}", e))
             {
                 library.import(&self.settings.import);
                 library.flush();
@@ -130,7 +131,7 @@ impl Context {
                 continue;
             }
             if let Ok(layout) = load_json::<Layout, _>(path)
-                .map_err(|e| eprintln!("Can't load {}: {:#?}.", path.display(), e))
+                .map_err(|e| error!("Can't load {}: {:#?}.", path.display(), e))
             {
                 self.keyboard_layouts.insert(layout.name.clone(), layout);
             }

--- a/crates/core/src/document/djvu.rs
+++ b/crates/core/src/document/djvu.rs
@@ -10,6 +10,7 @@ use std::os::unix::ffi::OsStrExt;
 use std::path::Path;
 use std::ptr;
 use std::rc::Rc;
+use tracing::error;
 
 impl Into<DjvuRect> for Rectangle {
     fn into(self) -> DjvuRect {
@@ -46,10 +47,10 @@ impl DjvuContext {
                 let filename = msg.filename;
                 let lineno = msg.lineno;
                 if filename.is_null() {
-                    eprintln!("Error: {}.", message);
+                    error!("Error: {}.", message);
                 } else {
                     let filename = CStr::from_ptr(filename).to_string_lossy();
-                    eprintln!("Error: {}: '{}:{}'.", message, filename, lineno);
+                    error!("Error: {}: '{}:{}'.", message, filename, lineno);
                 }
             }
             ddjvu_message_pop(self.0);

--- a/crates/core/src/document/epub/mod.rs
+++ b/crates/core/src/document/epub/mod.rs
@@ -109,9 +109,10 @@ impl EpubDocument {
                             archive
                                 .by_name(path)
                                 .map_err(|e| {
-                                    eprintln!(
+                                    tracing::error!(
                                         "Can't retrieve '{}' from the archive: {:#}.",
-                                        path, e
+                                        path,
+                                        e
                                     )
                                     // We're assuming that the size of the spine is less than 4 GiB.
                                 })

--- a/crates/core/src/document/html/css.rs
+++ b/crates/core/src/document/html/css.rs
@@ -495,12 +495,13 @@ impl<'a> CssParser<'a> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use tracing::debug;
 
     #[test]
     fn simple_css() {
         let text = "a, .b { b: c; d: e }";
         let css = CssParser::new(text).parse();
-        println!("{:?}", css);
+        debug!("{:?}", css);
     }
 
     #[test]

--- a/crates/core/src/document/mod.rs
+++ b/crates/core/src/document/mod.rs
@@ -29,6 +29,7 @@ use std::fs::{self, File};
 use std::os::unix::fs::FileExt;
 use std::path::Path;
 use std::process::Command;
+use tracing::error;
 use unicode_normalization::char::is_combining_mark;
 use unicode_normalization::UnicodeNormalization;
 
@@ -236,11 +237,11 @@ pub fn asciify(name: &str) -> String {
 pub fn open<P: AsRef<Path>>(path: P) -> Option<Box<dyn Document>> {
     file_kind(path.as_ref()).and_then(|k| match k.as_ref() {
         "epub" => EpubDocument::new(&path)
-            .map_err(|e| eprintln!("{}: {:#}.", path.as_ref().display(), e))
+            .map_err(|e| error!("{}: {:#}.", path.as_ref().display(), e))
             .map(|d| Box::new(d) as Box<dyn Document>)
             .ok(),
         "html" | "htm" => HtmlDocument::new(&path)
-            .map_err(|e| eprintln!("{}: {:#}.", path.as_ref().display(), e))
+            .map_err(|e| error!("{}: {:#}.", path.as_ref().display(), e))
             .map(|d| Box::new(d) as Box<dyn Document>)
             .ok(),
         "djvu" | "djv" => {
@@ -558,7 +559,7 @@ pub fn sys_info_as_html() -> String {
 
     let output = Command::new("scripts/ip.sh")
         .output()
-        .map_err(|e| eprintln!("Can't execute command: {:#}.", e))
+        .map_err(|e| error!("Can't execute command: {:#}.", e))
         .ok();
 
     if let Some(stdout) = output
@@ -630,7 +631,7 @@ pub fn sys_info_as_html() -> String {
     let output = Command::new("/bin/ntx_hwconfig")
         .args(&["-s", "/dev/mmcblk0"])
         .output()
-        .map_err(|e| eprintln!("Can't execute command: {:#}.", e))
+        .map_err(|e| error!("Can't execute command: {:#}.", e))
         .ok();
 
     let mut map = FxHashMap::default();

--- a/crates/core/src/document/pdf.rs
+++ b/crates/core/src/document/pdf.rs
@@ -15,6 +15,7 @@ use std::path::Path;
 use std::ptr;
 use std::rc::Rc;
 use std::slice;
+use tracing::error;
 
 const USER_STYLESHEET: &str = "css/html-user.css";
 
@@ -100,7 +101,7 @@ impl PdfOpener {
             .and_then(|s| CString::new(s).map_err(Into::into))
             .map_err(|e| {
                 if e.kind() != ErrorKind::NotFound {
-                    eprintln!("{:#}", e)
+                    error!("{:#}", e)
                 }
             })
         {

--- a/crates/core/src/font/mod.rs
+++ b/crates/core/src/font/mod.rs
@@ -24,6 +24,7 @@ use std::rc::Rc;
 use std::slice;
 use std::str;
 use thiserror::Error;
+use tracing::{error, warn};
 use walkdir::WalkDir;
 
 // Font sizes in 1/64th of a point
@@ -587,12 +588,12 @@ pub fn family_names<P: AsRef<Path>>(search_path: P) -> Result<BTreeSet<String>, 
         }
         if let Ok(font) = opener
             .open(path)
-            .map_err(|e| eprintln!("Can't open '{}': {:#}.", path.display(), e))
+            .map_err(|e| error!("Can't open '{}': {:#}.", path.display(), e))
         {
             if let Some(family_name) = font.family_name() {
                 families.insert(family_name.to_string());
             } else {
-                eprintln!("Can't get the family name of '{}'.", path.display());
+                warn!("Can't get the family name of '{}'.", path.display());
             }
         }
     }
@@ -624,7 +625,7 @@ impl FontFamily {
             }
             if let Ok(font) = opener
                 .open(path)
-                .map_err(|e| eprintln!("Can't open '{}': {:#}.", path.display(), e))
+                .map_err(|e| error!("Can't open '{}': {:#}.", path.display(), e))
             {
                 if font.family_name() == Some(family_name) {
                     styles.insert(

--- a/crates/core/src/framebuffer/kobo1.rs
+++ b/crates/core/src/framebuffer/kobo1.rs
@@ -13,6 +13,7 @@ use std::os::unix::io::AsRawFd;
 use std::path::Path;
 use std::ptr;
 use std::slice;
+use tracing::{error, info};
 
 impl Into<MxcfbRect> for Rectangle {
     fn into(self) -> MxcfbRect {
@@ -376,7 +377,7 @@ impl Framebuffer for KoboFramebuffer1 {
         self.fix_info = fix_screen_info(&self.file)?;
         self.frame_size = (self.var_info.yres * self.fix_info.line_length) as libc::size_t;
 
-        println!("Framebuffer rotation: {} -> {}.", n, self.rotation());
+        info!("Framebuffer rotation: {} -> {}.", n, self.rotation());
 
         Ok((self.var_info.xres, self.var_info.yres))
     }
@@ -404,7 +405,7 @@ impl Framebuffer for KoboFramebuffer1 {
                         b"night_mode 0"
                     })
                 })
-                .map_err(|e| eprintln!("Failed to invert colors: {:#?}", e))
+                .map_err(|e| error!("Failed to invert colors: {:#?}", e))
                 .ok();
         }
     }

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -15,10 +15,13 @@ pub mod helpers;
 pub mod input;
 pub mod library;
 pub mod lightsensor;
+pub mod logging;
 pub mod metadata;
 pub mod ota;
 pub mod rtc;
 pub mod settings;
+#[cfg(feature = "otel")]
+pub mod telemetry;
 mod unit;
 pub mod view;
 

--- a/crates/core/src/logging.rs
+++ b/crates/core/src/logging.rs
@@ -1,0 +1,464 @@
+//! Structured logging infrastructure with JSON output and OpenTelemetry integration.
+//!
+//! This module provides logging functionality for Cadmus, including:
+//! - JSON-structured logs written to rotating files
+//! - Configurable log levels and filtering  
+//! - Automatic log file cleanup based on retention policies
+//! - Optional OpenTelemetry export (when `otel` feature is enabled)
+//! - Unique run ID for correlating logs across a session
+//!
+//! # Architecture
+//!
+//! The logging system is built on the `tracing` crate ecosystem:
+//! - `tracing_subscriber` for composable logging layers
+//! - `tracing_appender` for non-blocking file I/O
+//! - JSON formatting for structured, machine-readable logs
+//! - `EnvFilter` for flexible log level control
+//!
+//! Each application run generates a unique Run ID (UUID v7) that appears in:
+//! - The log filename: `cadmus-<run_id>.json`
+//! - OpenTelemetry resource attributes
+//! - All log entries for correlation
+//!
+//! # Log File Management
+//!
+//! Log files are automatically managed:
+//! - Files are named with the run ID: `cadmus-<run_id>.json`
+//! - Older files are deleted when `max_files` limit is exceeded
+//! - Cleanup happens at initialization, keeping only the most recent files
+//!
+//! # Configuration
+//!
+//! Logging is configured via `LoggingSettings`:
+//!
+//! ```toml
+//! [logging]
+//! enabled = true
+//! level = "info"
+//! max-files = 3
+//! directory = "logs"
+//! otlp-endpoint = "http://localhost:4318"  # Optional
+//! ```
+//!
+//! The log level can be overridden with the `RUST_LOG` environment variable:
+//!
+//! ```bash
+//! RUST_LOG=debug ./cadmus
+//! RUST_LOG=cadmus::view=trace,info ./cadmus
+//! ```
+//!
+//! # Example Usage
+//!
+//! ```rust
+//! use cadmus_core::settings::LoggingSettings;
+//! use cadmus_core::logging::{init_logging, shutdown_logging, get_run_id};
+//!
+//! let settings = LoggingSettings {
+//!     enabled: true,
+//!     level: "info".to_string(),
+//!     max_files: 3,
+//!     directory: "logs".into(),
+//!     otlp_endpoint: None,
+//! };
+//!
+//! // Initialize at application startup
+//! init_logging(&settings)?;
+//! eprintln!("Started with run ID: {}", get_run_id());
+//!
+//! // Use tracing macros throughout the application
+//! tracing::info!("Application started");
+//!
+//! // Shutdown at application exit (flushes buffers)
+//! shutdown_logging();
+//! # Ok::<(), anyhow::Error>(())
+//! ```
+
+use crate::settings::LoggingSettings;
+#[cfg(feature = "otel")]
+use crate::telemetry;
+use anyhow::{Context, Error};
+use std::fs;
+use std::fs::DirEntry;
+use std::sync::mpsc;
+use std::sync::{Mutex, OnceLock};
+use std::thread;
+use std::time::Duration;
+use tracing_appender::non_blocking::WorkerGuard;
+use tracing_subscriber::prelude::*;
+use tracing_subscriber::EnvFilter;
+use uuid::Uuid;
+
+const GIT_VERSION: &str = env!("GIT_VERSION");
+const LOG_FILE_PREFIX: &str = "cadmus-";
+const LOG_FILE_SUFFIX: &str = "json";
+
+static LOG_GUARD: OnceLock<Mutex<Option<WorkerGuard>>> = OnceLock::new();
+static RUN_ID: OnceLock<String> = OnceLock::new();
+
+/// Returns the unique run ID for this application session.
+///
+/// The run ID is a UUID v7 generated at first access and remains constant
+/// for the lifetime of the process. It is used to:
+/// - Name the log file: `cadmus-<run_id>.json`
+/// - Tag OpenTelemetry telemetry exports
+/// - Correlate all operations within a single run
+///
+/// # Returns
+///
+/// A string slice containing the run ID, valid for the program's lifetime.
+///
+/// # Example
+///
+/// ```
+/// use cadmus_core::logging::get_run_id;
+///
+/// let run_id = get_run_id();
+/// eprintln!("Application run ID: {}", run_id);
+/// assert_eq!(get_run_id(), run_id); // Consistent across calls
+/// ```
+pub fn get_run_id() -> &'static str {
+    RUN_ID.get_or_init(|| Uuid::now_v7().to_string()).as_str()
+}
+
+/// Removes old log files to maintain the configured retention limit.
+///
+/// This function scans the log directory for files matching the pattern
+/// `cadmus-*.json` and deletes the oldest files if the count exceeds `max_files`.
+///
+/// Note: this relies on the run ID being a UUID v7 (time-ordered). Filenames are
+/// `cadmus-<run_id>.json` where `<run_id>` is generated with `Uuid::now_v7()`,
+/// so lexicographic sorting of the filenames corresponds to chronological order.
+/// Sorting by file name therefore yields oldest-first ordering for removal.
+///
+/// # Arguments
+///
+/// * `log_dir` - Path to the directory containing log files
+/// * `max_files` - Maximum number of log files to retain (0 = keep all)
+///
+/// # Returns
+///
+/// Returns `Ok(())` on success.
+///
+/// # Errors
+///
+/// Returns an error if:
+/// - The log directory cannot be read
+/// - Individual directory entries cannot be read
+/// - Old log files cannot be deleted
+fn cleanup_run_logs(log_dir: &std::path::Path, max_files: usize) -> Result<(), Error> {
+    if max_files == 0 {
+        return Ok(());
+    }
+
+    let mut entries = collect_run_log_entries(log_dir)?;
+    if entries.len() <= max_files {
+        return Ok(());
+    }
+
+    entries.sort_by_key(|entry| entry.file_name());
+    let remove_count = entries.len().saturating_sub(max_files);
+    for entry in entries.into_iter().take(remove_count) {
+        fs::remove_file(entry.path())
+            .with_context(|| format!("can't remove old log file {}", entry.path().display()))?;
+    }
+
+    Ok(())
+}
+
+/// Collects all Cadmus log file entries from the specified directory.
+///
+/// Only files matching the pattern `cadmus-*.json` are collected.
+///
+/// # Arguments
+///
+/// * `log_dir` - Path to the directory to scan
+///
+/// # Returns
+///
+/// Returns a vector of directory entries representing log files.
+///
+/// # Errors
+///
+/// Returns an error if the directory cannot be read or entries are inaccessible.
+fn collect_run_log_entries(log_dir: &std::path::Path) -> Result<Vec<DirEntry>, Error> {
+    let mut entries = Vec::new();
+    for entry in fs::read_dir(log_dir)
+        .with_context(|| format!("can't read log directory {}", log_dir.display()))?
+    {
+        let entry = entry.context("can't read log directory entry")?;
+        if is_run_log_entry(&entry) {
+            entries.push(entry);
+        }
+    }
+
+    Ok(entries)
+}
+
+/// Determines whether a directory entry is a Cadmus log file.
+///
+/// Returns `true` if the filename starts with `cadmus-` and ends with `.json`.
+///
+/// # Arguments
+///
+/// * `entry` - Directory entry to check
+///
+/// # Returns
+///
+/// `true` if the entry is a log file, `false` otherwise.
+fn is_run_log_entry(entry: &DirEntry) -> bool {
+    let file_name = entry.file_name();
+    let file_name = file_name.to_string_lossy();
+    if !file_name.starts_with(LOG_FILE_PREFIX) {
+        return false;
+    }
+
+    file_name.ends_with(LOG_FILE_SUFFIX)
+}
+
+/// Initializes the logging system with JSON output and optional OpenTelemetry export.
+///
+/// This function sets up the complete logging infrastructure:
+/// - Creates the log directory if it doesn't exist
+/// - Cleans up old log files based on retention policy
+/// - Configures a rolling file appender with non-blocking I/O
+/// - Applies log level filtering from settings or environment
+/// - Sets up JSON formatting for structured logs
+/// - Initializes OpenTelemetry export if the `otel` feature is enabled
+///
+/// The function should only be called once at application startup.
+/// The logging system remains active until `shutdown_logging()` is called.
+///
+/// # Arguments
+///
+/// * `settings` - Logging configuration including level, directory, and retention
+///
+/// # Returns
+///
+/// Returns `Ok(())` on successful initialization.
+///
+/// # Errors
+///
+/// Returns an error if:
+/// - The current working directory cannot be determined
+/// - The log directory cannot be created
+/// - Log file cleanup fails
+/// - The rolling file appender cannot be initialized
+/// - The log filter configuration is invalid
+/// - The tracing subscriber cannot be initialized
+/// - OpenTelemetry initialization fails (when `otel` feature is enabled)
+///
+/// # Example
+///
+/// ```
+/// use cadmus_core::settings::LoggingSettings;
+/// use cadmus_core::logging::init_logging;
+///
+/// let settings = LoggingSettings {
+///     enabled: true,
+///     level: "debug".to_string(),
+///     max_files: 5,
+///     directory: "logs".into(),
+///     otlp_endpoint: Some("http://localhost:4318".to_string()),
+/// };
+///
+/// init_logging(&settings)?;
+/// # Ok::<(), anyhow::Error>(())
+/// ```
+pub fn init_logging(settings: &LoggingSettings) -> Result<(), Error> {
+    if !settings.enabled {
+        return Ok(());
+    }
+
+    let current_working_dir =
+        std::env::current_dir().context("can't get current working directory")?;
+    let log_dir = current_working_dir.join(&settings.directory);
+    fs::create_dir_all(&log_dir)
+        .with_context(|| format!("can't create log directory {}", &log_dir.display()))?;
+
+    cleanup_run_logs(&log_dir, settings.max_files)?;
+
+    let appender = tracing_appender::rolling::Builder::new()
+        .rotation(tracing_appender::rolling::Rotation::NEVER)
+        .filename_prefix(format!("{}{}", LOG_FILE_PREFIX, get_run_id()))
+        .filename_suffix(LOG_FILE_SUFFIX)
+        .max_log_files(settings.max_files)
+        .build(&log_dir)
+        .context("can't initialize rolling log file appender")?;
+
+    let (non_blocking, guard) = tracing_appender::non_blocking(appender);
+    let _ = LOG_GUARD.set(Mutex::new(Some(guard)));
+
+    let filter = build_filter(settings)?;
+
+    let fmt_layer = tracing_subscriber::fmt::layer()
+        .json()
+        .with_ansi(false)
+        .with_writer(non_blocking)
+        .with_current_span(true);
+
+    let subscriber = tracing_subscriber::registry().with(filter).with(fmt_layer);
+
+    #[cfg(feature = "otel")]
+    let subscriber = subscriber.with(telemetry::init_telemetry(settings, get_run_id())?);
+
+    subscriber
+        .try_init()
+        .context("can't initialize tracing subscriber")?;
+
+    eprintln!(
+        "Cadmus run started with ID: {} (version {})",
+        get_run_id(),
+        GIT_VERSION
+    );
+
+    Ok(())
+}
+
+/// Gracefully shuts down the logging system and flushes buffered data.
+///
+/// This function ensures all buffered log data is written to disk and, if enabled,
+/// exported to OpenTelemetry endpoints before the application exits. It:
+/// - Flushes the file appender buffer (happens automatically via `LOG_GUARD` drop)
+/// - Shuts down OpenTelemetry providers (when `otel` feature is enabled)
+/// - Ensures no log data is lost on exit
+///
+/// This function should be called once at application shutdown.
+///
+/// # Example
+///
+/// ```no_run
+/// use cadmus_core::logging::{init_logging, shutdown_logging};
+/// use cadmus_core::settings::LoggingSettings;
+///
+/// // At application start
+/// let settings = LoggingSettings::default();
+/// init_logging(&settings)?;
+///
+/// // ... application runs ...
+///
+/// // At application exit
+/// shutdown_logging();
+/// # Ok::<(), anyhow::Error>(())
+/// ```
+pub fn shutdown_logging() {
+    if let Some(mutex) = LOG_GUARD.get() {
+        if let Ok(mut guard_opt) = mutex.lock() {
+            if let Some(guard) = guard_opt.take() {
+                let (tx, rx) = mpsc::channel();
+
+                thread::spawn(move || {
+                    drop(guard);
+                    let _ = tx.send(());
+                });
+
+                let _ = rx.recv_timeout(Duration::from_secs(5));
+                eprintln!("Logging shutdown complete.");
+            }
+        }
+    }
+
+    #[cfg(feature = "otel")]
+    telemetry::shutdown_telemetry();
+}
+
+/// Builds an `EnvFilter` from settings or environment variables.
+///
+/// The function checks for the `RUST_LOG` environment variable first, which
+/// overrides the `level` setting. If `RUST_LOG` is not set, it uses the
+/// level from `LoggingSettings` (defaulting to "info" if empty).
+///
+/// # Arguments
+///
+/// * `settings` - Logging settings containing the default level
+///
+/// # Returns
+///
+/// Returns a configured `EnvFilter` instance.
+///
+/// # Errors
+///
+/// Returns an error if the log level string cannot be parsed.
+///
+/// # Example Filter Syntax
+///
+/// ```bash
+/// # Global level
+/// RUST_LOG=debug
+///
+/// # Per-module levels
+/// RUST_LOG=cadmus::view=trace,info
+///
+/// # Complex filtering
+/// RUST_LOG=warn,cadmus::document=debug,cadmus::sync=trace
+/// ```
+fn build_filter(settings: &LoggingSettings) -> Result<EnvFilter, Error> {
+    if let Ok(filter) = EnvFilter::try_from_default_env() {
+        return Ok(filter);
+    }
+
+    let level = settings.level.trim();
+    let level = if level.is_empty() { "info" } else { level };
+
+    EnvFilter::builder()
+        .parse(level)
+        .context("invalid logging level")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn create_log_file(dir: &std::path::Path, index: usize) -> Result<(), Error> {
+        let file_name = format!("{}{:04}.{}", LOG_FILE_PREFIX, index, LOG_FILE_SUFFIX);
+        fs::write(dir.join(file_name), b"{}")?;
+        Ok(())
+    }
+
+    fn collect_log_file_names(dir: &std::path::Path) -> Result<Vec<String>, Error> {
+        let mut entries = collect_run_log_entries(dir)?;
+        entries.sort_by_key(|entry| entry.file_name());
+        Ok(entries
+            .into_iter()
+            .map(|entry| entry.file_name().to_string_lossy().into_owned())
+            .collect())
+    }
+
+    #[test]
+    fn test_cleanup_run_logs_removes_oldest_entries() -> Result<(), Error> {
+        let temp_dir = TempDir::new()?;
+        for index in 1..=5 {
+            create_log_file(temp_dir.path(), index)?;
+        }
+
+        cleanup_run_logs(temp_dir.path(), 3)?;
+
+        let remaining = collect_log_file_names(temp_dir.path())?;
+        assert_eq!(remaining.len(), 3);
+        assert_eq!(
+            remaining,
+            vec![
+                format!("{}0003.{}", LOG_FILE_PREFIX, LOG_FILE_SUFFIX),
+                format!("{}0004.{}", LOG_FILE_PREFIX, LOG_FILE_SUFFIX),
+                format!("{}0005.{}", LOG_FILE_PREFIX, LOG_FILE_SUFFIX),
+            ]
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_cleanup_run_logs_max_files_zero_keeps_all() -> Result<(), Error> {
+        let temp_dir = TempDir::new()?;
+        for index in 1..=3 {
+            create_log_file(temp_dir.path(), index)?;
+        }
+
+        cleanup_run_logs(temp_dir.path(), 0)?;
+
+        let remaining = collect_log_file_names(temp_dir.path())?;
+        assert_eq!(remaining.len(), 3);
+
+        Ok(())
+    }
+}

--- a/crates/core/src/settings/mod.rs
+++ b/crates/core/src/settings/mod.rs
@@ -169,6 +169,7 @@ pub struct Settings {
     pub battery: BatterySettings,
     pub frontlight_levels: LightLevels,
     pub ota: OtaSettings,
+    pub logging: LoggingSettings,
 }
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Serialize, Deserialize)]
@@ -408,6 +409,23 @@ pub struct BatterySettings {
     pub power_off: f32,
 }
 
+/// Configures structured logging to disk and optional OTLP export.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(default, rename_all = "kebab-case")]
+pub struct LoggingSettings {
+    /// Enables logging output when set to true.
+    pub enabled: bool,
+    /// Minimum log level to record (for example: "info", "debug").
+    pub level: String,
+    /// Maximum number of rotated log files to keep.
+    pub max_files: usize,
+    /// Directory where JSON log files are written.
+    pub directory: PathBuf,
+    /// Optional OTLP endpoint; env vars override this value.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub otlp_endpoint: Option<String>,
+}
+
 /// Configuration for Over-the-Air (OTA) update feature.
 ///
 /// Stores the GitHub personal access token required for downloading
@@ -586,6 +604,18 @@ impl Default for BatterySettings {
     }
 }
 
+impl Default for LoggingSettings {
+    fn default() -> Self {
+        LoggingSettings {
+            enabled: true,
+            level: "info".to_string(),
+            max_files: 3,
+            directory: PathBuf::from("logs"),
+            otlp_endpoint: None,
+        }
+    }
+}
+
 impl Default for Settings {
     fn default() -> Self {
         Settings {
@@ -647,6 +677,7 @@ impl Default for Settings {
             frontlight_levels: LightLevels::default(),
             frontlight_presets: Vec::new(),
             ota: OtaSettings::default(),
+            logging: LoggingSettings::default(),
         }
     }
 }

--- a/crates/core/src/telemetry.rs
+++ b/crates/core/src/telemetry.rs
@@ -1,0 +1,284 @@
+//! OpenTelemetry integration for exporting logs and traces to OTLP endpoints.
+//!
+//! This module provides initialization and shutdown functions for OpenTelemetry telemetry
+//! when the `otel` feature is enabled. It configures both trace and log exporters that
+//! send data to an OTLP-compatible backend.
+//!
+//! # Architecture
+//!
+//! The telemetry system uses:
+//! - **Tracer Provider**: Exports distributed traces via OTLP HTTP
+//! - **Logger Provider**: Exports structured logs via OTLP HTTP  
+//! - **Batch Processors**: Buffer and send data asynchronously to minimize overhead
+//! - **Resource Attributes**: Attach service metadata to all telemetry data
+//!
+//! # Configuration
+//!
+//! The OTLP endpoint can be configured in two ways (environment variable takes precedence):
+//! 1. `OTEL_EXPORTER_OTLP_ENDPOINT` environment variable
+//! 2. `otlp_endpoint` field in `LoggingSettings`
+//!
+//! # Example
+//!
+//! ```
+//! use cadmus_core::settings::LoggingSettings;
+//! use cadmus_core::telemetry;
+//! use cadmus_core::logging::get_run_id;
+//!
+//! let mut settings = LoggingSettings::default();
+//! settings.otlp_endpoint = Some("http://localhost:4318".to_string());
+//!
+//! // Initialize telemetry (returns layer for tracing subscriber)
+//! let layer = telemetry::init_telemetry(&settings, get_run_id())?;
+//!
+//! // ... application runs ...
+//!
+//! // Flush and shutdown at exit
+//! telemetry::shutdown_telemetry();
+//! # Ok::<(), anyhow::Error>(())
+//! ```
+
+use crate::settings::LoggingSettings;
+use anyhow::{Context, Error};
+use gethostname::gethostname;
+use opentelemetry::{global, KeyValue};
+use opentelemetry_otlp::WithExportConfig;
+use opentelemetry_sdk::logs::{BatchLogProcessor, LoggerProvider as SdkLoggerProvider};
+use opentelemetry_sdk::trace::{
+    BatchSpanProcessor, Config as TraceConfig, TracerProvider as SdkTracerProvider,
+};
+use opentelemetry_sdk::{runtime, Resource};
+use std::sync::{mpsc, OnceLock};
+use std::thread;
+use std::time::Duration;
+
+const GIT_VERSION: &str = env!("GIT_VERSION");
+const SERVICE_NAME: &str = "cadmus";
+static TRACER_PROVIDER: OnceLock<SdkTracerProvider> = OnceLock::new();
+static LOGGER_PROVIDER: OnceLock<SdkLoggerProvider> = OnceLock::new();
+
+/// Initializes OpenTelemetry telemetry with trace and log exporters.
+///
+/// This function sets up:
+/// - A tracer provider for distributed tracing
+/// - A logger provider for structured log export
+/// - Resource attributes identifying the service
+///
+/// If no OTLP endpoint is configured (via settings or environment variable),
+/// this function returns `Ok(None)` and telemetry export is disabled.
+///
+/// # Arguments
+///
+/// * `settings` - Logging configuration containing optional OTLP endpoint
+/// * `run_id` - Unique identifier for this application run
+///
+/// # Returns
+///
+/// Returns an optional `OpenTelemetryTracingBridge` layer that can be added to
+/// the tracing subscriber. Returns `None` if OTLP export is not configured.
+///
+/// # Errors
+///
+/// Returns an error if:
+/// - The OTLP exporter cannot be built
+/// - The tracer or logger provider initialization fails
+///
+/// # Example
+///
+/// ```
+/// use cadmus_core::settings::LoggingSettings;
+/// use cadmus_core::telemetry::init_telemetry;
+///
+/// let settings = LoggingSettings {
+///     enabled: true,
+///     level: "info".to_string(),
+///     max_files: 3,
+///     directory: "logs".into(),
+///     otlp_endpoint: Some("http://localhost:4318".to_string()),
+/// };
+///
+/// let layer = init_telemetry(&settings, "run-123")?;
+/// # Ok::<(), anyhow::Error>(())
+/// ```
+pub fn init_telemetry(
+    settings: &LoggingSettings,
+    run_id: &str,
+) -> Result<
+    Option<
+        opentelemetry_appender_tracing::layer::OpenTelemetryTracingBridge<
+            SdkLoggerProvider,
+            opentelemetry_sdk::logs::Logger,
+        >,
+    >,
+    Error,
+> {
+    let endpoint = match otel_endpoint(settings) {
+        Some(endpoint) => endpoint,
+        None => return Ok(None),
+    };
+
+    let hostname = gethostname().to_string_lossy().into_owned();
+
+    let resource = Resource::new([
+        KeyValue::new("service.name", SERVICE_NAME),
+        KeyValue::new("service.version", GIT_VERSION),
+        KeyValue::new("cadmus.run_id", run_id.to_string()),
+        KeyValue::new("hostname", hostname),
+    ]);
+
+    let tracer_provider = build_tracer_provider(&endpoint, resource.clone())?;
+    let logger_provider = build_logger_provider(&endpoint, resource)?;
+
+    let tracer_provider = TRACER_PROVIDER.get_or_init(|| tracer_provider);
+    let logger_provider = LOGGER_PROVIDER.get_or_init(|| logger_provider);
+
+    global::set_tracer_provider(tracer_provider.clone());
+
+    let layer =
+        opentelemetry_appender_tracing::layer::OpenTelemetryTracingBridge::new(logger_provider);
+
+    println!(
+        "Initialized OpenTelemetry telemetry with endpoint {}",
+        endpoint
+    );
+
+    Ok(Some(layer))
+}
+
+/// This ensures that when there are connection failures during shutdown, it doesn't block
+/// forever.
+fn shutdown_with_timeout(shutdown: impl FnOnce() + Send + 'static, timeout: Duration) {
+    let (tx, rx) = mpsc::channel();
+
+    thread::spawn(move || {
+        shutdown();
+        let _ = tx.send(());
+    });
+
+    let _ = rx.recv_timeout(timeout);
+}
+
+/// Shuts down OpenTelemetry providers and flushes buffered telemetry.
+///
+/// This function should be called before application exit to ensure all
+/// buffered traces and logs are exported to the OTLP endpoint. It:
+/// - Shuts down the tracer provider (flushes pending traces)
+/// - Shuts down the logger provider (flushes pending logs)  
+/// - Cleans up the global tracer provider
+///
+/// After calling this function, no more telemetry will be exported.
+/// This function is idempotent and safe to call multiple times.
+///
+/// # Example
+///
+/// ```
+/// use cadmus_core::telemetry::shutdown_telemetry;
+///
+/// // At application exit
+/// shutdown_telemetry();
+/// ```
+pub fn shutdown_telemetry() {
+    let timeout = Duration::from_millis(1500);
+
+    if let Some(provider) = TRACER_PROVIDER.get() {
+        shutdown_with_timeout(
+            {
+                move || {
+                    let _ = provider.shutdown();
+                }
+            },
+            timeout,
+        );
+    }
+
+    if let Some(provider) = LOGGER_PROVIDER.get() {
+        shutdown_with_timeout(
+            {
+                move || {
+                    let _ = provider.shutdown();
+                }
+            },
+            timeout,
+        );
+    }
+
+    global::shutdown_tracer_provider();
+}
+
+/// Determines the OTLP endpoint from settings or environment variables.
+///
+/// Environment variables take precedence over configuration file settings.
+///
+/// # Arguments
+///
+/// * `settings` - Logging configuration that may contain an OTLP endpoint
+///
+/// # Returns
+///
+/// Returns `Some(endpoint)` if an OTLP endpoint is configured, `None` otherwise.
+fn otel_endpoint(settings: &LoggingSettings) -> Option<String> {
+    if let Ok(value) = std::env::var("OTEL_EXPORTER_OTLP_ENDPOINT") {
+        return Some(value);
+    }
+
+    settings.otlp_endpoint.clone()
+}
+
+/// Builds a tracer provider with OTLP HTTP export.
+///
+/// # Arguments
+///
+/// * `endpoint` - Base OTLP endpoint URL
+/// * `resource` - Resource attributes to attach to all traces
+///
+/// # Returns
+///
+/// Returns a configured `SdkTracerProvider` ready for use.
+///
+/// # Errors
+///
+/// Returns an error if the OTLP span exporter cannot be built.
+fn build_tracer_provider(endpoint: &str, resource: Resource) -> Result<SdkTracerProvider, Error> {
+    let exporter = opentelemetry_otlp::new_exporter()
+        .http()
+        .with_endpoint(endpoint)
+        .build_span_exporter()
+        .context("can't build otlp span exporter")?;
+    let processor = BatchSpanProcessor::builder(exporter, runtime::TokioCurrentThread).build();
+    let config = TraceConfig::default().with_resource(resource);
+
+    Ok(SdkTracerProvider::builder()
+        .with_span_processor(processor)
+        .with_config(config)
+        .build())
+}
+
+/// Builds a logger provider with OTLP HTTP export.
+///
+/// The logger provider exports logs to `<endpoint>/v1/logs`.
+///
+/// # Arguments
+///
+/// * `endpoint` - Base OTLP endpoint URL  
+/// * `resource` - Resource attributes to attach to all logs
+///
+/// # Returns
+///
+/// Returns a configured `SdkLoggerProvider` ready for use.
+///
+/// # Errors
+///
+/// Returns an error if the OTLP log exporter cannot be built.
+fn build_logger_provider(endpoint: &str, resource: Resource) -> Result<SdkLoggerProvider, Error> {
+    let exporter = opentelemetry_otlp::new_exporter()
+        .http()
+        .with_endpoint(format!("{}/v1/logs", endpoint.trim_end_matches('/')))
+        .build_log_exporter()
+        .context("can't build otlp log exporter")?;
+    let processor = BatchLogProcessor::builder(exporter, runtime::TokioCurrentThread).build();
+
+    Ok(SdkLoggerProvider::builder()
+        .with_log_processor(processor)
+        .with_resource(resource)
+        .build())
+}

--- a/crates/core/src/view/calculator/mod.rs
+++ b/crates/core/src/view/calculator/mod.rs
@@ -29,6 +29,7 @@ use std::io::{BufRead, BufReader};
 use std::path::Path;
 use std::process::{Child, Command, Stdio};
 use std::thread;
+use tracing::error;
 
 const APP_DIR: &str = "bin/ivy";
 const APP_NAME: &str = "ivy";
@@ -649,7 +650,7 @@ impl Calculator {
         unsafe { libc::kill(self.process.id() as libc::pid_t, libc::SIGTERM) };
         self.process
             .wait()
-            .map_err(|e| eprintln!("Can't wait for child process: {:#}.", e))
+            .map_err(|e| error!("Can't wait for child process: {:#}.", e))
             .ok();
         context.settings.calculator.font_size = self.font_size;
         context.settings.calculator.margin_width = self.margin_width;

--- a/crates/core/src/view/dictionary/mod.rs
+++ b/crates/core/src/view/dictionary/mod.rs
@@ -25,6 +25,7 @@ use crate::view::{Bus, Event, Hub, RenderData, RenderQueue, View};
 use crate::view::{EntryId, EntryKind, Id, ViewId, ID_FEEDER};
 use crate::view::{BIG_BAR_HEIGHT, SMALL_BAR_HEIGHT, THICKNESS_MEDIUM};
 use regex::Regex;
+use tracing::error;
 
 const VIEWER_STYLESHEET: &str = "css/dictionary.css";
 const USER_STYLESHEET: &str = "css/dictionary-user.css";
@@ -66,7 +67,7 @@ fn query_to_content(
 
         if let Some(results) = dict
             .lookup(query, fuzzy)
-            .map_err(|e| eprintln!("Can't search dictionary: {:#}.", e))
+            .map_err(|e| error!("Can't search dictionary: {:#}.", e))
             .ok()
             .filter(|r| !r.is_empty())
         {

--- a/crates/core/src/view/home/directories_bar.rs
+++ b/crates/core/src/view/home/directories_bar.rs
@@ -13,6 +13,7 @@ use crate::view::{Align, Bus, Event, Hub, Id, RenderData, RenderQueue, View, ID_
 use crate::view::{SMALL_BAR_HEIGHT, THICKNESS_MEDIUM};
 use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
+use tracing::warn;
 
 #[derive(Debug)]
 pub struct DirectoriesBar {
@@ -574,7 +575,7 @@ impl View for DirectoriesBar {
                         if let Some(icon) = page[index].downcast_mut::<Icon>() {
                             icon.active = false;
                         } else {
-                            println!("oups");
+                            warn!("Unexpected directory bar icon type");
                         }
                         rq.add(RenderData::new(self.id, self.rect, UpdateMode::Gui));
                     }

--- a/crates/core/src/view/home/mod.rs
+++ b/crates/core/src/view/home/mod.rs
@@ -47,6 +47,7 @@ use std::mem;
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Stdio};
 use std::thread;
+use tracing::error;
 
 pub const TRASH_DIRNAME: &str = ".trash";
 
@@ -1492,7 +1493,7 @@ impl Home {
 
             let trash_path = context.library.home.join(TRASH_DIRNAME);
             if let Ok(trash) = Library::new(trash_path, LibraryMode::Database)
-                .map_err(|e| eprintln!("Can't inspect trash: {:#?}.", e))
+                .map_err(|e| error!("Can't inspect trash: {:#?}.", e))
             {
                 if trash.is_empty() == Some(false) {
                     entries.push(EntryKind::Separator);
@@ -1547,7 +1548,7 @@ impl Home {
         let trash_path = context.library.home.join(TRASH_DIRNAME);
 
         let trash = Library::new(trash_path, LibraryMode::Database)
-            .map_err(|e| eprintln!("Can't load trash: {:#}.", e));
+            .map_err(|e| error!("Can't load trash: {:#}.", e));
         if trash.is_err() {
             return;
         }
@@ -1562,7 +1563,7 @@ impl Home {
         let mut count = 0;
         for info in files {
             match trash.remove(&info.file.path) {
-                Err(e) => eprintln!("Can't erase {}: {:#}.", info.file.path.display(), e),
+                Err(e) => error!("Can't erase {}: {:#}.", info.file.path.display(), e),
                 Ok(()) => count += 1,
             }
         }
@@ -1611,7 +1612,7 @@ impl Home {
                 while size > context.settings.home.max_trash_size {
                     let info = files.pop().unwrap();
                     if let Err(e) = trash.remove(&info.file.path) {
-                        eprintln!("Can't erase {}: {:#}", info.file.path.display(), e);
+                        error!("Can't erase {}: {:#}", info.file.path.display(), e);
                         break;
                     }
                     size -= info.file.size;
@@ -1714,7 +1715,7 @@ impl Home {
 
         let library_settings = context.settings.libraries[index].clone();
         let library = Library::new(&library_settings.path, library_settings.mode)
-            .map_err(|e| eprintln!("Can't load library: {:#}.", e));
+            .map_err(|e| error!("Can't load library: {:#}.", e));
 
         if library.is_err() {
             return;
@@ -1857,7 +1858,7 @@ impl Home {
                     },
                 );
             }
-            Err(e) => eprintln!("Can't spawn child: {:#}.", e),
+            Err(e) => error!("Can't spawn child: {:#}.", e),
         }
     }
 
@@ -2214,7 +2215,7 @@ impl View for Home {
             Event::Submit(ViewId::RenameDocumentInput, ref file_name) => {
                 if let Some(ref path) = self.target_document.take() {
                     self.rename(path, file_name, hub, rq, context)
-                        .map_err(|e| eprintln!("Can't rename document: {:#}.", e))
+                        .map_err(|e| error!("Can't rename document: {:#}.", e))
                         .ok();
                 }
                 true
@@ -2244,19 +2245,19 @@ impl View for Home {
             Event::Select(EntryId::Remove(ref path))
             | Event::FetcherRemoveDocument(_, ref path) => {
                 self.remove(path, hub, rq, context)
-                    .map_err(|e| eprintln!("Can't remove document: {:#}.", e))
+                    .map_err(|e| error!("Can't remove document: {:#}.", e))
                     .ok();
                 true
             }
             Event::Select(EntryId::CopyTo(ref path, index)) => {
                 self.copy_to(path, index, context)
-                    .map_err(|e| eprintln!("Can't copy document: {:#}.", e))
+                    .map_err(|e| error!("Can't copy document: {:#}.", e))
                     .ok();
                 true
             }
             Event::Select(EntryId::MoveTo(ref path, index)) => {
                 self.move_to(path, index, hub, rq, context)
-                    .map_err(|e| eprintln!("Can't move document: {:#}.", e))
+                    .map_err(|e| error!("Can't move document: {:#}.", e))
                     .ok();
                 true
             }

--- a/crates/core/src/view/mod.rs
+++ b/crates/core/src/view/mod.rs
@@ -70,6 +70,7 @@ use std::path::PathBuf;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::mpsc::Sender;
 use std::time::{Duration, Instant};
+use tracing::error;
 
 // Border thicknesses in pixels, at 300 DPI.
 pub const THICKNESS_SMALL: f32 = 1.0;
@@ -234,10 +235,7 @@ pub fn render(
                     if overlaps && !update.has_completed() {
                         fb.wait(update.token)
                             .map_err(|e| {
-                                eprintln!(
-                                    "Can't wait for {}, {}: {:#}",
-                                    update.token, update.rect, e
-                                )
+                                error!("Can't wait for {}, {}: {:#}", update.token, update.rect, e)
                             })
                             .ok();
                     }
@@ -333,7 +331,7 @@ pub fn process_render_queue(
                     });
                 }
                 Err(err) => {
-                    eprintln!("Can't update {}: {:#}.", rect, err);
+                    error!("Can't update {}: {:#}.", rect, err);
                 }
             }
         }
@@ -349,7 +347,7 @@ pub fn wait_for_all(updating: &mut Vec<UpdateData>, context: &mut Context) {
         context
             .fb
             .wait(update.token)
-            .map_err(|e| eprintln!("Can't wait for {}, {}: {:#}", update.token, update.rect, e))
+            .map_err(|e| error!("Can't wait for {}, {}: {:#}", update.token, update.rect, e))
             .ok();
     }
 }

--- a/crates/core/src/view/ota.rs
+++ b/crates/core/src/view/ota.rs
@@ -16,6 +16,7 @@ use crate::view::filler::Filler;
 use crate::view::BIG_BAR_HEIGHT;
 use secrecy::SecretString;
 use std::thread;
+use tracing::{error, info};
 
 /// Attempts to show the OTA update view with validation checks.
 ///
@@ -256,7 +257,7 @@ impl OtaView {
             let client = match OtaClient::new(github_token) {
                 Ok(c) => c,
                 Err(e) => {
-                    eprintln!("[OTA] Failed to create github client {:?}", e);
+                    error!("[OTA] Failed to create github client {:?}", e);
                     let error_msg = format!("Failed to create client: {}", e);
                     hub2.send(Event::Notification(NotificationEvent::Show(error_msg)))
                         .ok();
@@ -295,7 +296,7 @@ impl OtaView {
 
             match download_result {
                 Ok(zip_path) => {
-                    println!("[OTA] Download completed, starting extraction...");
+                    info!("[OTA] Download completed, starting extraction...");
 
                     match client.extract_and_deploy(zip_path) {
                         Ok(_) => {
@@ -305,7 +306,7 @@ impl OtaView {
                             .ok();
                         }
                         Err(e) => {
-                            println!("[OTA] Deployment error: {:?}", e);
+                            error!("[OTA] Deployment error: {:?}", e);
                             let error_msg = format!("Deployment failed: {}", e);
                             hub2.send(Event::Notification(NotificationEvent::Show(error_msg)))
                                 .ok();
@@ -313,7 +314,7 @@ impl OtaView {
                     }
                 }
                 Err(e) => {
-                    println!("[OTA] Download error: {:?}", e);
+                    error!("[OTA] Download error: {:?}", e);
                     let error_msg = format!("Download failed: {}", e);
                     hub2.send(Event::Notification(NotificationEvent::Show(error_msg)))
                         .ok();

--- a/crates/core/src/view/reader/mod.rs
+++ b/crates/core/src/view/reader/mod.rs
@@ -69,6 +69,7 @@ use std::sync::atomic::AtomicBool;
 use std::sync::atomic::Ordering as AtomicOrdering;
 use std::sync::{Arc, Mutex};
 use std::thread;
+use tracing::{error, info};
 
 const HISTORY_SIZE: usize = 32;
 const RECT_DIST_JITTER: f32 = 24.0;
@@ -418,7 +419,7 @@ impl Reader {
             let synthetic = doc.has_synthetic_page_numbers();
             let reflowable = doc.is_reflowable();
 
-            println!("{}", info.file.path.display());
+            info!("{}", info.file.path.display());
 
             hub.send(Event::Update(UpdateMode::Partial)).ok();
 
@@ -2565,7 +2566,7 @@ impl Reader {
             }
 
             let mut families = family_names(&context.settings.reader.font_path)
-                .map_err(|e| eprintln!("Can't get family names: {:#}.", e))
+                .map_err(|e| error!("Can't get family names: {:#}.", e))
                 .unwrap_or_default();
             let current_family = self
                 .info
@@ -4286,7 +4287,7 @@ impl View for Reader {
                                     OpenOptions::new().create(true).append(true).open(path)
                                 {
                                     if let Err(e) = writeln!(file, "{}", link.text) {
-                                        eprintln!("Couldn't write to {}: {:#}.", path.display(), e);
+                                        error!("Couldn't write to {}: {:#}.", path.display(), e);
                                     } else {
                                         let message = format!("Queued {}.", link.text);
                                         let notif = Notification::new(
@@ -4297,7 +4298,7 @@ impl View for Reader {
                                 }
                             }
                         } else {
-                            eprintln!("Can't resolve URI: {}.", link.text);
+                            error!("Can't resolve URI: {}.", link.text);
                         }
                     }
                     return true;

--- a/crates/core/src/view/rotation_values/mod.rs
+++ b/crates/core/src/view/rotation_values/mod.rs
@@ -8,6 +8,7 @@ use crate::gesture::GestureEvent;
 use crate::view::{Bus, Event, Hub, RenderData, RenderQueue, View};
 use crate::view::{Id, ID_FEEDER};
 use std::mem;
+use tracing::{debug, error, info};
 
 const MESSAGE_1: &str = "Hold you device in portrait mode\n\
                          with the Kobo logo at the bottom,\n\
@@ -80,7 +81,7 @@ impl View for RotationValues {
                     mem::swap(&mut pt.x, &mut pt.y);
                 }
 
-                println!("Tap {} {:?}", pt, context.fb.dims());
+                debug!("Tap {} {:?}", pt, context.fb.dims());
 
                 self.taps.push(pt);
                 self.finished = self.taps.len() >= 2 * CORNERS_COUNT;
@@ -94,7 +95,7 @@ impl View for RotationValues {
                     context
                         .fb
                         .set_rotation(rotation)
-                        .map_err(|e| eprintln!("Can't set rotation: {:#}.", e))
+                        .map_err(|e| error!("Can't set rotation: {:#}.", e))
                         .ok();
                     if context.fb.rotation() == self.read_rotation {
                         self.written_rotation = rotation;
@@ -122,8 +123,8 @@ impl View for RotationValues {
                     let next = self.taps[CORNERS_COUNT + (center + 1) % 4];
                     let polarity = 2 * ((origin + startup_rotation) as i8 % 2) - 1;
                     let dir = if next.x < next.y { polarity } else { -polarity };
-                    println!("Startup rotation: {}.", startup_rotation);
-                    println!("Mirroring scheme: ({}, {}).", center, dir);
+                    info!("Startup rotation: {}.", startup_rotation);
+                    info!("Mirroring scheme: ({}, {}).", center, dir);
                     hub.send(Event::Back).ok();
                 } else {
                     rq.add(RenderData::new(self.id, self.rect, UpdateMode::Full));

--- a/crates/emulator/Cargo.toml
+++ b/crates/emulator/Cargo.toml
@@ -11,3 +11,8 @@ path = "src/main.rs"
 [dependencies]
 cadmus-core = { path = "../core" }
 sdl2 = "0.38.0"
+tracing = "0.1"
+
+[features]
+default = []
+otel = ["cadmus-core/otel"]

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -1,6 +1,13 @@
-# Summary
+[Overview](index.md)
 
-- [Overview](index.md)
+# User Guide
+
 - [Installation](installation/index.md)
   - [Test builds](installation/test-builds.md)
 - [Settings](settings/index.md)
+
+---
+
+# Contributor Guide
+
+- [OpenTelemetry Integration](contributing/telemetry.md)

--- a/docs/src/contributing/telemetry.md
+++ b/docs/src/contributing/telemetry.md
@@ -1,0 +1,97 @@
+# OpenTelemetry Integration
+
+Cadmus supports exporting logs and traces to OpenTelemetry-compatible backends when built with the `otel` feature flag.
+
+## Overview
+
+The OpenTelemetry (OTEL) integration allows Cadmus to export structured logs and distributed traces to observability platforms like Grafana Loki/Tempo, or any OTLP-compatible service. This is useful for monitoring application behavior, debugging issues, and analyzing performance.
+
+## Architecture
+
+The telemetry system consists of two main components:
+
+- **Logging**: JSON-structured logs written to disk via `tracing_subscriber`
+- **OTLP Export**: Optional export of logs and traces to a remote OTLP endpoint
+
+Each Cadmus run is assigned a unique Run ID (UUID v7) that ties together all logs and traces for that session.
+
+## Building with OTEL Support
+
+To enable OpenTelemetry, build Cadmus with the `otel` feature:
+
+```bash
+cargo build --features otel
+```
+
+## Configuration
+
+### Settings File
+
+Configure OpenTelemetry in your `Settings.toml`:
+
+```toml
+[logging]
+enabled = true
+level = "info"
+max-files = 3
+directory = "logs"
+otlp-endpoint = "https://otel.example.com:4318"
+```
+
+#### Configuration Options
+
+- **enabled**: Enable or disable logging entirely
+- **level**: Minimum log level (`trace`, `debug`, `info`, `warn`, `error`)
+- **max-files**: Number of log files to retain (0 = keep all)
+- **directory**: Path to log directory (relative to installation directory)
+- **otlp-endpoint**: OTLP HTTP endpoint URL (optional)
+
+### Environment Variables
+
+You can override the OTLP endpoint using an environment variable:
+
+```bash
+export OTEL_EXPORTER_OTLP_ENDPOINT="https://otel.example.com:4318"
+./cadmus
+```
+
+Environment variables take precedence over `Settings.toml` configuration.
+
+### Log Level Control
+
+The log level can be controlled via the `RUST_LOG` environment variable, which overrides the `level` setting:
+
+```bash
+# Enable debug logs for all modules
+export RUST_LOG=debug
+./cadmus
+
+# Enable trace logs only for specific modules
+export RUST_LOG=cadmus::view=trace,info
+./cadmus
+```
+
+## Resource Attributes
+
+Each telemetry export includes the following resource attributes:
+
+- **service.name**: Always `cadmus`
+- **service.version**: Git version from build metadata
+- **cadmus.run_id**: Unique identifier for the application run
+- **hostname**: System hostname
+
+## Log File Format
+
+Logs are written as newline-delimited JSON to files named:
+
+```text
+cadmus-<run_id>.json
+```
+
+Each log entry includes:
+
+- **timestamp**: ISO 8601 formatted timestamp
+- **level**: Log level (TRACE, DEBUG, INFO, WARN, ERROR)
+- **target**: Module path where the log originated
+- **fields**: Structured log data
+- **spans**: Active tracing spans providing context

--- a/docs/src/settings/index.md
+++ b/docs/src/settings/index.md
@@ -17,3 +17,23 @@ GitHub personal access token used to access CI artifacts.
 [ota]
 github-token = "ghp_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
 ```
+
+## Logging
+
+Cadmus writes JSON logs to disk. When the build enables the `otel` feature, it
+can also export logs to an OpenTelemetry endpoint.
+
+### `logging`
+
+```toml
+[logging]
+enabled = true
+level = "info"
+max-files = 3
+directory = "logs"
+# otlp-endpoint = "https://otel.example.com:4318"
+```
+
+Environment overrides:
+
+- `OTEL_EXPORTER_OTLP_ENDPOINT` takes precedence over `logging.otlp-endpoint`.


### PR DESCRIPTION
Introduce structured JSON logging with a per-run ID and optional OpenTelemetry (OTLP) export when built with the `otel` feature.

- Add `[logging]` settings with retention and OTLP endpoint support
- Initialize `tracing` in cadmus, emulator, and fetcher; replace prints
- Provide OTEL dev stack wiring in `devenv.nix` and document telemetry

Change-Id: b31d112c64ecc22cbf595bcf21e91e27
Change-Id-Short: owymyyxntvln

<!--
BEGIN_COMMIT_OVERRIDE
chore: add json logging
END_COMMIT_OVERRIDE
-->