### PR TITLE
feat: instrument views with otel tracing

### DIFF
--- a/.github/instructions/rust-instrumentation.instructions.md
+++ b/.github/instructions/rust-instrumentation.instructions.md
@@ -1,0 +1,119 @@
+---
+description: "Rust instrumentation guidelines for tracing and observability"
+applyTo: "**/*.rs"
+---
+
+# Rust Instrumentation Guidelines
+
+## Tracing and Observability
+
+All `handle_event` and `render` methods in view components must be instrumented with the OpenTelemetry tracing attribute to enable proper observability and debugging.
+
+### Required Attributes
+
+#### handle_event Method
+
+Add the following attribute before every `handle_event` method implementation in View traits:
+
+```rust
+#[cfg_attr(feature = "otel", tracing::instrument(skip(self, hub, bus, rq, context), fields(event = ?evt), ret(level=tracing::Level::TRACE)))]
+fn handle_event(
+    &mut self,
+    evt: &Event,
+    hub: &Hub,
+    bus: &mut Bus,
+    rq: &mut RenderQueue,
+    context: &mut Context,
+) -> bool {
+    // implementation
+}
+```
+
+#### render Method
+
+Add the following attribute before every `render` method implementation in View traits:
+
+```rust
+#[cfg_attr(feature = "otel", tracing::instrument(skip(self, fb, fonts), fields(rect = ?rect)))]
+fn render(&self, fb: &mut dyn Framebuffer, rect: Rectangle, fonts: &mut Fonts) {
+    // implementation
+}
+```
+
+### Key Points
+
+- **Conditional Compilation**: The attribute is only active when the `otel` feature is enabled, ensuring zero overhead in production builds without observability
+- **Event Field Capture**: `fields(event = ?evt)` captures the event type in traces for debugging event flow
+- **Rect Field Capture**: `fields(rect = ?rect)` captures the rendering rectangle for debugging layout issues
+- **Selective Skipping**: Skip only large data structures (self, hub, bus, rq, context, fb, fonts) while capturing critical information (event, rect)
+- **Return Value Tracing**: The `ret(level=tracing::Level::TRACE)` logs the return value at TRACE level for debugging
+- **Applies to All Views**: Every view component's `handle_event` and `render` methods must have these attributes
+
+### Examples
+
+**Good:**
+
+```rust
+impl View for Button {
+    #[cfg_attr(feature = "otel", tracing::instrument(skip(self, hub, bus, rq, context), fields(event = ?evt), ret(level=tracing::Level::TRACE)))]
+    fn handle_event(
+        &mut self,
+        evt: &Event,
+        hub: &Hub,
+        bus: &mut Bus,
+        rq: &mut RenderQueue,
+        context: &mut Context,
+    ) -> bool {
+        match *evt {
+            Event::Gesture(GestureEvent::Tap(center)) if self.rect.includes(center) => {
+                bus.push_back(self.event.clone());
+                true
+            }
+            _ => false,
+        }
+    }
+
+    #[cfg_attr(feature = "otel", tracing::instrument(skip(self, fb, fonts), fields(rect = ?rect)))]
+    fn render(&self, fb: &mut dyn Framebuffer, rect: Rectangle, fonts: &mut Fonts) {
+        // rendering implementation
+    }
+}
+```
+
+**Bad:**
+
+```rust
+impl View for Button {
+    fn handle_event(  // Missing instrumentation attribute
+        &mut self,
+        evt: &Event,
+        hub: &Hub,
+        bus: &mut Bus,
+        rq: &mut RenderQueue,
+        context: &mut Context,
+    ) -> bool {
+        // implementation
+    }
+
+    fn render(&self, fb: &mut dyn Framebuffer, _rect: Rectangle, fonts: &mut Fonts) {
+        // Missing instrumentation attribute
+    }
+}
+```
+
+### Rationale
+
+Instrumenting `handle_event` methods provides:
+
+- Complete event flow tracing through the UI hierarchy
+- Event type visibility for debugging interactions
+- Performance profiling of event handling
+- Return value tracking for understanding event consumption
+
+Instrumenting `render` methods provides:
+
+- Rendering performance analysis
+- Identification of rendering bottlenecks
+- Frame time profiling for smooth UI
+
+All view components process events through `handle_event` and update UI through `render`, making them critical chokepoints for observability.

--- a/crates/core/src/view/battery.rs
+++ b/crates/core/src/view/battery.rs
@@ -43,6 +43,7 @@ impl Battery {
 }
 
 impl View for Battery {
+    #[cfg_attr(feature = "otel", tracing::instrument(skip(self, _hub, bus, rq, context), fields(event = ?evt), ret(level=tracing::Level::TRACE)))]
     fn handle_event(
         &mut self,
         evt: &Event,
@@ -64,6 +65,7 @@ impl View for Battery {
         }
     }
 
+    #[cfg_attr(feature = "otel", tracing::instrument(skip(self, fb, _fonts, _rect), fields(rect = ?_rect)))]
     fn render(&self, fb: &mut dyn Framebuffer, _rect: Rectangle, _fonts: &mut Fonts) {
         let dpi = CURRENT_DEVICE.dpi;
 

--- a/crates/core/src/view/button.rs
+++ b/crates/core/src/view/button.rs
@@ -40,6 +40,7 @@ impl Button {
 }
 
 impl View for Button {
+    #[cfg_attr(feature = "otel", tracing::instrument(skip(self, _hub, bus, rq, _context), fields(event = ?evt), ret(level=tracing::Level::TRACE)))]
     fn handle_event(
         &mut self,
         evt: &Event,
@@ -74,6 +75,7 @@ impl View for Button {
         }
     }
 
+    #[cfg_attr(feature = "otel", tracing::instrument(skip(self, fb, fonts, _rect), fields(rect = ?_rect)))]
     fn render(&self, fb: &mut dyn Framebuffer, _rect: Rectangle, fonts: &mut Fonts) {
         let dpi = CURRENT_DEVICE.dpi;
 

--- a/crates/core/src/view/calculator/bottom_bar.rs
+++ b/crates/core/src/view/calculator/bottom_bar.rs
@@ -9,7 +9,6 @@ use crate::view::filler::Filler;
 use crate::view::labeled_icon::LabeledIcon;
 use crate::view::{Bus, Event, Hub, Id, RenderQueue, View, ViewId, ID_FEEDER};
 
-#[derive(Debug)]
 pub struct BottomBar {
     id: Id,
     rect: Rectangle,
@@ -91,6 +90,7 @@ impl BottomBar {
 }
 
 impl View for BottomBar {
+    #[cfg_attr(feature = "otel", tracing::instrument(skip(self, _hub, _bus, _rq, _context), fields(event = ?evt), ret(level=tracing::Level::TRACE)))]
     fn handle_event(
         &mut self,
         evt: &Event,
@@ -114,6 +114,7 @@ impl View for BottomBar {
         }
     }
 
+    #[cfg_attr(feature = "otel", tracing::instrument(skip(self, _fb, _fonts, _rect), fields(rect = ?_rect)))]
     fn render(&self, _fb: &mut dyn Framebuffer, _rect: Rectangle, _fonts: &mut Fonts) {}
 
     fn resize(&mut self, rect: Rectangle, hub: &Hub, rq: &mut RenderQueue, context: &mut Context) {

--- a/crates/core/src/view/calculator/code_area.rs
+++ b/crates/core/src/view/calculator/code_area.rs
@@ -69,6 +69,7 @@ impl CodeArea {
 }
 
 impl View for CodeArea {
+    #[cfg_attr(feature = "otel", tracing::instrument(skip(self, _hub, bus, _rq, _context), fields(event = ?evt), ret(level=tracing::Level::TRACE)))]
     fn handle_event(
         &mut self,
         evt: &Event,
@@ -113,6 +114,7 @@ impl View for CodeArea {
         }
     }
 
+    #[cfg_attr(feature = "otel", tracing::instrument(skip(self, fb, fonts), fields(rect = ?rect)))]
     fn render(&self, fb: &mut dyn Framebuffer, rect: Rectangle, fonts: &mut Fonts) {
         let dpi = CURRENT_DEVICE.dpi;
 

--- a/crates/core/src/view/calculator/input_bar.rs
+++ b/crates/core/src/view/calculator/input_bar.rs
@@ -12,7 +12,6 @@ use crate::view::icon::Icon;
 use crate::view::input_field::InputField;
 use crate::view::{Bus, Event, Hub, Id, RenderQueue, View, ViewId, ID_FEEDER, THICKNESS_MEDIUM};
 
-#[derive(Debug)]
 pub struct InputBar {
     id: Id,
     pub rect: Rectangle,
@@ -100,6 +99,7 @@ impl InputBar {
 }
 
 impl View for InputBar {
+    #[cfg_attr(feature = "otel", tracing::instrument(skip(self, _hub, _bus, _rq, _context), fields(event = ?evt), ret(level=tracing::Level::TRACE)))]
     fn handle_event(
         &mut self,
         evt: &Event,
@@ -123,6 +123,7 @@ impl View for InputBar {
         }
     }
 
+    #[cfg_attr(feature = "otel", tracing::instrument(skip(self, _fb, _fonts, _rect), fields(rect = ?_rect)))]
     fn render(&self, _fb: &mut dyn Framebuffer, _rect: Rectangle, _fonts: &mut Fonts) {}
 
     fn resize(&mut self, rect: Rectangle, hub: &Hub, rq: &mut RenderQueue, context: &mut Context) {

--- a/crates/core/src/view/calculator/mod.rs
+++ b/crates/core/src/view/calculator/mod.rs
@@ -658,6 +658,7 @@ impl Calculator {
 }
 
 impl View for Calculator {
+    #[cfg_attr(feature = "otel", tracing::instrument(skip(self, hub, _bus, rq, context), fields(event = ?evt), ret(level=tracing::Level::TRACE)))]
     fn handle_event(
         &mut self,
         evt: &Event,
@@ -759,6 +760,7 @@ impl View for Calculator {
         }
     }
 
+    #[cfg_attr(feature = "otel", tracing::instrument(skip(self, _fb, _fonts, _rect), fields(rect = ?_rect)))]
     fn render(&self, _fb: &mut dyn Framebuffer, _rect: Rectangle, _fonts: &mut Fonts) {}
 
     fn resize(&mut self, rect: Rectangle, hub: &Hub, rq: &mut RenderQueue, context: &mut Context) {

--- a/crates/core/src/view/clock.rs
+++ b/crates/core/src/view/clock.rs
@@ -42,6 +42,7 @@ impl Clock {
 }
 
 impl View for Clock {
+    #[cfg_attr(feature = "otel", tracing::instrument(skip(self, _hub, bus, rq, _context), fields(event = ?evt), ret(level=tracing::Level::TRACE)))]
     fn handle_event(
         &mut self,
         evt: &Event,
@@ -63,6 +64,7 @@ impl View for Clock {
         }
     }
 
+    #[cfg_attr(feature = "otel", tracing::instrument(skip(self, fb, fonts, _rect), fields(rect = ?_rect)))]
     fn render(&self, fb: &mut dyn Framebuffer, _rect: Rectangle, fonts: &mut Fonts) {
         let dpi = CURRENT_DEVICE.dpi;
         let font = font_from_style(fonts, &NORMAL_STYLE, dpi);

--- a/crates/core/src/view/dialog.rs
+++ b/crates/core/src/view/dialog.rs
@@ -117,6 +117,7 @@ impl Dialog {
 }
 
 impl View for Dialog {
+    #[cfg_attr(feature = "otel", tracing::instrument(skip(self, hub, bus, _rq, _context), fields(event = ?evt), ret(level=tracing::Level::TRACE)))]
     fn handle_event(
         &mut self,
         evt: &Event,
@@ -153,6 +154,7 @@ impl View for Dialog {
         }
     }
 
+    #[cfg_attr(feature = "otel", tracing::instrument(skip(self, fb, _fonts, _rect), fields(rect = ?_rect)))]
     fn render(&self, fb: &mut dyn Framebuffer, _rect: Rectangle, _fonts: &mut Fonts) {
         let dpi = CURRENT_DEVICE.dpi;
 

--- a/crates/core/src/view/dictionary/bottom_bar.rs
+++ b/crates/core/src/view/dictionary/bottom_bar.rs
@@ -10,7 +10,6 @@ use crate::view::icon::Icon;
 use crate::view::label::Label;
 use crate::view::{Align, Bus, Event, Hub, Id, RenderData, RenderQueue, View, ViewId, ID_FEEDER};
 
-#[derive(Debug)]
 pub struct BottomBar {
     id: Id,
     rect: Rectangle,
@@ -104,6 +103,7 @@ impl BottomBar {
 }
 
 impl View for BottomBar {
+    #[cfg_attr(feature = "otel", tracing::instrument(skip(self, _hub, _bus, _rq, _context), fields(event = ?evt), ret(level=tracing::Level::TRACE)))]
     fn handle_event(
         &mut self,
         evt: &Event,
@@ -126,6 +126,7 @@ impl View for BottomBar {
         }
     }
 
+    #[cfg_attr(feature = "otel", tracing::instrument(skip(self, _fb, _fonts, _rect), fields(rect = ?_rect)))]
     fn render(&self, _fb: &mut dyn Framebuffer, _rect: Rectangle, _fonts: &mut Fonts) {}
 
     fn resize(&mut self, rect: Rectangle, hub: &Hub, rq: &mut RenderQueue, context: &mut Context) {

--- a/crates/core/src/view/dictionary/mod.rs
+++ b/crates/core/src/view/dictionary/mod.rs
@@ -646,6 +646,7 @@ impl Dictionary {
 }
 
 impl View for Dictionary {
+    #[cfg_attr(feature = "otel", tracing::instrument(skip(self, hub, _bus, rq, context), fields(event = ?evt), ret(level=tracing::Level::TRACE)))]
     fn handle_event(
         &mut self,
         evt: &Event,
@@ -814,6 +815,7 @@ impl View for Dictionary {
         }
     }
 
+    #[cfg_attr(feature = "otel", tracing::instrument(skip(self, _fb, _fonts, _rect), fields(rect = ?_rect)))]
     fn render(&self, _fb: &mut dyn Framebuffer, _rect: Rectangle, _fonts: &mut Fonts) {}
 
     fn resize(&mut self, rect: Rectangle, hub: &Hub, rq: &mut RenderQueue, context: &mut Context) {

--- a/crates/core/src/view/filler.rs
+++ b/crates/core/src/view/filler.rs
@@ -24,6 +24,7 @@ impl Filler {
 }
 
 impl View for Filler {
+    #[cfg_attr(feature = "otel", tracing::instrument(skip(self, _evt, _hub, _bus, _rq, _context), fields(event = ?_evt), ret(level=tracing::Level::TRACE)))]
     fn handle_event(
         &mut self,
         _evt: &Event,
@@ -35,6 +36,7 @@ impl View for Filler {
         false
     }
 
+    #[cfg_attr(feature = "otel", tracing::instrument(skip(self, fb, _fonts), fields(rect = ?rect)))]
     fn render(&self, fb: &mut dyn Framebuffer, rect: Rectangle, _fonts: &mut Fonts) {
         if let Some(r) = self.rect.intersection(&rect) {
             fb.draw_rectangle(&r, self.color);

--- a/crates/core/src/view/frontlight.rs
+++ b/crates/core/src/view/frontlight.rs
@@ -280,6 +280,7 @@ impl FrontlightWindow {
 }
 
 impl View for FrontlightWindow {
+    #[cfg_attr(feature = "otel", tracing::instrument(skip(self, hub, _bus, rq, context), fields(event = ?evt), ret(level=tracing::Level::TRACE)))]
     fn handle_event(
         &mut self,
         evt: &Event,
@@ -383,6 +384,7 @@ impl View for FrontlightWindow {
         }
     }
 
+    #[cfg_attr(feature = "otel", tracing::instrument(skip(self, fb, _fonts, _rect), fields(rect = ?_rect)))]
     fn render(&self, fb: &mut dyn Framebuffer, _rect: Rectangle, _fonts: &mut Fonts) {
         let dpi = CURRENT_DEVICE.dpi;
 

--- a/crates/core/src/view/home/address_bar.rs
+++ b/crates/core/src/view/home/address_bar.rs
@@ -12,7 +12,6 @@ use crate::view::icon::Icon;
 use crate::view::input_field::InputField;
 use crate::view::{Bus, Event, Hub, Id, RenderQueue, View, ViewId, ID_FEEDER, THICKNESS_MEDIUM};
 
-#[derive(Debug)]
 pub struct AddressBar {
     id: Id,
     pub rect: Rectangle,
@@ -97,6 +96,7 @@ impl AddressBar {
 }
 
 impl View for AddressBar {
+    #[cfg_attr(feature = "otel", tracing::instrument(skip(self, _hub, _bus, _rq, _context), fields(event = ?evt), ret(level=tracing::Level::TRACE)))]
     fn handle_event(
         &mut self,
         evt: &Event,
@@ -120,6 +120,7 @@ impl View for AddressBar {
         }
     }
 
+    #[cfg_attr(feature = "otel", tracing::instrument(skip(self, _fb, _fonts, _rect), fields(rect = ?_rect)))]
     fn render(&self, _fb: &mut dyn Framebuffer, _rect: Rectangle, _fonts: &mut Fonts) {}
 
     fn resize(&mut self, rect: Rectangle, hub: &Hub, rq: &mut RenderQueue, context: &mut Context) {

--- a/crates/core/src/view/home/book.rs
+++ b/crates/core/src/view/home/book.rs
@@ -53,6 +53,7 @@ impl Book {
 }
 
 impl View for Book {
+    #[cfg_attr(feature = "otel", tracing::instrument(skip(self, hub, bus, rq, _context), fields(event = ?evt), ret(level=tracing::Level::TRACE)))]
     fn handle_event(
         &mut self,
         evt: &Event,
@@ -96,7 +97,7 @@ impl View for Book {
             _ => false,
         }
     }
-
+    #[cfg_attr(feature = "otel", tracing::instrument(skip(self, fb, fonts, _rect), fields(rect = ?_rect)))]
     fn render(&self, fb: &mut dyn Framebuffer, _rect: Rectangle, fonts: &mut Fonts) {
         let dpi = CURRENT_DEVICE.dpi;
 

--- a/crates/core/src/view/home/bottom_bar.rs
+++ b/crates/core/src/view/home/bottom_bar.rs
@@ -9,7 +9,6 @@ use crate::view::icon::Icon;
 use crate::view::page_label::PageLabel;
 use crate::view::{Bus, Event, Hub, Id, RenderData, RenderQueue, View, ID_FEEDER};
 
-#[derive(Debug)]
 pub struct BottomBar {
     id: Id,
     rect: Rectangle,
@@ -156,6 +155,7 @@ impl BottomBar {
 }
 
 impl View for BottomBar {
+    #[cfg_attr(feature = "otel", tracing::instrument(skip(self, _evt, _hub, _bus, _rq, _context), fields(event = ?_evt), ret(level=tracing::Level::TRACE)))]
     fn handle_event(
         &mut self,
         _evt: &Event,
@@ -167,6 +167,7 @@ impl View for BottomBar {
         false
     }
 
+    #[cfg_attr(feature = "otel", tracing::instrument(skip(self, _fb, _fonts, _rect), fields(rect = ?_rect)))]
     fn render(&self, _fb: &mut dyn Framebuffer, _rect: Rectangle, _fonts: &mut Fonts) {}
 
     fn resize(&mut self, rect: Rectangle, hub: &Hub, rq: &mut RenderQueue, context: &mut Context) {

--- a/crates/core/src/view/home/directories_bar.rs
+++ b/crates/core/src/view/home/directories_bar.rs
@@ -15,7 +15,6 @@ use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
 use tracing::warn;
 
-#[derive(Debug)]
 pub struct DirectoriesBar {
     id: Id,
     pub rect: Rectangle,
@@ -526,6 +525,7 @@ impl DirectoriesBar {
 }
 
 impl View for DirectoriesBar {
+    #[cfg_attr(feature = "otel", tracing::instrument(skip(self, _hub, _bus, rq, _context), fields(event = ?evt), ret(level=tracing::Level::TRACE)))]
     fn handle_event(
         &mut self,
         evt: &Event,
@@ -586,6 +586,7 @@ impl View for DirectoriesBar {
         }
     }
 
+    #[cfg_attr(feature = "otel", tracing::instrument(skip(self, _fb, _fonts, _rect), fields(rect = ?_rect)))]
     fn render(&self, _fb: &mut dyn Framebuffer, _rect: Rectangle, _fonts: &mut Fonts) {}
 
     fn rect(&self) -> &Rectangle {

--- a/crates/core/src/view/home/directory.rs
+++ b/crates/core/src/view/home/directory.rs
@@ -47,6 +47,7 @@ impl Directory {
 }
 
 impl View for Directory {
+    #[cfg_attr(feature = "otel", tracing::instrument(skip(self, _hub, bus, _rq, _context), fields(event = ?evt), ret(level=tracing::Level::TRACE)))]
     fn handle_event(
         &mut self,
         evt: &Event,
@@ -63,7 +64,7 @@ impl View for Directory {
             _ => false,
         }
     }
-
+    #[cfg_attr(feature = "otel", tracing::instrument(skip(self, fb, fonts, _rect), fields(rect = ?_rect)))]
     fn render(&self, fb: &mut dyn Framebuffer, _rect: Rectangle, fonts: &mut Fonts) {
         let dpi = CURRENT_DEVICE.dpi;
         fb.draw_rectangle(&self.rect, TEXT_BUMP_SMALL[0]);

--- a/crates/core/src/view/home/library_label.rs
+++ b/crates/core/src/view/home/library_label.rs
@@ -71,6 +71,7 @@ impl LibraryLabel {
 }
 
 impl View for LibraryLabel {
+    #[cfg_attr(feature = "otel", tracing::instrument(skip(self, _hub, bus, _rq, _context), fields(event = ?evt), ret(level=tracing::Level::TRACE)))]
     fn handle_event(
         &mut self,
         evt: &Event,
@@ -88,6 +89,7 @@ impl View for LibraryLabel {
         }
     }
 
+    #[cfg_attr(feature = "otel", tracing::instrument(skip(self, fb, fonts, _rect), fields(rect = ?_rect)))]
     fn render(&self, fb: &mut dyn Framebuffer, _rect: Rectangle, fonts: &mut Fonts) {
         let dpi = CURRENT_DEVICE.dpi;
         let font = font_from_style(fonts, &NORMAL_STYLE, dpi);

--- a/crates/core/src/view/home/mod.rs
+++ b/crates/core/src/view/home/mod.rs
@@ -51,7 +51,6 @@ use tracing::error;
 
 pub const TRASH_DIRNAME: &str = ".trash";
 
-#[derive(Debug)]
 pub struct Home {
     id: Id,
     rect: Rectangle,
@@ -69,7 +68,6 @@ pub struct Home {
     background_fetchers: FxHashMap<u32, Fetcher>,
 }
 
-#[derive(Debug)]
 struct Fetcher {
     path: PathBuf,
     full_path: PathBuf,
@@ -1972,6 +1970,7 @@ impl Home {
 }
 
 impl View for Home {
+    #[cfg_attr(feature = "otel", tracing::instrument(skip(self, hub, _bus, rq, context), fields(event = ?evt), ret(level=tracing::Level::TRACE)))]
     fn handle_event(
         &mut self,
         evt: &Event,
@@ -2403,6 +2402,7 @@ impl View for Home {
         }
     }
 
+    #[cfg_attr(feature = "otel", tracing::instrument(skip(self, _fb, _fonts, _rect), fields(rect = ?_rect)))]
     fn render(&self, _fb: &mut dyn Framebuffer, _rect: Rectangle, _fonts: &mut Fonts) {}
 
     fn resize(&mut self, rect: Rectangle, hub: &Hub, rq: &mut RenderQueue, context: &mut Context) {

--- a/crates/core/src/view/home/navigation_bar.rs
+++ b/crates/core/src/view/home/navigation_bar.rs
@@ -14,7 +14,6 @@ use fxhash::FxHashMap;
 use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
 
-#[derive(Debug)]
 pub struct NavigationBar {
     id: Id,
     pub rect: Rectangle,
@@ -343,6 +342,7 @@ fn guess_bar_size(dirs: &BTreeSet<PathBuf>) -> usize {
 }
 
 impl View for NavigationBar {
+    #[cfg_attr(feature = "otel", tracing::instrument(skip(self, _hub, bus, _rq, context), fields(event = ?evt), ret(level=tracing::Level::TRACE)))]
     fn handle_event(
         &mut self,
         evt: &Event,
@@ -376,6 +376,7 @@ impl View for NavigationBar {
         }
     }
 
+    #[cfg_attr(feature = "otel", tracing::instrument(skip(self, _fb, _fonts, _rect), fields(rect = ?_rect)))]
     fn render(&self, _fb: &mut dyn Framebuffer, _rect: Rectangle, _fonts: &mut Fonts) {}
 
     fn rect(&self) -> &Rectangle {

--- a/crates/core/src/view/home/shelf.rs
+++ b/crates/core/src/view/home/shelf.rs
@@ -167,6 +167,7 @@ impl Shelf {
 }
 
 impl View for Shelf {
+    #[cfg_attr(feature = "otel", tracing::instrument(skip(self, _hub, bus, _rq, _context), fields(event = ?evt), ret(level=tracing::Level::TRACE)))]
     fn handle_event(
         &mut self,
         evt: &Event,
@@ -193,6 +194,7 @@ impl View for Shelf {
         }
     }
 
+    #[cfg_attr(feature = "otel", tracing::instrument(skip(self, _fb, _fonts, _rect), fields(rect = ?_rect)))]
     fn render(&self, _fb: &mut dyn Framebuffer, _rect: Rectangle, _fonts: &mut Fonts) {}
 
     fn rect(&self) -> &Rectangle {

--- a/crates/core/src/view/icon.rs
+++ b/crates/core/src/view/icon.rs
@@ -122,6 +122,7 @@ impl Icon {
 }
 
 impl View for Icon {
+    #[cfg_attr(feature = "otel", tracing::instrument(skip(self, hub, bus, rq, _context), fields(event = ?evt), ret(level=tracing::Level::TRACE)))]
     fn handle_event(
         &mut self,
         evt: &Event,
@@ -172,6 +173,7 @@ impl View for Icon {
         }
     }
 
+    #[cfg_attr(feature = "otel", tracing::instrument(skip(self, fb, _fonts, _rect), fields(rect = ?_rect)))]
     fn render(&self, fb: &mut dyn Framebuffer, _rect: Rectangle, _fonts: &mut Fonts) {
         let scheme = if self.active {
             TEXT_INVERTED_HARD

--- a/crates/core/src/view/image.rs
+++ b/crates/core/src/view/image.rs
@@ -29,6 +29,7 @@ impl Image {
 }
 
 impl View for Image {
+    #[cfg_attr(feature = "otel", tracing::instrument(skip(self, _evt, _hub, _bus, _rq, _context), fields(event = ?_evt), ret(level=tracing::Level::TRACE)))]
     fn handle_event(
         &mut self,
         _evt: &Event,
@@ -40,6 +41,7 @@ impl View for Image {
         false
     }
 
+    #[cfg_attr(feature = "otel", tracing::instrument(skip(self, fb, _fonts), fields(rect = ?rect)))]
     fn render(&self, fb: &mut dyn Framebuffer, rect: Rectangle, _fonts: &mut Fonts) {
         let x0 = self.rect.min.x + (self.rect.width() - self.pixmap.width) as i32 / 2;
         let y0 = self.rect.min.y + (self.rect.height() - self.pixmap.height) as i32 / 2;

--- a/crates/core/src/view/input_field.rs
+++ b/crates/core/src/view/input_field.rs
@@ -214,6 +214,7 @@ impl InputField {
 }
 
 impl View for InputField {
+    #[cfg_attr(feature = "otel", tracing::instrument(skip(self, hub, bus, rq, context), fields(event = ?evt), ret(level=tracing::Level::TRACE)))]
     fn handle_event(
         &mut self,
         evt: &Event,
@@ -300,6 +301,7 @@ impl View for InputField {
         }
     }
 
+    #[cfg_attr(feature = "otel", tracing::instrument(skip(self, fb, fonts, _rect), fields(rect = ?_rect)))]
     fn render(&self, fb: &mut dyn Framebuffer, _rect: Rectangle, fonts: &mut Fonts) {
         let dpi = CURRENT_DEVICE.dpi;
         let font = font_from_style(fonts, &NORMAL_STYLE, dpi);

--- a/crates/core/src/view/intermission.rs
+++ b/crates/core/src/view/intermission.rs
@@ -57,6 +57,7 @@ impl Intermission {
 }
 
 impl View for Intermission {
+    #[cfg_attr(feature = "otel", tracing::instrument(skip(self, _evt, _hub, _bus, _rq, _context), fields(event = ?_evt), ret(level=tracing::Level::TRACE)))]
     fn handle_event(
         &mut self,
         _evt: &Event,
@@ -68,6 +69,7 @@ impl View for Intermission {
         true
     }
 
+    #[cfg_attr(feature = "otel", tracing::instrument(skip(self, fb, fonts, _rect), fields(rect = ?_rect)))]
     fn render(&self, fb: &mut dyn Framebuffer, _rect: Rectangle, fonts: &mut Fonts) {
         let scheme = if self.halt {
             TEXT_INVERTED_HARD

--- a/crates/core/src/view/key.rs
+++ b/crates/core/src/view/key.rs
@@ -203,6 +203,7 @@ impl Key {
 }
 
 impl View for Key {
+    #[cfg_attr(feature = "otel", tracing::instrument(skip(self, hub, bus, rq, _context), fields(event = ?evt), ret(level=tracing::Level::TRACE)))]
     fn handle_event(
         &mut self,
         evt: &Event,
@@ -272,6 +273,7 @@ impl View for Key {
         }
     }
 
+    #[cfg_attr(feature = "otel", tracing::instrument(skip(self, fb, fonts, _rect), fields(rect = ?_rect)))]
     fn render(&self, fb: &mut dyn Framebuffer, _rect: Rectangle, fonts: &mut Fonts) {
         let dpi = CURRENT_DEVICE.dpi;
         fb.draw_rectangle(&self.rect, KEYBOARD_BG);

--- a/crates/core/src/view/keyboard.rs
+++ b/crates/core/src/view/keyboard.rs
@@ -211,6 +211,7 @@ impl Keyboard {
 }
 
 impl View for Keyboard {
+    #[cfg_attr(feature = "otel", tracing::instrument(skip(self, hub, _bus, rq, context), fields(event = ?evt), ret(level=tracing::Level::TRACE)))]
     fn handle_event(
         &mut self,
         evt: &Event,
@@ -309,6 +310,7 @@ impl View for Keyboard {
         )
     }
 
+    #[cfg_attr(feature = "otel", tracing::instrument(skip(self, fb, _fonts), fields(rect = ?rect)))]
     fn render(&self, fb: &mut dyn Framebuffer, rect: Rectangle, _fonts: &mut Fonts) {
         for child in &self.children {
             if *child.rect() == rect {

--- a/crates/core/src/view/label.rs
+++ b/crates/core/src/view/label.rs
@@ -49,6 +49,7 @@ impl Label {
 }
 
 impl View for Label {
+    #[cfg_attr(feature = "otel", tracing::instrument(skip(self, _hub, bus, _rq, _context), fields(event = ?evt), ret(level=tracing::Level::TRACE)))]
     fn handle_event(
         &mut self,
         evt: &Event,
@@ -76,6 +77,7 @@ impl View for Label {
         }
     }
 
+    #[cfg_attr(feature = "otel", tracing::instrument(skip(self, fb, fonts, _rect), fields(rect = ?_rect)))]
     fn render(&self, fb: &mut dyn Framebuffer, _rect: Rectangle, fonts: &mut Fonts) {
         let dpi = CURRENT_DEVICE.dpi;
 

--- a/crates/core/src/view/labeled_icon.rs
+++ b/crates/core/src/view/labeled_icon.rs
@@ -6,7 +6,6 @@ use crate::view::icon::Icon;
 use crate::view::label::Label;
 use crate::view::{Align, Bus, Event, Hub, Id, RenderQueue, View, ID_FEEDER};
 
-#[derive(Debug)]
 pub struct LabeledIcon {
     id: Id,
     rect: Rectangle,
@@ -51,6 +50,7 @@ impl LabeledIcon {
 }
 
 impl View for LabeledIcon {
+    #[cfg_attr(feature = "otel", tracing::instrument(skip(self, _hub, bus, _rq, _context), fields(event = ?evt), ret(level=tracing::Level::TRACE)))]
     fn handle_event(
         &mut self,
         evt: &Event,
@@ -72,6 +72,7 @@ impl View for LabeledIcon {
         }
     }
 
+    #[cfg_attr(feature = "otel", tracing::instrument(skip(self, _fb, _fonts, _rect), fields(rect = ?_rect)))]
     fn render(&self, _fb: &mut dyn Framebuffer, _rect: Rectangle, _fonts: &mut Fonts) {}
 
     fn resize(&mut self, rect: Rectangle, hub: &Hub, rq: &mut RenderQueue, context: &mut Context) {

--- a/crates/core/src/view/menu.rs
+++ b/crates/core/src/view/menu.rs
@@ -260,6 +260,7 @@ impl Menu {
 }
 
 impl View for Menu {
+    #[cfg_attr(feature = "otel", tracing::instrument(skip(self, hub, bus, rq, context), fields(event = ?evt), ret(level=tracing::Level::TRACE)))]
     fn handle_event(
         &mut self,
         evt: &Event,
@@ -338,6 +339,7 @@ impl View for Menu {
         }
     }
 
+    #[cfg_attr(feature = "otel", tracing::instrument(skip(self, fb, fonts, _rect), fields(rect = ?_rect)))]
     fn render(&self, fb: &mut dyn Framebuffer, _rect: Rectangle, fonts: &mut Fonts) {
         let dpi = CURRENT_DEVICE.dpi;
         let border_radius = scale_by_dpi(BORDER_RADIUS_MEDIUM, dpi) as i32;

--- a/crates/core/src/view/menu_entry.rs
+++ b/crates/core/src/view/menu_entry.rs
@@ -59,6 +59,7 @@ impl MenuEntry {
 }
 
 impl View for MenuEntry {
+    #[cfg_attr(feature = "otel", tracing::instrument(skip(self, _hub, bus, rq, _context), fields(event = ?evt), ret(level=tracing::Level::TRACE)))]
     fn handle_event(
         &mut self,
         evt: &Event,
@@ -133,6 +134,7 @@ impl View for MenuEntry {
         }
     }
 
+    #[cfg_attr(feature = "otel", tracing::instrument(skip(self, fb, fonts, _rect), fields(rect = ?_rect)))]
     fn render(&self, fb: &mut dyn Framebuffer, _rect: Rectangle, fonts: &mut Fonts) {
         let dpi = CURRENT_DEVICE.dpi;
         let style = if matches!(self.kind, EntryKind::More(..)) {

--- a/crates/core/src/view/mod.rs
+++ b/crates/core/src/view/mod.rs
@@ -165,6 +165,7 @@ impl Debug for Box<dyn View> {
 // capture any tap gesture with a touch point inside their rectangle.
 // A child can send events to the main channel through the *hub* or communicate with its parent through the *bus*.
 // A view that wants to render can write to the rendering queue.
+#[cfg_attr(feature = "otel", tracing::instrument(skip(view, hub, parent_bus, rq, context), fields(event = ?evt), ret(level=tracing::Level::TRACE)))]
 pub fn handle_event(
     view: &mut dyn View,
     evt: &Event,
@@ -206,6 +207,7 @@ pub fn handle_event(
 // We render from bottom to top. For a view to render it has to either appear in `ids` or intersect
 // one of the rectangles in `bgs`. When we're about to render a view, if `wait` is true, we'll wait
 // for all the updates in `updating` that intersect with the view.
+#[cfg_attr(feature = "otel", tracing::instrument(skip(view, ids, rects, bgs, fb, fonts, updating), fields(wait = wait)))]
 pub fn render(
     view: &dyn View,
     wait: bool,

--- a/crates/core/src/view/named_input.rs
+++ b/crates/core/src/view/named_input.rs
@@ -101,6 +101,7 @@ impl NamedInput {
 }
 
 impl View for NamedInput {
+    #[cfg_attr(feature = "otel", tracing::instrument(skip(self, _hub, bus, _rq, context), fields(event = ?evt), ret(level=tracing::Level::TRACE)))]
     fn handle_event(
         &mut self,
         evt: &Event,
@@ -130,6 +131,7 @@ impl View for NamedInput {
         }
     }
 
+    #[cfg_attr(feature = "otel", tracing::instrument(skip(self, fb, _fonts, _rect), fields(rect = ?_rect)))]
     fn render(&self, fb: &mut dyn Framebuffer, _rect: Rectangle, _fonts: &mut Fonts) {
         let dpi = CURRENT_DEVICE.dpi;
         let border_radius = scale_by_dpi(BORDER_RADIUS_MEDIUM, dpi) as i32;

--- a/crates/core/src/view/notification.rs
+++ b/crates/core/src/view/notification.rs
@@ -191,6 +191,7 @@ impl Notification {
 }
 
 impl View for Notification {
+    #[cfg_attr(feature = "otel", tracing::instrument(skip(self, _hub, _bus, _rq, _context), fields(event = ?evt), ret(level=tracing::Level::TRACE)))]
     fn handle_event(
         &mut self,
         evt: &Event,
@@ -209,6 +210,7 @@ impl View for Notification {
         }
     }
 
+    #[cfg_attr(feature = "otel", tracing::instrument(skip(self, fb, fonts, _rect), fields(rect = ?_rect)))]
     fn render(&self, fb: &mut dyn Framebuffer, _rect: Rectangle, fonts: &mut Fonts) {
         let dpi = CURRENT_DEVICE.dpi;
 

--- a/crates/core/src/view/ota.rs
+++ b/crates/core/src/view/ota.rs
@@ -325,6 +325,7 @@ impl OtaView {
 }
 
 impl View for OtaView {
+    #[cfg_attr(feature = "otel", tracing::instrument(skip(self, hub, _bus, rq, context), fields(event = ?evt), ret(level=tracing::Level::TRACE)))]
     fn handle_event(
         &mut self,
         evt: &Event,
@@ -353,7 +354,7 @@ impl View for OtaView {
             _ => false,
         }
     }
-
+    #[cfg_attr(feature = "otel", tracing::instrument(skip(self, _fb, _fonts, _rect), fields(rect = ?_rect)))]
     fn render(&self, _fb: &mut dyn Framebuffer, _rect: Rectangle, _fonts: &mut Fonts) {}
 
     fn rect(&self) -> &Rectangle {

--- a/crates/core/src/view/page_label.rs
+++ b/crates/core/src/view/page_label.rs
@@ -83,6 +83,7 @@ impl PageLabel {
 }
 
 impl View for PageLabel {
+    #[cfg_attr(feature = "otel", tracing::instrument(skip(self, _hub, bus, _rq, _context), fields(event = ?evt), ret(level=tracing::Level::TRACE)))]
     fn handle_event(
         &mut self,
         evt: &Event,
@@ -106,6 +107,7 @@ impl View for PageLabel {
         }
     }
 
+    #[cfg_attr(feature = "otel", tracing::instrument(skip(self, fb, fonts, _rect), fields(rect = ?_rect)))]
     fn render(&self, fb: &mut dyn Framebuffer, _rect: Rectangle, fonts: &mut Fonts) {
         let dpi = CURRENT_DEVICE.dpi;
         let font = font_from_style(fonts, &NORMAL_STYLE, dpi);

--- a/crates/core/src/view/preset.rs
+++ b/crates/core/src/view/preset.rs
@@ -36,6 +36,7 @@ impl Preset {
 }
 
 impl View for Preset {
+    #[cfg_attr(feature = "otel", tracing::instrument(skip(self, _hub, bus, rq, _context), fields(event = ?evt), ret(level=tracing::Level::TRACE)))]
     fn handle_event(
         &mut self,
         evt: &Event,
@@ -79,6 +80,7 @@ impl View for Preset {
         }
     }
 
+    #[cfg_attr(feature = "otel", tracing::instrument(skip(self, fb, fonts, _rect), fields(rect = ?_rect)))]
     fn render(&self, fb: &mut dyn Framebuffer, _rect: Rectangle, fonts: &mut Fonts) {
         let dpi = CURRENT_DEVICE.dpi;
 

--- a/crates/core/src/view/presets_list.rs
+++ b/crates/core/src/view/presets_list.rs
@@ -101,6 +101,7 @@ impl PresetsList {
 }
 
 impl View for PresetsList {
+    #[cfg_attr(feature = "otel", tracing::instrument(skip(self, _hub, _bus, rq, _context), fields(event = ?evt), ret(level=tracing::Level::TRACE)))]
     fn handle_event(
         &mut self,
         evt: &Event,
@@ -134,6 +135,7 @@ impl View for PresetsList {
         }
     }
 
+    #[cfg_attr(feature = "otel", tracing::instrument(skip(self, fb, _fonts, _rect), fields(rect = ?_rect)))]
     fn render(&self, fb: &mut dyn Framebuffer, _rect: Rectangle, _fonts: &mut Fonts) {
         fb.draw_rectangle(&self.rect, WHITE);
     }

--- a/crates/core/src/view/reader/bottom_bar.rs
+++ b/crates/core/src/view/reader/bottom_bar.rs
@@ -12,7 +12,6 @@ use crate::view::icon::Icon;
 use crate::view::page_label::PageLabel;
 use crate::view::{Bus, Event, Hub, Id, RenderData, RenderQueue, View, ID_FEEDER};
 
-#[derive(Debug)]
 pub struct BottomBar {
     id: Id,
     rect: Rectangle,
@@ -146,6 +145,7 @@ impl BottomBar {
 }
 
 impl View for BottomBar {
+    #[cfg_attr(feature = "otel", tracing::instrument(skip(self, _hub, _bus, _rq, _context), fields(event = ?evt), ret(level=tracing::Level::TRACE)))]
     fn handle_event(
         &mut self,
         evt: &Event,
@@ -173,6 +173,7 @@ impl View for BottomBar {
         }
     }
 
+    #[cfg_attr(feature = "otel", tracing::instrument(skip(self, _fb, _fonts, _rect), fields(rect = ?_rect)))]
     fn render(&self, _fb: &mut dyn Framebuffer, _rect: Rectangle, _fonts: &mut Fonts) {}
 
     fn resize(&mut self, rect: Rectangle, hub: &Hub, rq: &mut RenderQueue, context: &mut Context) {

--- a/crates/core/src/view/reader/chapter_label.rs
+++ b/crates/core/src/view/reader/chapter_label.rs
@@ -43,6 +43,7 @@ impl ChapterLabel {
 }
 
 impl View for ChapterLabel {
+    #[cfg_attr(feature = "otel", tracing::instrument(skip(self, _hub, bus, _rq, _context), fields(event = ?evt), ret(level=tracing::Level::TRACE)))]
     fn handle_event(
         &mut self,
         evt: &Event,
@@ -60,6 +61,7 @@ impl View for ChapterLabel {
         }
     }
 
+    #[cfg_attr(feature = "otel", tracing::instrument(skip(self, fb, fonts, _rect), fields(rect = ?_rect)))]
     fn render(&self, fb: &mut dyn Framebuffer, _rect: Rectangle, fonts: &mut Fonts) {
         fb.draw_rectangle(&self.rect, WHITE);
         if !self.title.is_empty() {

--- a/crates/core/src/view/reader/margin_cropper.rs
+++ b/crates/core/src/view/reader/margin_cropper.rs
@@ -146,6 +146,7 @@ impl MarginCropper {
 }
 
 impl View for MarginCropper {
+    #[cfg_attr(feature = "otel", tracing::instrument(skip(self, _hub, bus, rq, _context), fields(event = ?evt), ret(level=tracing::Level::TRACE)))]
     fn handle_event(
         &mut self,
         evt: &Event,
@@ -182,7 +183,7 @@ impl View for MarginCropper {
             _ => false,
         }
     }
-
+    #[cfg_attr(feature = "otel", tracing::instrument(skip(self, fb, _fonts, _rect), fields(rect = ?_rect)))]
     fn render(&self, fb: &mut dyn Framebuffer, _rect: Rectangle, _fonts: &mut Fonts) {
         let dpi = CURRENT_DEVICE.dpi;
         let dx = (self.rect.width() as i32 - self.pixmap.width as i32) / 2;

--- a/crates/core/src/view/reader/mod.rs
+++ b/crates/core/src/view/reader/mod.rs
@@ -107,7 +107,6 @@ pub struct Reader {
     finished: bool,
 }
 
-#[derive(Debug)]
 struct ViewPort {
     zoom_mode: ZoomMode,
     scroll_mode: ScrollMode,
@@ -133,14 +132,12 @@ enum State {
     AdjustSelection,
 }
 
-#[derive(Debug)]
 struct Selection {
     start: TextLocation,
     end: TextLocation,
     anchor: TextLocation,
 }
 
-#[derive(Debug)]
 struct Resource {
     pixmap: Pixmap,
     frame: Rectangle, // The pixmap's rectangle minus the cropping margins.
@@ -155,7 +152,6 @@ struct RenderChunk {
     scale: f32,
 }
 
-#[derive(Debug)]
 struct Search {
     query: String,
     highlights: BTreeMap<usize, Vec<Vec<Boundary>>>,
@@ -176,7 +172,6 @@ impl Default for Search {
     }
 }
 
-#[derive(Debug)]
 struct Contrast {
     exponent: f32,
     gray: f32,
@@ -3763,6 +3758,7 @@ impl Reader {
 }
 
 impl View for Reader {
+    #[cfg_attr(feature = "otel", tracing::instrument(skip(self, hub, _bus, rq, context), fields(event = ?evt), ret(level=tracing::Level::TRACE)))]
     fn handle_event(
         &mut self,
         evt: &Event,
@@ -5180,6 +5176,7 @@ impl View for Reader {
         }
     }
 
+    #[cfg_attr(feature = "otel", tracing::instrument(skip(self, fb, _fonts), fields(rect = ?rect)))]
     fn render(&self, fb: &mut dyn Framebuffer, rect: Rectangle, _fonts: &mut Fonts) {
         fb.draw_rectangle(&rect, WHITE);
 

--- a/crates/core/src/view/reader/results_bar.rs
+++ b/crates/core/src/view/reader/results_bar.rs
@@ -11,7 +11,6 @@ use crate::view::icon::Icon;
 use crate::view::page_label::PageLabel;
 use crate::view::{Bus, Event, Hub, Id, RenderData, RenderQueue, View, ViewId, ID_FEEDER};
 
-#[derive(Debug)]
 pub struct ResultsBar {
     id: Id,
     rect: Rectangle,
@@ -155,6 +154,7 @@ impl ResultsBar {
 }
 
 impl View for ResultsBar {
+    #[cfg_attr(feature = "otel", tracing::instrument(skip(self, _hub, bus, _rq, _context), fields(event = ?evt), ret(level=tracing::Level::TRACE)))]
     fn handle_event(
         &mut self,
         evt: &Event,
@@ -183,6 +183,7 @@ impl View for ResultsBar {
         }
     }
 
+    #[cfg_attr(feature = "otel", tracing::instrument(skip(self, _fb, _fonts, _rect), fields(rect = ?_rect)))]
     fn render(&self, _fb: &mut dyn Framebuffer, _rect: Rectangle, _fonts: &mut Fonts) {}
 
     fn resize(&mut self, rect: Rectangle, hub: &Hub, rq: &mut RenderQueue, context: &mut Context) {

--- a/crates/core/src/view/reader/results_label.rs
+++ b/crates/core/src/view/reader/results_label.rs
@@ -42,6 +42,7 @@ impl ResultsLabel {
 }
 
 impl View for ResultsLabel {
+    #[cfg_attr(feature = "otel", tracing::instrument(skip(self, _hub, _bus, rq, _context), fields(event = ?evt), ret(level=tracing::Level::TRACE)))]
     fn handle_event(
         &mut self,
         evt: &Event,
@@ -60,6 +61,7 @@ impl View for ResultsLabel {
         }
     }
 
+    #[cfg_attr(feature = "otel", tracing::instrument(skip(self, fb, fonts, _rect), fields(rect = ?_rect)))]
     fn render(&self, fb: &mut dyn Framebuffer, _rect: Rectangle, fonts: &mut Fonts) {
         let dpi = CURRENT_DEVICE.dpi;
         let font = font_from_style(fonts, &NORMAL_STYLE, dpi);

--- a/crates/core/src/view/reader/tool_bar.rs
+++ b/crates/core/src/view/reader/tool_bar.rs
@@ -19,7 +19,6 @@ use crate::view::{
     THICKNESS_MEDIUM,
 };
 
-#[derive(Debug)]
 pub struct ToolBar {
     id: Id,
     rect: Rectangle,
@@ -351,6 +350,7 @@ impl ToolBar {
 }
 
 impl View for ToolBar {
+    #[cfg_attr(feature = "otel", tracing::instrument(skip(self, _hub, _bus, _rq, _context), fields(event = ?evt), ret(level=tracing::Level::TRACE)))]
     fn handle_event(
         &mut self,
         evt: &Event,
@@ -374,6 +374,7 @@ impl View for ToolBar {
         }
     }
 
+    #[cfg_attr(feature = "otel", tracing::instrument(skip(self, _fb, _fonts, _rect), fields(rect = ?_rect)))]
     fn render(&self, _fb: &mut dyn Framebuffer, _rect: Rectangle, _fonts: &mut Fonts) {}
 
     fn resize(&mut self, rect: Rectangle, hub: &Hub, rq: &mut RenderQueue, context: &mut Context) {

--- a/crates/core/src/view/rotation_values/mod.rs
+++ b/crates/core/src/view/rotation_values/mod.rs
@@ -59,6 +59,7 @@ impl RotationValues {
 }
 
 impl View for RotationValues {
+    #[cfg_attr(feature = "otel", tracing::instrument(skip(self, hub, _bus, rq, context), fields(event = ?evt), ret(level=tracing::Level::TRACE)))]
     fn handle_event(
         &mut self,
         evt: &Event,
@@ -136,6 +137,7 @@ impl View for RotationValues {
         }
     }
 
+    #[cfg_attr(feature = "otel", tracing::instrument(skip(self, fb, fonts, _rect), fields(rect = ?_rect)))]
     fn render(&self, fb: &mut dyn Framebuffer, _rect: Rectangle, fonts: &mut Fonts) {
         let dpi = CURRENT_DEVICE.dpi;
         let width = self.rect.width() as i32;

--- a/crates/core/src/view/rounded_button.rs
+++ b/crates/core/src/view/rounded_button.rs
@@ -34,6 +34,7 @@ impl RoundedButton {
 }
 
 impl View for RoundedButton {
+    #[cfg_attr(feature = "otel", tracing::instrument(skip(self, _hub, bus, rq, _context), fields(event = ?evt), ret(level=tracing::Level::TRACE)))]
     fn handle_event(
         &mut self,
         evt: &Event,
@@ -65,7 +66,7 @@ impl View for RoundedButton {
             _ => false,
         }
     }
-
+    #[cfg_attr(feature = "otel", tracing::instrument(skip(self, fb, _fonts, _rect), fields(rect = ?_rect)))]
     fn render(&self, fb: &mut dyn Framebuffer, _rect: Rectangle, _fonts: &mut Fonts) {
         let dpi = CURRENT_DEVICE.dpi;
         let thickness = scale_by_dpi(THICKNESS_MEDIUM, dpi) as u16;

--- a/crates/core/src/view/search_bar.rs
+++ b/crates/core/src/view/search_bar.rs
@@ -12,7 +12,6 @@ use crate::gesture::GestureEvent;
 use crate::input::DeviceEvent;
 use crate::unit::scale_by_dpi;
 
-#[derive(Debug)]
 pub struct SearchBar {
     id: Id,
     pub rect: Rectangle,
@@ -99,6 +98,7 @@ impl SearchBar {
 }
 
 impl View for SearchBar {
+    #[cfg_attr(feature = "otel", tracing::instrument(skip(self, _hub, _bus, _rq, _context), fields(event = ?evt), ret(level=tracing::Level::TRACE)))]
     fn handle_event(
         &mut self,
         evt: &Event,
@@ -121,7 +121,7 @@ impl View for SearchBar {
             _ => false,
         }
     }
-
+    #[cfg_attr(feature = "otel", tracing::instrument(skip(self, _fb, _fonts, _rect), fields(rect = ?_rect)))]
     fn render(&self, _fb: &mut dyn Framebuffer, _rect: Rectangle, _fonts: &mut Fonts) {}
 
     fn resize(&mut self, rect: Rectangle, hub: &Hub, rq: &mut RenderQueue, context: &mut Context) {

--- a/crates/core/src/view/sketch/mod.rs
+++ b/crates/core/src/view/sketch/mod.rs
@@ -293,6 +293,7 @@ fn draw_segment(
 }
 
 impl View for Sketch {
+    #[cfg_attr(feature = "otel", tracing::instrument(skip(self, hub, _bus, rq, context), fields(event = ?evt), ret(level=tracing::Level::TRACE)))]
     fn handle_event(
         &mut self,
         evt: &Event,
@@ -416,6 +417,7 @@ impl View for Sketch {
         }
     }
 
+    #[cfg_attr(feature = "otel", tracing::instrument(skip(self, fb, _fonts), fields(rect = ?rect)))]
     fn render(&self, fb: &mut dyn Framebuffer, rect: Rectangle, _fonts: &mut Fonts) {
         fb.draw_framed_pixmap_halftone(&self.pixmap, &rect, rect.min);
     }

--- a/crates/core/src/view/slider.rs
+++ b/crates/core/src/view/slider.rs
@@ -68,6 +68,7 @@ impl Slider {
 }
 
 impl View for Slider {
+    #[cfg_attr(feature = "otel", tracing::instrument(skip(self, _hub, bus, rq, _context), fields(event = ?evt), ret(level=tracing::Level::TRACE)))]
     fn handle_event(
         &mut self,
         evt: &Event,
@@ -115,6 +116,7 @@ impl View for Slider {
         }
     }
 
+    #[cfg_attr(feature = "otel", tracing::instrument(skip(self, fb, fonts, _rect), fields(rect = ?_rect)))]
     fn render(&self, fb: &mut dyn Framebuffer, _rect: Rectangle, fonts: &mut Fonts) {
         let dpi = CURRENT_DEVICE.dpi;
         let progress_height = scale_by_dpi(PROGRESS_HEIGHT, dpi) as i32;

--- a/crates/core/src/view/toggleable_keyboard.rs
+++ b/crates/core/src/view/toggleable_keyboard.rs
@@ -199,6 +199,7 @@ impl ToggleableKeyboard {
 }
 
 impl View for ToggleableKeyboard {
+    #[cfg_attr(feature = "otel", tracing::instrument(skip(self, hub, bus, rq, context), fields(event = ?evt), ret(level=tracing::Level::TRACE)))]
     fn handle_event(
         &mut self,
         evt: &Event,
@@ -219,7 +220,7 @@ impl View for ToggleableKeyboard {
 
         false
     }
-
+    #[cfg_attr(feature = "otel", tracing::instrument(skip(self, fb, fonts), fields(rect = ?rect)))]
     fn render(&self, fb: &mut dyn Framebuffer, rect: Rectangle, fonts: &mut Fonts) {
         if !self.visible {
             return;

--- a/crates/core/src/view/top_bar.rs
+++ b/crates/core/src/view/top_bar.rs
@@ -10,7 +10,6 @@ use crate::view::icon::Icon;
 use crate::view::label::Label;
 use crate::view::{Align, Bus, Event, Hub, Id, RenderData, RenderQueue, View, ViewId, ID_FEEDER};
 
-#[derive(Debug)]
 pub struct TopBar {
     id: Id,
     rect: Rectangle,
@@ -118,6 +117,7 @@ impl TopBar {
 }
 
 impl View for TopBar {
+    #[cfg_attr(feature = "otel", tracing::instrument(skip(self, _hub, _bus, _rq, _context), fields(event = ?evt), ret(level=tracing::Level::TRACE)))]
     fn handle_event(
         &mut self,
         evt: &Event,
@@ -145,6 +145,7 @@ impl View for TopBar {
         }
     }
 
+    #[cfg_attr(feature = "otel", tracing::instrument(skip(self, _fb, _fonts, _rect), fields(rect = ?_rect)))]
     fn render(&self, _fb: &mut dyn Framebuffer, _rect: Rectangle, _fonts: &mut Fonts) {}
 
     fn resize(&mut self, rect: Rectangle, hub: &Hub, rq: &mut RenderQueue, context: &mut Context) {

--- a/crates/core/src/view/touch_events/mod.rs
+++ b/crates/core/src/view/touch_events/mod.rs
@@ -50,6 +50,7 @@ impl TouchEvents {
 }
 
 impl View for TouchEvents {
+    #[cfg_attr(feature = "otel", tracing::instrument(skip(self, hub, _bus, rq, context), fields(event = ?evt), ret(level=tracing::Level::TRACE)))]
     fn handle_event(
         &mut self,
         evt: &Event,
@@ -68,6 +69,7 @@ impl View for TouchEvents {
         }
     }
 
+    #[cfg_attr(feature = "otel", tracing::instrument(skip(self, fb, _fonts), fields(rect = ?rect)))]
     fn render(&self, fb: &mut dyn Framebuffer, rect: Rectangle, _fonts: &mut Fonts) {
         for x in rect.min.x..rect.max.x {
             for y in rect.min.y..rect.max.y {

--- a/devenv.nix
+++ b/devenv.nix
@@ -312,8 +312,7 @@ in
               search:
                 max_duration: 1h
           ''} \
-          -target=all \
-          -backend-scheduler.local-work-path=${config.devenv.state}/tempo/work
+          -target=all
       '';
     };
 
@@ -517,6 +516,7 @@ in
       echo ""
 
       export OTEL_EXPORTER_OTLP_ENDPOINT="http://localhost:4318"
+      export RUST_LOG="trace"
 
       ./run-emulator.sh --features otel "$@"
     '';


### PR DESCRIPTION
Add tracing instrumentation for UI views and improve OpenTelemetry setup.

- Instrument View handle_event/render paths behind `otel`
- Combine tracing and log layers when telemetry is enabled
- Configure OTLP HTTP binary exporters and dev env defaults

Change-Id: 1a8d638da0045409ed43b48f9aab4937
Change-Id-Short: yprmtwrmpzzv

<!--
BEGIN_COMMIT_OVERRIDE
chore: instrument views with otel
END_COMMIT_OVERRIDE
-->