### PR TITLE
dev: add emulator feature flag

### DIFF
--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -73,6 +73,7 @@ tempfile = "3.14"
 
 [features]
 default = []
+emulator = []
 test = []
 otel = [
     "tracing-opentelemetry",

--- a/crates/core/src/ota/client.rs
+++ b/crates/core/src/ota/client.rs
@@ -9,7 +9,7 @@ use std::time::Duration;
 use tracing::info;
 use zip::ZipArchive;
 
-#[cfg(not(test))]
+#[cfg(all(not(test), not(feature = "emulator")))]
 use crate::settings::INTERNAL_CARD_ROOT;
 
 /// Size of each download chunk in bytes (10 MB)
@@ -433,9 +433,6 @@ impl OtaClient {
             kobo_root_name
         );
 
-        #[cfg(not(test))]
-        let deploy_path = PathBuf::from(format!("{}/.kobo/KoboRoot.tgz", INTERNAL_CARD_ROOT));
-
         #[cfg(test)]
         let deploy_path = {
             std::env::temp_dir()
@@ -443,7 +440,13 @@ impl OtaClient {
                 .join("KoboRoot.tgz")
         };
 
-        #[cfg(test)]
+        #[cfg(all(feature = "emulator", not(test)))]
+        let deploy_path = PathBuf::from("/tmp/.kobo/KoboRoot.tgz");
+
+        #[cfg(all(not(feature = "emulator"), not(test)))]
+        let deploy_path = PathBuf::from(format!("{}/.kobo/KoboRoot.tgz", INTERNAL_CARD_ROOT));
+
+        #[cfg(any(test, feature = "emulator"))]
         {
             if let Some(parent) = deploy_path.parent() {
                 std::fs::create_dir_all(parent)?;

--- a/crates/emulator/Cargo.toml
+++ b/crates/emulator/Cargo.toml
@@ -15,5 +15,6 @@ tracing = "0.1"
 
 [features]
 default = []
+emulator = ["cadmus-core/emulator"]
 otel = ["cadmus-core/otel"]
 test = ["cadmus-core/test"]

--- a/devenv.nix
+++ b/devenv.nix
@@ -588,7 +588,7 @@ in
       export OTEL_EXPORTER_OTLP_ENDPOINT="http://localhost:4318"
       export RUST_LOG="trace"
 
-      ./run-emulator.sh --features otel "$@"
+      ./run-emulator.sh --features otel,test,emulator "$@"
     '';
   };
 


### PR DESCRIPTION
This PR introduces an `emulator` feature flag to distinguish between two build targets: real Kobo device and emulator. 

The main behavioral change is in the OTA client's `extract_and_deploy` method, which writes firmware updates to different paths depending on the target:

```text
emulator → /tmp/.kobo/KoboRoot.tgz
device builds → /mnt/onboard/.kobo/KoboRoot.tgz
```