### PR TITLE
feat(OTA): adaptive chunk sizing based on observed throughput

### DIFF
--- a/crates/core/src/github/client.rs
+++ b/crates/core/src/github/client.rs
@@ -6,7 +6,7 @@ use rustls::RootCertStore;
 use secrecy::{ExposeSecret, SecretString};
 use std::time::Duration;
 
-const CHUNK_TIMEOUT_SECS: u64 = 30;
+pub const CLIENT_TIMEOUT_SECS: u64 = 30;
 
 /// GitHub OAuth App client ID, baked in at build time via `GH_OAUTH_CLIENT_ID` env var.
 ///
@@ -82,7 +82,7 @@ impl GithubClient {
         let client = Client::builder()
             .use_preconfigured_tls(tls_config)
             .user_agent("github.com/OGKevin/cadmus")
-            .timeout(Duration::from_secs(CHUNK_TIMEOUT_SECS))
+            .timeout(Duration::from_secs(CLIENT_TIMEOUT_SECS))
             .build()
             .map_err(|e| format!("Failed to build HTTP client: {}", e))?;
 

--- a/crates/core/src/github/mod.rs
+++ b/crates/core/src/github/mod.rs
@@ -9,5 +9,6 @@ mod client;
 pub mod device_flow;
 pub(crate) mod types;
 
+pub use client::CLIENT_TIMEOUT_SECS;
 pub use client::{GithubClient, REQUIRED_SCOPES};
 pub use types::{DeviceCodeResponse, OtaProgress, ScopeError, TokenPollResult, VerifyScopesError};

--- a/crates/core/src/ota/client.rs
+++ b/crates/core/src/ota/client.rs
@@ -12,8 +12,11 @@ use zip::ZipArchive;
 #[cfg(all(not(test), not(feature = "emulator")))]
 use crate::settings::INTERNAL_CARD_ROOT;
 
-/// Size of each download chunk in bytes (10 MB)
-const CHUNK_SIZE: usize = 10 * 1024 * 1024;
+const MIN_CHUNK_SIZE: usize = 256 * 1024;
+const MAX_CHUNK_SIZE: usize = 10 * 1024 * 1024;
+const INITIAL_CHUNK_SIZE: usize = 1024 * 1024;
+/// Target 80% of the HTTP timeout to leave headroom for throughput variance.
+const TARGET_CHUNK_SECS: f64 = crate::github::CLIENT_TIMEOUT_SECS as f64 * 0.8;
 
 /// Maximum number of retry attempts for failed chunks
 const MAX_RETRIES: usize = 3;
@@ -750,23 +753,44 @@ impl OtaClient {
         let mut file = File::create(download_path)?;
 
         let mut downloaded = 0u64;
+        let mut chunk_size = INITIAL_CHUNK_SIZE;
 
         tracing::debug!(
-            chunk_size_mb = CHUNK_SIZE / (1024 * 1024),
+            initial_chunk_size = INITIAL_CHUNK_SIZE,
             "Starting chunked download"
         );
 
         while downloaded < total_size {
             let chunk_start = downloaded;
-            let chunk_end = std::cmp::min(downloaded + CHUNK_SIZE as u64 - 1, total_size - 1);
+            let chunk_end = std::cmp::min(downloaded + chunk_size as u64 - 1, total_size - 1);
 
-            tracing::debug!(chunk_start, chunk_end, total_size, "Downloading chunk");
+            tracing::debug!(
+                chunk_start,
+                chunk_end,
+                chunk_size,
+                total_size,
+                "Downloading chunk"
+            );
 
+            let start = std::time::Instant::now();
             let chunk_data =
                 self.download_chunk_with_retries(url, chunk_start, chunk_end, use_auth)?;
+            let elapsed_secs = start.elapsed().as_secs_f64();
 
             file.write_all(&chunk_data)?;
             downloaded += chunk_data.len() as u64;
+
+            if elapsed_secs > 0.0 {
+                let throughput = chunk_data.len() as f64 / elapsed_secs;
+                chunk_size = ((throughput * TARGET_CHUNK_SECS) as usize)
+                    .clamp(MIN_CHUNK_SIZE, MAX_CHUNK_SIZE);
+                tracing::debug!(
+                    elapsed_secs,
+                    throughput_bytes_per_sec = throughput as u64,
+                    next_chunk_size = chunk_size,
+                    "Adjusted chunk size"
+                );
+            }
 
             progress_callback(OtaProgress::DownloadingArtifact {
                 downloaded,


### PR DESCRIPTION
Replace the fixed 10 MB CHUNK_SIZE constant with a dynamic chunk sizing algorithm that measures actual download speed and adjusts each subsequent chunk to target 80% of the HTTP timeout (24s).

- Start conservatively at 1 MB to avoid overwhelming slow devices
- After each chunk, compute throughput and scale the next chunk size to fill ~24s at that rate
- Clamp between 256 KB (floor) and 10 MB (ceiling)
- Reference CLIENT_TIMEOUT_SECS from github::client as the single source of truth for the timeout value

Change-Id: 4418dc6ca6ee1fb96696dfd3869c0a3e
Change-Id-Short: vvyrmntnptll
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ogkevin/cadmus/pull/228" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
