### PR TITLE
fix(settings editor): library editor

### DIFF
--- a/crates/core/src/view/mod.rs
+++ b/crates/core/src/view/mod.rs
@@ -500,6 +500,8 @@ pub enum Event {
     FileChooserClosed(Option<PathBuf>),
     /// GitHub authentication and API interaction events.
     Github(GithubEvent),
+    /// Settings-specific events
+    Settings(settings_editor::SettingsEvent),
     /// Progress update from a background OTA download thread.
     ///
     /// `OtaView` handles this by updating the status label text and the

--- a/crates/core/src/view/settings_editor/category_editor.rs
+++ b/crates/core/src/view/settings_editor/category_editor.rs
@@ -686,11 +686,14 @@ impl CategoryEditor {
     ) -> bool {
         if index < context.settings.libraries.len() {
             context.settings.libraries[index] = library.clone();
-
-            self.rebuild_library_rows(rq, context, None);
+        } else if index == context.settings.libraries.len() {
+            context.settings.libraries.push(library.clone());
+        } else {
+            return true;
         }
 
-        false
+        self.rebuild_library_rows(rq, context, None);
+        true
     }
 
     #[inline]
@@ -1163,7 +1166,7 @@ mod tests {
             &mut context,
         );
 
-        assert!(!handled);
+        assert!(handled);
         assert_eq!(context.settings.libraries.len(), 1);
         assert_eq!(context.settings.libraries[0].name, "Updated Library");
         assert_eq!(

--- a/crates/core/src/view/settings_editor/library_editor.rs
+++ b/crates/core/src/view/settings_editor/library_editor.rs
@@ -1,5 +1,6 @@
 use super::bottom_bar::{BottomBarVariant, SettingsEditorBottomBar};
 use super::setting_row::{Kind as RowKind, SettingRow};
+use super::setting_value::{Kind as ValueKind, SettingsEvent};
 use crate::color::{BLACK, WHITE};
 use crate::context::Context;
 use crate::device::CURRENT_DEVICE;
@@ -242,12 +243,6 @@ impl LibraryEditor {
     }
 
     #[inline]
-    fn update_row_value(&mut self, rq: &mut RenderQueue) {
-        // Event propagation via UpdateLibrary will handle updating the SettingValue widgets
-        rq.add(RenderData::new(self.id, self.rect, UpdateMode::Gui));
-    }
-
-    #[inline]
     fn toggle_keyboard(
         &mut self,
         visible: bool,
@@ -361,9 +356,12 @@ impl LibraryEditor {
     }
 
     #[inline]
-    fn handle_submit_name_event(&mut self, text: &str, rq: &mut RenderQueue) -> bool {
+    fn handle_submit_name_event(&mut self, text: &str, bus: &mut Bus) -> bool {
         self.library.name = text.to_string();
-        self.update_row_value(rq);
+        bus.push_back(Event::Settings(SettingsEvent::UpdateValue {
+            kind: ValueKind::LibraryName(self.library_index),
+            value: text.to_string(),
+        }));
         false
     }
 
@@ -371,11 +369,14 @@ impl LibraryEditor {
     fn handle_file_chooser_closed_event(
         &mut self,
         path: &Option<std::path::PathBuf>,
-        rq: &mut RenderQueue,
+        bus: &mut Bus,
     ) -> bool {
         if let Some(path) = path {
             self.library.path = path.clone();
-            self.update_row_value(rq);
+            bus.push_back(Event::Settings(SettingsEvent::UpdateValue {
+                kind: ValueKind::LibraryPath(self.library_index),
+                value: path.display().to_string(),
+            }));
         }
         false
     }
@@ -467,9 +468,9 @@ impl View for LibraryEditor {
                 self.handle_edit_path_event(hub, rq, context)
             }
             Event::Submit(ViewId::LibraryRenameInput, ref text) => {
-                self.handle_submit_name_event(text, rq)
+                self.handle_submit_name_event(text, bus)
             }
-            Event::FileChooserClosed(ref path) => self.handle_file_chooser_closed_event(path, rq),
+            Event::FileChooserClosed(ref path) => self.handle_file_chooser_closed_event(path, bus),
             Event::SubMenu(rect, ref entries) => {
                 self.handle_submenu_event(rect, entries, rq, context)
             }
@@ -702,7 +703,7 @@ mod tests {
         assert!(!handled);
         assert_ne!(editor.library.path, original_path);
         assert_eq!(editor.library.path, new_path);
-        assert!(!rq.is_empty());
+        assert!(rq.is_empty());
     }
 
     #[test]
@@ -733,6 +734,6 @@ mod tests {
         assert!(!handled);
         assert_ne!(editor.library.name, original_name);
         assert_eq!(editor.library.name, new_name);
-        assert!(!rq.is_empty());
+        assert!(rq.is_empty());
     }
 }

--- a/crates/core/src/view/settings_editor/mod.rs
+++ b/crates/core/src/view/settings_editor/mod.rs
@@ -51,7 +51,7 @@ mod library_editor;
 mod setting_row;
 mod setting_value;
 
-pub use setting_value::ToggleSettings;
+pub use setting_value::{SettingsEvent, ToggleSettings};
 
 pub use self::bottom_bar::{BottomBarVariant, SettingsEditorBottomBar};
 pub use self::category::Category;

--- a/crates/core/src/view/settings_editor/setting_value.rs
+++ b/crates/core/src/view/settings_editor/setting_value.rs
@@ -11,6 +11,21 @@ use anyhow::Error;
 use std::fs;
 use std::path::Path;
 
+#[derive(Debug, Clone)]
+pub enum SettingsEvent {
+    /// Updates a SettingValue view by its Kind with a new value.
+    ///
+    /// Each SettingValue checks if the kind matches its own kind, and updates
+    /// itself if there's a match. This allows targeted updates without needing
+    /// to know the specific view ID.
+    UpdateValue {
+        /// The Kind of SettingValue to update (matches against self.kind)
+        kind: Kind,
+        /// The new value to display
+        value: String,
+    },
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ToggleSettings {
     /// Sleep cover enable/disable setting
@@ -25,7 +40,7 @@ pub enum ToggleSettings {
 ///
 /// This enum categorizes different settings that can be configured in the application,
 /// including keyboard layout, power management, button schemes, and library settings.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum Kind {
     /// Keyboard layout selection setting
     KeyboardLayout,
@@ -157,6 +172,12 @@ impl SettingValue {
     ///
     /// This method updates the ActionLabel text to reflect the current state of the setting
     /// in context.settings. It should be called whenever the underlying setting changes.
+    ///
+    /// # Deprecated
+    /// This method relies on context.settings which may not reflect the current
+    /// editing state. Use `Event::Settings(SettingsEvent::UpdateValue { kind, value })`
+    /// instead to directly update SettingValue views during editing.
+    #[deprecated(note = "use Event::Settings(SettingsEvent::UpdateValue { kind, value }) instead")]
     pub fn refresh_from_context(&mut self, context: &Context, rq: &mut RenderQueue) {
         let (value, entries, _enabled_toggle) =
             Self::fetch_data_for_kind(&self.kind, &context.settings);
@@ -438,16 +459,26 @@ impl SettingValue {
 }
 
 impl View for SettingValue {
-    #[cfg_attr(feature = "otel", tracing::instrument(skip(self, _hub, _bus, _rq, _context), fields(event = ?_evt), ret(level=tracing::Level::TRACE)))]
+    #[cfg_attr(feature = "otel", tracing::instrument(skip(self, _hub, _bus, rq, _context), fields(event = ?evt), ret(level=tracing::Level::TRACE)))]
     fn handle_event(
         &mut self,
-        _evt: &Event,
+        evt: &Event,
         _hub: &Hub,
         _bus: &mut Bus,
-        _rq: &mut RenderQueue,
+        rq: &mut RenderQueue,
         _context: &mut Context,
     ) -> bool {
-        false
+        match evt {
+            Event::Settings(SettingsEvent::UpdateValue { kind, value }) => {
+                if self.kind == *kind {
+                    self.update(value.clone(), rq);
+                    true
+                } else {
+                    false
+                }
+            }
+            _ => false,
+        }
     }
 
     #[cfg_attr(feature = "otel", tracing::instrument(skip(self, _fb, _fonts), fields(rect = ?_rect)))]
@@ -709,5 +740,256 @@ mod tests {
         } else {
             panic!("Expected EditLibrary event");
         }
+    }
+
+    #[test]
+    fn test_update_value_event_updates_library_name_display() {
+        use crate::settings::LibrarySettings;
+        let mut context = create_test_context();
+        context.settings.libraries.clear();
+        context.settings.libraries.push(LibrarySettings {
+            name: "Old Name".to_string(),
+            path: PathBuf::from("/tmp"),
+            ..Default::default()
+        });
+        let rect = rect![0, 0, 200, 50];
+
+        let mut value = SettingValue::new(
+            Kind::LibraryName(0),
+            rect,
+            &context.settings,
+            &mut context.fonts,
+        );
+        let (hub, _receiver) = channel();
+        let mut bus = VecDeque::new();
+        let mut rq = RenderQueue::new();
+
+        assert_eq!(value.value(), "Old Name");
+
+        let update_event = Event::Settings(SettingsEvent::UpdateValue {
+            kind: Kind::LibraryName(0),
+            value: "New Name".to_string(),
+        });
+        let handled = value.handle_event(&update_event, &hub, &mut bus, &mut rq, &mut context);
+
+        assert!(
+            handled,
+            "UpdateValue event should be handled when kind matches"
+        );
+        assert_eq!(value.value(), "New Name");
+    }
+
+    #[test]
+    fn test_update_value_event_updates_library_path_display() {
+        use crate::settings::LibrarySettings;
+        let mut context = create_test_context();
+        context.settings.libraries.clear();
+        context.settings.libraries.push(LibrarySettings {
+            name: "Test Library".to_string(),
+            path: PathBuf::from("/old/path"),
+            ..Default::default()
+        });
+        let rect = rect![0, 0, 200, 50];
+
+        let mut value = SettingValue::new(
+            Kind::LibraryPath(0),
+            rect,
+            &context.settings,
+            &mut context.fonts,
+        );
+        let (hub, _receiver) = channel();
+        let mut bus = VecDeque::new();
+        let mut rq = RenderQueue::new();
+
+        assert_eq!(value.value(), "/old/path");
+
+        let update_event = Event::Settings(SettingsEvent::UpdateValue {
+            kind: Kind::LibraryPath(0),
+            value: "/new/path".to_string(),
+        });
+        let handled = value.handle_event(&update_event, &hub, &mut bus, &mut rq, &mut context);
+
+        assert!(
+            handled,
+            "UpdateValue event should be handled when kind matches"
+        );
+        assert_eq!(value.value(), "/new/path");
+    }
+
+    #[test]
+    fn test_update_value_event_ignores_wrong_kind() {
+        use crate::settings::LibrarySettings;
+        let mut context = create_test_context();
+        context.settings.libraries.clear();
+        context.settings.libraries.push(LibrarySettings {
+            name: "Test Library".to_string(),
+            path: PathBuf::from("/tmp"),
+            ..Default::default()
+        });
+        let rect = rect![0, 0, 200, 50];
+
+        let mut value = SettingValue::new(
+            Kind::LibraryName(0),
+            rect,
+            &context.settings,
+            &mut context.fonts,
+        );
+        let (hub, _receiver) = channel();
+        let mut bus = VecDeque::new();
+        let mut rq = RenderQueue::new();
+
+        assert_eq!(value.value(), "Test Library");
+
+        let update_event = Event::Settings(SettingsEvent::UpdateValue {
+            kind: Kind::LibraryPath(0),
+            value: "Some Path".to_string(),
+        });
+        let handled = value.handle_event(&update_event, &hub, &mut bus, &mut rq, &mut context);
+
+        assert!(
+            !handled,
+            "UpdateValue event should not be handled when kind does not match"
+        );
+        assert_eq!(
+            value.value(),
+            "Test Library",
+            "Value should not change when kind mismatches"
+        );
+    }
+
+    #[test]
+    fn test_update_value_event_ignores_wrong_index() {
+        use crate::settings::LibrarySettings;
+        let mut context = create_test_context();
+        context.settings.libraries.clear();
+        context.settings.libraries.push(LibrarySettings {
+            name: "Library 0".to_string(),
+            path: PathBuf::from("/path0"),
+            ..Default::default()
+        });
+        context.settings.libraries.push(LibrarySettings {
+            name: "Library 1".to_string(),
+            path: PathBuf::from("/path1"),
+            ..Default::default()
+        });
+        let rect = rect![0, 0, 200, 50];
+
+        let mut value = SettingValue::new(
+            Kind::LibraryName(0),
+            rect,
+            &context.settings,
+            &mut context.fonts,
+        );
+        let (hub, _receiver) = channel();
+        let mut bus = VecDeque::new();
+        let mut rq = RenderQueue::new();
+
+        assert_eq!(value.value(), "Library 0");
+
+        let update_event = Event::Settings(SettingsEvent::UpdateValue {
+            kind: Kind::LibraryName(1),
+            value: "Updated Library 1".to_string(),
+        });
+        let handled = value.handle_event(&update_event, &hub, &mut bus, &mut rq, &mut context);
+
+        assert!(
+            !handled,
+            "UpdateValue event should not be handled when index does not match"
+        );
+        assert_eq!(
+            value.value(),
+            "Library 0",
+            "Value should not change when index mismatches"
+        );
+    }
+
+    #[test]
+    fn test_update_value_event_updates_auto_suspend() {
+        let rect = rect![0, 0, 200, 50];
+
+        let mut context = create_test_context();
+        let mut value = SettingValue::new(
+            Kind::AutoSuspend,
+            rect,
+            &context.settings,
+            &mut context.fonts,
+        );
+        let (hub, _receiver) = channel();
+        let mut bus = VecDeque::new();
+        let mut rq = RenderQueue::new();
+
+        assert_eq!(value.value(), "30.0");
+
+        let update_event = Event::Settings(SettingsEvent::UpdateValue {
+            kind: Kind::AutoSuspend,
+            value: "60.0".to_string(),
+        });
+        let handled = value.handle_event(&update_event, &hub, &mut bus, &mut rq, &mut context);
+
+        assert!(
+            handled,
+            "UpdateValue event should be handled when kind matches"
+        );
+        assert_eq!(value.value(), "60.0");
+    }
+
+    #[test]
+    fn test_update_value_event_updates_auto_power_off() {
+        let rect = rect![0, 0, 200, 50];
+
+        let mut context = create_test_context();
+        let mut value = SettingValue::new(
+            Kind::AutoPowerOff,
+            rect,
+            &context.settings,
+            &mut context.fonts,
+        );
+        let (hub, _receiver) = channel();
+        let mut bus = VecDeque::new();
+        let mut rq = RenderQueue::new();
+
+        assert_eq!(value.value(), "3.0");
+
+        let update_event = Event::Settings(SettingsEvent::UpdateValue {
+            kind: Kind::AutoPowerOff,
+            value: "60.0".to_string(),
+        });
+        let handled = value.handle_event(&update_event, &hub, &mut bus, &mut rq, &mut context);
+
+        assert!(
+            handled,
+            "UpdateValue event should be handled when kind matches"
+        );
+        assert_eq!(value.value(), "60.0");
+    }
+
+    #[test]
+    fn test_update_value_event_updates_settings_retention() {
+        let rect = rect![0, 0, 200, 50];
+
+        let mut context = create_test_context();
+        let mut value = SettingValue::new(
+            Kind::SettingsRetention,
+            rect,
+            &context.settings,
+            &mut context.fonts,
+        );
+        let (hub, _receiver) = channel();
+        let mut bus = VecDeque::new();
+        let mut rq = RenderQueue::new();
+
+        assert_eq!(value.value(), "3");
+
+        let update_event = Event::Settings(SettingsEvent::UpdateValue {
+            kind: Kind::SettingsRetention,
+            value: "5".to_string(),
+        });
+        let handled = value.handle_event(&update_event, &hub, &mut bus, &mut rq, &mut context);
+
+        assert!(
+            handled,
+            "UpdateValue event should be handled when kind matches"
+        );
+        assert_eq!(value.value(), "5");
     }
 }


### PR DESCRIPTION
When adding or updating a library, the underlying UI views are not updated to reflect the changes until the user navigates away and back to the settings, which can be confusing.

Also, the library is only added to global context.settings when the save button is pressed, but the UI should reflect the changes immediately during editing.

Change-Id: adc77f0c5f46a1c8b7bcdcbd7ba0cc8a
Change-Id-Short: pmnsskznukvt
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ogkevin/cadmus/pull/205" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
