### PR TITLE
chore: dont disable wifi in usb in test

### DIFF
--- a/crates/cadmus/src/app.rs
+++ b/crates/cadmus/src/app.rs
@@ -307,6 +307,7 @@ fn prepare_share_for_usb(
         context.frontlight.set_intensity(0.0);
         context.frontlight.set_warmth(0.0);
     }
+    #[cfg(not(feature = "test"))]
     if context.settings.wifi {
         Command::new("scripts/wifi-disable.sh").status().ok();
         context.online = false;


### PR DESCRIPTION
Change-Id: 03c6a3013ca2b8d7d11ec09541bdb0cc
Change-Id-Short: zwntpwzywnpx

Rleates-To: #246 #247 

This allows for OTEL to e.g. continue to ship logs, or the ability to ssh onto the device while usb sessions is in play. 