### PR TITLE
chore: add structured error handling and logging for document loading

### DIFF
--- a/.github/actions/cache-thirdparty/action.yml
+++ b/.github/actions/cache-thirdparty/action.yml
@@ -20,7 +20,7 @@ runs:
           libs/
           thirdparty/
           mupdf_wrapper/
-        key: ${{ runner.os }}-thirdparty-libs-${{ inputs.kind }}-${{ hashFiles('thirdparty/**/build-kobo.sh', 'thirdparty/**/*.patch', 'xtask/src/tasks/util/thirdparty.rs') }}
+        key: ${{ runner.os }}-thirdparty-libs-${{ inputs.kind }}-${{ hashFiles('thirdparty/**/build-kobo.sh', 'thirdparty/**/*.patch', 'xtask/src/tasks/util/thirdparty.rs', 'mupdf_wrapper/mupdf_wrapper.c') }}
 
     - name: Cache thirdparty libraries (native)
       if: inputs.kind == 'native'
@@ -29,4 +29,4 @@ runs:
         path: |
           thirdparty/mupdf
           mupdf_wrapper/
-        key: ${{ runner.os }}-thirdparty-libs-native-${{ hashFiles('xtask/src/tasks/util/thirdparty.rs', 'xtask/src/tasks/setup_native.rs') }}
+        key: ${{ runner.os }}-thirdparty-libs-native-${{ hashFiles('xtask/src/tasks/util/thirdparty.rs', 'xtask/src/tasks/setup_native.rs', 'mupdf_wrapper/mupdf_wrapper.c') }}

--- a/crates/cadmus/src/app.rs
+++ b/crates/cadmus/src/app.rs
@@ -57,7 +57,7 @@ use std::process::Command;
 use std::sync::mpsc::{self, Receiver, Sender};
 use std::thread;
 use std::time::{Duration, Instant};
-use tracing::{debug, error, info};
+use tracing::{debug, error, info, warn};
 
 pub const APP_NAME: &str = "Cadmus";
 const DB_FILENAME: &str = "cadmus.sqlite";
@@ -1191,6 +1191,11 @@ pub fn run() -> Result<(), Error> {
                         }
                     }
                     context.fb.set_dithered(dithered);
+                    warn!(
+                        path = %path.display(),
+                        library_home = %context.library.home.display(),
+                        "Reader::new returned None, dispatching Event::Invalid"
+                    );
                     handle_event(
                         view.as_mut(),
                         &Event::Invalid(path),

--- a/crates/core/src/document/mod.rs
+++ b/crates/core/src/document/mod.rs
@@ -29,7 +29,7 @@ use std::fs::{self, File};
 use std::os::unix::fs::FileExt;
 use std::path::Path;
 use std::process::Command;
-use tracing::error;
+use tracing::{error, warn};
 use unicode_normalization::char::is_combining_mark;
 use unicode_normalization::UnicodeNormalization;
 
@@ -234,25 +234,54 @@ pub fn asciify(name: &str) -> String {
         .replace('’', "'")
 }
 
+#[cfg_attr(feature = "otel", tracing::instrument(skip(path), fields(path = %path.as_ref().display())))]
 pub fn open<P: AsRef<Path>>(path: P) -> Option<Box<dyn Document>> {
-    file_kind(path.as_ref()).and_then(|k| match k.as_ref() {
+    let kind = file_kind(path.as_ref());
+    if kind.is_none() {
+        warn!(path = %path.as_ref().display(), "Failed to determine file kind");
+    }
+    kind.and_then(|k| match k.as_ref() {
         "epub" => EpubDocument::new(&path)
-            .map_err(|e| error!("{}: {:#}.", path.as_ref().display(), e))
+            .map_err(|e| error!(path = %path.as_ref().display(), error = %e, "Failed to open epub document"))
             .map(|d| Box::new(d) as Box<dyn Document>)
             .ok(),
         "html" | "htm" => HtmlDocument::new(&path)
-            .map_err(|e| error!("{}: {:#}.", path.as_ref().display(), e))
+            .map_err(|e| error!(path = %path.as_ref().display(), error = %e, "Failed to open html document"))
             .map(|d| Box::new(d) as Box<dyn Document>)
             .ok(),
         "djvu" | "djv" => {
-            DjvuOpener::new().and_then(|o| o.open(path).map(|d| Box::new(d) as Box<dyn Document>))
-        }
-        _ => PdfOpener::new().and_then(|mut o| {
-            if matches!(k.as_ref(), "mobi" | "fb2" | "xps" | "txt") {
-                o.load_user_stylesheet();
+            let opener = DjvuOpener::new();
+            if opener.is_none() {
+                warn!(path = %path.as_ref().display(), "Failed to create DjvuOpener");
             }
-            o.open(path).map(|d| Box::new(d) as Box<dyn Document>)
-        }),
+            opener.and_then(|o| {
+                let doc = o.open(&path).map(|d| Box::new(d) as Box<dyn Document>);
+                if doc.is_none() {
+                    warn!(path = %path.as_ref().display(), "DjvuOpener failed to open document");
+                }
+                doc
+            })
+        }
+        _ => {
+            let opener = PdfOpener::new();
+            if opener.is_none() {
+                warn!(path = %path.as_ref().display(), "Failed to create PdfOpener");
+            }
+            opener.and_then(|mut o| {
+                if matches!(k.as_ref(), "mobi" | "fb2" | "xps" | "txt") {
+                    o.load_user_stylesheet();
+                }
+                o.open(&path)
+                    .map_err(|e| warn!(
+                        path = %path.as_ref().display(),
+                        kind = %k,
+                        error = %e,
+                        "PdfOpener failed to open document"
+                    ))
+                    .ok()
+                    .map(|d| Box::new(d) as Box<dyn Document>)
+            })
+        }
     })
 }
 

--- a/crates/core/src/document/mupdf_sys.rs
+++ b/crates/core/src/document/mupdf_sys.rs
@@ -74,6 +74,12 @@ extern "C" {
     pub fn fz_set_user_css(ctx: *mut FzContext, user_css: *const libc::c_char);
     pub fn fz_set_use_document_css(ctx: *mut FzContext, should_use: libc::c_int);
     pub fn mp_open_document(ctx: *mut FzContext, path: *const libc::c_char) -> *mut FzDocument;
+    pub fn mp_open_document_with_error(
+        ctx: *mut FzContext,
+        path: *const libc::c_char,
+        err_buf: *mut libc::c_char,
+        err_buf_len: libc::c_int,
+    ) -> *mut FzDocument;
     pub fn mp_open_document_with_stream(
         ctx: *mut FzContext,
         kind: *const libc::c_char,

--- a/crates/core/src/document/pdf.rs
+++ b/crates/core/src/document/pdf.rs
@@ -15,9 +15,19 @@ use std::path::Path;
 use std::ptr;
 use std::rc::Rc;
 use std::slice;
+use thiserror::Error;
 use tracing::error;
 
 const USER_STYLESHEET: &str = "css/html-user.css";
+
+/// Error returned when MuPDF fails to open a document.
+#[derive(Debug, Error)]
+pub enum PdfOpenError {
+    #[error("MuPDF error: {0}")]
+    MuPdf(String),
+    #[error("MuPDF returned no error message")]
+    Unknown,
+}
 
 impl Into<Boundary> for FzRect {
     fn into(self) -> Boundary {
@@ -45,6 +55,7 @@ pub struct PdfPage<'a> {
 }
 
 impl PdfOpener {
+    #[cfg_attr(feature = "otel", tracing::instrument)]
     pub fn new() -> Option<PdfOpener> {
         unsafe {
             let version = CString::new(FZ_VERSION).unwrap();
@@ -59,14 +70,28 @@ impl PdfOpener {
         }
     }
 
-    pub fn open<P: AsRef<Path>>(&self, path: P) -> Option<PdfDocument> {
+    #[cfg_attr(feature = "otel", tracing::instrument(skip(self, path), fields(path = %path.as_ref().display())))]
+    pub fn open<P: AsRef<Path>>(&self, path: P) -> Result<PdfDocument, PdfOpenError> {
         unsafe {
             let c_path = CString::new(path.as_ref().as_os_str().as_bytes()).unwrap();
-            let doc = mp_open_document((self.0).0, c_path.as_ptr());
+            let mut err_buf: [libc::c_char; 256] = [0; 256];
+            let doc = mp_open_document_with_error(
+                (self.0).0,
+                c_path.as_ptr(),
+                err_buf.as_mut_ptr(),
+                err_buf.len() as libc::c_int,
+            );
             if doc.is_null() {
-                None
+                let msg = CStr::from_ptr(err_buf.as_ptr())
+                    .to_string_lossy()
+                    .into_owned();
+                Err(if msg.is_empty() {
+                    PdfOpenError::Unknown
+                } else {
+                    PdfOpenError::MuPdf(msg)
+                })
             } else {
-                Some(PdfDocument {
+                Ok(PdfDocument {
                     ctx: self.0.clone(),
                     doc,
                 })

--- a/crates/core/src/metadata.rs
+++ b/crates/core/src/metadata.rs
@@ -898,7 +898,7 @@ pub fn extract_metadata_from_document(prefix: &Path, info: &mut Info) {
             }
             Err(e) => error!("Can't open {}: {:#}.", info.file.path.display(), e),
         },
-        "pdf" => match PdfOpener::new().and_then(|o| o.open(path)) {
+        "pdf" => match PdfOpener::new().and_then(|o| o.open(path).ok()) {
             Some(doc) => {
                 info.title = doc.title().unwrap_or_default();
                 info.author = doc.author().unwrap_or_default();

--- a/crates/core/src/view/icon.rs
+++ b/crates/core/src/view/icon.rs
@@ -77,7 +77,7 @@ lazy_static! {
         .cloned()
         {
             let path = dir.join(format!("{}.svg", name));
-            let doc = PdfOpener::new().and_then(|o| o.open(&path)).unwrap();
+            let doc = PdfOpener::new().and_then(|o| o.open(&path).ok()).unwrap();
             let pixmap = doc.page(0).and_then(|p| p.pixmap(scale, 1)).unwrap();
             m.insert(name, pixmap);
         }

--- a/crates/core/src/view/reader/mod.rs
+++ b/crates/core/src/view/reader/mod.rs
@@ -70,7 +70,7 @@ use std::sync::atomic::AtomicBool;
 use std::sync::atomic::Ordering as AtomicOrdering;
 use std::sync::{Arc, Mutex};
 use std::thread;
-use tracing::{error, info};
+use tracing::{debug, error, info, warn};
 
 const HISTORY_SIZE: usize = 32;
 const RECT_DIST_JITTER: f32 = 24.0;
@@ -283,7 +283,23 @@ impl Reader {
         let settings = &context.settings;
         let path = context.library.home.join(&info.file.path);
 
-        open(&path).and_then(|mut doc| {
+        debug!(
+            resolved_path = %path.display(),
+            file_exists = path.exists(),
+            library_home = %context.library.home.display(),
+            relative_path = %info.file.path.display(),
+            "Opening document"
+        );
+
+        let doc = open(&path);
+        if doc.is_none() {
+            warn!(
+                resolved_path = %path.display(),
+                file_exists = path.exists(),
+                "Failed to open document: open() returned None"
+            );
+        }
+        doc.and_then(|mut doc| {
             let (width, height) = context.display.dims;
             let font_size = info
                 .reader
@@ -349,7 +365,14 @@ impl Reader {
                 doc.set_ignore_document_css(true);
             }
 
-            let first_location = doc.resolve_location(Location::Exact(0))?;
+            let first_location = doc.resolve_location(Location::Exact(0));
+            if first_location.is_none() {
+                warn!(
+                    resolved_path = %path.display(),
+                    "Document opened but resolve_location(Exact(0)) returned None"
+                );
+            }
+            let first_location = first_location?;
 
             let mut view_port = ViewPort::default();
             let mut contrast = Contrast::default();

--- a/crates/emulator/src/main.rs
+++ b/crates/emulator/src/main.rs
@@ -56,7 +56,7 @@ use std::mem;
 use std::sync::mpsc;
 use std::thread;
 use std::time::Duration;
-use tracing::info;
+use tracing::{info, warn};
 
 pub const APP_NAME: &str = "Cadmus";
 const DB_FILENAME: &str = "cadmus.sqlite";
@@ -550,6 +550,11 @@ fn main() -> Result<(), Error> {
                                 context.display.dims = dims;
                             }
                         }
+                        warn!(
+                            path = %path.display(),
+                            library_home = %context.library.home.display(),
+                            "Reader::new returned None, dispatching Event::Invalid"
+                        );
                         handle_event(
                             view.as_mut(),
                             &Event::Invalid(path),

--- a/mupdf_wrapper/mupdf_wrapper.c
+++ b/mupdf_wrapper/mupdf_wrapper.c
@@ -10,6 +10,18 @@
 
 WRAP(open_document, fz_document*, NULL, fz_open_document(ctx, path), char *path)
 WRAP(open_document_with_stream, fz_document*, NULL, fz_open_document_with_stream(ctx, kind, stream), const char *kind, fz_stream *stream)
+
+fz_document* mp_open_document_with_error(fz_context *ctx, char *path,
+                                          char *err_buf, int err_buf_len) {
+    fz_document* ret = NULL;
+    fz_try (ctx) { ret = fz_open_document(ctx, path); }
+    fz_catch (ctx) {
+        const char *msg = fz_caught_message(ctx);
+        strncpy(err_buf, msg, err_buf_len - 1);
+        err_buf[err_buf_len - 1] = '\0';
+    }
+    return ret;
+}
 WRAP(load_page, fz_page*, NULL, fz_load_page(ctx, doc, pageno), fz_document *doc, int pageno)
 WRAP(load_outline, fz_outline*, NULL, fz_load_outline(ctx, doc), fz_document *doc)
 WRAP(load_links, fz_link*, NULL, fz_load_links(ctx, page), fz_page *page)


### PR DESCRIPTION
Improve observability and error diagnostics across the document opening pipeline by:

- Add mp_open_document_with_error FFI binding to capture MuPDF error messages in C wrapper
- Create PdfOpenError enum with structured error types for better error propagation
- Convert document::open() to log warnings at each failure point (file type detection, opener creation, document opening)
- Add structured logging in Reader::new() to diagnose why document opening failed
- Replace unstructured error logging with structured tracing fields (path, kind, error, library_home)
- Add diagnostic logging in reader initialization showing resolved paths and file existence checks

Change-Id: 61384ba58be7ed2317123505d2a658bd
Change-Id-Short: tywrvopurols
Relates-To: #233 
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ogkevin/cadmus/pull/281" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
