### PR TITLE
docs: make mermaid diagrams wider than text content

### DIFF
--- a/.github/instructions/documentation-review-user.instructions.md
+++ b/.github/instructions/documentation-review-user.instructions.md
@@ -35,3 +35,26 @@ Assume the reader is using Cadmus on their Kobo e-reader and needs clear, simple
 
 - Format Markdown with Prettier
 - Ensure Markdown passes markdownlint
+
+## Tips and Notes etc
+
+When a document includes tips, notes, warnings, etc, ensure they are formatted according to:
+
+```
+> [!NOTE]
+> General information or additional context.
+
+> [!TIP]
+> A helpful suggestion or best practice.
+
+> [!IMPORTANT]
+> Key information that shouldn't be missed.
+
+> [!WARNING]
+> Critical information that highlights a potential risk.
+
+> [!CAUTION]
+> Information about potential issues that require caution.
+```
+
+Source: https://rust-lang.github.io/mdBook/format/markdown.html?highlight=note#admonitions

--- a/docs/custom.css
+++ b/docs/custom.css
@@ -1,14 +1,16 @@
-/*
-// Source - https://stackoverflow.com/a/73617163
-// Posted by Sandman, modified by community. See post 'Timeline' for change history
-// Retrieved 2026-02-17, License - CC BY-SA 4.0
-*/
-:root {
-  --content-max-width: 1500px;
+.mermaid {
+  display: flex;
+  justify-content: center;
+  width: 100vw;
+  max-width: 100vw;
+  margin-left: 50%;
+  transform: translateX(-50%);
+  overflow-x: auto;
+  padding: 1rem 0;
 }
 
-/* Align tables to the left */
-table {
-  margin-left: 0;
-  margin-right: auto;
+.mermaid svg {
+  width: 100%;
+  max-width: 1600px;
+  height: auto;
 }

--- a/docs/src/contributing/event-system.md
+++ b/docs/src/contributing/event-system.md
@@ -4,6 +4,13 @@ Cadmus uses a tree-based event system where views are organized hierarchically a
 through two distinct channels: the **Hub** and the **Bus**. Understanding the difference between
 these channels is essential for implementing correct event handling in views.
 
+> [!TIP]
+> CSS is hard, this page might render better on 80% zoom on smaller screens.
+> I tried to make the mermaid diagrams as big as possible to make them easier to read,
+> which made them overflow a bit.
+>
+> You might also want to hide the sidebar.
+
 ## Overview
 
 The UI is a tree of `View` objects. Each view can have children, forming a hierarchy like:

--- a/docs/src/installation/ota.md
+++ b/docs/src/installation/ota.md
@@ -22,7 +22,8 @@ update from:
 | **Main Branch**    | Latest development build (most recent changes) |
 | **PR Build**       | Test a specific pull request                   |
 
-> **Note:** The _Stable Release_ option is not shown in test builds.
+> [!NOTE]
+> The _Stable Release_ option is not shown in test builds.
 
 ## Updating from the main branch
 
@@ -48,7 +49,8 @@ Select **PR Build** to try out a specific change before it's released. Enter the
 PR number when prompted. The same one-time GitHub sign-in applies if you haven't
 authenticated before.
 
-> **Tip:** Find the PR number in the GitHub URL. For example, in
+> [!TIP]
+> Find the PR number in the GitHub URL. For example, in
 > `github.com/OGKevin/cadmus/pull/42` the PR number is **42**.
 
 ## Normal vs test builds


### PR DESCRIPTION
Make mermaid diagrams expand to full viewport width while keeping text content at default width. Diagrams now use 100vw container with centered SVG that scales to fit and allows horizontal scrolling if needed.

- Replace global content-max-width with mermaid-specific styling
- Center mermaid diagrams using transform: translateX(-50%)
- Allow diagrams up to 1600px wide on large screens
- Add overflow-x: auto for responsive scrolling
- Scale SVG width: 100% with auto height for proper aspect ratio

Change-Id: 8a82e12ba00a302b1be46c8e3de6922c
Change-Id-Short: rprxlyxopzzp