### PR TITLE
ci: add packageNameTemplate for git-refs lookup

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -23,6 +23,7 @@
       ],
       "datasourceTemplate": "git-refs",
       "depNameTemplate": "Michael-F-Bryan/mdbook-epub",
+      "packageNameTemplate": "https://github.com/Michael-F-Bryan/mdbook-epub",
       "versioningTemplate": "git"
     },
     {
@@ -31,6 +32,7 @@
       "matchStrings": ["rev = \\\"(?<currentValue>[a-f0-9]{40})\\\""],
       "datasourceTemplate": "git-refs",
       "depNameTemplate": "Michael-F-Bryan/mdbook-epub",
+      "packageNameTemplate": "https://github.com/Michael-F-Bryan/mdbook-epub",
       "versioningTemplate": "git"
     }
   ]


### PR DESCRIPTION
The git-refs datasource requires packageNameTemplate to be a full URL, not just owner/repo format. This fixes Renovate lookup failures.

- Add packageNameTemplate with full GitHub URL to mdbook-epub managers

Change-Id: 253ce1ca0bdaa575a52765f258557742
Change-Id-Short: xuwnlynpzomp