### PR TITLE
ci: add path filters to cargo workflow

### DIFF
--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -4,6 +4,11 @@ on:
   push:
     branches: [main, master]
   pull_request:
+    paths:
+      - "**/*.rs"
+      - "Cargo.*"
+      - "**/Cargo.*"
+      - ".github/workflows/cargo.yml"
 
 jobs:
   format:


### PR DESCRIPTION
Add path filters to the cargo CI workflow to prevent unnecessary builds on non-Rust changes.

- Filter pull requests on Rust source files (*.rs)
- Filter on Cargo manifest files (Cargo.toml, Cargo.lock)
- Filter on workflow file itself for self-updates

Change-Id: 78412004330852941190b26e35f7d099
Change-Id-Short: srvyxzzvwwzr