### PR TITLE
dev: add macOS support for devenv.nix

### DIFF
--- a/.github/instructions/devenv-docs.instructions.md
+++ b/.github/instructions/devenv-docs.instructions.md
@@ -1,0 +1,55 @@
+---
+description: "Development environment documentation sync policy"
+applyTo: "devenv.nix"
+---
+
+# Development environment documentation
+
+The devenv setup guide lives at `docs/src/contributing/devenv-setup.md`.
+
+When modifying `devenv.nix`, ensure the documentation stays in sync.
+
+## Key sections to update
+
+### Available Commands
+
+Update the commands table if you add, remove, or rename scripts in `scripts = { ... }`:
+
+- `cadmus-setup-native` - Native development setup
+- `cadmus-build-kobo` - Kobo cross-compilation (Linux only)
+- `cadmus-dev-otel` - OTEL-instrumented emulator
+
+### Platform Support
+
+Update platform-specific notes if you modify:
+
+- `packages` with `pkgs.lib.optionals isLinux/isDarwin` conditionals
+- `env` with `pkgs.lib.optionalAttrs isLinux` conditionals
+- `enterShell` with `pkgs.lib.optionalString isLinux/isDarwin` conditionals
+- `git-hooks.hooks` enable flags
+- `languages.c.debugger` or other platform-conditional settings
+
+### Observability Stack
+
+Update the services table if you modify ports or add/remove services:
+
+- `services.opentelemetry-collector`
+- `services.prometheus`
+- `processes.tempo`
+- `processes.loki`
+- `processes.grafana`
+
+### Troubleshooting
+
+Add troubleshooting entries for known issues, especially platform-specific ones.
+Reference nixpkgs issues with full URLs when documenting workarounds.
+
+## Sync checklist
+
+When reviewing changes to `devenv.nix`:
+
+- [ ] New scripts documented in "Available Commands" table
+- [ ] Platform limitations documented in "Platform Support" section
+- [ ] New services/ports documented in "Observability Stack" section
+- [ ] Breaking changes noted in "Troubleshooting" section
+- [ ] Environment variables mentioned if user-configurable

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1201,7 +1201,7 @@ dependencies = [
  "futures-sink",
  "js-sys",
  "pin-project-lite",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tracing",
 ]
 
@@ -1243,7 +1243,7 @@ dependencies = [
  "opentelemetry_sdk",
  "prost",
  "reqwest 0.12.28",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tracing",
 ]
 
@@ -1278,7 +1278,7 @@ dependencies = [
  "opentelemetry",
  "percent-encoding",
  "rand",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
 ]
@@ -1431,7 +1431,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.6.1",
+ "socket2",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -1496,7 +1496,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
  "rand_chacha",
- "rand_core",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -1506,7 +1506,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.9.5",
 ]
 
 [[package]]

--- a/crates/core/src/ota/client.rs
+++ b/crates/core/src/ota/client.rs
@@ -566,7 +566,7 @@ fn check_disk_space(path: &str) -> Result<(), OtaError> {
     use nix::sys::statvfs::statvfs;
 
     let stat = statvfs(path)?;
-    let available_mb = (stat.blocks_available() * stat.block_size()) / (1024 * 1024);
+    let available_mb = (stat.blocks_available() as u64 * stat.block_size() as u64) / (1024 * 1024);
     info!(
         "[OTA] Available disk space in {}: {} MB",
         path, available_mb

--- a/devenv.lock
+++ b/devenv.lock
@@ -3,10 +3,10 @@
     "devenv": {
       "locked": {
         "dir": "src/modules",
-        "lastModified": 1769790358,
+        "lastModified": 1770214004,
         "owner": "cachix",
         "repo": "devenv",
-        "rev": "4bd7bbda7c267865d2d0cc31764e7c104e3a2218",
+        "rev": "b91e1b24ff6f7bddcdbb00e5834ed457a4126bf2",
         "type": "github"
       },
       "original": {
@@ -40,10 +40,10 @@
         ]
       },
       "locked": {
-        "lastModified": 1769069492,
+        "lastModified": 1769939035,
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "a1ef738813b15cf8ec759bdff5761b027e3e1d23",
+        "rev": "a8ca480175326551d6c4121498316261cbb5b260",
         "type": "github"
       },
       "original": {
@@ -74,10 +74,10 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1769740369,
+        "lastModified": 1770169770,
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "6308c3b21396534d8aaeac46179c14c439a89b8a",
+        "rev": "aa290c9891fa4ebe88f8889e59633d20cc06a5f2",
         "type": "github"
       },
       "original": {
@@ -105,10 +105,10 @@
         ]
       },
       "locked": {
-        "lastModified": 1769742225,
+        "lastModified": 1770260791,
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "bcdd8d37594f0e201639f55889c01c827baf5c75",
+        "rev": "42ec85352e419e601775c57256a52f6d48a39906",
         "type": "github"
       },
       "original": {

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -10,4 +10,5 @@
 
 # Contributor Guide
 
+- [Development Environment](contributing/devenv-setup.md)
 - [OpenTelemetry Integration](contributing/telemetry.md)

--- a/docs/src/contributing/devenv-setup.md
+++ b/docs/src/contributing/devenv-setup.md
@@ -1,0 +1,140 @@
+# Development Environment Setup
+
+Cadmus uses [devenv](https://devenv.sh/) with Nix to provide a reproducible development environment.
+This guide covers setup on both Linux and macOS.
+
+## Prerequisites
+
+1. Install Nix with flakes enabled. The easiest way is using the [Determinate Nix Installer](https://github.com/DeterminateSystems/nix-installer).
+2. Install [devenv](https://devenv.sh/getting-started).
+
+## Quick Start
+
+1. Clone the repository and enter the devenv shell:
+
+   ```bash
+   git clone https://github.com/OGKevin/cadmus.git
+   cd cadmus
+   devenv shell
+   ```
+
+2. Run the one-time setup to build native dependencies:
+
+   ```bash
+   cadmus-setup-native
+   ```
+
+3. Run the emulator:
+
+   ```bash
+   ./run-emulator.sh
+   ```
+
+## Available Commands
+
+Once inside the devenv shell, these commands are available:
+
+| Command               | Description                                      |
+| --------------------- | ------------------------------------------------ |
+| `cadmus-setup-native` | Build MuPDF for native development (run once)    |
+| `cargo test`          | Run the test suite                               |
+| `./run-emulator.sh`   | Run the emulator                                 |
+| `cadmus-build-kobo`   | Build for Kobo device (Linux only)               |
+| `cadmus-dev-otel`     | Run emulator with OpenTelemetry instrumentation  |
+| `devenv up`           | Start observability stack (Grafana, Tempo, Loki) |
+
+## Running Tests
+
+Tests require the `TEST_ROOT_DIR` environment variable to be set:
+
+```bash
+TEST_ROOT_DIR=$(pwd) cargo test
+```
+
+This is automatically configured in CI but must be set manually for local testing.
+
+## Platform Support
+
+### Linux (Full Support)
+
+Linux provides full development capabilities including:
+
+- Native development (emulator, tests)
+- Cross-compilation for Kobo devices using the Linaro ARM toolchain
+- Git hooks (actionlint, shellcheck, shfmt, markdownlint, prettier)
+
+The Linaro toolchain is automatically added to `PATH` and provides `arm-linux-gnueabihf-*` commands.
+
+### macOS (Native Development Only)
+
+macOS supports native development but has some limitations:
+
+| Feature           | Status        | Notes                          |
+| ----------------- | ------------- | ------------------------------ |
+| Native builds     | Supported     | Emulator and tests work        |
+| Cross-compilation | Not supported | Linaro toolchain is Linux-only |
+
+#### macOS-Specific Notes
+
+**Cross-compilation for Kobo**: The Linaro ARM cross-compilation toolchain consists of x86_64 Linux
+ELF binaries that cannot run on macOS. To build for Kobo devices on macOS, use Docker with a Linux
+container or a Linux VM.
+
+**MuPDF build**: On macOS, the native setup script manually gathers pkg-config CFLAGS for system
+libraries because MuPDF's build system doesn't properly detect them on Darwin.
+
+## Observability Stack
+
+The devenv includes a full observability stack for development:
+
+```bash
+# Start all services
+devenv up
+
+# In another terminal, run the instrumented emulator
+cadmus-dev-otel
+```
+
+Services available after `devenv up`:
+
+| Service        | URL                     | Purpose                    |
+| -------------- | ----------------------- | -------------------------- |
+| Grafana        | <http://localhost:3000> | Dashboards and exploration |
+| Tempo          | <http://localhost:3200> | Distributed tracing        |
+| Loki           | <http://localhost:3100> | Log aggregation            |
+| Prometheus     | <http://localhost:9090> | Metrics                    |
+| OTLP Collector | <http://localhost:4318> | Telemetry ingestion        |
+
+For more details on telemetry, see [OpenTelemetry Integration](telemetry.md).
+
+## Troubleshooting
+
+### Shell takes a long time to start
+
+The first `devenv shell` invocation downloads and builds dependencies, which can take several
+minutes. Subsequent invocations are cached and should be fast.
+
+### Tests fail with "TEST_ROOT_DIR must be set"
+
+Set the environment variable before running tests:
+
+```bash
+TEST_ROOT_DIR=$(pwd) cargo test
+```
+
+## Local Configuration
+
+Create `devenv.local.nix` to override settings without modifying the tracked configuration:
+
+```nix
+{ pkgs, ... }:
+
+{
+  env = {
+    # Example: Set TEST_ROOT_DIR automatically
+    TEST_ROOT_DIR = builtins.getEnv "PWD";
+  };
+}
+```
+
+This file is gitignored and won't affect other contributors.


### PR DESCRIPTION
Add platform detection and conditional configuration to support native development on macOS (aarch64-darwin) while preserving full Linux functionality.

- Add platform detection using builtins.currentSystem for overlays
- Make packages conditional: patchelf, gcc, Linaro toolchain Linux-only
- Add macOS-specific pkg-config CFLAGS gathering for MuPDF build
- Make target directory platform-aware (Darwin vs Linux)
- Disable git hooks on macOS due to GDB dependency chain
- Fix statvfs type cast in ota/client.rs for cross-platform support
- Add contributor documentation for devenv setup with macOS notes

Change-Id: 58f73e6a06b6adb514c415fc28a70edc
Change-Id-Short: urkswltpztot

<img width="712" height="940" alt="image" src="https://github.com/user-attachments/assets/e3748fa3-52c6-4bcb-a3e0-38d12e30eb6c" />
