### PR TITLE
refactor: use builder pattern for Dialog

### DIFF
--- a/.github/instructions/rust-docs.instructions.md
+++ b/.github/instructions/rust-docs.instructions.md
@@ -1,0 +1,126 @@
+---
+description: "Guidelines for writing compilable rustdoc examples in Rust code"
+applyTo: "**/*.rs"
+---
+
+# Rustdoc Examples Guidelines
+
+Writing high-quality documentation examples is critical for API usability and maintainability. All rustdoc examples should be compilable and demonstrate actual usage patterns.
+
+## Core Principles
+
+- **Examples must be compilable** unless there is a clear reason they cannot be (document the reason in a comment).
+- Use the `no_run` attribute only when the example cannot actually execute at compile-time (e.g., requires runtime setup like a filesystem, network, or database).
+- Always verify examples compile by running `cargo test --doc`.
+- Examples should demonstrate actual usage patterns, not pseudocode.
+- For complex setup requirements (like loading fonts or initializing context), show the minimal setup needed or explain why it cannot be included.
+
+## Example Patterns
+
+### ❌ Avoid: Using `ignore` attribute
+
+````rust
+/// ```ignore  // Don't just ignore compilation
+/// let x = some_function();
+/// ```
+````
+
+This hides compilation issues and makes examples unreliable.
+
+### ✅ Good: Using `compile_fail` for intentional errors
+
+````rust
+/// ```compile_fail
+/// let x: i32 = "not an integer";  // This should not compile
+/// ```
+````
+
+Use this when you want to show code that intentionally fails to compile (e.g., demonstrating type safety).
+
+### ✅ Good: Using `no_run` for I/O operations
+
+````rust
+/// ```no_run
+/// use std::fs;
+/// let contents = fs::read_to_string("file.txt")?;
+/// ```
+````
+
+Use this for examples that compile but cannot run in `cargo test --doc` (file I/O, network calls, database queries, complex initialization).
+
+### ✅ Best: Fully compilable and runnable examples
+
+````rust
+/// ```
+/// let x = 2 + 2;
+/// assert_eq!(x, 4);
+/// ```
+````
+
+This is the ideal: examples that both compile and run. Use this whenever possible.
+
+## Special Cases
+
+### Complex Initialization (Unsafe Context)
+
+When your example requires complex initialization (like a Context struct), document why it cannot be included:
+
+````rust
+/// ```no_run
+/// use cadmus_core::view::dialog::Dialog;
+/// use cadmus_core::view::{Event, ViewId};
+///
+/// // Note: In actual use, `context` is provided by the application.
+/// // Dialog::builder requires a properly initialized Context with
+/// // Display and Fonts, so we show the API pattern here.
+/// # let mut context = unsafe { std::mem::zeroed() };
+/// let dialog = Dialog::builder(ViewId::AboutDialog, "Are you sure?".to_string())
+///     .add_button("Cancel", Event::Close(ViewId::AboutDialog))
+///     .add_button("Confirm", Event::Validate)
+///     .build(&mut context);
+/// ```
+````
+
+### Multi-line Example Setup
+
+Use line comments (`#` prefix) to hide boilerplate setup that distracts from the main concept:
+
+````rust
+/// ```
+/// # fn my_function(x: i32) -> i32 { x * 2 }
+/// let result = my_function(5);
+/// assert_eq!(result, 10);
+/// ```
+````
+
+Lines starting with `#` are compiled but hidden from documentation output.
+
+## Verification Workflow
+
+Before committing rustdoc examples:
+
+1. **Write the example** with appropriate attributes
+2. **Test it compiles**: `cargo test --doc`
+3. **Verify in documentation**: `cargo doc --open`
+4. **Review the output** to ensure examples are clear and properly formatted
+
+## Common Issues and Solutions
+
+| Issue                         | Solution                                |
+| ----------------------------- | --------------------------------------- |
+| Example doesn't compile       | Check imports and type signatures       |
+| Boilerplate distracts         | Use `#` to hide setup code              |
+| Can't run in test environment | Use `no_run` attribute and document why |
+| Example is pseudocode         | Rewrite to be actual, working code      |
+| Example confuses API usage    | Simplify or add explanatory comments    |
+
+## Quality Checklist
+
+Before committing code with rustdoc examples:
+
+- [ ] All examples compile (`cargo test --doc`)
+- [ ] Examples demonstrate actual usage patterns
+- [ ] Unnecessary boilerplate is hidden with `#`
+- [ ] `no_run` is justified with a comment
+- [ ] Examples appear correctly in generated documentation
+- [ ] Complex examples are broken into smaller, digestible pieces

--- a/crates/cadmus/src/app.rs
+++ b/crates/cadmus/src/app.rs
@@ -614,12 +614,13 @@ pub fn run() -> Result<(), Error> {
                             if context.settings.auto_share {
                                 tx.send(Event::PrepareShare).ok();
                             } else {
-                                let dialog = Dialog::new(
+                                let dialog = Dialog::builder(
                                     ViewId::ShareDialog,
-                                    Some(Event::PrepareShare),
                                     "Share storage via USB?".to_string(),
-                                    &mut context,
-                                );
+                                )
+                                .add_button("Cancel", Event::Close(ViewId::ShareDialog))
+                                .add_button("Share", Event::PrepareShare)
+                                .build(&mut context);
                                 rq.add(RenderData::new(
                                     dialog.id(),
                                     *dialog.rect(),
@@ -1034,7 +1035,9 @@ pub fn run() -> Result<(), Error> {
                     None => format!("Cadmus {}", env!("GIT_VERSION")),
                 };
 
-                let dialog = Dialog::new(ViewId::AboutDialog, None, version_text, &mut context);
+                let dialog = Dialog::builder(ViewId::AboutDialog, version_text)
+                    .add_button("OK", Event::Close(ViewId::AboutDialog))
+                    .build(&mut context);
                 rq.add(RenderData::new(
                     dialog.id(),
                     *dialog.rect(),

--- a/crates/core/src/view/dialog.rs
+++ b/crates/core/src/view/dialog.rs
@@ -1,7 +1,56 @@
+//! A modal dialog view that displays a message and custom buttons.
+//!
+//! The dialog component provides a flexible way to display modal dialogs with a title
+//! message and multiple custom buttons. Dialogs are centered on the display and render
+//! with a bordered white background.
+//!
+//! # Building a Dialog
+//!
+//! Use the [`Dialog::builder`] method to create a dialog with a fluent API:
+//!
+//! ```no_run
+//! use cadmus_core::view::dialog::Dialog;
+//! use cadmus_core::view::{Event, ViewId};
+//!
+//! # let mut context = unsafe { std::mem::zeroed() };
+//! let dialog = Dialog::builder(ViewId::BookMenu, "Confirm deletion?".to_string())
+//!     .add_button("Cancel", Event::Close(ViewId::BookMenu))
+//!     .add_button("Delete", Event::Close(ViewId::BookMenu))
+//!     .build(&mut context);
+//! ```
+//!
+//! # Behavior
+//!
+//! - **Multi-line messages**: The title supports multi-line text via newline characters
+//! - **Dynamic layout**: Buttons are evenly distributed horizontally regardless of count
+//! - **Button events**: When a button is tapped, it sends the event configured for that button.
+//!   To close the dialog, you can either make the button event an [`Event::Close`] or handle
+//!   the event in your view logic to remove the dialog from the view hierarchy.
+//! - **Outside tap**: Tapping outside the dialog area automatically sends an [`Event::Close`]
+//!
+//! # Example: Adding to a View
+//!
+//! ```no_run
+//! use cadmus_core::view::dialog::Dialog;
+//! use cadmus_core::view::{Event, ViewId, View};
+//!
+//! # let mut context = unsafe { std::mem::zeroed() };
+//! # let mut view_children: Vec<Box<dyn View>> = Vec::new();
+//! let dialog = Dialog::builder(ViewId::BookMenu, "Save changes?".to_string())
+//!     .add_button("Discard", Event::Close(ViewId::BookMenu))
+//!     .add_button("Save", Event::Close(ViewId::BookMenu))
+//!     .build(&mut context);
+//!
+//! // Add the dialog to your view hierarchy
+//! view_children.push(Box::new(dialog) as Box<dyn View>);
+//! ```
+//!
+//! [`Event`]: super::Event
+
 use super::button::Button;
 use super::label::Label;
 use super::{Align, Bus, Event, Hub, Id, RenderQueue, View, ViewId, ID_FEEDER};
-use super::{BORDER_RADIUS_MEDIUM, CLOSE_IGNITION_DELAY, THICKNESS_LARGE};
+use super::{BORDER_RADIUS_MEDIUM, THICKNESS_LARGE};
 use crate::color::{BLACK, WHITE};
 use crate::context::Context;
 use crate::device::CURRENT_DEVICE;
@@ -10,27 +59,75 @@ use crate::framebuffer::Framebuffer;
 use crate::geom::{BorderSpec, CornerSpec, Rectangle};
 use crate::gesture::GestureEvent;
 use crate::unit::scale_by_dpi;
-use std::thread;
 
-const LABEL_VALIDATE: &str = "OK";
-const LABEL_CANCEL: &str = "Cancel";
-
-pub struct Dialog {
-    id: Id,
-    rect: Rectangle,
-    children: Vec<Box<dyn View>>,
+/// Builder for constructing a [`Dialog`] with custom buttons and message.
+///
+/// Use [`Dialog::builder`] to create a new builder, then chain calls to
+/// [`add_button`](DialogBuilder::add_button) to define the buttons, and finally
+/// call [`build`](DialogBuilder::build) to create the dialog.
+///
+/// # Example
+///
+/// ```no_run
+/// use cadmus_core::view::dialog::Dialog;
+/// use cadmus_core::view::{Event, ViewId};
+///
+/// // Note: In actual use, `context` is provided by the application.
+/// // Dialog::builder requires a properly initialized Context with
+/// // Display and Fonts, so we show the API pattern here.
+/// # let mut context = unsafe { std::mem::zeroed() };
+/// let dialog = Dialog::builder(ViewId::AboutDialog, "Are you sure?".to_string())
+///     .add_button("Cancel", Event::Close(ViewId::AboutDialog))
+///     .add_button("Confirm", Event::Validate)
+///     .build(&mut context);
+/// ```
+pub struct DialogBuilder {
     view_id: ViewId,
-    event: Option<Event>,
-    will_close: bool,
+    title: String,
+    buttons: Vec<(String, Event)>,
 }
 
-impl Dialog {
-    pub fn new(
-        view_id: ViewId,
-        event: Option<Event>,
-        text: String,
-        context: &mut Context,
-    ) -> Dialog {
+impl DialogBuilder {
+    fn new(view_id: ViewId, title: String) -> Self {
+        DialogBuilder {
+            view_id,
+            title,
+            buttons: Vec::new(),
+        }
+    }
+
+    /// Add a button to the dialog.
+    ///
+    /// Buttons are displayed from left to right in the order they are added.
+    /// Each button sends a specific event when tapped.
+    ///
+    /// # Arguments
+    ///
+    /// * `text` - The label text displayed on the button
+    /// * `event` - The event sent when the button is tapped
+    ///
+    /// # Returns
+    ///
+    /// Returns `self` to allow method chaining.
+    pub fn add_button(mut self, text: &str, event: Event) -> Self {
+        self.buttons.push((text.to_string(), event));
+        self
+    }
+
+    /// Build the dialog with the configured title and buttons.
+    ///
+    /// Calculates the dialog layout, creates label and button views, and
+    /// centers the dialog on the display.
+    ///
+    /// # Arguments
+    ///
+    /// * `context` - The rendering context, used for font metrics and display dimensions
+    ///
+    /// # Returns
+    ///
+    /// A new [`Dialog`] instance ready to be displayed.
+    #[cfg_attr(feature = "otel", tracing::instrument(skip(self, context), fields(view_id = ?self.view_id, title = ?self.title)))]
+    pub fn build(self, context: &mut Context) -> Dialog {
         let id = ID_FEEDER.next();
         let mut children = Vec::new();
         let dpi = CURRENT_DEVICE.dpi;
@@ -42,10 +139,10 @@ impl Dialog {
 
         let min_message_width = width as i32 / 2;
         let max_message_width = width as i32 - 3 * padding;
-        let max_button_width = width as i32 / 4;
+        let max_button_width = width as i32 / 5;
         let button_height = 4 * x_height;
 
-        let text_lines: Vec<&str> = text.lines().collect();
+        let text_lines: Vec<&str> = self.title.lines().collect();
         let line_count = text_lines.len().max(1);
         let line_height = font.line_height();
 
@@ -76,75 +173,128 @@ impl Dialog {
             children.push(Box::new(label) as Box<dyn View>);
         }
 
-        let plan_cancel = event
-            .as_ref()
-            .map(|_| font.plan(LABEL_CANCEL, Some(max_button_width), None));
-        let plan_validate = font.plan(LABEL_VALIDATE, Some(max_button_width), None);
+        let button_count = self.buttons.len().max(1);
+        let mut max_button_text_width = 0;
+        for (text, _) in &self.buttons {
+            let plan = font.plan(text, Some(max_button_width), None);
+            max_button_text_width = max_button_text_width.max(plan.width);
+        }
+        let button_width = max_button_text_width + padding;
 
-        let button_width =
-            plan_validate.width.max(plan_cancel.map_or(0, |p| p.width)) as i32 + padding;
+        let button_area_width = rect.width() as i32 - 2 * padding;
+        let button_spacing =
+            (button_area_width - button_count as i32 * button_width) / (button_count as i32 + 1);
 
-        if event.is_some() {
-            let rect_cancel = rect![
-                rect.min.x + padding,
+        for (idx, (text, event)) in self.buttons.iter().enumerate() {
+            let x_offset = rect.min.x
+                + padding
+                + (idx as i32 + 1) * button_spacing
+                + idx as i32 * button_width;
+            let rect_button = rect![
+                x_offset,
                 rect.max.y - button_height - padding,
-                rect.min.x + button_width + 2 * padding,
+                x_offset + button_width,
                 rect.max.y - padding
             ];
-            let button_cancel = Button::new(rect_cancel, Event::Cancel, LABEL_CANCEL.to_string());
-            children.push(Box::new(button_cancel) as Box<dyn View>);
+            let button = Button::new(rect_button, event.clone(), text.clone());
+            children.push(Box::new(button) as Box<dyn View>);
         }
-
-        let rect_validate = rect![
-            rect.max.x - button_width - 2 * padding,
-            rect.max.y - button_height - padding,
-            rect.max.x - padding,
-            rect.max.y - padding
-        ];
-        let button_validate =
-            Button::new(rect_validate, Event::Validate, LABEL_VALIDATE.to_string());
-        children.push(Box::new(button_validate) as Box<dyn View>);
 
         Dialog {
             id,
             rect,
             children,
-            view_id,
-            event,
-            will_close: false,
+            view_id: self.view_id,
+            button_count,
         }
     }
 }
 
+/// A modal dialog view that displays a message and allows users to select from custom buttons.
+///
+/// The dialog is centered on the display and renders a bordered rectangle containing:
+/// - A title message (can be multi-line)
+/// - Buttons evenly distributed horizontally
+///
+/// # Closing a Dialog
+///
+/// The dialog sends an [`Event::Close`] when the user taps outside the dialog area.
+/// To close the dialog from a button tap, configure the button with a [`Event::Close`] event.
+/// Other button events are propagated without closing the dialog. Which means you must handle the
+/// closing of the dialog.
+///
+/// # Lifecycle
+///
+/// Create a dialog using the builder pattern via [`Dialog::builder`], which handles
+/// automatic layout calculation based on the display dimensions and text content.
+///
+/// # Example
+///
+/// ```no_run
+/// use cadmus_core::view::dialog::Dialog;
+/// use cadmus_core::view::{Event, ViewId, View};
+///
+/// # let mut context = unsafe { std::mem::zeroed() };
+/// let mut view_children: Vec<Box<dyn View>> = Vec::new();
+///
+/// // Note: In actual use, `context` is provided by the application.
+/// // Dialog::builder requires a properly initialized Context with
+/// // Display and Fonts, so we show the API pattern here.
+/// let dialog = Dialog::builder(ViewId::BookMenu, "Delete this file?".to_string())
+///     .add_button("No", Event::Close(ViewId::BookMenu))
+///     .add_button("Yes", Event::Close(ViewId::BookMenu))
+///     .build(&mut context);
+///
+/// view_children.push(Box::new(dialog) as Box<dyn View>);
+/// ```
+pub struct Dialog {
+    id: Id,
+    rect: Rectangle,
+    children: Vec<Box<dyn View>>,
+    view_id: ViewId,
+    button_count: usize,
+}
+
+impl Dialog {
+    /// Create a builder for a new dialog.
+    ///
+    /// # Arguments
+    ///
+    /// * `view_id` - Unique identifier for the dialog
+    /// * `title` - The message text to display (supports multi-line text)
+    ///
+    /// # Returns
+    ///
+    /// A [`DialogBuilder`] that can be configured with buttons via [`add_button`](DialogBuilder::add_button).
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use cadmus_core::view::dialog::Dialog;
+    /// use cadmus_core::view::{Event, ViewId};
+    ///
+    /// # let mut context = unsafe { std::mem::zeroed() };
+    /// let _dialog = Dialog::builder(ViewId::BookMenu, "Are you sure?".to_string())
+    ///     .add_button("Cancel", Event::Close(ViewId::BookMenu))
+    ///     .add_button("OK", Event::Validate)
+    ///     .build(&mut context);
+    /// ```
+    pub fn builder(view_id: ViewId, title: String) -> DialogBuilder {
+        DialogBuilder::new(view_id, title)
+    }
+}
+
 impl View for Dialog {
-    #[cfg_attr(feature = "otel", tracing::instrument(skip(self, hub, bus, _rq, _context), fields(event = ?evt), ret(level=tracing::Level::TRACE)))]
+    #[cfg_attr(feature = "otel", tracing::instrument(skip(self, hub, _bus, _rq, _context), fields(event = ?evt), ret(level=tracing::Level::TRACE)))]
     fn handle_event(
         &mut self,
         evt: &Event,
         hub: &Hub,
-        bus: &mut Bus,
+        _bus: &mut Bus,
         _rq: &mut RenderQueue,
         _context: &mut Context,
     ) -> bool {
         match *evt {
-            Event::Validate | Event::Cancel => {
-                if self.will_close {
-                    return true;
-                }
-                let hub2 = hub.clone();
-                let view_id = self.view_id;
-                thread::spawn(move || {
-                    thread::sleep(CLOSE_IGNITION_DELAY);
-                    hub2.send(Event::Close(view_id)).ok();
-                });
-                if let Event::Validate = *evt {
-                    if let Some(event) = self.event.as_ref() {
-                        bus.push_back(event.clone());
-                    }
-                }
-                self.will_close = true;
-                true
-            }
             Event::Gesture(GestureEvent::Tap(center)) if !self.rect.includes(center) => {
                 hub.send(Event::Close(self.view_id)).ok();
                 true
@@ -177,20 +327,12 @@ impl View for Dialog {
         let (width, height) = context.display.dims;
         let dialog_width = self.rect.width() as i32;
         let dialog_height = self.rect.height() as i32;
-        let max_button_width = width as i32 / 4;
 
-        let (x_height, padding, button_width) = {
+        let (x_height, padding) = {
             let font = font_from_style(&mut context.fonts, &NORMAL_STYLE, dpi);
-            let plan_cancel = self
-                .event
-                .as_ref()
-                .map(|_| font.plan(LABEL_CANCEL, Some(max_button_width), None));
-            let plan_validate = font.plan(LABEL_VALIDATE, Some(max_button_width), None);
             let x_height = font.x_heights.0 as i32;
             let padding = font.em() as i32;
-            let button_width =
-                plan_validate.width.max(plan_cancel.map_or(0, |p| p.width)) as i32 + padding;
-            (x_height, padding, button_width)
+            (x_height, padding)
         };
         let button_height = 4 * x_height;
 
@@ -201,11 +343,7 @@ impl View for Dialog {
         let font = font_from_style(&mut context.fonts, &NORMAL_STYLE, dpi);
         let line_height = font.line_height();
 
-        let label_count = if self.event.is_some() {
-            self.children.len() - 2
-        } else {
-            self.children.len() - 1
-        };
+        let label_count = self.children.len() - self.button_count;
 
         for i in 0..label_count {
             let y_offset = rect.min.y + padding + (i as i32 * line_height);
@@ -218,25 +356,21 @@ impl View for Dialog {
             self.children[i].resize(label_rect, hub, rq, context);
         }
 
-        let mut index = label_count;
-        if self.event.is_some() {
-            let cancel_rect = rect![
-                rect.min.x + padding,
+        let button_area_width = rect.width() as i32 - 2 * padding;
+        let button_width = (button_area_width - (self.button_count as i32 + 1) * padding)
+            / self.button_count as i32;
+
+        for (idx, i) in (label_count..self.children.len()).enumerate() {
+            let x_offset = rect.min.x + padding + (idx as i32) * (button_width + padding);
+            let button_rect = rect![
+                x_offset,
                 rect.max.y - button_height - padding,
-                rect.min.x + button_width + 2 * padding,
+                x_offset + button_width,
                 rect.max.y - padding
             ];
-            self.children[index].resize(cancel_rect, hub, rq, context);
-            index += 1;
+            self.children[i].resize(button_rect, hub, rq, context);
         }
 
-        let validate_rect = rect![
-            rect.max.x - button_width - 2 * padding,
-            rect.max.y - button_height - padding,
-            rect.max.x - padding,
-            rect.max.y - padding
-        ];
-        self.children[index].resize(validate_rect, hub, rq, context);
         self.rect = rect;
     }
 

--- a/crates/emulator/src/main.rs
+++ b/crates/emulator/src/main.rs
@@ -674,12 +674,12 @@ fn main() -> Result<(), Error> {
                     }
                 }
                 Event::Select(EntryId::About) => {
-                    let dialog = Dialog::new(
+                    let dialog = Dialog::builder(
                         ViewId::AboutDialog,
-                        None,
                         format!("Cadmus {}", env!("GIT_VERSION")),
-                        &mut context,
-                    );
+                    )
+                    .add_button("OK", Event::Close(ViewId::AboutDialog))
+                    .build(&mut context);
                     rq.add(RenderData::new(
                         dialog.id(),
                         *dialog.rect(),


### PR DESCRIPTION
Dialog is refactored from a rigid two-button component (always "OK", optionally "Cancel") to a flexible builder pattern supporting any number of custom buttons.

Before: ` Dialog::new` took an Option<Event> — if Some, you got OK + Cancel; if None, just OK. The dialog internally handled closing itself by spawning a thread with a delay.

```rust
// Two buttons: OK + Cancel
Dialog::new(id, Some(event), text, ctx)
// One button: OK only
Dialog::new(id, None, text, ctx)
```

After: `Dialog::builder` returns a `DialogBuilder` where each button's label and event are defined explicitly. Closing is the caller's responsibility — configure a button with Event::Close(...) if you want it to dismiss the dialog.

```rust
Dialog::builder(id, text) 
  .add_button("Cancel", Event::Close(id)) 
  .add_button("OK", Event::Validate)
  .build(ctx)
```

The key behavioral change: the dialog no longer spawns a background thread to self-close after a delay. Buttons directly emit their configured events, and the bus parameter in handle_event is now unused.

---

Relates-To: #40, #120, #114 