### PR TITLE
dev(logging): add kernel log capture for test builds

### DIFF
--- a/contrib/Settings-sample.toml
+++ b/contrib/Settings-sample.toml
@@ -43,6 +43,8 @@ max-files = 3
 directory = "logs"
 # Optional OTLP endpoint for exporting logs when the build enables the otel feature.
 # otlp-endpoint = "https://otel.example.com:4318"
+# Capture kernel logs (requires test build).
+# enable-kern-log = false
 
 # You can create libraries by adding further [[libraries]] entries.
 [[libraries]]

--- a/crates/cadmus/Cargo.toml
+++ b/crates/cadmus/Cargo.toml
@@ -9,8 +9,10 @@ name = "cadmus"
 path = "src/main.rs"
 
 [features]
+default = ["kobo"]
 test = ["cadmus-core/test"]
 otel = ["cadmus-core/otel"]
+kobo = ["cadmus-core/kobo"]
 
 [dependencies]
 cadmus-core = { path = "../core" }

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -88,8 +88,9 @@ tempfile = "3.14"
 uuid = { version = "1.20.0", features = ["v7"] }
 
 [features]
-default = []
+default = ["kobo"]
 emulator = []
+kobo = []
 test = []
 otel = [
     "tracing-opentelemetry",

--- a/crates/core/src/logging.rs
+++ b/crates/core/src/logging.rs
@@ -59,6 +59,7 @@
 //!     max_files: 3,
 //!     directory: "logs".into(),
 //!     otlp_endpoint: None,
+//!     enable_kern_log: false,
 //! };
 //!
 //! // Initialize at application startup
@@ -87,6 +88,8 @@ use tracing_appender::non_blocking::WorkerGuard;
 use tracing_subscriber::prelude::*;
 use tracing_subscriber::EnvFilter;
 use uuid::Uuid;
+
+mod kern;
 
 const GIT_VERSION: &str = env!("GIT_VERSION");
 const LOG_FILE_PREFIX: &str = "cadmus-";
@@ -259,6 +262,7 @@ fn is_run_log_entry(entry: &DirEntry) -> bool {
 ///     max_files: 5,
 ///     directory: "logs".into(),
 ///     otlp_endpoint: Some("http://localhost:4318".to_string()),
+///     enable_kern_log: false,
 /// };
 ///
 /// init_logging(&settings)?;
@@ -322,6 +326,11 @@ pub fn init_logging(settings: &LoggingSettings) -> Result<(), Error> {
         get_run_id(),
         GIT_VERSION
     );
+
+    #[cfg(feature = "test")]
+    if settings.enable_kern_log {
+        kern::spawn_kern_log_thread();
+    }
 
     Ok(())
 }

--- a/crates/core/src/logging/kern.rs
+++ b/crates/core/src/logging/kern.rs
@@ -1,0 +1,325 @@
+//! Kernel log capture.
+//!
+//! This module provides functionality to capture kernel logs and forward them
+//! to the tracing system.
+//!
+//! By default, if no platform-specific implementation is available, the module
+//! logs a debug message indicating that kernel log capture is not implemented
+//! for the current platform.
+//!
+//! ## Example Log Retreival
+//!
+//! ```sh
+//! [root@monza cadmus-tst]# cat logs/cadmus-019cf7e3-ef3a-7752-846f-83b92ac90634.json | jq '. | select(.target == "cadmus_core::logging::kern")| .fields.body' -r | tail
+//! Mar 16 18:31:49 kernel: [ 3854.620803] -(0)[0:swapper/0][wlan] In HIF ISR.
+//! Mar 16 18:31:50 kernel: [ 3855.188306] -(0)[2715:main_thread][wlan][2715]wlanDumpBssStatistics:(SW4 INFO) LLS BSS[0] BE: T[053937] R[000000] T_D[000000] T_F[000000]
+//! Mar 16 18:31:50 kernel: [ 3855.188331] -(0)[2715:main_thread][wlan][2715]wlanDumpBssStatistics:(SW4 INFO) LLS BSS[0] BK: T[001878] R[000000] T_D[000000] T_F[000000]
+//! Mar 16 18:31:50 kernel: [ 3855.188342] -(0)[2715:main_thread][wlan][2715]wlanDumpBssStatistics:(SW4 INFO) LLS BSS[0] VI: T[000000] R[000000] T_D[000000] T_F[000000]
+//! Mar 16 18:31:50 kernel: [ 3855.188353] -(0)[2715:main_thread][wlan][2715]wlanDumpBssStatistics:(SW4 INFO) LLS BSS[0] VO: T[000004] R[000000] T_D[000000] T_F[000000]
+//! Mar 16 18:31:50 kernel: [ 3855.188485] .(0)[2716:hif_thread]padding for alignment
+//! Mar 16 18:31:50 kernel: [ 3855.641193] .(0)[2715:main_thread][wlan][2715]nicEventLayer0ExtMagic:(NIC INFO) Amsdu update event ucWlanIdx[1] ucLen[0] ucMaxMpduCount[0]
+//! Mar 16 18:31:50 kernel: [ 3855.842447] .(0)[2715:main_thread][wlan][2715]nicEventLayer0ExtMagic:(NIC INFO) Amsdu update event ucWlanIdx[1] ucLen[0] ucMaxMpduCount[0]
+//! Mar 16 18:31:51 kernel: [ 3856.636823] -(0)[0:swapper/0]mtk_axi_interrupt: 252 callbacks suppressed
+//! Mar 16 18:31:51 kernel: [ 3856.636842] -(0)[0:swapper/0][wlan] In HIF ISR.
+//! ```
+
+/// Parsed kernel log entry with extracted fields.
+#[derive(Debug, PartialEq)]
+#[cfg(all(feature = "kobo", feature = "test"))]
+struct ParsedKernelLog {
+    /// The log timestamp (e.g., "Mar 16 17:30:46")
+    pub timestamp: String,
+    /// System uptime in seconds (e.g., "1293.879480")
+    pub uptime: String,
+    /// Process ID (e.g., "0")
+    pub pid: String,
+    /// Thread ID (e.g., "1697")
+    pub thread_id: String,
+    /// Thread name (e.g., "hif_thread", "main_thread", "kworker/0:3")
+    pub thread: String,
+    /// Kernel subsystem (e.g., "wlan") - may be empty
+    pub subsystem: String,
+    /// The actual log message
+    pub message: String,
+}
+
+/// Parses a Kobo kernel log line into structured fields.
+///
+/// Supports multiple log formats:
+/// - Kernel format: `<timestamp> kernel: [<uptime>] -(<pid>)[<thread_id>][<thread>][<subsystem>] <message>`
+/// - Service format: `<timestamp> <service>[<pid>]: <message>`
+///
+/// Returns `Some(ParsedKernelLog)` if the line matches the expected format,
+/// or `None` if the line doesn't match.
+#[cfg(all(feature = "kobo", feature = "test"))]
+fn parse_kern_log(line: &str) -> Option<ParsedKernelLog> {
+    use regex::Regex;
+
+    lazy_static::lazy_static! {
+        // Kernel log format: Mar 16 17:30:46 kernel: [ 1293.879480] -(0)[1697:hif_thread][wlan] In HIF ISR.
+        static ref KERNEL_RE: Regex = Regex::new(
+            r"^(\w{3}\s+\d{1,2}\s+\d{2}:\d{2}:\d{2})\s+\w+:\s+\[\s*(\d+\.\d+)\]\s+[.-]\((\d+)\)\[(\d+):([^\]]+)\](?:\[(\w+)\])?(?:\[\d+\])?\s*(.+)$"
+        ).unwrap();
+
+        // Generic service log format: Mar 16 17:39:06 wpa_supplicant[2000]: wlan0: CTRL-EVENT...
+        static ref SERVICE_RE: Regex = Regex::new(
+            r"^(\w{3}\s+\d{1,2}\s+\d{2}:\d{2}:\d{2})\s+(\w+)\[(\d+)\]:\s+(.+)$"
+        ).unwrap();
+    }
+
+    if let Some(caps) = KERNEL_RE.captures(line) {
+        return Some(ParsedKernelLog {
+            timestamp: caps.get(1)?.as_str().to_string(),
+            uptime: caps.get(2)?.as_str().to_string(),
+            pid: caps.get(3)?.as_str().to_string(),
+            thread_id: caps.get(4)?.as_str().to_string(),
+            thread: caps.get(5)?.as_str().to_string(),
+            subsystem: caps
+                .get(6)
+                .map(|m| m.as_str().to_string())
+                .unwrap_or_default(),
+            message: caps.get(7)?.as_str().to_string(),
+        });
+    }
+
+    if let Some(caps) = SERVICE_RE.captures(line) {
+        return Some(ParsedKernelLog {
+            timestamp: caps.get(1)?.as_str().to_string(),
+            uptime: "".to_string(),
+            pid: caps.get(3)?.as_str().to_string(),
+            thread_id: "".to_string(),
+            thread: caps.get(2)?.as_str().to_string(),
+            subsystem: "".to_string(),
+            message: caps.get(4)?.as_str().to_string(),
+        });
+    }
+
+    None
+}
+
+/// Spawns a background thread that captures kernel logs.
+///
+/// # Platform-specific behavior
+///
+/// ## Kobo
+/// When the `kobo` feature is enabled, this starts `klogd` to enable kernel
+/// logging, then runs `logread -F` to read kernel log messages line by line.
+///
+/// The kernel log format used on Kobo devices:
+/// `<timestamp> kernel: [<uptime>] -(<pid>)[<thread_id>][<thread>][<subsystem>] <message>`
+///
+/// Examples:
+/// - `Mar 16 17:30:46 kernel: [ 1293.879480] -(0)[1697:hif_thread][wlan] In HIF ISR.`
+/// - `Mar 16 17:30:46 kernel: [ 1293.131642] .(0)[1696:main_thread][wlan][1696]wlanPktTxDone:...`
+///
+/// Parsed fields:
+/// - `timestamp`: The log timestamp (e.g., "Mar 16 17:30:46")
+/// - `uptime`: System uptime in seconds (e.g., "1293.879480")
+/// - `pid`: Process ID (e.g., "0")
+/// - `thread_id`: Thread ID (e.g., "1697")
+/// - `thread`: Thread name (e.g., "hif_thread", "main_thread", "kworker/0:3")
+/// - `subsystem`: Kernel subsystem (e.g., "wlan") - may be empty
+/// - `message`: The actual log message
+#[cfg(all(feature = "kobo", feature = "test"))]
+pub fn spawn_kern_log_thread() {
+    use std::io::{BufRead, BufReader};
+    use std::process::{Command, Stdio};
+    use std::thread;
+
+    fn is_process_running(name: &str) -> bool {
+        Command::new("pgrep")
+            .arg("-x")
+            .arg(name)
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .and_then(|mut child| child.wait().map(|status| status.success()))
+            .unwrap_or(false)
+    }
+
+    let klogd_running = is_process_running("klogd");
+    if klogd_running {
+        tracing::info!("klogd already running, reusing existing process");
+    }
+
+    thread::spawn(move || {
+        tracing::info!("Starting kernel log capture thread");
+
+        let klogd = if klogd_running {
+            None
+        } else {
+            match Command::new("klogd").spawn() {
+                Ok(child) => Some(child),
+                Err(e) => {
+                    tracing::warn!(error = %e, "Failed to start klogd");
+                    None
+                }
+            }
+        };
+
+        let mut child = match Command::new("logread")
+            .arg("-F")
+            .stdout(Stdio::piped())
+            .stderr(Stdio::null())
+            .spawn()
+        {
+            Ok(child) => child,
+            Err(e) => {
+                tracing::warn!(error = %e, "Failed to start logread command");
+                return;
+            }
+        };
+
+        let stdout = match child.stdout.take() {
+            Some(stdout) => stdout,
+            None => {
+                tracing::warn!("Failed to capture logread stdout");
+                return;
+            }
+        };
+
+        let reader = BufReader::new(stdout);
+
+        for line in reader.lines() {
+            match line {
+                Ok(line) => {
+                    if let Some(parsed) = parse_kern_log(&line) {
+                        tracing::debug!(
+                            body = %line,
+                            timestamp = %parsed.timestamp,
+                            uptime = %parsed.uptime,
+                            pid = %parsed.pid,
+                            thread_id = %parsed.thread_id,
+                            thread = %parsed.thread,
+                            subsystem = %parsed.subsystem,
+                            message = %parsed.message,
+                        );
+                    } else {
+                        tracing::debug!("{}", line);
+                    }
+                }
+                Err(e) => {
+                    tracing::warn!(error = %e, "Error reading from logread");
+                    break;
+                }
+            }
+        }
+
+        tracing::info!("Kernel log capture thread ending");
+
+        let _ = child.wait();
+        if let Some(mut klogd) = klogd {
+            let _ = klogd.kill();
+            let _ = klogd.wait();
+        }
+    });
+}
+
+#[cfg(all(not(feature = "kobo"), feature = "test"))]
+pub fn spawn_kern_log_thread() {
+    tracing::debug!("Kernel log capture is a no-op on non-Kobo platforms");
+}
+
+#[cfg(test)]
+#[cfg(all(feature = "kobo", feature = "test"))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_kern_log_basic() {
+        let line = "Mar 16 17:30:46 kernel: [ 1293.879480] -(0)[1697:hif_thread][wlan] In HIF ISR.";
+        let parsed = parse_kern_log(line).unwrap();
+
+        assert_eq!(parsed.timestamp, "Mar 16 17:30:46");
+        assert_eq!(parsed.uptime, "1293.879480");
+        assert_eq!(parsed.pid, "0");
+        assert_eq!(parsed.thread_id, "1697");
+        assert_eq!(parsed.thread, "hif_thread");
+        assert_eq!(parsed.subsystem, "wlan");
+        assert_eq!(parsed.message, "In HIF ISR.");
+    }
+
+    #[test]
+    fn test_parse_kern_log_with_dot_prefix() {
+        let line = "Mar 16 17:30:46 kernel: [ 1293.131642] .(0)[1696:main_thread][wlan][1696]wlanPktTxDone:(TX INFO) TX DONE, Type[ARP] Tag[0xea769a80] WIDX:PID[1:15] Status[0], SeqNo: 15<1576 -> 1862> ";
+        let parsed = parse_kern_log(line).unwrap();
+
+        assert_eq!(parsed.timestamp, "Mar 16 17:30:46");
+        assert_eq!(parsed.uptime, "1293.131642");
+        assert_eq!(parsed.pid, "0");
+        assert_eq!(parsed.thread_id, "1696");
+        assert_eq!(parsed.thread, "main_thread");
+        assert_eq!(parsed.subsystem, "wlan");
+        assert!(parsed.message.contains("wlanPktTxDone"));
+    }
+
+    #[test]
+    fn test_parse_kern_log_without_subsystem() {
+        let line = "Mar 16 17:30:46 kernel: [ 1293.879468] -(0)[1697:hif_thread]mtk_axi_interrupt: 191 callbacks suppressed";
+        let parsed = parse_kern_log(line).unwrap();
+
+        assert_eq!(parsed.timestamp, "Mar 16 17:30:46");
+        assert_eq!(parsed.uptime, "1293.879468");
+        assert_eq!(parsed.pid, "0");
+        assert_eq!(parsed.thread_id, "1697");
+        assert_eq!(parsed.thread, "hif_thread");
+        assert_eq!(parsed.subsystem, "");
+        assert!(parsed.message.contains("mtk_axi_interrupt"));
+    }
+
+    #[test]
+    fn test_parse_kern_log_kworker() {
+        let line = "Mar 16 17:30:42 kernel: [ 1289.462571] .(0)[1409:kworker/0:3]bd71827-power bd_work_callback()";
+        let parsed = parse_kern_log(line).unwrap();
+
+        assert_eq!(parsed.timestamp, "Mar 16 17:30:42");
+        assert_eq!(parsed.uptime, "1289.462571");
+        assert_eq!(parsed.pid, "0");
+        assert_eq!(parsed.thread_id, "1409");
+        assert_eq!(parsed.thread, "kworker/0:3");
+        assert_eq!(parsed.subsystem, "");
+        assert!(parsed.message.contains("bd71827-power"));
+    }
+
+    #[test]
+    fn test_parse_kern_log_unparseable() {
+        let line = "Some random log line without expected format";
+        let parsed = parse_kern_log(line);
+        assert!(parsed.is_none());
+    }
+
+    #[test]
+    fn test_parse_kern_log_empty_line() {
+        let line = "";
+        let parsed = parse_kern_log(line);
+        assert!(parsed.is_none());
+    }
+
+    #[test]
+    fn test_parse_kern_log_wpa_supplicant() {
+        let line = "Mar 16 17:39:06 wpa_supplicant[2000]: wlan0: CTRL-EVENT-REGDOM-CHANGE init=COUNTRY_IE type=COUNTRY alpha2=NL";
+        let parsed = parse_kern_log(line).unwrap();
+
+        assert_eq!(parsed.timestamp, "Mar 16 17:39:06");
+        assert_eq!(parsed.uptime, "");
+        assert_eq!(parsed.pid, "2000");
+        assert_eq!(parsed.thread_id, "");
+        assert_eq!(parsed.thread, "wpa_supplicant");
+        assert_eq!(parsed.subsystem, "");
+        assert!(parsed.message.contains("CTRL-EVENT-REGDOM-CHANGE"));
+    }
+
+    #[test]
+    fn test_parse_generic_service_log() {
+        let line = "Mar 16 17:39:06 GenericService[1500]: <info> connectivity check";
+        let parsed = parse_kern_log(line).unwrap();
+
+        assert_eq!(parsed.timestamp, "Mar 16 17:39:06");
+        assert_eq!(parsed.uptime, "");
+        assert_eq!(parsed.pid, "1500");
+        assert_eq!(parsed.thread_id, "");
+        assert_eq!(parsed.thread, "GenericService");
+        assert_eq!(parsed.subsystem, "");
+        assert!(parsed.message.contains("connectivity check"));
+    }
+}

--- a/crates/core/src/settings/mod.rs
+++ b/crates/core/src/settings/mod.rs
@@ -440,6 +440,8 @@ pub struct LoggingSettings {
     /// Optional OTLP endpoint; env vars override this value.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub otlp_endpoint: Option<String>,
+    /// Captures kernel logs via logread if kernel log capture is supported.
+    pub enable_kern_log: bool,
 }
 
 /// OTA update settings.
@@ -608,6 +610,7 @@ impl Default for LoggingSettings {
             max_files: 3,
             directory: PathBuf::from("logs"),
             otlp_endpoint: None,
+            enable_kern_log: false,
         }
     }
 }

--- a/crates/core/src/telemetry.rs
+++ b/crates/core/src/telemetry.rs
@@ -95,6 +95,7 @@ static LOGGER_PROVIDER: OnceLock<SdkLoggerProvider> = OnceLock::new();
 ///     max_files: 3,
 ///     directory: "logs".into(),
 ///     otlp_endpoint: Some("http://localhost:4318".to_string()),
+///     enable_kern_log: false,
 /// };
 ///
 /// let layer = init_telemetry::<tracing_subscriber::Registry>(&settings, "run-123")?;

--- a/crates/core/src/view/settings_editor/category.rs
+++ b/crates/core/src/view/settings_editor/category.rs
@@ -56,12 +56,19 @@ impl Category {
                         RowKind::LoggingEnabled,
                         RowKind::LogLevel,
                         RowKind::OtlpEndpoint,
+                        #[cfg(feature = "test")]
+                        RowKind::EnableKernLog,
                     ];
                     rows
                 }
                 #[cfg(not(feature = "otel"))]
                 {
-                    vec![RowKind::LoggingEnabled, RowKind::LogLevel]
+                    vec![
+                        RowKind::LoggingEnabled,
+                        RowKind::LogLevel,
+                        #[cfg(feature = "test")]
+                        RowKind::EnableKernLog,
+                    ]
                 }
             }
         }

--- a/crates/core/src/view/settings_editor/category_editor.rs
+++ b/crates/core/src/view/settings_editor/category_editor.rs
@@ -1005,9 +1005,18 @@ impl CategoryEditor {
                     ),
                 },
                 ToggleSettings::LoggingEnabled => self.handle_toggle_logging_enabled(context),
+                #[cfg(feature = "test")]
+                ToggleSettings::EnableKernLog => self.handle_toggle_enable_kern_log(context),
             },
             _ => unreachable!("mismatched toggle event"),
         }
+    }
+
+    #[cfg(feature = "test")]
+    #[inline]
+    fn handle_toggle_enable_kern_log(&mut self, context: &mut Context) -> bool {
+        context.settings.logging.enable_kern_log = !context.settings.logging.enable_kern_log;
+        true
     }
 }
 

--- a/crates/core/src/view/settings_editor/setting_row.rs
+++ b/crates/core/src/view/settings_editor/setting_row.rs
@@ -28,6 +28,8 @@ pub enum Kind {
     LogLevel,
     #[cfg(feature = "otel")]
     OtlpEndpoint,
+    #[cfg(feature = "test")]
+    EnableKernLog,
 }
 
 impl Kind {
@@ -65,6 +67,8 @@ impl Kind {
             Kind::LogLevel => "Log Level".to_string(),
             #[cfg(feature = "otel")]
             Kind::OtlpEndpoint => "OTLP Endpoint".to_string(),
+            #[cfg(feature = "test")]
+            Kind::EnableKernLog => "Enable Kernel Log".to_string(),
         }
     }
 
@@ -89,6 +93,8 @@ impl Kind {
             Kind::LogLevel => ValueKind::LogLevel,
             #[cfg(feature = "otel")]
             Kind::OtlpEndpoint => ValueKind::OtlpEndpoint,
+            #[cfg(feature = "test")]
+            Kind::EnableKernLog => ValueKind::Toggle(ToggleSettings::EnableKernLog),
         }
     }
 }

--- a/crates/core/src/view/settings_editor/setting_value.rs
+++ b/crates/core/src/view/settings_editor/setting_value.rs
@@ -36,6 +36,9 @@ pub enum ToggleSettings {
     ButtonScheme,
     /// Logging enabled setting
     LoggingEnabled,
+    /// Kernel logging enabled setting (test builds only)
+    #[cfg(feature = "test")]
+    EnableKernLog,
 }
 
 /// Represents the type of setting value being displayed.
@@ -183,6 +186,16 @@ impl SettingValue {
                     fonts,
                     Align::Right(10),
                 )),
+                #[cfg(feature = "test")]
+                ToggleSettings::EnableKernLog => Box::new(Toggle::new(
+                    self.rect,
+                    "on",
+                    "off",
+                    enabled_toggle.expect("enabled bool should be Some for toggle settings"),
+                    event.expect("Event should not be None for toggle"),
+                    fonts,
+                    Align::Right(10),
+                )),
             },
             _ => Box::new(ActionLabel::new(self.rect, value, Align::Right(10)).event(event)),
         }
@@ -245,6 +258,8 @@ impl SettingValue {
                 ToggleSettings::AutoShare => Self::fetch_auto_share_data(settings),
                 ToggleSettings::ButtonScheme => Self::fetch_button_scheme_data(settings),
                 ToggleSettings::LoggingEnabled => Self::fetch_logging_enabled_data(settings),
+                #[cfg(feature = "test")]
+                ToggleSettings::EnableKernLog => Self::fetch_enable_kern_log_data(settings),
             },
         }
     }
@@ -333,6 +348,17 @@ impl SettingValue {
     fn fetch_logging_enabled_data(settings: &Settings) -> (String, Vec<EntryKind>, Option<bool>) {
         let toggle = settings.logging.enabled;
         (toggle.to_string(), vec![], Some(settings.logging.enabled))
+    }
+
+    #[cfg(feature = "test")]
+    #[inline]
+    fn fetch_enable_kern_log_data(settings: &Settings) -> (String, Vec<EntryKind>, Option<bool>) {
+        let toggle = settings.logging.enable_kern_log;
+        (
+            toggle.to_string(),
+            vec![],
+            Some(settings.logging.enable_kern_log),
+        )
     }
 
     #[inline]

--- a/docs/src/settings/index.md
+++ b/docs/src/settings/index.md
@@ -1,12 +1,14 @@
 # Settings
 
 Cadmus reads settings from `Settings/Settings-*.toml`.
-Settings can be changed on your Kobo through **Main Menu → Settings**, which opens the built-in settings editor.
+Settings can be changed via **Main Menu → Settings**, which opens the built-in settings editor.
 
 **Legend:**
 
 - ✏️ Editable in the settings editor
 - 🔑 Required for feature to work
+- 🧪 Only available in test builds
+- 📱 Kobo
 
 ## General Settings
 
@@ -268,6 +270,18 @@ otlp-endpoint = "https://otel.example.com:4318"
 Environment override:
 
 - `OTEL_EXPORTER_OTLP_ENDPOINT` takes precedence over `logging.otlp-endpoint`.
+
+### `logging.enable-kern-log`
+
+🧪 📱 ✏️
+
+Captures kernel logs via `logread -F` and forwards them to structured logging
+with the target `cadmus_core::logging:kern`.
+
+```toml
+[logging]
+enable-kern-log = false
+```
 
 ## Settings Retention
 

--- a/xtask/src/tasks/util/matrix.rs
+++ b/xtask/src/tasks/util/matrix.rs
@@ -281,8 +281,8 @@ mod tests {
         assert!(labels.contains(&"test"));
         assert_eq!(
             entries.len(),
-            16,
-            "3 features → 2³ = 8 combos × 2 OSes = 16 entries"
+            32,
+            "4 features → 2⁴ = 16 combos × 2 OSes = 32 entries"
         );
     }
 }


### PR DESCRIPTION
Add enable_kern_log setting to capture kernel logs in test builds. Uses klogd and logread -F on Kobo to forward kernel logs to tracing with target logging:kern for crash diagnostics.

- Add kobo feature flag (enabled by default)
- Add logging.enable_kern_log setting (default: false)
- Create kern module with platform-specific implementations
- Add 🧪 and 📱 legend entries for test/Kobo-only settings
- Update settings documentation

Change-Id: a3a3e0d85867ade19ad8e56abcc36e28
Change-Id-Short: pwpwlzmrurts

---

```sh
[root@monza cadmus-tst]# cat logs/cadmus-019cf7e3-ef3a-7752-846f-83b92ac90634.json | jq '. | select(.target == "cadmus_core::logging::kern")| .fields.body' -r | tail
Mar 16 18:31:49 kernel: [ 3854.620803] -(0)[0:swapper/0][wlan] In HIF ISR.
Mar 16 18:31:50 kernel: [ 3855.188306] -(0)[2715:main_thread][wlan][2715]wlanDumpBssStatistics:(SW4 INFO) LLS BSS[0] BE: T[053937] R[000000] T_D[000000] T_F[000000]
Mar 16 18:31:50 kernel: [ 3855.188331] -(0)[2715:main_thread][wlan][2715]wlanDumpBssStatistics:(SW4 INFO) LLS BSS[0] BK: T[001878] R[000000] T_D[000000] T_F[000000]
Mar 16 18:31:50 kernel: [ 3855.188342] -(0)[2715:main_thread][wlan][2715]wlanDumpBssStatistics:(SW4 INFO) LLS BSS[0] VI: T[000000] R[000000] T_D[000000] T_F[000000]
Mar 16 18:31:50 kernel: [ 3855.188353] -(0)[2715:main_thread][wlan][2715]wlanDumpBssStatistics:(SW4 INFO) LLS BSS[0] VO: T[000004] R[000000] T_D[000000] T_F[000000]
Mar 16 18:31:50 kernel: [ 3855.188485] .(0)[2716:hif_thread]padding for alignment
Mar 16 18:31:50 kernel: [ 3855.641193] .(0)[2715:main_thread][wlan][2715]nicEventLayer0ExtMagic:(NIC INFO) Amsdu update event ucWlanIdx[1] ucLen[0] ucMaxMpduCount[0]
Mar 16 18:31:50 kernel: [ 3855.842447] .(0)[2715:main_thread][wlan][2715]nicEventLayer0ExtMagic:(NIC INFO) Amsdu update event ucWlanIdx[1] ucLen[0] ucMaxMpduCount[0]
Mar 16 18:31:51 kernel: [ 3856.636823] -(0)[0:swapper/0]mtk_axi_interrupt: 252 callbacks suppressed
Mar 16 18:31:51 kernel: [ 3856.636842] -(0)[0:swapper/0][wlan] In HIF ISR.

```
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ogkevin/cadmus/pull/253" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
