### PR TITLE
ci: build docs in copilot-setup-steps workflow

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -92,6 +92,9 @@ jobs:
       - name: Install mdbook-mermaid assets
         run: mdbook-mermaid install docs
 
+      - name: Build documentation
+        run: cargo xtask docs --mdbook-only
+
       - name: Download thirdparty dependencies
         run: cargo xtask build-kobo --slow --download-only
 


### PR DESCRIPTION
The assets.rs module embeds the documentation EPUB at compile time, so the docs must be built before any Cargo build step runs.

This makes the agent fail when resolving e.g. dependency issues raised by renovate.

Change-Id: ce68db9de8e0f66ae19bf5c79f9dc738
Change-Id-Short: nltrmoqmlrlz