### PR TITLE
chore: use tmp dir for intermission path in tests

### DIFF
--- a/crates/core/src/view/settings_editor/category_editor.rs
+++ b/crates/core/src/view/settings_editor/category_editor.rs
@@ -587,7 +587,15 @@ impl CategoryEditor {
 
         self.active_intermission_edit = Some(*kind);
 
+        #[cfg(not(test))]
         let initial_path = PathBuf::from("/mnt/onboard");
+        #[cfg(test)]
+        let initial_path = PathBuf::from(
+            tempfile::tempdir()
+                .expect("failed to crete temp dir for test")
+                .path(),
+        );
+
         let file_chooser = FileChooser::new(
             rect!(
                 0,


### PR DESCRIPTION
Better test isolation by using a temporary directory for the intermission path in tests instead of a fixed path. 

Change-Id: 7f039a29ad04bcd4cffef1600deea92f
Change-Id-Short: skzwqpxqpmzv