### PR TITLE
fix(Top Menu): make restart and reboot clearer

### DIFF
--- a/crates/core/i18n/en-GB/cadmus_core.ftl
+++ b/crates/core/i18n/en-GB/cadmus_core.ftl
@@ -1,2 +1,11 @@
+# Keep the message ID's sorted please.
+
+-app-name = Cadmus
+
 english = English
+
 startup-loading = Cadmus starting up…
+
+# Top Menu Strings
+top-menu-reboot-device = Reboot Device
+top-menu-restart-app = Restart {-app-name}

--- a/crates/core/src/view/common.rs
+++ b/crates/core/src/view/common.rs
@@ -3,6 +3,7 @@ use super::notification::Notification;
 use super::{AppCmd, EntryId, EntryKind, RenderData, RenderQueue, View, ViewId};
 use crate::context::Context;
 use crate::device::CURRENT_DEVICE;
+use crate::fl;
 use crate::framebuffer::UpdateMode;
 use crate::geom::{Point, Rectangle};
 use crate::settings::{ButtonScheme, RotationLock};
@@ -227,8 +228,8 @@ pub fn toggle_main_menu(
             EntryKind::Separator,
             EntryKind::SubMenu("Applications".to_string(), apps),
             EntryKind::Separator,
-            EntryKind::Command("Restart".to_string(), EntryId::Restart),
-            EntryKind::Command("Reboot".to_string(), EntryId::Reboot),
+            EntryKind::Command(fl!("top-menu-restart-app").to_string(), EntryId::Restart),
+            EntryKind::Command(fl!("top-menu-reboot-device").to_string(), EntryId::Reboot),
             EntryKind::Command("Quit".to_string(), EntryId::Quit),
         ]);
 


### PR DESCRIPTION
- Add top-menu-restart-app and top-menu-reboot-device translation keys
- Replace hardcoded strings with fl!() macro calls
- Add app-name variable for consistent branding
- make it clear that "Restart" is for the app and "Reboot" is for the device

Change-Id: fbeaf35bb0fce4d28e982ad739f08364
Change-Id-Short: kolpkwuoozkn

<!--
Fixes CAD-14
-->