### PR TITLE
dev: add cargo-diff-tools to devenv for clippy diff support 

### DIFF
--- a/devenv.nix
+++ b/devenv.nix
@@ -9,6 +9,26 @@ let
   inherit (pkgs.stdenv) isLinux;
   inherit (pkgs.stdenv) isDarwin;
 
+  # cargo-diff-tools with Rust 1.70 for clap v2 compatibility
+  cargo-diff-tools = let
+    rustPlatform170 = pkgs.makeRustPlatform {
+      rustc = pkgs.rust-bin.stable."1.70.0".default;
+      cargo = pkgs.rust-bin.stable."1.70.0".default;
+    };
+  in
+  rustPlatform170.buildRustPackage rec {
+    pname = "cargo-diff-tools";
+    version = "0.1.2";
+
+    src = pkgs.fetchCrate {
+      inherit pname version;
+      sha256 = "1a6878v73zx9kx31jcyzf9gks8dfb1074xk4qhy3xr2gfx2pkmv4";
+    };
+
+    cargoHash = "sha256-sy1b/bIIsG5eyR0medE5Ztv39jI2HtWeiVc207ViYCA=";
+    doCheck = false;
+  };
+
   # Linaro GCC toolchain for Kobo - same as used by Kobo Reader
   # https://github.com/kobolabs/Kobo-Reader/blob/master/toolchain/gcc-linaro-4.9.4-2017.01-x86_64_arm-linux-gnueabihf.tar.xz
   # NOTE: This toolchain is x86_64 Linux-only (ELF binaries with autoPatchelfHook)
@@ -119,6 +139,8 @@ in
     pkgs.mdbook
     mdbook-epub-custom
     pkgs.zola
+
+    cargo-diff-tools
 
     # C/C++ build tools for compiling thirdparty libraries
     pkgs.gnumake

--- a/renovate.json
+++ b/renovate.json
@@ -39,6 +39,16 @@
     {
       "customType": "regex",
       "managerFilePatterns": ["/^devenv\\.nix$/"],
+      "matchStrings": [
+        "pname = \\\"cargo-diff-tools\\\";\\s+version = \\\"(?<currentValue>[^\\\"]+)\\\""
+      ],
+      "datasourceTemplate": "crate",
+      "depNameTemplate": "cargo-diff-tools",
+      "versioningTemplate": "semver"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": ["/^devenv\\.nix$/"],
       "matchStrings": ["rev = \\\"(?<currentValue>[a-f0-9]{40})\\\""],
       "datasourceTemplate": "git-refs",
       "depNameTemplate": "Michael-F-Bryan/mdbook-epub",


### PR DESCRIPTION
Added cargo-diff-tools v0.1.2 package to devenv.nix to provide
cargo-clippy-diff binary for local development. Uses Rust 1.70.0
for clap v2 compatibility. Also added Renovate configuration for
automatic dependency updates.

- Built with custom Rust platform using Rust 1.70.0
- Includes cargo-check-diff, cargo-clippy-diff, and filter-by-diff
- Added rust-overlay to devenv overlays for version flexibility