### PR TITLE
fix: remove --first-parent from git describe

### DIFF
--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -84,6 +84,7 @@ jobs:
             echo "PR_NUMBER=${{ github.event.pull_request.number }}" >> $GITHUB_ENV
             echo "PR_HEAD_SHA=${{ github.event.pull_request.head.sha }}" >> $GITHUB_ENV
           fi
+          echo "GIT_VERSION=$(git describe --tags --dirty --always)" >> $GITHUB_ENV
       - name: Cache
         uses: actions/cache@v5
         with:
@@ -334,7 +335,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          fetch-depth: 20
+          fetch-depth: 0
           fetch-tags: true
 
       - *set-build-metadata
@@ -486,7 +487,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          fetch-depth: 20
+          fetch-depth: 0
           fetch-tags: true
 
       - *set-build-metadata

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,7 +49,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           ref: ${{ needs.release-please.outputs.tag_name }}
-          fetch-depth: 20
+          fetch-depth: 0
           fetch-tags: true
 
       - uses: dtolnay/rust-toolchain@stable

--- a/crates/cadmus/build.rs
+++ b/crates/cadmus/build.rs
@@ -12,13 +12,7 @@ fn main() {
 
 fn get_version_info() -> Result<(String, Option<String>), VarError> {
     let git_version = Command::new("git")
-        .args([
-            "describe",
-            "--tags",
-            "--always",
-            "--dirty",
-            "--first-parent",
-        ])
+        .args(["describe", "--tags", "--always", "--dirty"])
         .output()
         .ok()
         .and_then(|output| {

--- a/crates/core/build.rs
+++ b/crates/core/build.rs
@@ -50,13 +50,7 @@ fn main() {
 
 fn get_version_info() -> Result<(String, Option<String>), VarError> {
     let git_version = Command::new("git")
-        .args([
-            "describe",
-            "--tags",
-            "--always",
-            "--dirty",
-            "--first-parent",
-        ])
+        .args(["describe", "--tags", "--always", "--dirty"])
         .output()
         .ok()
         .and_then(|output| {

--- a/crates/emulator/build.rs
+++ b/crates/emulator/build.rs
@@ -12,13 +12,7 @@ fn main() {
 
 fn get_version_info() -> Result<(String, Option<String>), VarError> {
     let git_version = Command::new("git")
-        .args([
-            "describe",
-            "--tags",
-            "--always",
-            "--dirty",
-            "--first-parent",
-        ])
+        .args(["describe", "--tags", "--always", "--dirty"])
         .output()
         .ok()
         .and_then(|output| {


### PR DESCRIPTION
<!--
BEGIN_COMMIT_OVERRIDE
fix: reported version in about dialog (#160)
END_COMMIT_OVERRIDE
-->

Remove the --first-parent flag from git describe commands in build scripts across all crates. This should fix the incorrect version reporting.

- cadmus/build.rs: Remove --first-parent flag
- core/build.rs: Remove --first-parent flag
- emulator/build.rs: Remove --first-parent flag

Change-Id: 97cff480928c187f90a2c1f56ef1907d
Change-Id-Short: qsnkkvrzqxrn