### PR TITLE
ci: inject git version into docs build

### DIFF
--- a/.github/workflows/cadmus-docs.yml
+++ b/.github/workflows/cadmus-docs.yml
@@ -38,17 +38,23 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          fetch-tags: true
       - uses: dtolnay/rust-toolchain@stable
 
       - name: Set build metadata
         run: |
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            echo "PR_NUMBER=${{ github.event.number }}" >> "$GITHUB_ENV"
-            echo "PR_HEAD_SHA=${{ github.event.pull_request.head.sha }}" >> "$GITHUB_ENV"
-            echo "ZOLA_BASE_URL=https://pr-${{ github.event.number }}.cadmus-dt6.pages.dev/" >> "$GITHUB_ENV"
-          else
-            echo "ZOLA_BASE_URL=https://cadmus-dt6.pages.dev/" >> "$GITHUB_ENV"
-          fi
+          {
+            if [ "${{ github.event_name }}" = "pull_request" ]; then
+              echo "PR_NUMBER=${{ github.event.number }}"
+              echo "PR_HEAD_SHA=${{ github.event.pull_request.head.sha }}"
+              echo "ZOLA_BASE_URL=https://pr-${{ github.event.number }}.cadmus-dt6.pages.dev/"
+            else
+              echo "ZOLA_BASE_URL=https://cadmus-dt6.pages.dev/"
+            fi
+            echo "GIT_VERSION=$(git describe --tags --always)"
+          } >> "$GITHUB_ENV"
 
       - name: Cache Zola
         uses: actions/cache@v5
@@ -142,6 +148,15 @@ jobs:
 
       - name: Build Rust documentation
         run: cargo doc --no-deps --document-private-items
+
+      - name: Inject GIT_VERSION into Rust documentation
+        run: |
+          WORKSPACE_VERSION=$(grep '^version = ' crates/cadmus/Cargo.toml | sed 's/version = "\(.*\)"/\1/')
+          find target/doc -name "index.html" -type f | while read -r html_file; do
+            if grep -q "<span class=\"version\">$WORKSPACE_VERSION</span>" "$html_file"; then
+              sed -i "s|<span class=\"version\">$WORKSPACE_VERSION</span>|<span class=\"version\">${{ env.GIT_VERSION }}</span>|g" "$html_file"
+            fi
+          done
 
       - name: Create documentation symlinks
         run: |

--- a/devenv.nix
+++ b/devenv.nix
@@ -458,6 +458,20 @@ in
       exec = "bash build-docs.sh";
     };
 
+    # Inject GIT_VERSION into Rust documentation
+    "docs:inject-version" = {
+      after = [ "docs:zola-build" ];
+      exec = ''
+        WORKSPACE_VERSION=$(cargo metadata --format-version 1 --no-deps | jq -r '.packages[] | select(.name == "cadmus") | .version' | head -1)
+        for html_file in $(find target/doc -name "index.html" -type f); do
+          if grep -q "<span class=\"version\">$WORKSPACE_VERSION</span>" "$html_file"; then
+            GIT_VERSION=$(git describe --tags --always --dirty)
+            sed -i "s|<span class=\"version\">$WORKSPACE_VERSION</span>|<span class=\"version\">$GIT_VERSION</span>|g" "$html_file"
+          fi
+        done
+      '';
+    };
+
     # Build mupdf and wrapper for native development
     "deps:native" = {
       exec = ''
@@ -573,6 +587,7 @@ in
       echo "Building Cadmus documentation portal..."
       echo ""
       devenv tasks run docs:zola-build
+      devenv tasks run docs:inject-version
       echo ""
       echo "Documentation built successfully!"
       echo "Output: docs-portal/public/"


### PR DESCRIPTION
Enhance documentation builds to include git version metadata in Rust API documentation.

- Add git describe output to workflow environment variables
- Create docs:inject-version task to replace version spans
- Update checkout action to fetch tags for git describe
- Add version injection step after Zola build in CI
- Refactor docs:zola-build task to use root-level script

Change-Id: ee4bf95df9002237233de6c161c4172b
Change-Id-Short: llvokqumkqzz