### PR TITLE
chore: emulator is always online

### DIFF
--- a/crates/emulator/src/main.rs
+++ b/crates/emulator/src/main.rs
@@ -81,7 +81,7 @@ pub fn build_context(
     let frontlight = Box::new(LightLevels::default()) as Box<dyn Frontlight>;
     let lightsensor = Box::new(0u16) as Box<dyn LightSensor>;
 
-    Ok(Context::new(
+    let mut ctx = Context::new(
         fb,
         None,
         library,
@@ -91,7 +91,11 @@ pub fn build_context(
         battery,
         frontlight,
         lightsensor,
-    ))
+    );
+
+    ctx.online = true;
+
+    Ok(ctx)
 }
 
 #[inline]


### PR DESCRIPTION
Change emulator to always be online.

Change-Id: 0ac9b856947df49f0c087f25d307e9dc
Change-Id-Short: zpnqorutqvsm

Relates-To: #68 #232 