### PR TITLE
feat: add GitHub device flow OTA auth

### DIFF
--- a/.github/instructions/ota-feature.instructions.md
+++ b/.github/instructions/ota-feature.instructions.md
@@ -6,8 +6,12 @@ applyTo: "crates/core/src/view/ota.rs"
 # OTA test build updates
 
 The OTA view lets users download and install builds directly on device. It
-checks for WiFi before allowing updates. A GitHub token is required only for
-main branch and PR builds, not for stable releases.
+checks for WiFi before allowing updates. Main branch and PR builds require
+GitHub authentication, which is handled via device flow. When authentication is needed, a
+`DeviceAuthView` child is pushed that displays the user code and polls GitHub
+in a background thread. On success the token is saved to disk and the pending
+download resumes automatically. Stable releases are public and require no
+authentication.
 
 ## Keep this instruction current
 

--- a/contrib/Settings-sample.toml
+++ b/contrib/Settings-sample.toml
@@ -232,6 +232,5 @@ warmth = 0.0
 
 # Over-The-Air (OTA) updates allow you to download and install
 # Cadmus builds directly from GitHub.
-# A token is required for main branch and PR builds, but not for stable releases.
+# Authentication for main branch and PR builds is handled via GitHub device auth flow.
 [ota]
-# github-token = "ghp_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -50,6 +50,7 @@ chrono = { version = "0.4.42", features = [
 
 reqwest = { version = "0.13.1", default-features = false, features = [
     "blocking",
+    "form",
     "json",
     "rustls-no-provider",
 ] }

--- a/crates/core/build.rs
+++ b/crates/core/build.rs
@@ -15,6 +15,12 @@ fn main() {
     let build_uuid = Uuid::now_v7().to_string();
     println!("cargo:rustc-env=BUILD_UUID={}", build_uuid);
 
+    // GitHub OAuth App client ID for device flow authentication.
+    println!("cargo:rerun-if-env-changed=GH_OAUTH_CLIENT_ID");
+    let client_id =
+        env::var("GH_OAUTH_CLIENT_ID").unwrap_or_else(|_| "GH_OAUTH_CLIENT_ID_NOT_SET".to_string());
+    println!("cargo:rustc-env=GH_OAUTH_CLIENT_ID={}", client_id);
+
     // Cross-compiling for Kobo.
     if target == "arm-unknown-linux-gnueabihf" {
         println!("cargo:rustc-env=PKG_CONFIG_ALLOW_CROSS=1");

--- a/crates/core/src/github/client.rs
+++ b/crates/core/src/github/client.rs
@@ -1,0 +1,342 @@
+use super::types::{
+    AccessTokenResponse, DeviceCodeResponse, ScopeError, TokenPollResult, VerifyScopesError,
+};
+use reqwest::blocking::{Client, RequestBuilder};
+use rustls::RootCertStore;
+use secrecy::{ExposeSecret, SecretString};
+use std::time::Duration;
+
+const CHUNK_TIMEOUT_SECS: u64 = 30;
+
+/// GitHub OAuth App client ID, baked in at build time via `GH_OAUTH_CLIENT_ID` env var.
+///
+/// Kept private so callers never need to know or pass it; [`GithubClient`] uses it internally.
+const GITHUB_OAUTH_CLIENT_ID: &str = env!("GH_OAUTH_CLIENT_ID");
+
+/// OAuth scopes that the saved token must have for OTA operations to succeed.
+///
+/// This is the single source of truth for required scopes. Both
+/// [`GithubClient::initiate_device_flow`] and
+/// [`GithubClient::verify_token_scopes`] derive from this list, so adding or
+/// removing a scope here is the only change needed.
+///
+/// Current requirements:
+/// - `public_repo` — required to download Actions artifacts from public repositories
+pub const REQUIRED_SCOPES: &[&str] = &["public_repo"];
+
+/// Thin HTTP wrapper around the GitHub REST API.
+///
+/// Handles TLS setup, authentication headers, and base URL construction.
+/// Consumers (e.g. [`OtaClient`](crate::ota::OtaClient)) call the specific
+/// API methods they need.
+///
+/// # Examples
+///
+/// ```no_run
+/// use cadmus_core::github::GithubClient;
+///
+/// // Unauthenticated client for public endpoints
+/// let client = GithubClient::new(None).expect("failed to build client");
+/// ```
+///
+/// ```no_run
+/// use cadmus_core::github::GithubClient;
+/// use secrecy::SecretString;
+///
+/// // Authenticated client for private/token-gated endpoints
+/// let token = SecretString::from("ghp_…".to_owned());
+/// let client = GithubClient::new(Some(token)).expect("failed to build client");
+/// ```
+pub struct GithubClient {
+    client: Client,
+    token: Option<SecretString>,
+}
+
+impl GithubClient {
+    /// Creates a new client with optional GitHub token authentication.
+    ///
+    /// Uses `webpki-roots` certificates for TLS — no system cert store
+    /// required, which matters on Kobo devices that ship without a CA bundle.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error string if the underlying HTTP client fails to build.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use cadmus_core::github::GithubClient;
+    ///
+    /// let client = GithubClient::new(None).expect("failed to build client");
+    /// ```
+    #[cfg_attr(feature = "otel", tracing::instrument(skip_all))]
+    pub fn new(token: Option<SecretString>) -> Result<Self, String> {
+        tracing::debug!(token_provided = token.is_some(), "Building GitHub client");
+
+        let root_store = build_root_store();
+
+        let tls_config = rustls::ClientConfig::builder()
+            .with_root_certificates(root_store)
+            .with_no_client_auth();
+
+        let client = Client::builder()
+            .use_preconfigured_tls(tls_config)
+            .user_agent("github.com/OGKevin/cadmus")
+            .timeout(Duration::from_secs(CHUNK_TIMEOUT_SECS))
+            .build()
+            .map_err(|e| format!("Failed to build HTTP client: {}", e))?;
+
+        tracing::debug!("GitHub client built successfully");
+        Ok(Self { client, token })
+    }
+
+    /// Returns a GET request builder with the `Authorization` header set if a
+    /// token is present.
+    pub fn get(&self, url: &str) -> RequestBuilder {
+        self.with_auth(self.client.get(url))
+    }
+
+    /// Returns a POST request builder with the `Authorization` header set if a
+    /// token is present.
+    pub fn post(&self, url: &str) -> RequestBuilder {
+        self.with_auth(self.client.post(url))
+    }
+
+    /// Returns a GET request builder **without** any `Authorization` header.
+    ///
+    /// Used for public URLs (e.g. release asset downloads) where sending a
+    /// token would cause GitHub to reject the request with a 401.
+    pub fn get_unauthenticated(&self, url: &str) -> RequestBuilder {
+        self.client.get(url)
+    }
+
+    fn with_auth(&self, builder: RequestBuilder) -> RequestBuilder {
+        match &self.token {
+            Some(token) => {
+                builder.header("Authorization", format!("Bearer {}", token.expose_secret()))
+            }
+            None => {
+                tracing::warn!("Authentication requested but no token configured");
+                builder
+            }
+        }
+    }
+
+    /// Initiates GitHub device flow authentication.
+    ///
+    /// POSTs to `/login/device/code` to obtain a short user code and the
+    /// verification URL. The caller must display these to the user and then
+    /// call [`poll_device_token`](Self::poll_device_token) repeatedly until
+    /// authorization completes or the code expires.
+    ///
+    /// The required OAuth scopes are derived from [`REQUIRED_SCOPES`] so this
+    /// method and [`verify_token_scopes`](Self::verify_token_scopes) always
+    /// stay in sync.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the network request fails or GitHub returns a
+    /// non-2xx status.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use cadmus_core::github::GithubClient;
+    ///
+    /// let client = GithubClient::new(None).expect("failed to build client");
+    /// let response = client.initiate_device_flow().expect("device flow failed");
+    /// println!("Go to {} and enter {}", response.verification_uri, response.user_code);
+    /// ```
+    #[cfg_attr(feature = "otel", tracing::instrument(skip(self)))]
+    pub fn initiate_device_flow(&self) -> Result<DeviceCodeResponse, String> {
+        tracing::info!(
+            client_id = GITHUB_OAUTH_CLIENT_ID,
+            "Initiating GitHub device auth flow"
+        );
+
+        let scope = REQUIRED_SCOPES.join(" ");
+        tracing::debug!(scope = %scope, "Requesting device code with scopes");
+
+        let response = self
+            .client
+            .post("https://github.com/login/device/code")
+            .header("Accept", "application/json")
+            .form(&[("client_id", GITHUB_OAUTH_CLIENT_ID), ("scope", &scope)])
+            .send()
+            .map_err(|e| format!("Device code request failed: {}", e))?
+            .error_for_status()
+            .map_err(|e| format!("Device code request error: {}", e))?;
+
+        let device_code_response = response
+            .json::<DeviceCodeResponse>()
+            .map_err(|e| format!("Failed to parse device code response: {}", e))?;
+
+        tracing::debug!(
+            verification_uri = %device_code_response.verification_uri,
+            expires_in = device_code_response.expires_in,
+            interval = device_code_response.interval,
+            "Device code obtained"
+        );
+
+        Ok(device_code_response)
+    }
+
+    /// Verifies that the current token has all scopes listed in
+    /// [`REQUIRED_SCOPES`].
+    ///
+    /// Makes a lightweight `GET /user` request and reads the
+    /// `X-OAuth-Scopes` response header, which GitHub includes on every
+    /// authenticated API call. Returns `Ok(())` if all required scopes are
+    /// present, or `Err(missing)` listing the absent scope names.
+    ///
+    /// Call this once before starting a download to catch stale tokens
+    /// early, rather than failing mid-download with confusing 403.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Err` if the network request fails, GitHub returns a non-2xx
+    /// status, or one or more required scopes are absent.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use cadmus_core::github::GithubClient;
+    /// use secrecy::SecretString;
+    ///
+    /// let token = SecretString::from("ghp_…".to_owned());
+    /// let client = GithubClient::new(Some(token)).expect("failed to build client");
+    ///
+    /// match client.verify_token_scopes() {
+    ///     Ok(()) => println!("Token has all required scopes"),
+    ///     Err(e) => println!("Error: {}", e),
+    /// }
+    /// ```
+    #[cfg_attr(feature = "otel", tracing::instrument(skip(self)))]
+    pub fn verify_token_scopes(&self) -> Result<(), VerifyScopesError> {
+        tracing::debug!("Verifying token scopes");
+
+        let response = self
+            .get("https://api.github.com/user")
+            .header("Accept", "application/json")
+            .send()?
+            .error_for_status()?;
+
+        let granted: Vec<&str> = response
+            .headers()
+            .get("x-oauth-scopes")
+            .and_then(|v| v.to_str().ok())
+            .map(|s| s.split(',').map(str::trim).collect())
+            .unwrap_or_default();
+
+        tracing::debug!(granted = ?granted, required = ?REQUIRED_SCOPES, "Comparing token scopes");
+
+        let missing: Vec<String> = REQUIRED_SCOPES
+            .iter()
+            .filter(|&&required| !granted.contains(&required))
+            .map(|&s| s.to_owned())
+            .collect();
+
+        if missing.is_empty() {
+            tracing::debug!("Token scopes verified — all required scopes present");
+            Ok(())
+        } else {
+            tracing::warn!(missing = ?missing, "Token is missing required scopes");
+            Err(VerifyScopesError::from(ScopeError::new(missing)))
+        }
+    }
+
+    /// Polls GitHub once to check if the user has authorized the device.
+    ///
+    /// Must be called at least `interval` seconds apart (from the
+    /// [`DeviceCodeResponse`]). GitHub returns `slow_down` if polled too
+    /// frequently; the caller must add 5 seconds to the interval before the
+    /// next attempt.
+    ///
+    /// # Arguments
+    ///
+    /// * `device_code` - The `device_code` from [`initiate_device_flow`](Self::initiate_device_flow)
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the network request fails.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use cadmus_core::github::GithubClient;
+    /// use cadmus_core::github::TokenPollResult;
+    /// use std::time::Duration;
+    ///
+    /// let client = GithubClient::new(None).expect("failed to build client");
+    /// let flow = client.initiate_device_flow().expect("device flow failed");
+    ///
+    /// loop {
+    ///     std::thread::sleep(Duration::from_secs(flow.interval));
+    ///     match client.poll_device_token(&flow.device_code).expect("poll failed") {
+    ///         TokenPollResult::Complete(token) => break,
+    ///         TokenPollResult::Pending => continue,
+    ///         _ => break,
+    ///     }
+    /// }
+    /// ```
+    #[cfg_attr(feature = "otel", tracing::instrument(skip(self)))]
+    pub fn poll_device_token(&self, device_code: &str) -> Result<TokenPollResult, String> {
+        tracing::debug!("Polling GitHub for device token");
+
+        let response = self
+            .client
+            .post("https://github.com/login/oauth/access_token")
+            .header("Accept", "application/json")
+            .form(&[
+                ("client_id", GITHUB_OAUTH_CLIENT_ID),
+                ("device_code", device_code),
+                ("grant_type", "urn:ietf:params:oauth:grant-type:device_code"),
+            ])
+            .send()
+            .map_err(|e| format!("Token poll request failed: {}", e))?
+            .error_for_status()
+            .map_err(|e| format!("Token poll error response: {}", e))?;
+
+        let body: AccessTokenResponse = response
+            .json()
+            .map_err(|e| format!("Failed to parse token response: {}", e))?;
+
+        if let Some(token) = body.access_token {
+            tracing::info!("Device flow authorization complete");
+            return Ok(TokenPollResult::Complete(SecretString::from(token)));
+        }
+
+        match body.error.as_deref() {
+            Some("authorization_pending") => {
+                tracing::debug!("Device flow authorization pending");
+                Ok(TokenPollResult::Pending)
+            }
+            Some("slow_down") => {
+                tracing::warn!("Device flow polling too fast — caller must increase interval");
+                Ok(TokenPollResult::SlowDown)
+            }
+            Some("expired_token") => {
+                tracing::warn!("Device flow code expired");
+                Ok(TokenPollResult::Expired)
+            }
+            Some("access_denied") => {
+                tracing::info!("Device flow cancelled by user");
+                Ok(TokenPollResult::Cancelled)
+            }
+            Some(other) => {
+                tracing::error!(error = other, "Unexpected device flow error");
+                Err(format!("Unexpected device flow error: {}", other))
+            }
+            None => {
+                tracing::error!("Empty body from token poll endpoint");
+                Err("Empty response from token endpoint".to_owned())
+            }
+        }
+    }
+}
+
+fn build_root_store() -> RootCertStore {
+    let mut store = RootCertStore::empty();
+    store.extend(webpki_roots::TLS_SERVER_ROOTS.iter().cloned());
+    store
+}

--- a/crates/core/src/github/device_flow.rs
+++ b/crates/core/src/github/device_flow.rs
@@ -1,0 +1,113 @@
+use secrecy::{ExposeSecret, SecretString};
+use std::fs::{self, File};
+use std::io::{Read, Write};
+use std::path::PathBuf;
+
+/// Subdirectory and filename appended to the card root for token storage.
+///
+/// Uses `.adds/cadmus/` for normal builds and `.adds/cadmus-tst/` for test
+/// builds.
+#[cfg(not(feature = "test"))]
+const TOKEN_RELATIVE_PATH: &str = ".adds/cadmus/.github_token";
+
+#[cfg(feature = "test")]
+const TOKEN_RELATIVE_PATH: &str = ".adds/cadmus-tst/.github_token";
+
+/// Persists a GitHub OAuth token to disk for reuse across app restarts.
+///
+/// Writes to `{card_root}/.adds/cadmus/.github_token` with `0600` permissions.
+///
+/// # Errors
+///
+/// Returns an error string if directory creation or file write fails.
+pub fn save_token(token: &SecretString) -> Result<(), String> {
+    let path = token_path();
+    tracing::debug!(path = %path.display(), "Saving GitHub token");
+
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).map_err(|e| format!("Failed to create token dir: {}", e))?;
+    }
+
+    let mut file =
+        File::create(&path).map_err(|e| format!("Failed to create token file: {}", e))?;
+    file.write_all(token.expose_secret().as_bytes())
+        .map_err(|e| format!("Failed to write token: {}", e))?;
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(&path, fs::Permissions::from_mode(0o600))
+            .map_err(|e| format!("Failed to set token file permissions: {}", e))?;
+    }
+
+    tracing::info!("GitHub token saved");
+    Ok(())
+}
+
+/// Loads a previously saved GitHub OAuth token from disk.
+///
+/// Returns `None` if no token file exists (first-time setup).
+///
+/// # Errors
+///
+/// Returns an error string if the file exists but cannot be read.
+pub fn load_token() -> Result<Option<SecretString>, String> {
+    let path = token_path();
+    tracing::debug!(path = %path.display(), "Loading GitHub token");
+
+    if !path.exists() {
+        tracing::debug!("No saved token found");
+        return Ok(None);
+    }
+
+    let mut contents = String::new();
+    File::open(&path)
+        .map_err(|e| format!("Failed to open token file: {}", e))?
+        .read_to_string(&mut contents)
+        .map_err(|e| format!("Failed to read token file: {}", e))?;
+
+    let token = contents.trim().to_owned();
+    if token.is_empty() {
+        tracing::warn!("Token file exists but is empty");
+        return Ok(None);
+    }
+
+    tracing::info!("GitHub token loaded from disk");
+    Ok(Some(SecretString::from(token)))
+}
+
+/// Deletes the saved GitHub OAuth token from disk.
+///
+/// Called when a token is found to be invalid or revoked, so the next
+/// authentication attempt starts fresh via device flow.
+///
+/// Returns `Ok(())` if the file was deleted or did not exist.
+///
+/// # Errors
+///
+/// Returns an error string if the file exists but cannot be removed.
+pub fn delete_token() -> Result<(), String> {
+    let path = token_path();
+    tracing::debug!(path = %path.display(), "Deleting GitHub token");
+
+    if !path.exists() {
+        return Ok(());
+    }
+
+    fs::remove_file(&path).map_err(|e| format!("Failed to delete token file: {}", e))?;
+    tracing::info!("GitHub token deleted");
+    Ok(())
+}
+
+fn token_path() -> PathBuf {
+    #[cfg(test)]
+    return std::env::temp_dir()
+        .join("cadmus-test")
+        .join(TOKEN_RELATIVE_PATH);
+
+    #[cfg(all(not(test), feature = "emulator"))]
+    return PathBuf::from("/tmp").join(TOKEN_RELATIVE_PATH);
+
+    #[cfg(all(not(test), not(feature = "emulator")))]
+    return PathBuf::from(crate::settings::INTERNAL_CARD_ROOT).join(TOKEN_RELATIVE_PATH);
+}

--- a/crates/core/src/github/mod.rs
+++ b/crates/core/src/github/mod.rs
@@ -1,0 +1,13 @@
+//! GitHub API client and device flow authentication.
+//!
+//! This module provides:
+//! - [`GithubClient`] — a thin blocking HTTP wrapper for the GitHub REST API
+//! - [`device_flow`] — token persistence helpers (`save_token`, `load_token`)
+//! - Shared types used by both the client and callers
+
+mod client;
+pub mod device_flow;
+pub(crate) mod types;
+
+pub use client::{GithubClient, REQUIRED_SCOPES};
+pub use types::{DeviceCodeResponse, OtaProgress, ScopeError, TokenPollResult, VerifyScopesError};

--- a/crates/core/src/github/types.rs
+++ b/crates/core/src/github/types.rs
@@ -1,0 +1,172 @@
+use secrecy::SecretString;
+use serde::Deserialize;
+use std::path::PathBuf;
+
+/// Error returned when a GitHub token lacks required OAuth scopes.
+///
+/// OAuth scopes are required for certain GitHub API operations. When a token
+/// doesn't have the necessary scopes, this error indicates which ones are missing.
+///
+/// # Example
+///
+/// ```
+/// use cadmus_core::github::ScopeError;
+///
+/// let missing = vec!["public_repo".to_string(), "repo_deployment".to_string()];
+/// let error = ScopeError::new(missing);
+/// eprintln!("Missing scopes: {}", error);
+/// ```
+#[derive(Debug, Clone)]
+pub struct ScopeError {
+    missing: Vec<String>,
+}
+
+impl ScopeError {
+    /// Creates a new scope error with the given list of missing scopes.
+    pub fn new(missing: Vec<String>) -> Self {
+        ScopeError { missing }
+    }
+
+    /// Returns a reference to the list of missing scopes.
+    pub fn missing_scopes(&self) -> &[String] {
+        &self.missing
+    }
+}
+
+impl std::fmt::Display for ScopeError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "GitHub token missing required scopes: {}",
+            self.missing.join(", ")
+        )
+    }
+}
+
+impl std::error::Error for ScopeError {}
+
+/// Error returned by [`crate::github::GithubClient::verify_token_scopes`].
+///
+/// Distinguishes between a transport/HTTP failure during the scope check and a
+/// token that was accepted by GitHub but is missing required OAuth scopes.
+#[derive(Debug, thiserror::Error)]
+pub enum VerifyScopesError {
+    /// The HTTP request to GitHub failed (network error or non-2xx status).
+    #[error("scope check request failed: {0}")]
+    Request(#[from] reqwest::Error),
+
+    /// The token was accepted but lacks one or more required OAuth scopes.
+    #[error(transparent)]
+    InsufficientScopes(#[from] ScopeError),
+}
+
+// ── GitHub REST API response types ───────────────────────────────────────────
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct PullRequest {
+    pub head: PrHead,
+}
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct PrHead {
+    pub sha: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct WorkflowRunsResponse {
+    pub workflow_runs: Vec<WorkflowRun>,
+}
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct WorkflowRun {
+    pub name: String,
+    pub id: u64,
+    #[serde(default)]
+    pub head_sha: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct Repository {
+    pub default_branch: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct ArtifactsResponse {
+    pub artifacts: Vec<Artifact>,
+}
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct Artifact {
+    pub name: String,
+    pub id: u64,
+    pub size_in_bytes: u64,
+}
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct Release {
+    pub assets: Vec<ReleaseAsset>,
+}
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct ReleaseAsset {
+    pub name: String,
+    pub browser_download_url: String,
+    pub size: u64,
+}
+
+// ── Device flow types ─────────────────────────────────────────────────────────
+
+/// Response from the GitHub device code endpoint.
+///
+/// Contains the codes to display to the user and the polling parameters.
+#[derive(Debug, Deserialize)]
+pub struct DeviceCodeResponse {
+    /// Opaque code passed back to the poll endpoint — do not display to the user.
+    pub device_code: String,
+    /// Short code the user types at `verification_uri` (e.g. `WDJB-MJHT`).
+    pub user_code: String,
+    /// URL the user must visit to authorize (always `https://github.com/login/device`).
+    pub verification_uri: String,
+    /// Seconds until both codes expire (default 900 = 15 minutes).
+    pub expires_in: u64,
+    /// Minimum seconds to wait between poll attempts.
+    pub interval: u64,
+}
+
+/// Result of a single poll attempt during device flow.
+#[derive(Debug)]
+pub enum TokenPollResult {
+    /// User has not yet authorized — keep polling after `interval` seconds.
+    Pending,
+    /// GitHub is being polled too fast — caller must add 5 s to the poll interval.
+    SlowDown,
+    /// User authorized successfully; token is ready to use.
+    Complete(SecretString),
+    /// The device code expired before the user authorized.
+    Expired,
+    /// User explicitly cancelled the authorization on GitHub.
+    Cancelled,
+}
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct AccessTokenResponse {
+    pub access_token: Option<String>,
+    pub error: Option<String>,
+}
+
+// ── OTA progress ──────────────────────────────────────────────────────────────
+
+/// Progress states during an OTA download operation.
+#[derive(Debug, Clone)]
+pub enum OtaProgress {
+    /// Verifying the pull request exists and fetching its metadata.
+    CheckingPr,
+    /// Searching for the latest successful build on the default branch.
+    FindingLatestBuild,
+    /// Searching for the associated GitHub Actions workflow run.
+    FindingWorkflow,
+    /// Actively downloading the artifact with optional progress tracking.
+    DownloadingArtifact { downloaded: u64, total: u64 },
+    /// Download completed successfully, artifact saved to disk.
+    Complete { path: PathBuf },
+}

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -12,6 +12,7 @@ pub mod font;
 pub mod framebuffer;
 pub mod frontlight;
 pub mod gesture;
+pub mod github;
 pub mod helpers;
 pub mod input;
 pub mod library;

--- a/crates/core/src/ota/client.rs
+++ b/crates/core/src/ota/client.rs
@@ -1,8 +1,8 @@
+use crate::github::types::{
+    Artifact, ArtifactsResponse, Release, ReleaseAsset, Repository, WorkflowRunsResponse,
+};
+use crate::github::{GithubClient, OtaProgress};
 use percent_encoding::{utf8_percent_encode, NON_ALPHANUMERIC};
-use reqwest::blocking::Client;
-use rustls::RootCertStore;
-use secrecy::{ExposeSecret, SecretString};
-use serde::Deserialize;
 use std::fs::File;
 use std::io::{Read, Write};
 use std::path::PathBuf;
@@ -15,36 +15,48 @@ use crate::settings::INTERNAL_CARD_ROOT;
 /// Size of each download chunk in bytes (10 MB)
 const CHUNK_SIZE: usize = 10 * 1024 * 1024;
 
-/// Timeout for each chunk download attempt in seconds
-const CHUNK_TIMEOUT_SECS: u64 = 30;
-
 /// Maximum number of retry attempts for failed chunks
 const MAX_RETRIES: usize = 3;
 
-/// HTTP client for downloading OTA updates from GitHub.
+/// Downloads and deploys OTA updates from GitHub.
 ///
-/// This client handles the complete OTA update workflow:
-/// - Fetching PR information from GitHub API
-/// - Finding associated workflow runs
-/// - Downloading build artifacts and stable releases
-/// - Extracting and deploying updates
-///
-/// # Security
-///
-/// The GitHub personal access token is optional and wrapped in `SecretString`
-/// from the `secrecy` crate to prevent accidental exposure in logs, debug output,
-/// or error messages. The token is automatically wiped from memory when dropped.
-/// Access to the token value requires explicit use of `.expose_secret()`.
-///
-/// Token is required for:
-/// - PR build downloads
-/// - Default branch artifact downloads
-///
-/// Token is optional for:
-/// - Stable release downloads (public URLs)
+/// Delegates all HTTP communication to [`GithubClient`] and focuses solely on
+/// the OTA-specific workflow: finding artifacts, chunked downloading, ZIP
+/// extraction, and deploying `KoboRoot.tgz` to the Kobo device.
 pub struct OtaClient {
-    client: Client,
-    token: Option<SecretString>,
+    github: GithubClient,
+}
+
+/// Indicates where artifacts were expected but not found.
+#[derive(Debug, Clone)]
+pub enum ArtifactSource {
+    /// No artifacts found for a specific pull request
+    PullRequest(u32),
+    /// No artifacts found for the default branch
+    DefaultBranch,
+    /// No artifact matching the expected name pattern in a workflow run
+    WorkflowRun(String),
+    /// No release asset found with the expected name
+    ReleaseAsset(String),
+}
+
+impl std::fmt::Display for ArtifactSource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ArtifactSource::PullRequest(pr) => write!(f, "No build artifacts found for PR #{}", pr),
+            ArtifactSource::DefaultBranch => {
+                write!(f, "No build artifacts found for default branch")
+            }
+            ArtifactSource::WorkflowRun(pattern) => {
+                write!(
+                    f,
+                    "No artifact matching '{}' found in workflow run",
+                    pattern
+                )
+            }
+            ArtifactSource::ReleaseAsset(name) => write!(f, "No release asset '{}' found", name),
+        }
+    }
 }
 
 /// Error types that can occur during OTA operations.
@@ -62,21 +74,24 @@ pub enum OtaError {
     #[error("PR #{0} not found")]
     PrNotFound(u32),
 
-    /// No build artifacts matching the expected pattern were found for the PR
-    #[error("No build artifacts found for PR #{0}")]
-    NoArtifacts(u32),
+    /// No build artifacts found for the specified source
+    #[error("{0}")]
+    ArtifactsNotFound(ArtifactSource),
 
-    /// No build artifacts found for the default branch
-    #[error("No build artifacts found for default branch")]
-    NoDefaultBranchArtifacts,
-
-    /// No artifact matching the expected name prefix was found in a workflow run
-    #[error("No artifact matching '{0}' found in workflow run")]
-    ArtifactNotFound(String),
-
-    /// GitHub token was not provided in configuration
+    /// GitHub token was not provided
     #[error("GitHub token not configured")]
     NoToken,
+
+    /// GitHub token is invalid or has been revoked — re-authentication required
+    #[error("GitHub token is invalid or revoked")]
+    Unauthorized,
+
+    /// GitHub token is missing one or more required OAuth scopes
+    ///
+    /// The token was accepted by GitHub but lacks the permissions needed for
+    /// OTA operations. Re-authentication with the correct scopes is required.
+    #[error(transparent)]
+    InsufficientScopes(#[from] crate::github::ScopeError),
 
     /// Insufficient disk space available for download (requires 100MB minimum)
     #[error("Insufficient disk space: need 100MB, have {0}MB")]
@@ -103,133 +118,14 @@ pub enum OtaError {
     DeploymentError(String),
 }
 
-/// Progress states during an OTA download operation.
-///
-/// Used with progress callbacks to track download status.
-#[derive(Debug, Clone)]
-pub enum OtaProgress {
-    /// Verifying the pull request exists and fetching its metadata
-    CheckingPr,
-    /// Searching for the latest successful build on the default branch
-    FindingLatestBuild,
-    /// Searching for the associated GitHub Actions workflow run
-    FindingWorkflow,
-    /// Actively downloading the artifact with optional progress tracking
-    DownloadingArtifact { downloaded: u64, total: u64 },
-    /// Download completed successfully, artifact saved to disk
-    Complete { path: PathBuf },
-}
-
-#[derive(Debug, Deserialize)]
-struct PullRequest {
-    head: PrHead,
-}
-
-#[derive(Debug, Deserialize)]
-struct PrHead {
-    sha: String,
-}
-
-#[derive(Debug, Deserialize)]
-struct WorkflowRunsResponse {
-    workflow_runs: Vec<WorkflowRun>,
-}
-
-#[derive(Debug, Deserialize)]
-struct WorkflowRun {
-    name: String,
-    id: u64,
-    #[serde(default)]
-    head_sha: Option<String>,
-}
-
-#[derive(Debug, Deserialize)]
-struct Repository {
-    default_branch: String,
-}
-
-#[derive(Debug, Deserialize)]
-struct ArtifactsResponse {
-    artifacts: Vec<Artifact>,
-}
-
-#[derive(Debug, Deserialize)]
-struct Artifact {
-    name: String,
-    id: u64,
-    size_in_bytes: u64,
-}
-
-#[derive(Debug, Deserialize)]
-struct Release {
-    assets: Vec<ReleaseAsset>,
-}
-
-#[derive(Debug, Deserialize)]
-struct ReleaseAsset {
-    name: String,
-    browser_download_url: String,
-    size: u64,
-}
-
 impl OtaClient {
-    /// Creates a new OTA client with optional GitHub authentication.
-    ///
-    /// Initializes an HTTP client with TLS configured using webpki-roots
-    /// certificates for secure communication with GitHub's API.
-    ///
-    /// # Arguments
-    ///
-    /// * `github_token` - Optional personal access token wrapped in `SecretString`
-    ///   for secure handling. Required for artifact downloads, optional for
-    ///   stable release downloads.
+    /// Creates a new OTA client wrapping the provided GitHub client.
     ///
     /// # Errors
     ///
-    /// Returns `OtaError::TlsConfig` if the HTTP client fails to initialize
-    /// with the provided TLS configuration.
-    ///
-    /// # Security
-    ///
-    /// The token is stored securely and will never appear in debug output or logs.
-    /// It is only exposed when making authenticated API requests.
-    pub fn new(github_token: Option<SecretString>) -> Result<Self, OtaError> {
-        tracing::debug!("Initializing OTA client with webpki-roots certificates");
-
-        let root_store = create_webpki_root_store();
-        tracing::debug!(
-            certificate_count = root_store.len(),
-            "Created root certificate store"
-        );
-
-        let tls_config = rustls::ClientConfig::builder()
-            .with_root_certificates(root_store)
-            .with_no_client_auth();
-
-        tracing::debug!("Built TLS configuration");
-
-        let client = Client::builder()
-            .use_preconfigured_tls(tls_config)
-            .user_agent("cadmus-ota")
-            .timeout(Duration::from_secs(CHUNK_TIMEOUT_SECS))
-            .build()
-            .map_err(|e| OtaError::TlsConfig(format!("Failed to build HTTP client: {}", e)))?;
-
-        tracing::debug!("Successfully initialized OTA client");
-
-        Ok(Self {
-            client,
-            token: github_token,
-        })
-    }
-
-    /// Returns a reference to the GitHub token if available.
-    ///
-    /// # Errors
-    ///
-    /// Returns `OtaError::NoToken` if no token is configured.
-    fn get_token(&self) -> Result<&SecretString, OtaError> {
-        self.token.as_ref().ok_or_else(|| OtaError::NoToken)
+    /// Returns `OtaError::TlsConfig` if the underlying HTTP client fails to build.
+    pub fn new(github: GithubClient) -> Self {
+        Self { github }
     }
 
     /// Downloads the build artifact from a GitHub pull request.
@@ -257,7 +153,7 @@ impl OtaClient {
     /// * `OtaError::InsufficientSpace` - Less than 100MB available in /tmp
     /// * `OtaError::NoToken` - GitHub token not configured
     /// * `OtaError::PrNotFound` - PR number doesn't exist in repository
-    /// * `OtaError::NoArtifacts` - No matching build artifacts found for the PR
+    /// * `OtaError::ArtifactsNotFound` - No matching build artifacts found for the PR
     /// * `OtaError::Api` - GitHub API request failed
     /// * `OtaError::Request` - Network communication failed
     /// * `OtaError::Io` - Failed to write downloaded file to disk
@@ -270,6 +166,7 @@ impl OtaClient {
         F: FnMut(OtaProgress),
     {
         check_disk_space("/tmp")?;
+        verify_scopes(&self.github)?;
 
         progress_callback(OtaProgress::CheckingPr);
         tracing::info!(pr_number, "Starting PR build download");
@@ -282,33 +179,21 @@ impl OtaClient {
         tracing::debug!(url = %pr_url, "Fetching PR");
 
         let response = self
-            .client
+            .github
             .get(&pr_url)
-            .header(
-                "Authorization",
-                format!("Bearer {}", self.get_token()?.expose_secret()),
-            )
-            .send()?;
+            .send()?
+            .error_for_status()
+            .map_err(|e| {
+                tracing::error!(pr_number, status = ?e.status(), error = %e, "PR fetch failed");
+                if e.status() == Some(reqwest::StatusCode::UNAUTHORIZED) {
+                    OtaError::Unauthorized
+                } else {
+                    OtaError::PrNotFound(pr_number)
+                }
+            })?;
 
-        tracing::debug!(
-            status = %response.status(),
-            headers = ?response.headers(),
-            "PR fetch response"
-        );
-
-        let response = response.error_for_status().map_err(|e| {
-            tracing::error!(
-                pr_number,
-                status = ?e.status(),
-                error = %e,
-                "PR fetch failed"
-            );
-            OtaError::PrNotFound(pr_number)
-        })?;
-
-        let pr: PullRequest = response.json()?;
+        let pr: crate::github::types::PullRequest = response.json()?;
         tracing::debug!("Successfully parsed PR response");
-
         let head_sha = pr.head.sha;
         tracing::debug!(pr_number, head_sha = %head_sha, "Retrieved PR head SHA");
 
@@ -321,32 +206,17 @@ impl OtaClient {
         );
         tracing::debug!(url = %runs_url, "Fetching workflow runs");
 
-        let response = self
-            .client
+        let runs: WorkflowRunsResponse = self
+            .github
             .get(&runs_url)
-            .header(
-                "Authorization",
-                format!("Bearer {}", self.get_token()?.expose_secret()),
-            )
-            .send()?;
+            .send()?
+            .error_for_status()
+            .map_err(|e| {
+                tracing::error!(head_sha = %head_sha, status = ?e.status(), error = %e, "Workflow runs fetch failed");
+                api_error(e)
+            })?
+            .json()?;
 
-        tracing::debug!(
-            status = %response.status(),
-            headers = ?response.headers(),
-            "Workflow runs response"
-        );
-
-        let response = response.error_for_status().map_err(|e| {
-            tracing::error!(
-                head_sha = %head_sha,
-                status = ?e.status(),
-                error = %e,
-                "Workflow runs fetch failed"
-            );
-            OtaError::Api(format!("Failed to fetch workflow runs: {}", e))
-        })?;
-
-        let runs: WorkflowRunsResponse = response.json()?;
         tracing::debug!(count = runs.workflow_runs.len(), "Found workflow runs");
 
         #[cfg(feature = "otel")]
@@ -366,12 +236,8 @@ impl OtaClient {
             .iter()
             .find(|r| r.name == "Cargo")
             .ok_or_else(|| {
-                tracing::error!(
-                    pr_number,
-                    workflow_name = "Cargo",
-                    "No matching workflow run found"
-                );
-                OtaError::NoArtifacts(pr_number)
+                tracing::error!(pr_number, "No Cargo workflow run found");
+                OtaError::ArtifactsNotFound(ArtifactSource::PullRequest(pr_number))
             })?;
 
         tracing::debug!(run_id = run.id, "Found Cargo workflow run");
@@ -384,7 +250,9 @@ impl OtaClient {
         let artifact = self
             .find_artifact_in_run(run.id, &artifact_name_pattern)
             .map_err(|e| match e {
-                OtaError::ArtifactNotFound(_) => OtaError::NoArtifacts(pr_number),
+                OtaError::ArtifactsNotFound(ArtifactSource::WorkflowRun(_)) => {
+                    OtaError::ArtifactsNotFound(ArtifactSource::PullRequest(pr_number))
+                }
                 other => other,
             })?;
 
@@ -429,7 +297,7 @@ impl OtaClient {
     ///
     /// * `OtaError::InsufficientSpace` - Less than 100MB available in /tmp
     /// * `OtaError::NoToken` - GitHub token not configured
-    /// * `OtaError::NoDefaultBranchArtifacts` - No matching build artifacts found
+    /// * `OtaError::ArtifactsNotFound` - No matching build artifacts found for default branch
     /// * `OtaError::Api` - GitHub API request failed
     /// * `OtaError::Request` - Network communication failed
     /// * `OtaError::Io` - Failed to write downloaded file to disk
@@ -441,6 +309,7 @@ impl OtaClient {
         F: FnMut(OtaProgress),
     {
         check_disk_space("/tmp")?;
+        verify_scopes(&self.github)?;
 
         progress_callback(OtaProgress::FindingLatestBuild);
         tracing::info!("Starting main branch build download");
@@ -455,39 +324,20 @@ impl OtaClient {
         );
         tracing::debug!(url = %runs_url, "Fetching Cargo workflow runs on default branch");
 
-        let response = self
-            .client
-            .get(runs_url)
-            .header(
-                "Authorization",
-                format!("Bearer {}", self.get_token()?.expose_secret()),
-            )
-            .send()?;
-
-        tracing::debug!(
-            status = %response.status(),
-            headers = ?response.headers(),
-            "Cargo workflow runs response"
-        );
-
-        let response = response.error_for_status().map_err(|e| {
-            tracing::error!(
-                status = ?e.status(),
-                error = %e,
-                "Cargo workflow runs fetch failed"
-            );
-            OtaError::Api(format!("Failed to fetch Cargo workflow runs: {}", e))
-        })?;
-
-        let runs: WorkflowRunsResponse = response.json()?;
-        tracing::debug!(
-            count = runs.workflow_runs.len(),
-            "Found Cargo workflow runs"
-        );
+        let runs: WorkflowRunsResponse = self
+            .github
+            .get(&runs_url)
+            .send()?
+            .error_for_status()
+            .map_err(|e| {
+                tracing::error!(status = ?e.status(), error = %e, "Cargo workflow runs fetch failed");
+                api_error(e)
+            })?
+            .json()?;
 
         let cargo_run = runs.workflow_runs.first().ok_or_else(|| {
             tracing::error!("No successful Cargo workflow run found on default branch");
-            OtaError::NoDefaultBranchArtifacts
+            OtaError::ArtifactsNotFound(ArtifactSource::DefaultBranch)
         })?;
 
         tracing::debug!(run_id = cargo_run.id, "Found Cargo workflow run");
@@ -510,12 +360,9 @@ impl OtaClient {
         let artifact = self
             .find_artifact_in_run(cargo_run.id, &artifact_name_prefix)
             .map_err(|e| match e {
-                OtaError::ArtifactNotFound(pattern) => {
-                    tracing::error!(
-                        pattern = %pattern,
-                        "No matching artifact found on default branch"
-                    );
-                    OtaError::NoDefaultBranchArtifacts
+                OtaError::ArtifactsNotFound(ArtifactSource::WorkflowRun(pattern)) => {
+                    tracing::error!(pattern = %pattern, "No matching artifact found on default branch");
+                    OtaError::ArtifactsNotFound(ArtifactSource::DefaultBranch)
                 }
                 other => other,
             })?;
@@ -563,7 +410,7 @@ impl OtaClient {
     /// * `OtaError::InsufficientSpace` - Less than 100MB available in /tmp
     /// * `OtaError::Api` - GitHub API request failed
     /// * `OtaError::Request` - Network communication failed
-    /// * `OtaError::NoArtifacts` - KoboRoot.tgz not found in latest release
+    /// * `OtaError::ArtifactsNotFound` - KoboRoot.tgz not found in latest release
     /// * `OtaError::Io` - Failed to write downloaded file to disk
     #[cfg_attr(feature = "otel", tracing::instrument(skip_all))]
     pub fn download_stable_release_artifact<F>(
@@ -582,28 +429,17 @@ impl OtaClient {
         let releases_url = "https://api.github.com/repos/ogkevin/cadmus/releases/latest";
         tracing::debug!(url = %releases_url, "Fetching latest release");
 
-        let mut request = self.client.get(releases_url);
-        if let Some(ref token) = self.token {
-            request = request.header("Authorization", format!("Bearer {}", token.expose_secret()));
-        }
-        let response = request.send()?;
+        let release: Release = self
+            .github
+            .get_unauthenticated(releases_url)
+            .send()?
+            .error_for_status()
+            .map_err(|e| {
+                tracing::error!(status = ?e.status(), error = %e, "Latest release fetch failed");
+                api_error(e)
+            })?
+            .json()?;
 
-        tracing::debug!(
-            status = %response.status(),
-            headers = ?response.headers(),
-            "Latest release response"
-        );
-
-        let response = response.error_for_status().map_err(|e| {
-            tracing::error!(
-                status = ?e.status(),
-                error = %e,
-                "Latest release fetch failed"
-            );
-            OtaError::Api(format!("Failed to fetch latest release: {}", e))
-        })?;
-
-        let release: Release = response.json()?;
         tracing::debug!(asset_count = release.assets.len(), "Found release assets");
 
         #[cfg(feature = "otel")]
@@ -627,7 +463,7 @@ impl OtaClient {
                     target_asset = asset_name,
                     "Asset not found in latest release"
                 );
-                OtaError::ArtifactNotFound(asset_name.to_owned())
+                OtaError::ArtifactsNotFound(ArtifactSource::ReleaseAsset(asset_name.to_owned()))
             })?;
 
         tracing::debug!(
@@ -814,27 +650,18 @@ impl OtaClient {
         let repo_url = "https://api.github.com/repos/ogkevin/cadmus";
         tracing::debug!(url = %repo_url, "Fetching repository metadata");
 
-        let response = self
-            .client
+        let repo: Repository = self
+            .github
             .get(repo_url)
-            .header(
-                "Authorization",
-                format!("Bearer {}", self.get_token()?.expose_secret()),
-            )
-            .send()?;
+            .send()?
+            .error_for_status()
+            .map_err(|e| {
+                tracing::error!(status = ?e.status(), error = %e, "Repository metadata fetch failed");
+                api_error(e)
+            })?
+            .json()?;
 
-        let response = response.error_for_status().map_err(|e| {
-            tracing::error!(
-                status = ?e.status(),
-                error = %e,
-                "Repository metadata fetch failed"
-            );
-            OtaError::Api(format!("Failed to fetch repository metadata: {}", e))
-        })?;
-
-        let repo: Repository = response.json()?;
         tracing::debug!(default_branch = %repo.default_branch, "Resolved default branch");
-
         Ok(repo.default_branch)
     }
 
@@ -846,32 +673,17 @@ impl OtaClient {
         );
         tracing::debug!(url = %artifacts_url, "Fetching artifacts");
 
-        let response = self
-            .client
+        let artifacts: ArtifactsResponse = self
+            .github
             .get(&artifacts_url)
-            .header(
-                "Authorization",
-                format!("Bearer {}", self.get_token()?.expose_secret()),
-            )
-            .send()?;
+            .send()?
+            .error_for_status()
+            .map_err(|e| {
+                tracing::error!(run_id, status = ?e.status(), error = %e, "Artifacts fetch failed");
+                api_error(e)
+            })?
+            .json()?;
 
-        tracing::debug!(
-            status = %response.status(),
-            headers = ?response.headers(),
-            "Artifacts response"
-        );
-
-        let response = response.error_for_status().map_err(|e| {
-            tracing::error!(
-                run_id,
-                status = ?e.status(),
-                error = %e,
-                "Artifacts fetch failed"
-            );
-            OtaError::Api(format!("Failed to fetch artifacts: {}", e))
-        })?;
-
-        let artifacts: ArtifactsResponse = response.json()?;
         tracing::debug!(count = artifacts.artifacts.len(), "Found artifacts");
 
         #[cfg(feature = "otel")]
@@ -894,12 +706,8 @@ impl OtaClient {
             .into_iter()
             .find(|a| a.name.starts_with(name_prefix))
             .ok_or_else(|| {
-                tracing::error!(
-                    run_id,
-                    pattern = %name_prefix,
-                    "No matching artifact found"
-                );
-                OtaError::ArtifactNotFound(name_prefix.to_owned())
+                tracing::error!(run_id, pattern = %name_prefix, "No matching artifact found");
+                OtaError::ArtifactsNotFound(ArtifactSource::WorkflowRun(name_prefix.to_owned()))
             })
     }
 
@@ -1092,24 +900,19 @@ impl OtaClient {
     ) -> Result<Vec<u8>, OtaError> {
         let range_header = format!("bytes={}-{}", start, end);
 
-        let mut request = self.client.get(url).header("Range", range_header);
+        let builder = if use_auth {
+            self.github.get(url)
+        } else {
+            self.github.get_unauthenticated(url)
+        };
 
-        if use_auth {
-            if let Some(ref token) = self.token {
-                request =
-                    request.header("Authorization", format!("Bearer {}", token.expose_secret()));
-            } else {
-                tracing::error!("Attempted authenticated download without token");
-                return Err(OtaError::NoToken);
-            }
-        }
-
-        let response = request
+        let bytes = builder
+            .header("Range", range_header)
             .send()?
             .error_for_status()
-            .map_err(|e| OtaError::Api(format!("Failed to download chunk: {}", e)))?;
+            .map_err(api_error)?
+            .bytes()?;
 
-        let bytes = response.bytes()?;
         Ok(bytes.to_vec())
     }
 
@@ -1138,17 +941,36 @@ impl OtaClient {
     }
 }
 
-/// Verifies sufficient disk space is available in the specified path for download.
+/// Verifies that the GitHub token has all scopes required for OTA operations.
 ///
-/// Requires at least 100MB of free space for artifact download and extraction.
+/// Delegates to [`GithubClient::verify_token_scopes`], which reads the
+/// `X-OAuth-Scopes` header from a lightweight `/user` request and compares
+/// against [`crate::github::REQUIRED_SCOPES`].
 ///
-/// # Arguments
+/// Returns `Ok(())` if all scopes are present, or an `OtaError` that is
+/// either a transport failure or missing scopes, so the caller can trigger
+/// re-authentication.
+fn verify_scopes(github: &crate::github::GithubClient) -> Result<(), OtaError> {
+    github.verify_token_scopes().map_err(|e| match e {
+        crate::github::VerifyScopesError::Request(e) => api_error(e),
+        crate::github::VerifyScopesError::InsufficientScopes(e) => OtaError::InsufficientScopes(e),
+    })
+}
+
+/// Maps a failed `reqwest` response to the appropriate `OtaError`.
 ///
-/// * `path` - The path to check for available disk space
-///
-/// # Errors
-///
-/// Returns `OtaError::InsufficientSpace` if less than 100MB is available.
+/// A 401 Unauthorized response means the saved token has been revoked or
+/// expired — the caller should re-authenticate via device flow rather than
+/// treating this as a generic API error.
+fn api_error(e: reqwest::Error) -> OtaError {
+    if e.status() == Some(reqwest::StatusCode::UNAUTHORIZED) {
+        tracing::warn!("GitHub API returned 401 — token invalid or revoked");
+        OtaError::Unauthorized
+    } else {
+        OtaError::Api(e.to_string())
+    }
+}
+
 fn check_disk_space(path: &str) -> Result<(), OtaError> {
     use nix::sys::statvfs::statvfs;
 
@@ -1163,79 +985,29 @@ fn check_disk_space(path: &str) -> Result<(), OtaError> {
             required_mb = 100,
             "Insufficient disk space"
         );
-        return Err(OtaError::InsufficientSpace(available_mb as u64));
+        return Err(OtaError::InsufficientSpace(available_mb));
     }
     Ok(())
-}
-
-/// Creates a root certificate store with Mozilla's trusted CA certificates.
-///
-/// Uses the webpki-roots crate which embeds Mozilla's CA certificate bundle
-/// for verifying HTTPS connections to GitHub's API.
-fn create_webpki_root_store() -> RootCertStore {
-    tracing::debug!("Loading Mozilla root certificates from webpki-roots");
-    let mut root_store = RootCertStore::empty();
-
-    root_store.extend(webpki_roots::TLS_SERVER_ROOTS.iter().cloned());
-
-    tracing::debug!(
-        certificate_count = root_store.len(),
-        "Loaded root certificates from webpki-roots"
-    );
-    root_store
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use tempfile::TempDir;
+    use crate::github::GithubClient;
+    use secrecy::SecretString;
 
-    #[test]
-    fn test_create_webpki_root_store() {
-        let root_store = create_webpki_root_store();
-        assert!(
-            !root_store.is_empty(),
-            "Root certificate store should not be empty"
-        );
-    }
-
-    #[test]
-    fn test_create_webpki_root_store_has_certificates() {
-        let root_store = create_webpki_root_store();
-        assert!(
-            root_store.len() > 50,
-            "Expected at least 50 root certificates, got {}",
-            root_store.len()
-        );
-    }
-
-    #[test]
-    fn test_ota_error_from_reqwest_error() {
-        let reqwest_error = reqwest::blocking::Client::new()
-            .get("http://invalid-url-that-does-not-exist-12345.com")
-            .send()
-            .unwrap_err();
-        let ota_error: OtaError = reqwest_error.into();
-        assert!(matches!(ota_error, OtaError::Request(_)));
-    }
-
-    #[test]
-    fn test_check_disk_space_sufficient() {
-        let temp_dir = TempDir::new().unwrap();
-        let result = check_disk_space(temp_dir.path().to_str().unwrap());
-        assert!(
-            result.is_ok(),
-            "Should have sufficient disk space in temp directory"
-        );
+    fn make_client() -> OtaClient {
+        rustls::crypto::ring::default_provider()
+            .install_default()
+            .ok();
+        let github =
+            GithubClient::new(Some(SecretString::from("test_token"))).expect("client build");
+        OtaClient::new(github)
     }
 
     #[test]
     fn test_extract_and_deploy_success() {
-        rustls::crypto::ring::default_provider()
-            .install_default()
-            .ok();
-
-        let client = OtaClient::new(Some(SecretString::from("test_token".to_string()))).unwrap();
+        let client = make_client();
         let fixture_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
             .join("src/ota/tests/fixtures/test_artifact.zip");
 
@@ -1265,11 +1037,7 @@ mod tests {
 
     #[test]
     fn test_extract_and_deploy_missing_koboroot() {
-        rustls::crypto::ring::default_provider()
-            .install_default()
-            .ok();
-
-        let client = OtaClient::new(Some(SecretString::from("test_token".to_string()))).unwrap();
+        let client = make_client();
         let fixture_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
             .join("src/ota/tests/fixtures/empty_artifact.zip");
 
@@ -1286,6 +1054,17 @@ mod tests {
         }
     }
 
+    #[test]
+    fn test_check_disk_space_sufficient() {
+        use tempfile::TempDir;
+        let temp_dir = TempDir::new().unwrap();
+        let result = check_disk_space(temp_dir.path().to_str().unwrap());
+        assert!(
+            result.is_ok(),
+            "Should have sufficient disk space in temp directory"
+        );
+    }
+
     fn external_test_enabled() -> bool {
         std::env::var("CADMUS_TEST_OTA_EXTERNAL").is_ok() && std::env::var("GH_TOKEN").is_ok()
     }
@@ -1294,9 +1073,9 @@ mod tests {
         rustls::crypto::ring::default_provider()
             .install_default()
             .ok();
-
         let token = std::env::var("GH_TOKEN").expect("GH_TOKEN must be set");
-        OtaClient::new(Some(SecretString::from(token))).expect("Failed to create OtaClient")
+        let github = GithubClient::new(Some(SecretString::from(token))).expect("client build");
+        OtaClient::new(github)
     }
 
     #[test]
@@ -1357,11 +1136,7 @@ mod tests {
         }
 
         let client = create_external_client();
-        let mut last_progress = None;
-
-        let download_result = client.download_stable_release_artifact(|progress| {
-            last_progress = Some(format!("{:?}", progress));
-        });
+        let download_result = client.download_stable_release_artifact(|_| {});
 
         assert!(
             download_result.is_ok(),

--- a/crates/core/src/ota/mod.rs
+++ b/crates/core/src/ota/mod.rs
@@ -5,9 +5,9 @@
 //! - Extract and deploy KoboRoot.tgz packages
 //! - Track download progress with callbacks
 //!
-//! The OTA client requires a GitHub personal access token with permissions to
-//! read workflow artifacts from the ogkevin/cadmus repository.
+//! Authentication is handled via GitHub device auth flow — see [`crate::github`].
 
 mod client;
 
-pub use client::{OtaClient, OtaError, OtaProgress};
+pub use crate::github::OtaProgress;
+pub use client::{ArtifactSource, OtaClient, OtaError};

--- a/crates/core/src/settings/mod.rs
+++ b/crates/core/src/settings/mod.rs
@@ -7,7 +7,7 @@ use crate::frontlight::LightLevels;
 use crate::metadata::{SortMethod, TextAlign};
 use crate::unit::mm_to_px;
 use fxhash::FxHashSet;
-use secrecy::SecretString;
+
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, HashMap};
 use std::env;
@@ -458,49 +458,14 @@ pub struct LoggingSettings {
     pub otlp_endpoint: Option<String>,
 }
 
-/// Configuration for Over-the-Air (OTA) update feature.
+/// OTA update settings.
 ///
-/// Stores the GitHub personal access token required for downloading
-/// build artifacts from pull requests.
-///
-/// # Security
-///
-/// The GitHub token is stored using `SecretString` from the `secrecy` crate,
-/// which prevents accidental exposure in logs or debug output. The token is
-/// automatically wrapped when loaded from the configuration file and unwrapped
-/// only when needed for API authentication.
-#[derive(Debug, Clone, Deserialize)]
+/// Authentication is handled via GitHub device auth flow — no token configuration
+/// is required in `Settings.toml`. The token is obtained interactively and
+/// persisted to disk by the application.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(default, rename_all = "kebab-case")]
-pub struct OtaSettings {
-    /// GitHub personal access token with workflow artifact read permissions.
-    /// Required for authenticated API access to download build artifacts.
-    ///
-    /// When serialized, the token is stored as plain text in the configuration
-    /// file. However, once loaded into memory, it is wrapped in `SecretString`
-    /// to prevent accidental exposure.
-    ///
-    /// For development, you can set the `GH_TOKEN` environment variable to have it automatically
-    /// loaded into the default settings.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub github_token: Option<SecretString>,
-}
-
-impl Serialize for OtaSettings {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
-        use secrecy::ExposeSecret;
-        use serde::ser::SerializeStruct;
-
-        let field_count = if self.github_token.is_some() { 1 } else { 0 };
-        let mut state = serializer.serialize_struct("OtaSettings", field_count)?;
-        if let Some(token) = &self.github_token {
-            state.serialize_field("github-token", token.expose_secret())?;
-        }
-        state.end()
-    }
-}
+pub struct OtaSettings {}
 
 #[derive(Debug, Copy, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
@@ -726,120 +691,17 @@ impl Default for Settings {
     }
 }
 
-impl Default for OtaSettings {
-    /// Creates a default `OtaSettings` instance, attempting to read the GitHub token
-    /// from the `GH_TOKEN` environment variable. If the variable is set, its value is wrapped
-    /// in a `SecretString` and used as the default token.
-    fn default() -> Self {
-        env::var("GH_TOKEN")
-            .ok()
-            .map(|token| OtaSettings {
-                github_token: Some(SecretString::from(token)),
-            })
-            .unwrap_or(OtaSettings { github_token: None })
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
-    use secrecy::ExposeSecret;
 
     #[test]
-    fn test_ota_settings_secret_serialization() {
-        let test_token = "ghp_test1234567890abcdefghijklmnopqrstuvwxyz";
-
-        let mut settings = OtaSettings::default();
-        settings.github_token = Some(SecretString::from(test_token.to_string()));
-
+    fn test_ota_settings_serializes_empty() {
+        let settings = OtaSettings::default();
         let serialized = toml::to_string(&settings).expect("Failed to serialize");
-
-        assert!(
-            serialized.contains("github-token"),
-            "Serialized output should contain github-token field"
-        );
-        assert!(
-            serialized.contains(test_token),
-            "Serialized output should contain the actual token value for file storage"
-        );
-        assert!(
-            !serialized.contains("REDACTED"),
-            "Serialized output should not contain REDACTED placeholder"
-        );
-    }
-
-    #[test]
-    fn test_ota_settings_secret_deserialization() {
-        let test_token = "ghp_test1234567890abcdefghijklmnopqrstuvwxyz";
-        let toml_str = format!(r#"github-token = "{}""#, test_token);
-
-        let settings: OtaSettings = toml::from_str(&toml_str).expect("Failed to deserialize");
-
-        assert!(
-            settings.github_token.is_some(),
-            "Token should be present after deserialization"
-        );
-
-        let token = settings.github_token.as_ref().unwrap();
-        assert_eq!(
-            token.expose_secret(),
-            test_token,
-            "Deserialized token should match original"
-        );
-    }
-
-    #[test]
-    fn test_ota_settings_secret_round_trip() {
-        let test_token = "ghp_roundtrip_test_token_1234567890";
-
-        let mut original = OtaSettings::default();
-        original.github_token = Some(SecretString::from(test_token.to_string()));
-
-        let serialized = toml::to_string(&original).expect("Failed to serialize");
-        let deserialized: OtaSettings = toml::from_str(&serialized).expect("Failed to deserialize");
-
-        assert!(
-            deserialized.github_token.is_some(),
-            "Token should survive round trip"
-        );
-
-        assert_eq!(
-            deserialized.github_token.as_ref().unwrap().expose_secret(),
-            original.github_token.as_ref().unwrap().expose_secret(),
-            "Token value should be identical after round trip"
-        );
-    }
-
-    #[test]
-    fn test_ota_settings_secret_not_in_debug() {
-        let test_token = "ghp_secret_should_not_appear_in_debug";
-
-        let mut settings = OtaSettings::default();
-        settings.github_token = Some(SecretString::from(test_token.to_string()));
-
-        let debug_output = format!("{:?}", settings);
-
-        assert!(
-            !debug_output.contains(test_token),
-            "Debug output should NOT contain the actual token value. Got: {}",
-            debug_output
-        );
-    }
-
-    #[test]
-    fn test_ota_settings_none_token() {
-        let settings = OtaSettings { github_token: None };
-
-        let serialized = toml::to_string(&settings).expect("Failed to serialize");
-
-        assert!(
-            !serialized.contains("github-token"),
-            "Serialized output should not contain github-token field when None"
-        );
-
         assert!(
             serialized.is_empty(),
-            "Serialized output should be empty when token is None"
+            "OtaSettings should serialize to an empty string"
         );
     }
 
@@ -918,27 +780,5 @@ share = "/path/to/custom.png"
             original.share, deserialized.share,
             "share should survive round trip"
         );
-    }
-
-    #[test]
-    fn test_ota_default_from_env() {
-        let test_token = "ghp_env_default_test_token_1234567890";
-        env::set_var("GH_TOKEN", test_token);
-
-        let settings = OtaSettings::default();
-
-        assert!(
-            settings.github_token.is_some(),
-            "Default OtaSettings should read GH_TOKEN from environment"
-        );
-
-        let token = settings.github_token.as_ref().unwrap();
-        assert_eq!(
-            token.expose_secret(),
-            test_token,
-            "Token from environment should match expected value"
-        );
-
-        env::remove_var("GH_TOKEN");
     }
 }

--- a/crates/core/src/view/device_auth.rs
+++ b/crates/core/src/view/device_auth.rs
@@ -1,0 +1,302 @@
+//! Device flow authentication view for GitHub OAuth.
+//!
+//! Displays the user code and verification URL, then polls GitHub in a
+//! background thread until the user authorizes (or the code expires).
+//!
+//! On success, sends [`Event::GithubDeviceAuthComplete`] with the token.
+//! On expiry, sends [`Event::GithubDeviceAuthExpired`].
+//! On error, sends [`Event::GithubDeviceAuthError`].
+//! On cancel, the polling thread is stopped via a shared cancel flag.
+
+use super::button::Button;
+use super::filler::Filler;
+use super::label::Label;
+use super::{Align, Bus, Event, Hub, Id, RenderQueue, View, ViewId, ID_FEEDER};
+use crate::color::WHITE;
+use crate::context::Context;
+use crate::device::CURRENT_DEVICE;
+use crate::font::{font_from_style, Fonts, NORMAL_STYLE};
+use crate::framebuffer::Framebuffer;
+use crate::geom::Rectangle;
+use crate::gesture::GestureEvent;
+use crate::github::{GithubClient, TokenPollResult};
+use crate::unit::scale_by_dpi;
+use crate::view::ota::OtaViewId;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::thread;
+use std::time::Duration;
+
+/// Displays the GitHub device auth flow user code and polls for authorization.
+///
+/// Shows two lines of text:
+/// - The verification URL (`github.com/login/device`)
+/// - The user code to enter (e.g. `WDJB-MJHT`)
+///
+/// A Cancel button stops the background polling thread and closes the view.
+/// A background thread polls GitHub at the required interval. When the user
+/// authorizes, [`Event::GithubDeviceAuthComplete`] is sent through the hub.
+pub struct DeviceAuthView {
+    id: Id,
+    rect: Rectangle,
+    children: Vec<Box<dyn View>>,
+    view_id: ViewId,
+    /// Shared flag — set to `true` to stop the polling thread.
+    cancelled: Arc<AtomicBool>,
+}
+
+impl DeviceAuthView {
+    /// Creates a new device auth view and immediately starts polling.
+    ///
+    /// Initiates the GitHub device auth flow, builds the UI with the user code,
+    /// and spawns a background thread to poll for authorization.
+    ///
+    /// # Arguments
+    ///
+    /// * `hub` - Event hub used to send auth result events
+    /// * `context` - Application context for font metrics
+    ///
+    /// # Errors
+    ///
+    /// If the device flow initiation fails, sends [`Event::OtaDeviceAuthError`]
+    /// immediately and returns a view with an error message.
+    #[cfg_attr(feature = "otel", tracing::instrument(skip_all))]
+    pub fn new(hub: &Hub, context: &mut Context) -> Self {
+        let id = ID_FEEDER.next();
+        let view_id = ViewId::Ota(OtaViewId::DeviceAuth);
+        let (width, height) = CURRENT_DEVICE.dims;
+        let full_rect = rect![0, 0, width as i32, height as i32];
+        let cancelled = Arc::new(AtomicBool::new(false));
+
+        let mut children: Vec<Box<dyn View>> = Vec::new();
+        children.push(Box::new(Filler::new(full_rect, WHITE)));
+
+        let (url_text, code_text) = match Self::initiate_and_spawn(hub, Arc::clone(&cancelled)) {
+            Ok((url, code)) => (format!("Go to: {}", url), format!("Enter code: {}", code)),
+            Err(e) => {
+                tracing::error!(error = %e, "Device flow initiation failed");
+                hub.send(Event::GithubDeviceAuthError(e)).ok();
+                (
+                    "GitHub auth failed".to_owned(),
+                    "Check logs for details".to_owned(),
+                )
+            }
+        };
+
+        let dpi = CURRENT_DEVICE.dpi;
+        let font = font_from_style(&mut context.fonts, &NORMAL_STYLE, dpi);
+        let x_height = font.x_heights.0 as i32;
+        let padding = font.em() as i32;
+
+        let center_y = height as i32 / 2;
+        let line_height = 3 * x_height;
+
+        let url_rect = rect![
+            padding,
+            center_y - line_height - padding / 2,
+            width as i32 - padding,
+            center_y - padding / 2
+        ];
+        children.push(Box::new(Label::new(url_rect, url_text, Align::Center)));
+
+        let code_rect = rect![
+            padding,
+            center_y + padding / 2,
+            width as i32 - padding,
+            center_y + line_height + padding / 2
+        ];
+        children.push(Box::new(Label::new(code_rect, code_text, Align::Center)));
+
+        let button_width = scale_by_dpi(200.0, dpi) as i32;
+        let button_height = scale_by_dpi(40.0, dpi) as i32;
+        let button_x = (width as i32 - button_width) / 2;
+        let button_y = center_y + line_height + 2 * padding;
+        let cancel_rect = rect![
+            button_x,
+            button_y,
+            button_x + button_width,
+            button_y + button_height
+        ];
+        children.push(Box::new(Button::new(
+            cancel_rect,
+            Event::Close(view_id),
+            "Cancel".to_owned(),
+        )));
+
+        Self {
+            id,
+            rect: full_rect,
+            children,
+            view_id,
+            cancelled,
+        }
+    }
+
+    /// Initiates the device flow and spawns the polling thread.
+    ///
+    /// Returns `(verification_uri, user_code)` on success so the caller can
+    /// display them. The polling thread checks `cancelled` before each poll
+    /// and exits cleanly when it is set.
+    fn initiate_and_spawn(
+        hub: &Hub,
+        cancelled: Arc<AtomicBool>,
+    ) -> Result<(String, String), String> {
+        rustls::crypto::ring::default_provider()
+            .install_default()
+            .ok();
+
+        let client = GithubClient::new(None)?;
+        let device_code_response = client.initiate_device_flow()?;
+
+        let verification_uri = device_code_response.verification_uri.clone();
+        let user_code = device_code_response.user_code.clone();
+        let device_code = device_code_response.device_code.clone();
+        let interval_secs = device_code_response.interval;
+
+        tracing::info!(
+            user_code = %user_code,
+            verification_uri = %verification_uri,
+            "Device flow initiated"
+        );
+
+        let hub2 = hub.clone();
+        let parent_span = tracing::Span::current();
+
+        thread::spawn(move || {
+            let _span = tracing::info_span!(parent: &parent_span, "device_flow_poll").entered();
+
+            let poll_client = match GithubClient::new(None) {
+                Ok(c) => c,
+                Err(e) => {
+                    tracing::error!(error = %e, "Failed to create poll client");
+                    hub2.send(Event::GithubDeviceAuthError(e)).ok();
+                    return;
+                }
+            };
+
+            let mut interval = Duration::from_secs(interval_secs);
+
+            loop {
+                thread::sleep(interval);
+
+                if cancelled.load(Ordering::Relaxed) {
+                    tracing::info!("Device flow polling cancelled");
+                    return;
+                }
+
+                match poll_client.poll_device_token(&device_code) {
+                    Ok(TokenPollResult::Pending) => {
+                        tracing::debug!("Authorization pending, continuing to poll");
+                    }
+                    Ok(TokenPollResult::SlowDown) => {
+                        interval += Duration::from_secs(5);
+                        tracing::debug!(interval_secs = interval.as_secs(), "Slowing down poll");
+                    }
+                    Ok(TokenPollResult::Complete(token)) => {
+                        tracing::info!("Device flow authorization complete");
+                        hub2.send(Event::GithubDeviceAuthComplete(token)).ok();
+                        return;
+                    }
+                    Ok(TokenPollResult::Expired) => {
+                        tracing::warn!("Device flow code expired");
+                        hub2.send(Event::GithubDeviceAuthExpired).ok();
+                        return;
+                    }
+                    Ok(TokenPollResult::Cancelled) => {
+                        tracing::info!("Device flow cancelled by user on GitHub");
+                        hub2.send(Event::GithubDeviceAuthError(
+                            "Authorization cancelled".to_owned(),
+                        ))
+                        .ok();
+                        return;
+                    }
+                    Err(e) => {
+                        tracing::error!(error = %e, "Device flow poll error");
+                        hub2.send(Event::GithubDeviceAuthError(e)).ok();
+                        return;
+                    }
+                }
+            }
+        });
+
+        Ok((verification_uri, user_code))
+    }
+
+    /// Stops the background polling thread.
+    fn cancel_polling(&self) {
+        self.cancelled.store(true, Ordering::Relaxed);
+    }
+}
+
+impl View for DeviceAuthView {
+    /// Handles events for the device auth view.
+    ///
+    /// Captures all tap gestures within the view to prevent parent views from
+    /// handling them (which would close the modal). The user must use the
+    /// Cancel button to close this view and return to the parent.
+    #[cfg_attr(
+        feature = "otel",
+        tracing::instrument(
+            skip(self, _hub, bus, _rq, _context),
+            fields(event = ?evt),
+            ret(level = tracing::Level::TRACE)
+        )
+    )]
+    fn handle_event(
+        &mut self,
+        evt: &Event,
+        _hub: &Hub,
+        bus: &mut Bus,
+        _rq: &mut RenderQueue,
+        _context: &mut Context,
+    ) -> bool {
+        match evt {
+            Event::Close(id) if *id == self.view_id => {
+                self.cancel_polling();
+                bus.push_back(Event::Close(ViewId::Ota(OtaViewId::Main)));
+                true
+            }
+            Event::Gesture(GestureEvent::Tap(center)) if self.rect.includes(*center) => true,
+            _ => false,
+        }
+    }
+
+    #[cfg_attr(
+        feature = "otel",
+        tracing::instrument(skip(self, _fb, _fonts, _rect), fields(rect = ?_rect))
+    )]
+    fn render(&self, _fb: &mut dyn Framebuffer, _rect: Rectangle, _fonts: &mut Fonts) {}
+
+    fn rect(&self) -> &Rectangle {
+        &self.rect
+    }
+
+    fn rect_mut(&mut self) -> &mut Rectangle {
+        &mut self.rect
+    }
+
+    fn children(&self) -> &Vec<Box<dyn View>> {
+        &self.children
+    }
+
+    fn children_mut(&mut self) -> &mut Vec<Box<dyn View>> {
+        &mut self.children
+    }
+
+    fn id(&self) -> Id {
+        self.id
+    }
+
+    fn view_id(&self) -> Option<ViewId> {
+        Some(self.view_id)
+    }
+
+    fn resize(
+        &mut self,
+        _rect: Rectangle,
+        _hub: &Hub,
+        _rq: &mut RenderQueue,
+        _context: &mut Context,
+    ) {
+    }
+}

--- a/crates/core/src/view/mod.rs
+++ b/crates/core/src/view/mod.rs
@@ -15,6 +15,7 @@ pub mod button;
 pub mod calculator;
 pub mod clock;
 pub mod common;
+pub mod device_auth;
 pub mod dialog;
 pub mod dictionary;
 pub mod file_chooser;
@@ -40,6 +41,7 @@ pub use self::notification::NotificationEvent;
 pub mod page_label;
 pub mod preset;
 pub mod presets_list;
+pub mod progress_bar;
 pub mod reader;
 pub mod rotation_values;
 pub mod rounded_button;
@@ -498,6 +500,26 @@ pub enum Event {
     /// The file chooser was closed.
     ///  The `Option<PathBuf>` contains the selected path, if any.
     FileChooserClosed(Option<PathBuf>),
+    /// GitHub device flow completed successfully; carries the new access token.
+    GithubDeviceAuthComplete(secrecy::SecretString),
+    /// GitHub device flow code expired before the user authorized.
+    GithubDeviceAuthExpired,
+    /// GitHub device flow failed with an error message.
+    GithubDeviceAuthError(String),
+    /// A GitHub API call returned 401 or 403 — the saved token is invalid,
+    /// revoked, or missing required scopes.
+    ///
+    /// `OtaView` handles this by deleting the stale token, clearing its
+    /// in-memory token, and re-triggering device flow for the pending download.
+    GithubTokenInvalid,
+    /// Progress update from a background OTA download thread.
+    ///
+    /// `OtaView` handles this by updating the status label text and the
+    /// progress bar fill to reflect the current download state.
+    OtaDownloadProgress {
+        label: String,
+        percent: u8,
+    },
 }
 
 #[derive(Debug, Clone, Eq, PartialEq)]

--- a/crates/core/src/view/ota.rs
+++ b/crates/core/src/view/ota.rs
@@ -1,7 +1,9 @@
+use super::device_auth::DeviceAuthView;
 use super::dialog::Dialog;
 use super::input_field::InputField;
 use super::label::Label;
 use super::notification::Notification;
+use super::progress_bar::ProgressBar;
 use super::toggleable_keyboard::ToggleableKeyboard;
 use super::{
     Align, Bus, EntryId, Event, Hub, Id, NotificationEvent, RenderData, RenderQueue, UpdateMode,
@@ -14,7 +16,9 @@ use crate::font::{font_from_style, Fonts, NORMAL_STYLE};
 use crate::framebuffer::Framebuffer;
 use crate::geom::Rectangle;
 use crate::gesture::GestureEvent;
-use crate::ota::{OtaClient, OtaProgress};
+use crate::github::device_flow;
+use crate::github::GithubClient;
+use crate::ota::{OtaClient, OtaError, OtaProgress};
 use crate::unit::scale_by_dpi;
 use crate::view::filler::Filler;
 use crate::view::BIG_BAR_HEIGHT;
@@ -27,6 +31,7 @@ pub enum OtaViewId {
     Main,
     SourceSelection,
     PrInput,
+    DeviceAuth,
 }
 
 #[derive(Debug, Clone, Eq, PartialEq)]
@@ -85,10 +90,18 @@ pub fn show_ota_view(
         return false;
     }
 
-    let ota_view = OtaView::new(context.settings.ota.github_token.clone(), context);
+    let ota_view = OtaView::new(context);
     view.children_mut()
         .push(Box::new(ota_view) as Box<dyn View>);
     true
+}
+
+/// Which download to resume after device flow authentication completes.
+#[derive(Debug, Clone)]
+enum PendingDownload {
+    DefaultBranch,
+    PrInputPending,
+    Pr(u32),
 }
 
 /// UI view for downloading and installing OTA updates from GitHub.
@@ -98,9 +111,14 @@ pub fn show_ota_view(
 ///    (Stable Release, Main Branch, or PR Build)
 /// 2. PR input screen - prompts for PR number input (only for PR Build)
 ///
-/// The view transitions between screens based on user selections.
-/// Selecting Stable Release or Main Branch starts the download immediately,
-/// while PR Build first shows the input screen for a PR number.
+/// Once a download starts, the view transitions to a full-screen progress
+/// screen showing a status label and a [`ProgressBar`]. On successful
+/// deployment the label updates to "Rebooting…" and the app reboots
+/// automatically via [`Event::Select(EntryId::Reboot)`].
+///
+/// When a GitHub token is required but not present, the view pushes a
+/// [`DeviceAuthView`] child to guide the user through device flow
+/// authentication. Once authorized, the pending download resumes automatically.
 ///
 /// # Security
 ///
@@ -113,24 +131,39 @@ pub struct OtaView {
     view_id: ViewId,
     github_token: Option<SecretString>,
     keyboard_index: Option<usize>,
+    pending_download: Option<PendingDownload>,
+    /// Index into `children` of the status `Label` shown during download.
+    status_label_index: Option<usize>,
+    /// Index into `children` of the `ProgressBar` shown during download.
+    progress_bar_index: Option<usize>,
 }
 
 impl OtaView {
-    /// Creates a new OTA view with the configured GitHub token.
+    /// Creates a new OTA view.
+    ///
+    /// Attempts to load a previously saved GitHub token from disk. If none is
+    /// found the view will prompt for device flow authentication when a
+    /// token-gated download is requested.
     ///
     /// Initially displays the source selection dialog asking where to
     /// download updates from.
     ///
     /// # Arguments
     ///
-    /// * `github_token` - Optional GitHub personal access token wrapped in `SecretString`
-    ///   for secure handling. Not required for stable release downloads.
     /// * `context` - Application context containing fonts and device information
     #[cfg_attr(feature = "otel", tracing::instrument(skip_all))]
-    pub fn new(github_token: Option<SecretString>, context: &mut Context) -> OtaView {
+    pub fn new(context: &mut Context) -> OtaView {
         let id = ID_FEEDER.next();
         let view_id = ViewId::Ota(OtaViewId::Main);
         let (width, height) = CURRENT_DEVICE.dims;
+
+        let github_token = match device_flow::load_token() {
+            Ok(token) => token,
+            Err(e) => {
+                tracing::warn!(error = %e, "Failed to load saved GitHub token");
+                None
+            }
+        };
 
         let mut children: Vec<Box<dyn View>> = Vec::new();
 
@@ -149,6 +182,9 @@ impl OtaView {
             view_id,
             github_token,
             keyboard_index: None,
+            pending_download: None,
+            status_label_index: None,
+            progress_bar_index: None,
         }
     }
 
@@ -186,6 +222,9 @@ impl OtaView {
         let (width, height) = CURRENT_DEVICE.dims;
 
         self.children.clear();
+        self.status_label_index = None;
+        self.progress_bar_index = None;
+        self.keyboard_index = None;
 
         self.children.push(Box::new(Filler::new(
             rect![0, 0, width as i32, height as i32],
@@ -232,14 +271,63 @@ impl OtaView {
         self.rect = rect![0, 0, width as i32, height as i32];
     }
 
+    /// Builds the full-screen progress screen shown during download/deployment.
+    ///
+    /// Clears all existing children and adds:
+    /// 1. A white full-screen [`Filler`] background
+    /// 2. A centered [`Label`] with the given status text
+    /// 3. A centered [`ProgressBar`] below the label
+    ///
+    /// The indices of the label and progress bar are stored so they can be
+    /// updated incrementally as progress events arrive.
+    fn build_progress_screen(&mut self, status: &str, context: &mut Context) {
+        let dpi = CURRENT_DEVICE.dpi;
+        let (width, height) = CURRENT_DEVICE.dims;
+
+        self.children.clear();
+        self.status_label_index = None;
+        self.progress_bar_index = None;
+        self.keyboard_index = None;
+
+        self.children.push(Box::new(Filler::new(
+            rect![0, 0, width as i32, height as i32],
+            WHITE,
+        )));
+
+        let font = font_from_style(&mut context.fonts, &NORMAL_STYLE, dpi);
+        let label_height = font.x_heights.0 as i32 * 3;
+        let bar_height = scale_by_dpi(40.0, dpi) as i32;
+        let bar_width = (width as f32 * 0.6) as i32;
+        let center_y = height as i32 / 2;
+        let gap = scale_by_dpi(24.0, dpi) as i32;
+
+        let label_rect = rect![
+            0,
+            center_y - label_height - gap / 2,
+            width as i32,
+            center_y - gap / 2
+        ];
+        self.children.push(Box::new(Label::new(
+            label_rect,
+            status.to_string(),
+            Align::Center,
+        )));
+        self.status_label_index = Some(self.children.len() - 1);
+
+        let bar_x = (width as i32 - bar_width) / 2;
+        let bar_rect = rect![
+            bar_x,
+            center_y + gap / 2,
+            bar_x + bar_width,
+            center_y + gap / 2 + bar_height
+        ];
+        self.children.push(Box::new(ProgressBar::new(bar_rect, 0)));
+        self.progress_bar_index = Some(self.children.len() - 1);
+
+        self.rect = rect![0, 0, width as i32, height as i32];
+    }
+
     /// Toggles keyboard visibility based on focus state.
-    ///
-    /// # Arguments
-    ///
-    /// * `visible` - Whether the keyboard should be visible
-    /// * `hub` - Event hub for sending events
-    /// * `rq` - Render queue for UI updates
-    /// * `context` - Application context
     fn toggle_keyboard(
         &mut self,
         visible: bool,
@@ -258,21 +346,21 @@ impl OtaView {
 
     /// Handles submission of PR number from input field.
     ///
-    /// Validates the input, initiates download if valid, and closes the view.
-    ///
-    /// # Arguments
-    ///
-    /// * `text` - The input text to parse as PR number
-    /// * `hub` - Event hub for sending notifications
-    fn handle_pr_submission(&mut self, text: &str, hub: &Hub) {
+    /// Validates the input, transitions to the progress screen, and initiates
+    /// the download. The view stays alive so it can receive progress events and
+    /// handle token-invalid errors.
+    fn handle_pr_submission(
+        &mut self,
+        text: &str,
+        hub: &Hub,
+        rq: &mut RenderQueue,
+        context: &mut Context,
+    ) {
         if let Ok(pr_number) = text.trim().parse::<u32>() {
-            hub.send(Event::Notification(NotificationEvent::Show(format!(
-                "Downloading PR #{} build...",
-                pr_number
-            ))))
-            .ok();
+            self.pending_download = Some(PendingDownload::Pr(pr_number));
+            self.build_progress_screen(&format!("Downloading PR #{} build…", pr_number), context);
+            rq.add(RenderData::new(self.id, self.rect, UpdateMode::Gui));
             self.start_pr_download(pr_number, hub);
-            hub.send(Event::Close(self.view_id)).ok();
         } else {
             hub.send(Event::Notification(NotificationEvent::Show(
                 "Invalid PR number".to_string(),
@@ -299,35 +387,37 @@ impl OtaView {
         }
     }
 
-    /// Validates that a GitHub token is configured.
+    /// Checks that a GitHub token is available.
     ///
-    /// Returns true if a token is present. If not, sends a notification
-    /// explaining that the token is required.
-    #[inline]
-    fn require_github_token(&self, hub: &Hub, check_source: &str) -> bool {
-        if self.github_token.is_none() {
-            hub.send(Event::Notification(NotificationEvent::Show(format!(
-                "GitHub token required for {}. Add [ota] github-token to Settings.toml",
-                check_source
-            ))))
-            .ok();
-            return false;
+    /// Returns `true` if a token is present and the caller may proceed.
+    /// If no token is found, pushes a [`DeviceAuthView`] child to guide the
+    /// user through device flow authentication and returns `false`.
+    fn require_github_token(
+        &mut self,
+        pending: PendingDownload,
+        hub: &Hub,
+        rq: &mut RenderQueue,
+        context: &mut Context,
+    ) -> bool {
+        if self.github_token.is_some() {
+            return true;
         }
-        true
+
+        tracing::info!("No GitHub token found, starting device flow");
+        self.pending_download = Some(pending);
+        let auth_view = DeviceAuthView::new(hub, context);
+        self.children.push(Box::new(auth_view) as Box<dyn View>);
+        rq.add(RenderData::new(self.id, self.rect, UpdateMode::Gui));
+        false
     }
 
-    /// Initiates the download process in a background thread.
+    /// Initiates the PR artifact download in a background thread.
     ///
-    /// Spawns a thread that:
-    /// 1. Creates an OTA client
-    /// 2. Downloads the artifact for the specified PR
-    /// 3. Extracts and deploys KoboRoot.tgz
-    /// 4. Sends notification events on success or failure
-    ///
-    /// # Arguments
-    ///
-    /// * `pr_number` - The GitHub pull request number to download
-    /// * `hub` - Event hub for sending notifications and status updates
+    /// Sends [`Event::OtaDownloadProgress`] during the download. On success,
+    /// updates the status label to "Rebooting…" and sends
+    /// [`Event::Select(EntryId::Reboot)`] to trigger an automatic reboot.
+    /// On a 401 response, sends [`Event::GithubTokenInvalid`] without closing
+    /// the view so re-authentication can proceed.
     #[cfg_attr(feature = "otel", tracing::instrument(skip(self, hub)))]
     fn start_pr_download(&mut self, pr_number: u32, hub: &Hub) {
         let Some(github_token) = self.github_token.clone() else {
@@ -337,74 +427,78 @@ impl OtaView {
 
         let hub2 = hub.clone();
         let parent_span = tracing::Span::current();
+        let ota_view_id = self.view_id;
 
         thread::spawn(move || {
             let _span =
                 tracing::info_span!(parent: &parent_span, "pr_download_async", pr_number).entered();
-            let client = match OtaClient::new(Some(github_token)) {
+            let github = match GithubClient::new(Some(github_token)) {
                 Ok(c) => c,
                 Err(e) => {
-                    error!("[OTA] Failed to create github client {:?}", e);
-                    let error_msg = format!("Failed to create client: {}", e);
-                    hub2.send(Event::Notification(NotificationEvent::Show(error_msg)))
-                        .ok();
+                    error!(error = %e, "Failed to create GitHub client");
+                    hub2.send(Event::Close(ota_view_id)).ok();
+                    hub2.send(Event::Notification(NotificationEvent::Show(format!(
+                        "Failed to create client: {}",
+                        e
+                    ))))
+                    .ok();
                     return;
                 }
             };
+            let client = OtaClient::new(github);
 
-            let notify_id = ViewId::MessageNotif(ID_FEEDER.next());
-            hub2.send(Event::Notification(NotificationEvent::ShowPinned(
-                notify_id,
-                "Starting update download".to_string(),
-            )))
-            .ok();
-            hub2.send(Event::Notification(NotificationEvent::UpdateProgress(
-                notify_id, 0,
-            )))
+            hub2.send(Event::OtaDownloadProgress {
+                label: format!("Downloading PR #{} build… 0%", pr_number),
+                percent: 0,
+            })
             .ok();
 
             let download_result = client.download_pr_artifact(pr_number, |ota_progress| {
                 if let OtaProgress::DownloadingArtifact { downloaded, total } = ota_progress {
-                    let progress = (downloaded as f32 / total as f32) * 100.0;
-                    let msg = format!("Downloading update: {}%", progress as u8);
-                    hub2.send(Event::Notification(NotificationEvent::UpdateText(
-                        notify_id, msg,
-                    )))
-                    .ok();
-                    hub2.send(Event::Notification(NotificationEvent::UpdateProgress(
-                        notify_id,
-                        progress as u8,
-                    )))
+                    let percent = (downloaded as f32 / total as f32 * 100.0) as u8;
+                    hub2.send(Event::OtaDownloadProgress {
+                        label: format!("Downloading PR #{} build… {}%", pr_number, percent),
+                        percent,
+                    })
                     .ok();
                 }
             });
 
-            hub2.send(Event::Close(notify_id)).ok();
-
             match download_result {
                 Ok(zip_path) => {
-                    info!("[OTA] Download completed, starting extraction...");
-
+                    info!(pr_number, "Download completed, starting extraction");
                     match client.extract_and_deploy(zip_path) {
                         Ok(_) => {
-                            hub2.send(Event::Notification(NotificationEvent::Show(
-                                "Update installed! Reboot to apply.".to_string(),
-                            )))
+                            hub2.send(Event::OtaDownloadProgress {
+                                label: "Installing and rebooting…".to_string(),
+                                percent: 100,
+                            })
                             .ok();
+                            send_reboot_after_delay(hub2.clone());
                         }
                         Err(e) => {
-                            error!("[OTA] Deployment error: {:?}", e);
-                            let error_msg = format!("Deployment failed: {}", e);
-                            hub2.send(Event::Notification(NotificationEvent::Show(error_msg)))
-                                .ok();
+                            error!(error = %e, "Deployment failed");
+                            hub2.send(Event::Close(ota_view_id)).ok();
+                            hub2.send(Event::Notification(NotificationEvent::Show(format!(
+                                "Deployment failed: {}",
+                                e
+                            ))))
+                            .ok();
                         }
                     }
                 }
+                Err(OtaError::Unauthorized) | Err(OtaError::InsufficientScopes(_)) => {
+                    tracing::warn!(pr_number, "GitHub token rejected — triggering re-auth");
+                    hub2.send(Event::GithubTokenInvalid).ok();
+                }
                 Err(e) => {
-                    error!("[OTA] Download error: {:?}", e);
-                    let error_msg = format!("Download failed: {}", e);
-                    hub2.send(Event::Notification(NotificationEvent::Show(error_msg)))
-                        .ok();
+                    error!(error = %e, "PR download failed");
+                    hub2.send(Event::Close(ota_view_id)).ok();
+                    hub2.send(Event::Notification(NotificationEvent::Show(format!(
+                        "Download failed: {}",
+                        e
+                    ))))
+                    .ok();
                 }
             }
         });
@@ -412,15 +506,11 @@ impl OtaView {
 
     /// Initiates the default branch download in a background thread.
     ///
-    /// Spawns a thread that:
-    /// 1. Creates an OTA client
-    /// 2. Downloads the latest artifact from the default branch
-    /// 3. Extracts and deploys KoboRoot.tgz
-    /// 4. Sends notification events on success or failure
-    ///
-    /// # Arguments
-    ///
-    /// * `hub` - Event hub for sending notifications and status updates
+    /// Sends [`Event::OtaDownloadProgress`] during the download. On success,
+    /// updates the status label to "Rebooting…" and sends
+    /// [`Event::Select(EntryId::Reboot)`] to trigger an automatic reboot.
+    /// On a 401 response, sends [`Event::GithubTokenInvalid`] without closing
+    /// the view so re-authentication can proceed.
     #[cfg_attr(feature = "otel", tracing::instrument(skip(self, hub)))]
     fn start_default_branch_download(&mut self, hub: &Hub) {
         let Some(github_token) = self.github_token.clone() else {
@@ -430,74 +520,78 @@ impl OtaView {
 
         let hub2 = hub.clone();
         let parent_span = tracing::Span::current();
+        let ota_view_id = self.view_id;
 
         thread::spawn(move || {
             let _span = tracing::info_span!(parent: &parent_span, "default_branch_download_async")
                 .entered();
-            let client = match OtaClient::new(Some(github_token)) {
+            let github = match GithubClient::new(Some(github_token)) {
                 Ok(c) => c,
                 Err(e) => {
-                    error!(error = %e, "Failed to create OTA client");
-                    let error_msg = format!("Failed to create client: {}", e);
-                    hub2.send(Event::Notification(NotificationEvent::Show(error_msg)))
-                        .ok();
+                    error!(error = %e, "Failed to create GitHub client");
+                    hub2.send(Event::Close(ota_view_id)).ok();
+                    hub2.send(Event::Notification(NotificationEvent::Show(format!(
+                        "Failed to create client: {}",
+                        e
+                    ))))
+                    .ok();
                     return;
                 }
             };
+            let client = OtaClient::new(github);
 
-            let notify_id = ViewId::MessageNotif(ID_FEEDER.next());
-            hub2.send(Event::Notification(NotificationEvent::ShowPinned(
-                notify_id,
-                "Starting main branch download".to_string(),
-            )))
-            .ok();
-            hub2.send(Event::Notification(NotificationEvent::UpdateProgress(
-                notify_id, 0,
-            )))
+            hub2.send(Event::OtaDownloadProgress {
+                label: "Downloading main branch build… 0%".to_string(),
+                percent: 0,
+            })
             .ok();
 
             let download_result = client.download_default_branch_artifact(|ota_progress| {
                 if let OtaProgress::DownloadingArtifact { downloaded, total } = ota_progress {
-                    let progress = (downloaded as f32 / total as f32) * 100.0;
-                    let msg = format!("Downloading update: {}%", progress as u8);
-                    hub2.send(Event::Notification(NotificationEvent::UpdateText(
-                        notify_id, msg,
-                    )))
-                    .ok();
-                    hub2.send(Event::Notification(NotificationEvent::UpdateProgress(
-                        notify_id,
-                        progress as u8,
-                    )))
+                    let percent = (downloaded as f32 / total as f32 * 100.0) as u8;
+                    hub2.send(Event::OtaDownloadProgress {
+                        label: format!("Downloading main branch build… {}%", percent),
+                        percent,
+                    })
                     .ok();
                 }
             });
 
-            hub2.send(Event::Close(notify_id)).ok();
-
             match download_result {
                 Ok(zip_path) => {
                     info!("Main branch download completed, starting extraction");
-
                     match client.extract_and_deploy(zip_path) {
                         Ok(_) => {
-                            hub2.send(Event::Notification(NotificationEvent::Show(
-                                "Update installed! Reboot to apply.".to_string(),
-                            )))
+                            hub2.send(Event::OtaDownloadProgress {
+                                label: "Installing and rebooting…".to_string(),
+                                percent: 100,
+                            })
                             .ok();
+                            send_reboot_after_delay(hub2.clone());
                         }
                         Err(e) => {
                             error!(error = %e, "Deployment failed");
-                            let error_msg = format!("Deployment failed: {}", e);
-                            hub2.send(Event::Notification(NotificationEvent::Show(error_msg)))
-                                .ok();
+                            hub2.send(Event::Close(ota_view_id)).ok();
+                            hub2.send(Event::Notification(NotificationEvent::Show(format!(
+                                "Deployment failed: {}",
+                                e
+                            ))))
+                            .ok();
                         }
                     }
                 }
+                Err(OtaError::Unauthorized) | Err(OtaError::InsufficientScopes(_)) => {
+                    tracing::warn!("GitHub token rejected — triggering re-auth");
+                    hub2.send(Event::GithubTokenInvalid).ok();
+                }
                 Err(e) => {
                     error!(error = %e, "Main branch download failed");
-                    let error_msg = format!("Download failed: {}", e);
-                    hub2.send(Event::Notification(NotificationEvent::Show(error_msg)))
-                        .ok();
+                    hub2.send(Event::Close(ota_view_id)).ok();
+                    hub2.send(Event::Notification(NotificationEvent::Show(format!(
+                        "Download failed: {}",
+                        e
+                    ))))
+                    .ok();
                 }
             }
         });
@@ -505,11 +599,11 @@ impl OtaView {
 
     /// Initiates the stable release download in a background thread.
     ///
-    /// Spawns a thread that:
-    /// 1. Creates an OTA client
-    /// 2. Downloads the latest stable release asset
-    /// 3. Extracts and deploys KoboRoot.tgz
-    /// 4. Sends notification events on success or failure
+    /// Sends [`Event::OtaDownloadProgress`] during the download. On success,
+    /// updates the status label to "Rebooting…" and sends
+    /// [`Event::Select(EntryId::Reboot)`] to trigger an automatic reboot.
+    /// On a 401 response, sends [`Event::GithubTokenInvalid`] without closing
+    /// the view so re-authentication can proceed.
     ///
     /// GitHub authentication is not required for this operation.
     ///
@@ -521,77 +615,248 @@ impl OtaView {
         let github_token = self.github_token.clone();
         let hub2 = hub.clone();
         let parent_span = tracing::Span::current();
+        let ota_view_id = self.view_id;
 
         thread::spawn(move || {
             let _span = tracing::info_span!(parent: &parent_span, "stable_release_download_async")
                 .entered();
-            let client = match OtaClient::new(github_token) {
+            let github = match GithubClient::new(github_token) {
                 Ok(c) => c,
                 Err(e) => {
-                    error!(error = %e, "Failed to create OTA client");
-                    let error_msg = format!("Failed to create client: {}", e);
-                    hub2.send(Event::Notification(NotificationEvent::Show(error_msg)))
-                        .ok();
+                    error!(error = %e, "Failed to create GitHub client");
+                    hub2.send(Event::Close(ota_view_id)).ok();
+                    hub2.send(Event::Notification(NotificationEvent::Show(format!(
+                        "Failed to create client: {}",
+                        e
+                    ))))
+                    .ok();
                     return;
                 }
             };
+            let client = OtaClient::new(github);
 
-            let notify_id = ViewId::MessageNotif(ID_FEEDER.next());
-            hub2.send(Event::Notification(NotificationEvent::ShowPinned(
-                notify_id,
-                "Starting stable release download".to_string(),
-            )))
-            .ok();
-            hub2.send(Event::Notification(NotificationEvent::UpdateProgress(
-                notify_id, 0,
-            )))
+            hub2.send(Event::OtaDownloadProgress {
+                label: "Downloading stable release… 0%".to_string(),
+                percent: 0,
+            })
             .ok();
 
             let download_result = client.download_stable_release_artifact(|ota_progress| {
                 if let OtaProgress::DownloadingArtifact { downloaded, total } = ota_progress {
-                    let progress = (downloaded as f32 / total as f32) * 100.0;
-                    let msg = format!("Downloading update: {}%", progress as u8);
-                    hub2.send(Event::Notification(NotificationEvent::UpdateText(
-                        notify_id, msg,
-                    )))
-                    .ok();
-                    hub2.send(Event::Notification(NotificationEvent::UpdateProgress(
-                        notify_id,
-                        progress as u8,
-                    )))
+                    let percent = (downloaded as f32 / total as f32 * 100.0) as u8;
+                    hub2.send(Event::OtaDownloadProgress {
+                        label: format!("Downloading stable release… {}%", percent),
+                        percent,
+                    })
                     .ok();
                 }
             });
 
-            hub2.send(Event::Close(notify_id)).ok();
-
             match download_result {
                 Ok(asset_path) => {
                     info!("Stable release download completed, deploying update");
-
                     match client.deploy(asset_path) {
                         Ok(_) => {
-                            hub2.send(Event::Notification(NotificationEvent::Show(
-                                "Update installed! Reboot to apply.".to_string(),
-                            )))
+                            hub2.send(Event::OtaDownloadProgress {
+                                label: "Installing and rebooting…".to_string(),
+                                percent: 100,
+                            })
                             .ok();
+                            send_reboot_after_delay(hub2.clone());
                         }
                         Err(e) => {
                             error!(error = %e, "Deployment failed");
-                            let error_msg = format!("Deployment failed: {}", e);
-                            hub2.send(Event::Notification(NotificationEvent::Show(error_msg)))
-                                .ok();
+                            hub2.send(Event::Close(ota_view_id)).ok();
+                            hub2.send(Event::Notification(NotificationEvent::Show(format!(
+                                "Deployment failed: {}",
+                                e
+                            ))))
+                            .ok();
                         }
                     }
                 }
+                Err(OtaError::Unauthorized) | Err(OtaError::InsufficientScopes(_)) => {
+                    tracing::warn!("GitHub token rejected on stable release — triggering re-auth");
+                    hub2.send(Event::GithubTokenInvalid).ok();
+                }
                 Err(e) => {
                     error!(error = %e, "Stable release download failed");
-                    let error_msg = format!("Download failed: {}", e);
-                    hub2.send(Event::Notification(NotificationEvent::Show(error_msg)))
-                        .ok();
+                    hub2.send(Event::Close(ota_view_id)).ok();
+                    hub2.send(Event::Notification(NotificationEvent::Show(format!(
+                        "Download failed: {}",
+                        e
+                    ))))
+                    .ok();
                 }
             }
         });
+    }
+}
+
+/// Spawns a thread that sleeps for 1 second then sends `Event::Select(EntryId::Reboot)`.
+///
+/// The delay gives the render loop time to process the final
+/// `OtaDownloadProgress` label update before the event loop exits.
+fn send_reboot_after_delay(hub: Hub) {
+    thread::spawn(move || {
+        thread::sleep(std::time::Duration::from_secs(1));
+        hub.send(Event::Select(EntryId::Reboot)).ok();
+    });
+}
+
+impl OtaView {
+    #[inline]
+    fn on_select_default_branch(
+        &mut self,
+        hub: &Hub,
+        rq: &mut RenderQueue,
+        context: &mut Context,
+    ) -> bool {
+        if !self.require_github_token(PendingDownload::DefaultBranch, hub, rq, context) {
+            return true;
+        }
+        self.pending_download = Some(PendingDownload::DefaultBranch);
+        self.build_progress_screen("Downloading main branch build… 0%", context);
+        rq.add(RenderData::new(self.id, self.rect, UpdateMode::Gui));
+        self.start_default_branch_download(hub);
+        true
+    }
+
+    #[inline]
+    fn on_select_stable_release(
+        &mut self,
+        hub: &Hub,
+        rq: &mut RenderQueue,
+        context: &mut Context,
+    ) -> bool {
+        self.build_progress_screen("Downloading stable release… 0%", context);
+        rq.add(RenderData::new(self.id, self.rect, UpdateMode::Gui));
+        self.start_stable_release_download(hub);
+        true
+    }
+
+    #[inline]
+    fn on_show_pr_input(&mut self, hub: &Hub, rq: &mut RenderQueue, context: &mut Context) -> bool {
+        if !self.require_github_token(PendingDownload::PrInputPending, hub, rq, context) {
+            return true;
+        }
+        self.build_pr_input_screen(context);
+        rq.add(RenderData::new(self.id, self.rect, UpdateMode::Gui));
+        self.toggle_keyboard(true, hub, rq, context);
+        hub.send(Event::Focus(Some(ViewId::Ota(OtaViewId::PrInput))))
+            .ok();
+        true
+    }
+
+    #[inline]
+    fn on_download_progress(&mut self, label: &str, percent: u8, rq: &mut RenderQueue) -> bool {
+        if let Some(idx) = self.status_label_index {
+            if let Some(child) = self.children.get_mut(idx) {
+                if let Some(lbl) = child.downcast_mut::<Label>() {
+                    lbl.update(label, rq);
+                }
+            }
+        }
+
+        if percent == 100 {
+            if let Some(idx) = self.progress_bar_index.take() {
+                let bar_rect = *self.children[idx].rect();
+                self.children.remove(idx);
+                rq.add(RenderData::expose(bar_rect, UpdateMode::Gui));
+            }
+        } else if let Some(idx) = self.progress_bar_index {
+            if let Some(child) = self.children.get_mut(idx) {
+                if let Some(bar) = child.downcast_mut::<ProgressBar>() {
+                    bar.update(percent, rq);
+                }
+            }
+        }
+
+        true
+    }
+
+    #[inline]
+    fn on_device_auth_complete(
+        &mut self,
+        token: &secrecy::SecretString,
+        hub: &Hub,
+        rq: &mut RenderQueue,
+        context: &mut Context,
+    ) -> bool {
+        tracing::info!("Device auth complete, saving token");
+
+        if let Err(e) = device_flow::save_token(token) {
+            tracing::error!(error = %e, "Failed to save GitHub token");
+        }
+
+        self.github_token = Some(token.clone());
+
+        match self.pending_download.take() {
+            Some(PendingDownload::DefaultBranch) => {
+                self.build_progress_screen("Downloading main branch build… 0%", context);
+                rq.add(RenderData::new(self.id, self.rect, UpdateMode::Gui));
+                self.start_default_branch_download(hub);
+            }
+            Some(PendingDownload::PrInputPending) => {
+                self.build_pr_input_screen(context);
+                rq.add(RenderData::new(self.id, self.rect, UpdateMode::Gui));
+                self.toggle_keyboard(true, hub, rq, context);
+                hub.send(Event::Focus(Some(ViewId::Ota(OtaViewId::PrInput))))
+                    .ok();
+            }
+            Some(PendingDownload::Pr(pr_number)) => {
+                self.build_progress_screen(
+                    &format!("Downloading PR #{} build… 0%", pr_number),
+                    context,
+                );
+                rq.add(RenderData::new(self.id, self.rect, UpdateMode::Gui));
+                self.start_pr_download(pr_number, hub);
+            }
+            None => {}
+        }
+
+        true
+    }
+
+    #[inline]
+    fn on_token_invalid(&mut self, hub: &Hub, rq: &mut RenderQueue, context: &mut Context) -> bool {
+        tracing::warn!("Saved GitHub token is invalid — clearing and re-authenticating");
+
+        if let Err(e) = device_flow::delete_token() {
+            tracing::error!(error = %e, "Failed to delete stale token");
+        }
+
+        self.github_token = None;
+
+        let auth_view = DeviceAuthView::new(hub, context);
+        self.children.push(Box::new(auth_view) as Box<dyn View>);
+        rq.add(RenderData::new(self.id, self.rect, UpdateMode::Gui));
+        true
+    }
+
+    #[inline]
+    fn on_device_auth_expired(&mut self, hub: &Hub) -> bool {
+        tracing::warn!("Device flow code expired");
+        self.pending_download = None;
+        hub.send(Event::Notification(NotificationEvent::Show(
+            "GitHub authorization timed out. Please try again.".to_string(),
+        )))
+        .ok();
+        hub.send(Event::Close(self.view_id)).ok();
+        true
+    }
+
+    #[inline]
+    fn on_device_auth_error(&mut self, msg: &str, hub: &Hub) -> bool {
+        tracing::error!(error = %msg, "Device flow error");
+        self.pending_download = None;
+        hub.send(Event::Notification(NotificationEvent::Show(format!(
+            "GitHub auth error: {}",
+            msg
+        ))))
+        .ok();
+        hub.send(Event::Close(self.view_id)).ok();
+        true
     }
 }
 
@@ -605,44 +870,14 @@ impl View for OtaView {
         rq: &mut RenderQueue,
         context: &mut Context,
     ) -> bool {
-        match *evt {
+        match evt {
             Event::Select(EntryId::Ota(OtaEntryId::DefaultBranch)) => {
-                if !self.require_github_token(hub, "main branch builds") {
-                    return true;
-                }
-
-                hub.send(Event::Notification(NotificationEvent::Show(
-                    "Downloading latest main branch build...".to_string(),
-                )))
-                .ok();
-                self.start_default_branch_download(hub);
-                hub.send(Event::Close(self.view_id)).ok();
-                true
+                self.on_select_default_branch(hub, rq, context)
             }
             Event::Select(EntryId::Ota(OtaEntryId::StableRelease)) => {
-                hub.send(Event::Notification(NotificationEvent::Show(
-                    "Downloading latest stable release...".to_string(),
-                )))
-                .ok();
-                self.start_stable_release_download(hub);
-                hub.send(Event::Close(self.view_id)).ok();
-                true
+                self.on_select_stable_release(hub, rq, context)
             }
-            Event::Show(ViewId::Ota(OtaViewId::PrInput)) => {
-                if !self.require_github_token(hub, "PR builds") {
-                    return true;
-                }
-
-                #[cfg(feature = "otel")]
-                tracing::trace!("Showing PR input screen");
-
-                self.build_pr_input_screen(context);
-                rq.add(RenderData::new(self.id, self.rect, UpdateMode::Gui));
-                self.toggle_keyboard(true, hub, rq, context);
-                hub.send(Event::Focus(Some(ViewId::Ota(OtaViewId::PrInput))))
-                    .ok();
-                true
-            }
+            Event::Show(ViewId::Ota(OtaViewId::PrInput)) => self.on_show_pr_input(hub, rq, context),
             Event::Focus(None) => {
                 self.toggle_keyboard(false, hub, rq, context);
                 true
@@ -650,34 +885,50 @@ impl View for OtaView {
             Event::Focus(Some(ViewId::Ota(_))) => true,
             Event::Submit(ViewId::Ota(OtaViewId::PrInput), ref text) => {
                 self.toggle_keyboard(false, hub, rq, context);
-                self.handle_pr_submission(text, hub);
+                let text = text.clone();
+                self.handle_pr_submission(&text, hub, rq, context);
                 true
             }
             Event::Gesture(GestureEvent::Tap(center)) => {
-                self.handle_outside_tap(center, context, hub);
+                self.handle_outside_tap(*center, context, hub);
                 true
             }
+            Event::OtaDownloadProgress { label, percent } => {
+                self.on_download_progress(label, *percent, rq)
+            }
+            Event::GithubDeviceAuthComplete(ref token) => {
+                self.on_device_auth_complete(token, hub, rq, context)
+            }
+            Event::GithubTokenInvalid => self.on_token_invalid(hub, rq, context),
+            Event::GithubDeviceAuthExpired => self.on_device_auth_expired(hub),
+            Event::GithubDeviceAuthError(ref msg) => self.on_device_auth_error(msg, hub),
             _ => false,
         }
     }
+
     #[cfg_attr(feature = "otel", tracing::instrument(skip(self, _fb, _fonts, _rect), fields(rect = ?_rect)))]
     fn render(&self, _fb: &mut dyn Framebuffer, _rect: Rectangle, _fonts: &mut Fonts) {}
 
     fn rect(&self) -> &Rectangle {
         &self.rect
     }
+
     fn rect_mut(&mut self) -> &mut Rectangle {
         &mut self.rect
     }
+
     fn children(&self) -> &Vec<Box<dyn View>> {
         &self.children
     }
+
     fn children_mut(&mut self) -> &mut Vec<Box<dyn View>> {
         &mut self.children
     }
+
     fn id(&self) -> Id {
         self.id
     }
+
     fn view_id(&self) -> Option<ViewId> {
         Some(self.view_id)
     }
@@ -702,7 +953,7 @@ mod tests {
     use std::sync::mpsc::channel;
 
     fn create_ota_view(context: &mut Context) -> OtaView {
-        OtaView::new(Some(SecretString::from("test-token")), context)
+        OtaView::new(context)
     }
 
     /// A minimal parent view that mimics Home/Reader keyboard behavior.

--- a/crates/core/src/view/progress_bar.rs
+++ b/crates/core/src/view/progress_bar.rs
@@ -1,0 +1,118 @@
+use super::{Bus, Event, Hub, Id, RenderData, RenderQueue, View, ID_FEEDER};
+use crate::color::{BLACK, PROGRESS_EMPTY, PROGRESS_FULL, WHITE};
+use crate::context::Context;
+use crate::device::CURRENT_DEVICE;
+use crate::font::Fonts;
+use crate::framebuffer::{Framebuffer, UpdateMode};
+use crate::geom::{halves, BorderSpec, CornerSpec, Rectangle};
+use crate::unit::scale_by_dpi;
+
+const PROGRESS_HEIGHT: f32 = 7.0;
+const BORDER_THICKNESS: f32 = 1.0;
+
+/// A read-only horizontal progress bar.
+///
+/// Displays a filled track proportional to the current `percent` value (0–100).
+/// Unlike [`Slider`](super::slider::Slider), this view is non-interactive and
+/// has no draggable thumb — it is intended for displaying download or
+/// installation progress.
+pub struct ProgressBar {
+    id: Id,
+    rect: Rectangle,
+    children: Vec<Box<dyn View>>,
+    percent: u8,
+}
+
+impl ProgressBar {
+    /// Creates a new progress bar at the given rect with an initial percent (0–100).
+    pub fn new(rect: Rectangle, percent: u8) -> ProgressBar {
+        ProgressBar {
+            id: ID_FEEDER.next(),
+            rect,
+            children: Vec::new(),
+            percent: percent.min(100),
+        }
+    }
+
+    /// Updates the progress value and queues a re-render if the value changed.
+    pub fn update(&mut self, percent: u8, rq: &mut RenderQueue) {
+        let clamped = percent.min(100);
+
+        if self.percent != clamped {
+            self.percent = clamped;
+            rq.add(RenderData::new(self.id, self.rect, UpdateMode::Gui));
+        }
+    }
+}
+
+impl View for ProgressBar {
+    #[cfg_attr(feature = "otel", tracing::instrument(skip(self, _hub, _bus, _rq, _context), fields(event = ?_evt), ret(level = tracing::Level::TRACE)))]
+    fn handle_event(
+        &mut self,
+        _evt: &Event,
+        _hub: &Hub,
+        _bus: &mut Bus,
+        _rq: &mut RenderQueue,
+        _context: &mut Context,
+    ) -> bool {
+        false
+    }
+
+    #[cfg_attr(feature = "otel", tracing::instrument(skip(self, fb, _fonts, _rect), fields(rect = ?_rect)))]
+    fn render(&self, fb: &mut dyn Framebuffer, _rect: Rectangle, _fonts: &mut Fonts) {
+        let dpi = CURRENT_DEVICE.dpi;
+        let progress_height = scale_by_dpi(PROGRESS_HEIGHT, dpi) as i32;
+        let border_thickness = scale_by_dpi(BORDER_THICKNESS, dpi) as u16;
+
+        fb.draw_rectangle(&self.rect, WHITE);
+
+        let (small_half, _big_half) = halves(progress_height);
+        let (small_padding, big_padding) = halves(self.rect.height() as i32 - progress_height);
+
+        let track_rect = rect![
+            self.rect.min.x,
+            self.rect.min.y + small_padding,
+            self.rect.max.x,
+            self.rect.max.y - big_padding
+        ];
+
+        let fill_x =
+            self.rect.min.x + (self.rect.width() as f32 * self.percent as f32 / 100.0) as i32;
+
+        fb.draw_rounded_rectangle_with_border(
+            &track_rect,
+            &CornerSpec::Uniform(small_half),
+            &BorderSpec {
+                thickness: border_thickness,
+                color: BLACK,
+            },
+            &|x, _| {
+                if x < fill_x {
+                    PROGRESS_FULL
+                } else {
+                    PROGRESS_EMPTY
+                }
+            },
+        );
+    }
+
+    fn rect(&self) -> &Rectangle {
+        &self.rect
+    }
+
+    fn rect_mut(&mut self) -> &mut Rectangle {
+        &mut self.rect
+    }
+
+    fn children(&self) -> &Vec<Box<dyn View>> {
+        &self.children
+    }
+
+    fn children_mut(&mut self) -> &mut Vec<Box<dyn View>> {
+        &mut self.children
+    }
+
+    fn id(&self) -> Id {
+        self.id
+    }
+}

--- a/crates/emulator/src/main.rs
+++ b/crates/emulator/src/main.rs
@@ -832,6 +832,10 @@ fn main() -> Result<(), Error> {
                 Event::Device(DeviceEvent::RotateScreen(n)) => {
                     tx.send(Event::Select(EntryId::Rotate(n))).ok();
                 }
+                Event::Select(EntryId::Reboot) => {
+                    thread::sleep(Duration::from_secs(3));
+                    break 'outer;
+                }
                 Event::Select(EntryId::Quit) => {
                     break 'outer;
                 }

--- a/docs/src/installation/ota.md
+++ b/docs/src/installation/ota.md
@@ -7,17 +7,9 @@ computer. The OTA (Over-The-Air) feature downloads updates directly from GitHub.
 
 - A WiFi connection
 
-For main branch or PR builds, you also need a GitHub personal access token in
-your `Settings.toml` file:
-
-```toml
-[ota]
-github-token = "ghp_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
-```
-
-Stable releases do not require a token. See the
-[OTA settings](../settings/index.md#otagithub-token) reference for details on
-getting a token.
+Stable releases are public and require no authentication. Main branch and PR
+builds require a GitHub account — Cadmus will guide you through a one-time
+sign-in the first time you request one.
 
 ## How to update
 
@@ -37,16 +29,24 @@ update from:
 Select **Main Branch** to get the most recent development build. This includes
 changes that have been merged but not yet released officially.
 
-The update downloads from GitHub, installs automatically, and prompts you to
-reboot to finish.
+If this is your first time, Cadmus will show a screen with a URL and a short
+code. On any device with a browser:
+
+1. Go to the URL shown on screen
+2. Enter the code shown on your Device
+3. Sign in to GitHub and approve the request
+
+Cadmus will detect the approval automatically and start the download. The token
+is saved to disk so you won't need to sign in again.
+
+The update downloads from GitHub, installs automatically, and reboots the device
+to finish.
 
 ## Testing a pull request
 
 Select **PR Build** to try out a specific change before it's released. Enter the
-PR number when prompted.
-
-This downloads the update from that pull request, installs it, and asks you to
-reboot.
+PR number when prompted. The same one-time GitHub sign-in applies if you haven't
+authenticated before.
 
 > **Tip:** Find the PR number in the GitHub URL. For example, in
 > `github.com/OGKevin/cadmus/pull/42` the PR number is **42**.

--- a/docs/src/settings/index.md
+++ b/docs/src/settings/index.md
@@ -152,24 +152,14 @@ Image displayed when entering USB sharing mode.
 
 The OTA feature downloads builds from GitHub.
 
-### `ota.github-token`
+Authentication for main branch and PR builds uses **GitHub device auth flow**.
+When you select a build that requires authentication,
+Cadmus will display a short code and a URL. Visit
+`github.com/login/device` on any device, enter the code, and Cadmus will
+automatically continue the download once you authorize.
 
-GitHub personal access token needed to download development and test builds.
-Not required for stable releases.
-
-- Configure it under the `[ota]` section.
-
-```toml
-[ota]
-github-token = "ghp_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
-```
-
-To create a token:
-
-1. Go to <https://github.com/settings/personal-access-tokens/new>
-2. Under **Repository access**, select **Public repositories**
-3. No additional permissions are required
-4. Generate and copy the token to the latest settings file in `Settings`
+The token is saved to disk after the first authorization so you will not be
+prompted again on subsequent downloads.
 
 ## Logging
 


### PR DESCRIPTION
<!--
BEGIN_COMMIT_OVERRIDE
feat(OTA): add GitHub device auth flow (#170)
Fixes: #169 
END_COMMIT_OVERRIDE
-->

## GitHub Device Flow Authentication for OTA Updates

This PR replaces the old Personal Access Token (PAT) approach with OAuth device flow for GitHub authentication. This means users can now securely sign in on their device through a simple one-time process, and the token is saved for future updates, no manual token configuration needed!

### What's Changed

- **GithubClient**: New client that handles OAuth device flow, verifies token scopes, and manages token storage
- **DeviceAuthView**: A UI that shows users a code to enter on their computer when they first need to authenticate
- **ProgressBar**:  Progress indicator
- **OTA Updates**: Updated to use the new GitHub client and automatically verify permissions before downloading
- **Removed**: No need for `Settings.toml` configuration anymore, tokens are handled automatically

### How to Test This Feature

1. **Install the PR build** on your device using the standard OTA update process
2. **Once installed**, try to install the same PR build again through OTA
3. **Expect to see**:
   - A device code screen prompting you to authenticate
   - Instructions to visit GitHub on your computer
   - The device flow authentication process
   - Token saved automatically for future updates

---

Change-Id: 05f9cf9cbc8208c0c83dbf34156f6ff6
Change-Id-Short: zukqnkqnonrx
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ogkevin/cadmus/pull/170" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
