### PR TITLE
reafactor: use dialog box for OTA

### DIFF
--- a/crates/cadmus/src/app.rs
+++ b/crates/cadmus/src/app.rs
@@ -1271,9 +1271,7 @@ pub fn run() -> Result<(), Error> {
             }
             #[cfg(feature = "test")]
             Event::Select(EntryId::CheckForUpdates) => {
-                if show_ota_view(view.as_mut(), &tx, &mut rq, &mut context) {
-                    tx.send(Event::Focus(Some(ViewId::OtaPrInput))).ok();
-                }
+                show_ota_view(view.as_mut(), &tx, &mut rq, &mut context);
             }
             Event::Select(EntryId::ToggleWifi) => {
                 set_wifi(!context.settings.wifi, &mut context);

--- a/crates/core/src/view/input_field.rs
+++ b/crates/core/src/view/input_field.rs
@@ -247,8 +247,21 @@ impl View for InputField {
                 true
             }
             Event::Focus(id_opt) => {
+                #[cfg(feature = "otel")]
+                tracing::trace!(
+                    "InputField {:?} received focus event with id {:?}",
+                    self.view_id,
+                    id_opt,
+                );
+
                 let focused = id_opt.is_some() && id_opt.unwrap() == self.view_id;
                 if self.focused != focused {
+                    #[cfg(feature = "otel")]
+                    tracing::trace!(
+                        "InputField {:?} focus state changed to {:?}",
+                        self.view_id,
+                        focused,
+                    );
                     self.focused = focused;
                     rq.add(RenderData::new(self.id, self.rect, UpdateMode::Gui));
                 }


### PR DESCRIPTION
The OTA view previously jumped straight to a PR number input screen. This PR adds an intermediate source selection dialog ("Where to check for updates?") and fixes a focus isolation bug where parent views like Home/Reader would spawn their own keyboard when OtaView focused its input field.

The two key changes:

1. Two-screen flow - `OtaView::new` now shows a dialog first. Selecting "PR Build" transitions to the input screen via Event::Show. A new `OtaViewId` enum replaces the flat `ViewId::OtaView` / `ViewId::OtaPrInput` variants.
2. Focus isolation - `OtaView` now sends `Event::Focus` internally after building the PR input screen, and consumes it (returns true) so it never reaches parent views. Previously, the app's main loop sent the focus event, which would bubble up and cause parents to spawn a duplicate keyboard.

---

Relates-To: #40, #120, #114 