### PR TITLE
fix(Library): update root path when switching libraries

### DIFF
--- a/crates/core/src/view/home/mod.rs
+++ b/crates/core/src/view/home/mod.rs
@@ -1771,6 +1771,16 @@ impl Home {
         }
 
         let home = context.library.home.clone();
+
+        if context.settings.home.navigation_bar {
+            let nav_bar = self.children[self.shelf_index - 2]
+                .as_mut()
+                .downcast_mut::<StackNavigationBar<DirectoryNavigationProvider>>()
+                .unwrap();
+            nav_bar.provider_mut().set_root(home.clone());
+            nav_bar.clear();
+        }
+
         self.select_directory(&home, hub, rq, context);
     }
 

--- a/crates/core/src/view/navigation/providers/directory.rs
+++ b/crates/core/src/view/navigation/providers/directory.rs
@@ -92,6 +92,11 @@ impl DirectoryNavigationProvider {
         }
     }
 
+    /// Updates the root directory for this provider.
+    pub fn set_root(&mut self, root: PathBuf) {
+        self.root = root;
+    }
+
     /// Lists directories using the configured source.
     #[inline]
     fn list_directories(&self, path: &Path, context: &Context) -> BTreeSet<PathBuf> {

--- a/crates/core/src/view/navigation/stack_navigation_bar.rs
+++ b/crates/core/src/view/navigation/stack_navigation_bar.rs
@@ -313,6 +313,11 @@ impl<P: NavigationProvider + 'static> StackNavigationBar<P> {
         &self.selected
     }
 
+    /// Returns a mutable reference to the navigation provider.
+    pub fn provider_mut(&mut self) -> &mut P {
+        &mut self.provider
+    }
+
     /// Updates the selected level and rebuilds the navigation bar hierarchy.
     ///
     /// This method reuses existing bars when navigating to related


### PR DESCRIPTION
When load_library switches to a new library, the navigation bar was showing stale content because DirectoryNavigationProvider kept the old library's root path.

- Add set_root() mutator to DirectoryNavigationProvider
- Add provider_mut() accessor to StackNavigationBar
- Reset nav bar root and clear stale state in load_library

Change-Id: 466e8dd934471ed1e711d01e352cda75
Change-Id-Short: vttlrmmqwvvs