### PR TITLE
Correctly parse TOML in xtask

### DIFF
--- a/xtask/src/tasks/util/workspace.rs
+++ b/xtask/src/tasks/util/workspace.rs
@@ -53,7 +53,7 @@ pub fn current_version() -> Result<String> {
     let content = std::fs::read_to_string(&cargo_toml_path)
         .with_context(|| format!("failed to read {}", cargo_toml_path.display()))?;
 
-    let doc: toml::Value = content
+    let doc: toml::Table = content
         .parse()
         .with_context(|| format!("failed to parse {}", cargo_toml_path.display()))?;
 


### PR DESCRIPTION
I had to do this to get the kobo build to work on my system. It was failing with a TOML parse error on a Cargo.toml previously. Putting this here mainly to see what CI does, but merge if you think it's OK!