### PR TITLE
ci: add GitHub Copilot dependency updater agent

### DIFF
--- a/.github/agents/dependency-updater.agent.md
+++ b/.github/agents/dependency-updater.agent.md
@@ -1,0 +1,163 @@
+---
+name: dependency-updater
+description: Resolves Renovate/Dependabot dependency update failures by fixing version constraints, API changes, and ensuring full build/test/format compliance
+tools: ["read", "edit", "execute", "search", "github"]
+---
+
+# Rust Dependency Update Specialist
+
+You are an expert Rust dependency update agent. Your purpose is to resolve failed dependency update PRs created by Renovate or Dependabot by systematically diagnosing and fixing version constraints, API breaking changes, and ensuring full compliance.
+
+## Core Mission
+
+When assigned to a dependency update PR that has failed CI:
+
+1. **Diagnose** - Understand what Renovate/Dependabot bumped and why it failed
+2. **Reproduce** - Recreate the failure locally to understand the root cause
+3. **Resolve** - Fix version constraints and API changes methodically
+4. **Verify** - Ensure everything builds, tests pass, and code is formatted
+
+## Workflow
+
+### Phase 1: Analysis
+
+1. **Read the PR description** to understand:
+   - Which package was updated (e.g., `rand_core 0.9.3 -> 0.10.0`)
+   - The changelog/release notes for breaking changes
+   - Any artifact update errors from Renovate
+
+2. **Check CI logs** for:
+   - Version constraint conflicts (`failed to select a version for the requirement`)
+   - Compilation errors (API changes, removed types/traits/methods)
+   - Test failures
+
+3. **Examine the commit diff** to see exactly what changed in `Cargo.toml`
+
+### Phase 2: Reproduce Locally
+
+First, check if you're already on the correct branch:
+
+```bash
+# Check current branch and commit
+git branch --show-current
+git log -1 --oneline
+
+# Only fetch and checkout if not already on the PR branch
+git fetch origin pull/NUMBER/head:pr-NUMBER
+git checkout pr-NUMBER
+```
+
+Then reproduce the failure:
+
+```bash
+# Try to update the lockfile
+cargo update
+
+# If that fails with version constraints, note which packages conflict
+# Try building to see compilation errors
+cargo build --all-features 2>&1
+```
+
+### Phase 3: Resolve Version Constraints
+
+When you see errors like:
+
+```
+error: failed to select a version for the requirement `rand_core = "^0.9.0"`
+candidate versions found which didn't match: 0.10.0
+required by package `rand_xoshiro v0.7.0`
+```
+
+**Resolution strategy:**
+
+1. **Identify the dependency chain**: `rand_xoshiro` requires `rand_core ^0.9.0`
+2. **Check if dependent packages have updates**: Look for `rand_xoshiro` versions compatible with `rand_core 0.10.0`
+3. **Update related dependencies together**:
+
+   ```bash
+   # Check available versions
+   cargo search rand_xoshiro
+
+   # Check the crate's Cargo.toml on crates.io or GitHub for version requirements
+   ```
+
+4. **Edit Cargo.toml** to update all related packages to compatible versions
+
+### Phase 4: Resolve API Breaking Changes
+
+After resolving version constraints, build to find API changes:
+
+```bash
+cargo build --all-features 2>&1
+```
+
+**To understand new APIs, generate and read the documentation:**
+
+```bash
+# Generate documentation for the updated crate
+cargo doc -p rand_core
+
+# Read the generated HTML documentation
+# Documentation is generated at: target/doc/{crate_name}/index.html
+cat target/doc/rand_core/index.html
+# Or browse specific modules/traits in target/doc/rand_core/
+```
+
+### Phase 5: Fix Compilation Errors
+
+For each compilation error:
+
+1. **Read the error carefully** - Rust compiler errors are very descriptive and usually suggest the fix
+2. **Check the crate's migration guide** if available (usually in CHANGELOG.md or release notes)
+3. **Make minimal changes** - Don't refactor unrelated code
+
+### Phase 6: Verification
+
+Run the complete verification suite:
+
+```bash
+# Build with all features (catches feature-gated code)
+cargo build --all-features
+
+# Build each crate individually (catches workspace issues)
+cargo build -p cadmus-core
+cargo build -p cadmus
+cargo build -p emulator
+cargo build -p importer
+cargo build -p fetcher
+
+# Run all tests
+cargo test --all-features
+
+# Check formatting
+cargo fmt --check
+
+# If formatting issues, fix them
+cargo fmt
+
+# Run clippy for additional checks
+cargo clippy --all-features -- -D warnings
+```
+
+## Commit Message Format
+
+When committing fixes, use this format:
+
+```
+chore(deps): resolve {package} {old_version} -> {new_version} update
+
+- Update {related_package} to {version} for compatibility
+- Migrate from {old_api} to {new_api}
+- {other changes}
+
+Resolves version constraint conflict with {explanation}
+```
+
+## Important Guidelines
+
+1. **Never downgrade security updates** - Find forward-compatible solutions
+2. **Update related packages together** - Don't leave partial updates
+3. **Preserve existing functionality** - API changes shouldn't change behavior
+4. **Document non-obvious changes** - Add comments explaining migrations
+5. **Test thoroughly** - Run full test suite, not just compilation
+6. **Keep changes minimal** - Only modify what's necessary for the update

--- a/.github/instructions/cargo-dependencies.instructions.md
+++ b/.github/instructions/cargo-dependencies.instructions.md
@@ -1,0 +1,80 @@
+---
+description: "Instructions for managing Cargo.toml dependencies and resolving version conflicts"
+applyTo: "**/Cargo.toml"
+---
+
+# Cargo Dependency Management Instructions
+
+## Version Specification Best Practices
+
+- Use caret requirements (`"1.2.3"` or `"^1.2.3"`) for most dependencies
+- Use exact versions (`"=1.2.3"`) only when absolutely necessary
+- For workspace dependencies, define versions in root `Cargo.toml` under `[workspace.dependencies]`
+- Keep related crates at compatible versions (e.g., all `opentelemetry-*` crates at same minor version)
+
+## Dependency Organization
+
+1. **Group dependencies logically** with blank lines between groups:
+   - Core/standard functionality
+   - Serialization (serde, etc.)
+   - Async runtime (tokio, etc.)
+   - Logging/tracing
+   - Optional/feature-gated dependencies
+
+2. **Alphabetize within groups** for easier scanning
+
+3. **Use inline tables for simple features**:
+
+   ```toml
+   serde = { version = "1.0", features = ["derive"] }
+   ```
+
+4. **Use multi-line for complex configurations**:
+   ```toml
+   reqwest = { version = "0.13", default-features = false, features = [
+       "blocking",
+       "json",
+       "rustls-no-provider",
+   ] }
+   ```
+
+## Resolving Version Conflicts
+
+When Renovate/Dependabot updates cause version conflicts:
+
+1. **Identify the conflict chain**: Which package requires which version of what
+2. **Check for updates to intermediate packages**: Often the dependent package has a new version
+3. **Update related packages together**: Don't leave partial updates
+4. **Verify with**: `cargo update && cargo build --all-features`
+
+## Feature Flags
+
+- List features alphabetically within the array
+- Remove features that no longer exist in new versions
+- Check if features were renamed or merged in changelogs
+- Use `default-features = false` when you need fine-grained control
+
+## Workspace Dependencies
+
+For monorepos, prefer workspace dependencies:
+
+```toml
+# Root Cargo.toml
+[workspace.dependencies]
+serde = { version = "1.0", features = ["derive"] }
+
+# Crate Cargo.toml
+[dependencies]
+serde = { workspace = true }
+```
+
+## After Modifying Cargo.toml
+
+Always run:
+
+```bash
+cargo update           # Update Cargo.lock
+cargo build --all-features  # Verify compilation
+cargo test             # Verify tests pass
+cargo clippy           # Check for issues
+```

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -32,7 +32,7 @@ jobs:
             target/
           key: ${{ runner.os }}-cargo-${{ steps.rust-toolchain.outputs.cachekey }}-${{ hashFiles('**/Cargo.lock') }}
 
-      - name: Cache thirdparty libraries
+      - name: Cache thirdparty libraries (Kobo cross-compile)
         uses: actions/cache@v5
         with:
           path: |
@@ -40,6 +40,14 @@ jobs:
             thirdparty/
             mupdf_wrapper/
           key: ${{ runner.os }}-thirdparty-libs-kobo-${{ hashFiles('thirdparty/download.sh', 'thirdparty/**/build-kobo.sh', 'thirdparty/**/*.patch') }}
+
+      - name: Cache thirdparty libraries (native testing)
+        uses: actions/cache@v5
+        with:
+          path: |
+            thirdparty/mupdf
+            mupdf_wrapper/
+          key: ${{ runner.os }}-thirdparty-libs-native-${{ hashFiles('thirdparty/download.sh') }}
 
       - name: Cache Linaro toolchain
         id: cache-linaro
@@ -84,6 +92,46 @@ jobs:
           done
           cd ..
 
+      - name: Setup native dependencies for testing
+        env:
+          TEST_ROOT_DIR: ${{ github.workspace }}
+        run: |
+          # Build mupdf wrapper for Linux (required for cargo test)
+          cd mupdf_wrapper
+          ./build.sh
+          cd ..
+
+          # Build MuPDF for native development using system libraries
+          cd thirdparty/mupdf
+          [ -e .gitattributes ] && rm -rf .git*
+
+          # Clean any previous builds
+          make clean || true
+
+          # Generate sources
+          make verbose=yes generate
+
+          # Build MuPDF libraries using system libraries
+          make verbose=yes \
+            mujs=no tesseract=no extract=no archive=no brotli=no barcode=no commercial=no \
+            USE_SYSTEM_LIBS=yes \
+            XCFLAGS="-DFZ_ENABLE_ICC=0 -DFZ_ENABLE_SPOT_RENDERING=0 -DFZ_ENABLE_ODT_OUTPUT=0 -DFZ_ENABLE_OCR_OUTPUT=0" \
+            libs
+
+          cd ../..
+
+          # Create target directory structure
+          mkdir -p target/mupdf_wrapper/Linux
+
+          # Copy libmupdf.a
+          ln -sf "$(pwd)/thirdparty/mupdf/build/release/libmupdf.a" target/mupdf_wrapper/Linux/
+
+          # Create empty libmupdf-third.a (system libs used instead)
+          if [ ! -e thirdparty/mupdf/build/release/libmupdf-third.a ]; then
+            ar cr thirdparty/mupdf/build/release/libmupdf-third.a
+          fi
+          ln -sf "$(pwd)/thirdparty/mupdf/build/release/libmupdf-third.a" target/mupdf_wrapper/Linux/
+
       - name: Verify installation
         run: |
           rustc --version || true
@@ -91,3 +139,5 @@ jobs:
           cargo fmt --version || true
           cargo clippy --version || true
           arm-linux-gnueabihf-gcc --version || true
+          # Verify native test setup
+          ls -la target/mupdf_wrapper/Linux/ || true


### PR DESCRIPTION
Create specialized GitHub Copilot agent for resolving Renovate and Dependabot dependency update failures. Agent handles version constraints, API changes, and ensures full compliance with build/test/format requirements.

- Add dependency-updater.agent.md with 6-phase workflow
- Add cargo-dependencies.instructions.md for Cargo.toml files
- Update copilot-setup-steps.yml with native test dependencies
- Enable agents to run cargo test locally with MuPDF support

Change-Id: f813d92c8c110d089a5f68ce76a9d6cc
Change-Id-Short: krywmqxnrnyy