### PR TITLE
feat: Embed documentation in binary

### DIFF
--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -1,5 +1,9 @@
 name: Cargo
 
+env:
+  MDBOOK_VERSION: "0.5.2"
+  MDBOOK_EPUB_REV: "21a1c8134134201a2d555313447c96e56e2a8996"
+
 on:
   push:
     branches: [main, master]
@@ -95,6 +99,74 @@ jobs:
           tool: cargo-diff-tools
       - name: Fetch base ref
         run: git fetch origin ${{ github.base_ref }}
+
+      - &cache-mdbook
+        name: Cache mdBook tools
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cache/mdbook
+            ~/.cache/mdbook-epub
+          key: ${{ runner.os }}-mdbook-${{ env.MDBOOK_VERSION }}-epub-${{ env.MDBOOK_EPUB_REV }}
+
+      - &install-mdbook
+        name: Install mdBook tools
+        run: |
+          set -e
+
+          mkdir -p ~/.cache/mdbook ~/.cache/mdbook-epub ~/.local/bin
+
+          if [ ! -x ~/.cache/mdbook/mdbook ]; then
+            if [ "$(uname)" = "Darwin" ]; then
+              MDBOOK_ARCH="aarch64-apple-darwin"
+            else
+              MDBOOK_ARCH="x86_64-unknown-linux-gnu"
+            fi
+            curl -sSL -o /tmp/mdbook.tar.gz \
+              https://github.com/rust-lang/mdBook/releases/download/v${MDBOOK_VERSION}/mdbook-v${MDBOOK_VERSION}-${MDBOOK_ARCH}.tar.gz
+            tar -xzf /tmp/mdbook.tar.gz -C ~/.cache/mdbook
+          fi
+
+          MDBOOK_EPUB_BIN=~/.cache/mdbook-epub/bin/mdbook-epub
+          MDBOOK_EPUB_REV_FILE=~/.cache/mdbook-epub/.rev
+          MDBOOK_EPUB_NEEDS_INSTALL=0
+
+          if [ ! -x "$MDBOOK_EPUB_BIN" ]; then
+            MDBOOK_EPUB_NEEDS_INSTALL=1
+          fi
+
+          if [ -f "$MDBOOK_EPUB_REV_FILE" ]; then
+            MDBOOK_EPUB_INSTALLED_REV=$(cat "$MDBOOK_EPUB_REV_FILE")
+            if [ "$MDBOOK_EPUB_INSTALLED_REV" != "$MDBOOK_EPUB_REV" ]; then
+              MDBOOK_EPUB_NEEDS_INSTALL=1
+            fi
+          else
+            MDBOOK_EPUB_NEEDS_INSTALL=1
+          fi
+
+          if [ "$MDBOOK_EPUB_NEEDS_INSTALL" -eq 1 ]; then
+            rm -rf ~/.cache/mdbook-epub
+            MDBOOK_EPUB_DIR=$(mktemp -d)
+            MDBOOK_EPUB_TARBALL="$MDBOOK_EPUB_DIR/mdbook-epub.tar.gz"
+            MDBOOK_EPUB_URL="https://github.com/Michael-F-Bryan/mdbook-epub/archive/${MDBOOK_EPUB_REV}.tar.gz"
+
+            curl -sSL -o "$MDBOOK_EPUB_TARBALL" "$MDBOOK_EPUB_URL"
+
+            tar -xzf "$MDBOOK_EPUB_TARBALL" -C "$MDBOOK_EPUB_DIR"
+            cargo install --path "$MDBOOK_EPUB_DIR/mdbook-epub-$MDBOOK_EPUB_REV" --locked --root ~/.cache/mdbook-epub
+            rm -rf "$MDBOOK_EPUB_DIR"
+
+            echo "$MDBOOK_EPUB_REV" > ~/.cache/mdbook-epub/.rev
+          fi
+
+          ln -sf ~/.cache/mdbook/mdbook ~/.local/bin/mdbook
+          ln -sf ~/.cache/mdbook-epub/bin/mdbook-epub ~/.local/bin/mdbook-epub
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
+
+      - &build-docs
+        name: Build documentation
+        run: mdbook build docs
+
       - name: Run cargo clippy (${{ matrix.features }})
         run: cargo-clippy-diff -o GitHub origin/${{ github.base_ref }} -- -q ${{ matrix.cargo_args }}
 
@@ -144,6 +216,10 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         id: rust-toolchain
       - *set-build-metadata
+
+      - *cache-mdbook
+      - *install-mdbook
+      - *build-docs
 
       # --- Native dependency installation ---
       - name: Install apt packages (Linux)
@@ -326,6 +402,10 @@ jobs:
         run: |
           echo "$HOME/linaro-toolchain/bin" >> $GITHUB_PATH
 
+      - *cache-mdbook
+      - *install-mdbook
+      - *build-docs
+
       - name: Build for Kobo
         env:
           CC: arm-linux-gnueabihf-gcc
@@ -422,6 +502,9 @@ jobs:
       - *cache-nickelmenu
       - *install-deps
       - *setup-linaro
+      - *cache-mdbook
+      - *install-mdbook
+      - *build-docs
 
       - name: Build for Kobo (test build)
         env:

--- a/.github/workflows/mdbook-pages.yml
+++ b/.github/workflows/mdbook-pages.yml
@@ -35,8 +35,6 @@ jobs:
           path: |
             ~/.cache/mdbook
             ~/.cache/mdbook-epub
-            ~/.cargo/registry
-            ~/.cargo/git
           key: ${{ runner.os }}-mdbook-${{ env.MDBOOK_VERSION }}-epub-${{ env.MDBOOK_EPUB_REV }}
       - name: Install mdBook tools
         run: |

--- a/.github/workflows/mdbook-pr.yml
+++ b/.github/workflows/mdbook-pr.yml
@@ -22,8 +22,6 @@ jobs:
           path: |
             ~/.cache/mdbook
             ~/.cache/mdbook-epub
-            ~/.cargo/registry
-            ~/.cargo/git
           key: ${{ runner.os }}-mdbook-${{ env.MDBOOK_VERSION }}-epub-${{ env.MDBOOK_EPUB_REV }}
       - name: Install mdBook tools
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,9 @@
 name: Release
 
+env:
+  MDBOOK_VERSION: "0.5.2"
+  MDBOOK_EPUB_REV: "21a1c8134134201a2d555313447c96e56e2a8996"
+
 on:
   push:
     branches:
@@ -103,6 +107,65 @@ jobs:
       - name: Setup Linaro toolchain
         run: |
           echo "${HOME}/linaro-toolchain/bin" >> "${GITHUB_PATH}"
+
+      - name: Cache mdBook tools
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cache/mdbook
+            ~/.cache/mdbook-epub
+          key: ${{ runner.os }}-mdbook-${{ env.MDBOOK_VERSION }}-epub-${{ env.MDBOOK_EPUB_REV }}
+
+      - name: Install mdBook tools
+        run: |
+          set -e
+
+          mkdir -p ~/.cache/mdbook ~/.cache/mdbook-epub ~/.local/bin
+
+          if [ ! -x ~/.cache/mdbook/mdbook ]; then
+            curl -sSL -o /tmp/mdbook.tar.gz \
+              https://github.com/rust-lang/mdBook/releases/download/v${MDBOOK_VERSION}/mdbook-v${MDBOOK_VERSION}-x86_64-unknown-linux-gnu.tar.gz
+            tar -xzf /tmp/mdbook.tar.gz -C ~/.cache/mdbook
+          fi
+
+          MDBOOK_EPUB_BIN=~/.cache/mdbook-epub/bin/mdbook-epub
+          MDBOOK_EPUB_REV_FILE=~/.cache/mdbook-epub/.rev
+          MDBOOK_EPUB_NEEDS_INSTALL=0
+
+          if [ ! -x "$MDBOOK_EPUB_BIN" ]; then
+            MDBOOK_EPUB_NEEDS_INSTALL=1
+          fi
+
+          if [ -f "$MDBOOK_EPUB_REV_FILE" ]; then
+            MDBOOK_EPUB_INSTALLED_REV=$(cat "$MDBOOK_EPUB_REV_FILE")
+            if [ "$MDBOOK_EPUB_INSTALLED_REV" != "$MDBOOK_EPUB_REV" ]; then
+              MDBOOK_EPUB_NEEDS_INSTALL=1
+            fi
+          else
+            MDBOOK_EPUB_NEEDS_INSTALL=1
+          fi
+
+          if [ "$MDBOOK_EPUB_NEEDS_INSTALL" -eq 1 ]; then
+            rm -rf ~/.cache/mdbook-epub
+            MDBOOK_EPUB_DIR=$(mktemp -d)
+            MDBOOK_EPUB_TARBALL="$MDBOOK_EPUB_DIR/mdbook-epub.tar.gz"
+            MDBOOK_EPUB_URL="https://github.com/Michael-F-Bryan/mdbook-epub/archive/${MDBOOK_EPUB_REV}.tar.gz"
+
+            curl -sSL -o "$MDBOOK_EPUB_TARBALL" "$MDBOOK_EPUB_URL"
+
+            tar -xzf "$MDBOOK_EPUB_TARBALL" -C "$MDBOOK_EPUB_DIR"
+            cargo install --path "$MDBOOK_EPUB_DIR/mdbook-epub-$MDBOOK_EPUB_REV" --locked --root ~/.cache/mdbook-epub
+            rm -rf "$MDBOOK_EPUB_DIR"
+
+            echo "$MDBOOK_EPUB_REV" > ~/.cache/mdbook-epub/.rev
+          fi
+
+          ln -sf ~/.cache/mdbook/mdbook ~/.local/bin/mdbook
+          ln -sf ~/.cache/mdbook-epub/bin/mdbook-epub ~/.local/bin/mdbook-epub
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
+
+      - name: Build documentation
+        run: mdbook build docs
 
       - name: Build for Kobo
         env:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -213,6 +213,7 @@ dependencies = [
  "rand_xoshiro",
  "regex",
  "reqwest 0.13.2",
+ "rust-embed",
  "rustls",
  "secrecy",
  "septem",
@@ -1706,6 +1707,41 @@ dependencies = [
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rust-embed"
+version = "8.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04113cb9355a377d83f06ef1f0a45b8ab8cd7d8b1288160717d66df5c7988d27"
+dependencies = [
+ "rust-embed-impl",
+ "rust-embed-utils",
+ "walkdir",
+]
+
+[[package]]
+name = "rust-embed-impl"
+version = "8.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da0902e4c7c8e997159ab384e6d0fc91c221375f6894346ae107f47dd0f3ccaa"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rust-embed-utils",
+ "syn",
+ "walkdir",
+]
+
+[[package]]
+name = "rust-embed-utils"
+version = "8.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5bcdef0be6fe7f6fa333b1073c949729274b05f123a0ad7efcb8efd878e5c3b1"
+dependencies = [
+ "globset",
+ "sha2",
+ "walkdir",
 ]
 
 [[package]]

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -42,6 +42,7 @@ fxhash = "0.2.1"
 rand_core = "0.10.0"
 rand_xoshiro = "0.8.0"
 percent-encoding = "2.3.2"
+rust-embed = { version = "8.11", features = ["include-exclude"] }
 chrono = { version = "0.4.42", features = [
     "serde",
     "clock",

--- a/crates/core/src/assets.rs
+++ b/crates/core/src/assets.rs
@@ -1,0 +1,126 @@
+//! Embedded documentation assets.
+//!
+//! This module provides access to documentation files embedded in the binary
+//! at compile time using rust-embed.
+
+use rust_embed::Embed;
+use rust_embed::EmbeddedFile;
+
+#[cfg(debug_assertions)]
+use std::sync::OnceLock;
+
+/// Cached documentation bytes to prevent repeated memory leaks in debug builds.
+///
+/// In debug builds, rust-embed reads files from disk and returns `Cow::Owned`,
+/// requiring us to leak the data to get a 'static reference. This cache ensures
+/// the leak only happens once.
+#[cfg(debug_assertions)]
+static DOCUMENTATION_CACHE: OnceLock<&'static [u8]> = OnceLock::new();
+
+/// Embedded documentation EPUB file.
+///
+/// Contains the Cadmus documentation EPUB file generated from mdbook.
+/// Only the EPUB file is embedded, not the entire folder.
+///
+/// # Example
+///
+/// ```
+/// use cadmus_core::assets::DocumentationAssets;
+///
+/// let epub = DocumentationAssets::get_documentation();
+/// assert!(!epub.data.is_empty());
+/// ```
+#[derive(Embed)]
+#[folder = "../../docs/book/epub/"]
+#[include = "Cadmus Documentation.epub"]
+pub struct DocumentationAssets;
+
+impl DocumentationAssets {
+    /// Returns the embedded documentation EPUB file.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the documentation EPUB file is not found in embedded assets.
+    /// This should never happen in a properly built binary.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cadmus_core::assets::DocumentationAssets;
+    ///
+    /// let epub = DocumentationAssets::get_documentation();
+    /// // The EPUB data is available as a byte slice
+    /// let data: &[u8] = &epub.data;
+    /// ```
+    pub fn get_documentation() -> EmbeddedFile {
+        Self::get("Cadmus Documentation.epub")
+            .expect("Documentation EPUB not found in embedded assets")
+    }
+}
+
+/// Opens the embedded documentation in a Reader view.
+///
+/// This helper function is shared between the app and emulator to avoid code duplication.
+/// It retrieves the embedded EPUB, creates a Reader, and returns it.
+///
+/// The EPUB data is accessed without copying (zero-copy). In release builds, the data
+/// is embedded as a static reference. In debug builds, the data is loaded from disk
+/// and leaked to obtain a static reference, which is acceptable since the documentation
+/// is loaded once and lives for the entire program duration.
+///
+/// # Arguments
+///
+/// * `rect` - The rectangle defining the display area for the reader
+/// * `hub` - The event hub for sending update events
+/// * `context` - The application context containing display settings and fonts
+///
+/// # Returns
+///
+/// Returns `Some(Reader)` if the documentation was successfully opened,
+/// or `None` if there was an error parsing the EPUB.
+///
+/// # Example
+///
+/// ```no_run
+/// use cadmus_core::assets::open_documentation;
+/// use cadmus_core::context::Context;
+/// use cadmus_core::view::Hub;
+/// use cadmus_core::geom::Rectangle;
+/// use std::sync::mpsc::channel;
+///
+/// // Note: In actual use, context and hub are provided by the application.
+/// // This example shows the API pattern.
+/// # fn example(rect: Rectangle, hub: &Hub, context: &mut Context) {
+/// if let Some(reader) = open_documentation(rect, hub, context) {
+///     // Documentation opened successfully
+///     // The reader can be used to display the embedded EPUB
+/// }
+/// # }
+/// ```
+pub fn open_documentation(
+    rect: crate::geom::Rectangle,
+    hub: &crate::view::Hub,
+    context: &mut crate::context::Context,
+) -> Option<crate::view::reader::Reader> {
+    #[cfg(debug_assertions)]
+    let static_bytes = DOCUMENTATION_CACHE.get_or_init(|| {
+        let epub_file = DocumentationAssets::get_documentation();
+        match epub_file.data {
+            std::borrow::Cow::Borrowed(bytes) => bytes,
+            std::borrow::Cow::Owned(vec) => Box::leak(vec.into_boxed_slice()),
+        }
+    });
+
+    #[cfg(not(debug_assertions))]
+    let static_bytes = {
+        let epub_file = DocumentationAssets::get_documentation();
+        match epub_file.data {
+            std::borrow::Cow::Borrowed(bytes) => bytes,
+            std::borrow::Cow::Owned(_) => {
+                unreachable!("Owned data should not occur in release builds")
+            }
+        }
+    };
+
+    crate::view::reader::Reader::from_embedded_epub(rect, static_bytes, hub, context)
+}

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -1,6 +1,7 @@
 #[macro_use]
 pub mod geom;
 
+pub mod assets;
 pub mod battery;
 pub mod color;
 pub mod context;

--- a/crates/core/src/view/mod.rs
+++ b/crates/core/src/view/mod.rs
@@ -654,6 +654,7 @@ pub enum EntryKind {
 pub enum EntryId {
     About,
     SystemInfo,
+    OpenDocumentation,
     LoadLibrary(usize),
     Load(PathBuf),
     Flush,

--- a/docs/src/contributing/devenv-setup.md
+++ b/docs/src/contributing/devenv-setup.md
@@ -43,6 +43,30 @@ Once inside the devenv shell, these commands are available:
 | `cadmus-dev-otel`     | Run emulator with OpenTelemetry instrumentation  |
 | `devenv up`           | Start observability stack (Grafana, Tempo, Loki) |
 
+## Tasks
+
+The devenv environment uses [tasks](https://devenv.sh/tasks/) to manage build dependencies.
+Tasks are defined in `devenv.nix` and can be run with `devenv tasks run <task>`.
+
+### Available Tasks
+
+| Task          | Description                                               | Dependencies |
+| ------------- | --------------------------------------------------------- | ------------ |
+| `docs:build`  | Build documentation EPUB (only rebuilds if files changed) | None         |
+| `deps:native` | Build MuPDF and wrapper for native development            | None         |
+| `build:kobo`  | Build for Kobo device (Linux only)                        | `docs:build` |
+
+### How Tasks Work
+
+Tasks with dependencies automatically run their dependencies first. For example:
+
+```bash
+# This will first run docs:build (if needed), then build for Kobo
+devenv tasks run build:kobo
+```
+
+The `docs:build` task uses `execIfModified` to only rebuild when documentation files have actually changed.
+
 ## Running Tests
 
 Tests require the `TEST_ROOT_DIR` environment variable to be set:

--- a/renovate.json
+++ b/renovate.json
@@ -5,7 +5,9 @@
       "customType": "regex",
       "managerFilePatterns": [
         "/^\\.github\\/workflows\\/mdbook-pr\\.yml$/",
-        "/^\\.github\\/workflows\\/mdbook-pages\\.yml$/"
+        "/^\\.github\\/workflows\\/mdbook-pages\\.yml$/",
+        "/^\\.github\\/workflows\\/cargo\\.yml$/",
+        "/^\\.github\\/workflows\\/release\\.yml$/"
       ],
       "matchStrings": ["MDBOOK_VERSION:\\s+\\\"(?<currentValue>[^\\\"]+)\\\""],
       "datasourceTemplate": "github-releases",
@@ -16,7 +18,9 @@
       "customType": "regex",
       "managerFilePatterns": [
         "/^\\.github\\/workflows\\/mdbook-pr\\.yml$/",
-        "/^\\.github\\/workflows\\/mdbook-pages\\.yml$/"
+        "/^\\.github\\/workflows\\/mdbook-pages\\.yml$/",
+        "/^\\.github\\/workflows\\/cargo\\.yml$/",
+        "/^\\.github\\/workflows\\/release\\.yml$/"
       ],
       "matchStrings": [
         "MDBOOK_EPUB_REV:\\s+\\\"(?<currentValue>[a-f0-9]{40})\\\""


### PR DESCRIPTION
<!--
BEGIN_COMMIT_OVERRIDE
feat: Embed documentation in binary (#150)
fixes: #112 
END_COMMIT_OVERRIDE
-->

Add support for embedding EPUB documentation in the Cadmus binary and opening it directly from the app. This includes:

- New assets module for managing embedded documentation files
- Generalized EpubDocument to support both file and memory-based sources via Cursor<Vec<u8>>
- Reader::from_embedded_epub() method for opening embedded EPUBs
- "Docs" button in About dialog to launch documentation
- CI pipeline updates to build mdBook documentation before compiling Rust code
- DevEnv tasks for coordinating documentation and dependency builds with proper change detection

Change-Id: 4e8bbda4f4088022e63653420cf6c35f
Change-Id-Short: vlroompvkvzr