### PR TITLE
refactor: consolidate GitHub events into GithubEvent sub-enum

### DIFF
--- a/crates/core/src/view/device_auth.rs
+++ b/crates/core/src/view/device_auth.rs
@@ -3,9 +3,9 @@
 //! Displays the user code and verification URL, then polls GitHub in a
 //! background thread until the user authorizes (or the code expires).
 //!
-//! On success, sends [`Event::GithubDeviceAuthComplete`] with the token.
-//! On expiry, sends [`Event::GithubDeviceAuthExpired`].
-//! On error, sends [`Event::GithubDeviceAuthError`].
+//! On success, sends [`Event::Github`] with [`GithubEvent::DeviceAuthComplete`].
+//! On expiry, sends [`Event::Github`] with [`GithubEvent::DeviceAuthExpired`].
+//! On error, sends [`Event::Github`] with [`GithubEvent::DeviceAuthError`].
 //! On cancel, the polling thread is stopped via a shared cancel flag.
 
 use super::button::Button;
@@ -21,6 +21,7 @@ use crate::geom::Rectangle;
 use crate::gesture::GestureEvent;
 use crate::github::{GithubClient, TokenPollResult};
 use crate::unit::scale_by_dpi;
+use crate::view::github::GithubEvent;
 use crate::view::ota::OtaViewId;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
@@ -35,7 +36,7 @@ use std::time::Duration;
 ///
 /// A Cancel button stops the background polling thread and closes the view.
 /// A background thread polls GitHub at the required interval. When the user
-/// authorizes, [`Event::GithubDeviceAuthComplete`] is sent through the hub.
+/// authorizes, [`Event::Github(GithubEvent::DeviceAuthComplete)`] is sent through the hub.
 pub struct DeviceAuthView {
     id: Id,
     rect: Rectangle,
@@ -58,7 +59,7 @@ impl DeviceAuthView {
     ///
     /// # Errors
     ///
-    /// If the device flow initiation fails, sends [`Event::OtaDeviceAuthError`]
+    /// If the device flow initiation fails, sends [`Event::Github(GithubEvent::DeviceAuthError)`]
     /// immediately and returns a view with an error message.
     #[cfg_attr(feature = "otel", tracing::instrument(skip_all))]
     pub fn new(hub: &Hub, context: &mut Context) -> Self {
@@ -75,7 +76,8 @@ impl DeviceAuthView {
             Ok((url, code)) => (format!("Go to: {}", url), format!("Enter code: {}", code)),
             Err(e) => {
                 tracing::error!(error = %e, "Device flow initiation failed");
-                hub.send(Event::GithubDeviceAuthError(e)).ok();
+                hub.send(Event::Github(GithubEvent::DeviceAuthError(e)))
+                    .ok();
                 (
                     "GitHub auth failed".to_owned(),
                     "Check logs for details".to_owned(),
@@ -169,7 +171,8 @@ impl DeviceAuthView {
                 Ok(c) => c,
                 Err(e) => {
                     tracing::error!(error = %e, "Failed to create poll client");
-                    hub2.send(Event::GithubDeviceAuthError(e)).ok();
+                    hub2.send(Event::Github(GithubEvent::DeviceAuthError(e)))
+                        .ok();
                     return;
                 }
             };
@@ -194,25 +197,28 @@ impl DeviceAuthView {
                     }
                     Ok(TokenPollResult::Complete(token)) => {
                         tracing::info!("Device flow authorization complete");
-                        hub2.send(Event::GithubDeviceAuthComplete(token)).ok();
+                        hub2.send(Event::Github(GithubEvent::DeviceAuthComplete(token)))
+                            .ok();
                         return;
                     }
                     Ok(TokenPollResult::Expired) => {
                         tracing::warn!("Device flow code expired");
-                        hub2.send(Event::GithubDeviceAuthExpired).ok();
+                        hub2.send(Event::Github(GithubEvent::DeviceAuthExpired))
+                            .ok();
                         return;
                     }
                     Ok(TokenPollResult::Cancelled) => {
                         tracing::info!("Device flow cancelled by user on GitHub");
-                        hub2.send(Event::GithubDeviceAuthError(
+                        hub2.send(Event::Github(GithubEvent::DeviceAuthError(
                             "Authorization cancelled".to_owned(),
-                        ))
+                        )))
                         .ok();
                         return;
                     }
                     Err(e) => {
                         tracing::error!(error = %e, "Device flow poll error");
-                        hub2.send(Event::GithubDeviceAuthError(e)).ok();
+                        hub2.send(Event::Github(GithubEvent::DeviceAuthError(e)))
+                            .ok();
                         return;
                     }
                 }

--- a/crates/core/src/view/github.rs
+++ b/crates/core/src/view/github.rs
@@ -1,0 +1,18 @@
+use secrecy::SecretString;
+
+/// Events emitted by GitHub authentication and API interactions.
+#[derive(Debug, Clone)]
+pub enum GithubEvent {
+    /// Device flow completed successfully; carries the new access token.
+    DeviceAuthComplete(SecretString),
+    /// Device flow code expired before the user authorized.
+    DeviceAuthExpired,
+    /// Device flow failed with an error message.
+    DeviceAuthError(String),
+    /// A GitHub API call returned 401 or 403 — the saved token is invalid,
+    /// revoked, or missing required scopes.
+    ///
+    /// `OtaView` handles this by deleting the stale token, clearing its
+    /// in-memory token, and re-triggering device flow for the pending download.
+    TokenInvalid,
+}

--- a/crates/core/src/view/mod.rs
+++ b/crates/core/src/view/mod.rs
@@ -21,6 +21,7 @@ pub mod dictionary;
 pub mod file_chooser;
 pub mod filler;
 pub mod frontlight;
+pub mod github;
 pub mod home;
 pub mod icon;
 pub mod image;
@@ -55,6 +56,7 @@ pub mod top_bar;
 pub mod touch_events;
 
 use self::calculator::LineOrigin;
+use self::github::GithubEvent;
 use self::key::KeyKind;
 use crate::color::Color;
 use crate::context::Context;
@@ -500,18 +502,8 @@ pub enum Event {
     /// The file chooser was closed.
     ///  The `Option<PathBuf>` contains the selected path, if any.
     FileChooserClosed(Option<PathBuf>),
-    /// GitHub device flow completed successfully; carries the new access token.
-    GithubDeviceAuthComplete(secrecy::SecretString),
-    /// GitHub device flow code expired before the user authorized.
-    GithubDeviceAuthExpired,
-    /// GitHub device flow failed with an error message.
-    GithubDeviceAuthError(String),
-    /// A GitHub API call returned 401 or 403 — the saved token is invalid,
-    /// revoked, or missing required scopes.
-    ///
-    /// `OtaView` handles this by deleting the stale token, clearing its
-    /// in-memory token, and re-triggering device flow for the pending download.
-    GithubTokenInvalid,
+    /// GitHub authentication and API interaction events.
+    Github(GithubEvent),
     /// Progress update from a background OTA download thread.
     ///
     /// `OtaView` handles this by updating the status label text and the

--- a/crates/core/src/view/ota.rs
+++ b/crates/core/src/view/ota.rs
@@ -21,6 +21,7 @@ use crate::github::GithubClient;
 use crate::ota::{OtaClient, OtaError, OtaProgress};
 use crate::unit::scale_by_dpi;
 use crate::view::filler::Filler;
+use crate::view::github::GithubEvent;
 use crate::view::BIG_BAR_HEIGHT;
 use secrecy::SecretString;
 use std::thread;
@@ -416,7 +417,7 @@ impl OtaView {
     /// Sends [`Event::OtaDownloadProgress`] during the download. On success,
     /// updates the status label to "Rebooting…" and sends
     /// [`Event::Select(EntryId::Reboot)`] to trigger an automatic reboot.
-    /// On a 401 response, sends [`Event::GithubTokenInvalid`] without closing
+    /// On a 401 response, sends [`Event::Github(GithubEvent::TokenInvalid)`] without closing
     /// the view so re-authentication can proceed.
     #[cfg_attr(feature = "otel", tracing::instrument(skip(self, hub)))]
     fn start_pr_download(&mut self, pr_number: u32, hub: &Hub) {
@@ -489,7 +490,7 @@ impl OtaView {
                 }
                 Err(OtaError::Unauthorized) | Err(OtaError::InsufficientScopes(_)) => {
                     tracing::warn!(pr_number, "GitHub token rejected — triggering re-auth");
-                    hub2.send(Event::GithubTokenInvalid).ok();
+                    hub2.send(Event::Github(GithubEvent::TokenInvalid)).ok();
                 }
                 Err(e) => {
                     error!(error = %e, "PR download failed");
@@ -509,7 +510,7 @@ impl OtaView {
     /// Sends [`Event::OtaDownloadProgress`] during the download. On success,
     /// updates the status label to "Rebooting…" and sends
     /// [`Event::Select(EntryId::Reboot)`] to trigger an automatic reboot.
-    /// On a 401 response, sends [`Event::GithubTokenInvalid`] without closing
+    /// On a 401 response, sends [`Event::Github(GithubEvent::TokenInvalid)`] without closing
     /// the view so re-authentication can proceed.
     #[cfg_attr(feature = "otel", tracing::instrument(skip(self, hub)))]
     fn start_default_branch_download(&mut self, hub: &Hub) {
@@ -582,7 +583,7 @@ impl OtaView {
                 }
                 Err(OtaError::Unauthorized) | Err(OtaError::InsufficientScopes(_)) => {
                     tracing::warn!("GitHub token rejected — triggering re-auth");
-                    hub2.send(Event::GithubTokenInvalid).ok();
+                    hub2.send(Event::Github(GithubEvent::TokenInvalid)).ok();
                 }
                 Err(e) => {
                     error!(error = %e, "Main branch download failed");
@@ -602,7 +603,7 @@ impl OtaView {
     /// Sends [`Event::OtaDownloadProgress`] during the download. On success,
     /// updates the status label to "Rebooting…" and sends
     /// [`Event::Select(EntryId::Reboot)`] to trigger an automatic reboot.
-    /// On a 401 response, sends [`Event::GithubTokenInvalid`] without closing
+    /// On a 401 response, sends [`Event::Github(GithubEvent::TokenInvalid)`] without closing
     /// the view so re-authentication can proceed.
     ///
     /// GitHub authentication is not required for this operation.
@@ -677,7 +678,7 @@ impl OtaView {
                 }
                 Err(OtaError::Unauthorized) | Err(OtaError::InsufficientScopes(_)) => {
                     tracing::warn!("GitHub token rejected on stable release — triggering re-auth");
-                    hub2.send(Event::GithubTokenInvalid).ok();
+                    hub2.send(Event::Github(GithubEvent::TokenInvalid)).ok();
                 }
                 Err(e) => {
                     error!(error = %e, "Stable release download failed");
@@ -896,12 +897,14 @@ impl View for OtaView {
             Event::OtaDownloadProgress { label, percent } => {
                 self.on_download_progress(label, *percent, rq)
             }
-            Event::GithubDeviceAuthComplete(ref token) => {
+            Event::Github(GithubEvent::DeviceAuthComplete(ref token)) => {
                 self.on_device_auth_complete(token, hub, rq, context)
             }
-            Event::GithubTokenInvalid => self.on_token_invalid(hub, rq, context),
-            Event::GithubDeviceAuthExpired => self.on_device_auth_expired(hub),
-            Event::GithubDeviceAuthError(ref msg) => self.on_device_auth_error(msg, hub),
+            Event::Github(GithubEvent::TokenInvalid) => self.on_token_invalid(hub, rq, context),
+            Event::Github(GithubEvent::DeviceAuthExpired) => self.on_device_auth_expired(hub),
+            Event::Github(GithubEvent::DeviceAuthError(ref msg)) => {
+                self.on_device_auth_error(msg, hub)
+            }
             _ => false,
         }
     }


### PR DESCRIPTION
Move the four flat GitHub-related Event variants into a dedicated GithubEvent sub-enum defined in the github module, wrapped as Event::Github(GithubEvent).

- Add GithubEvent enum to crates/core/src/github/types.rs
- Re-export GithubEvent from crates/core/src/github/mod.rs
- Replace flat Github* variants with Event::Github(GithubEvent) in view/mod.rs
- Update all hub.send() call sites in device_auth.rs
- Update all match arms in ota.rs
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ogkevin/cadmus/pull/178" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
