### PR TITLE
refactor(settings-editor): restructure and i18n

### DIFF
--- a/crates/core/i18n/en-GB/cadmus_core.ftl
+++ b/crates/core/i18n/en-GB/cadmus_core.ftl
@@ -9,3 +9,60 @@ startup-loading = Cadmus starting up…
 # Top Menu Strings
 top-menu-reboot-device = Reboot Device
 top-menu-restart-app = Restart {-app-name}
+
+# Settings - Button Scheme
+settings-button-scheme-natural = Natural
+settings-button-scheme-inverted = Inverted
+
+# Settings - Finished Actions
+settings-finished-action-notify = Notify
+settings-finished-action-close = Close
+settings-finished-action-goto-next = Go to Next
+
+# Settings - General
+settings-general-language = Language
+settings-general-keyboard-layout = Keyboard Layout
+settings-general-auto-suspend = Auto Suspend (minutes)
+settings-general-auto-power-off = Auto Power Off (days)
+settings-general-enable-sleep-cover = Enable Sleep Cover
+settings-general-enable-auto-share = Enable Auto Share
+settings-general-button-scheme = Button Scheme
+settings-general-settings-retention = Settings Retention
+settings-general-auto-suspend-input = Auto Suspend (minutes, 0 = never)
+settings-general-auto-power-off-input = Auto Power Off (days, 0 = never)
+settings-general-toggle-on = on
+settings-general-toggle-off = off
+settings-general-never = Never
+settings-general-not-set = Not set
+settings-general-unknown = Unknown
+
+# Settings - Reader
+settings-reader-end-of-book-action = End of Book Action
+
+# Settings - Intermission
+settings-intermission-suspend-screen = Suspend Screen
+settings-intermission-power-off-screen = Power Off Screen
+settings-intermission-share-screen = Share Screen
+settings-intermission-logo = Logo
+settings-intermission-cover = Cover
+settings-intermission-custom-image = Custom Image...
+settings-intermission-custom = Custom
+
+# Settings - Library
+settings-library-name = Name
+settings-library-path = Path
+settings-library-end-of-book-action = End of Book Action
+settings-library-inherit = Inherit
+
+# Settings - Log Level
+settings-log-level-trace = TRACE
+settings-log-level-debug = DEBUG
+settings-log-level-info = INFO
+settings-log-level-warn = WARN
+settings-log-level-error = ERROR
+
+# Settings - Telemetry
+settings-telemetry-enable-logging = Enable Logging
+settings-telemetry-log-level = Log Level
+settings-telemetry-otlp-endpoint = OTLP Endpoint
+settings-telemetry-enable-kernel-log = Enable Kernel Log

--- a/crates/core/src/i18n.rs
+++ b/crates/core/src/i18n.rs
@@ -14,6 +14,12 @@ pub const DEFAULT_LOCALE: &str = "en-GB";
 #[folder = "i18n/"]
 struct Localizations;
 
+/// Trait for types that can provide localized string representations
+pub trait I18nDisplay {
+    /// Returns a localized string representation
+    fn to_i18n_string(&self) -> String;
+}
+
 /// Returns the global [`FluentLanguageLoader`], initialising it on first call.
 ///
 /// The fallback language ([DEFAULT_LOCALE]) is loaded automatically, so the loader is

--- a/crates/core/src/settings/mod.rs
+++ b/crates/core/src/settings/mod.rs
@@ -3,7 +3,9 @@ pub mod versioned;
 
 use crate::color::{Color, BLACK};
 use crate::device::CURRENT_DEVICE;
+use crate::fl;
 use crate::frontlight::LightLevels;
+use crate::i18n::I18nDisplay;
 use crate::metadata::{SortMethod, TextAlign};
 use crate::unit::mm_to_px;
 use fxhash::FxHashSet;
@@ -106,6 +108,15 @@ pub enum ButtonScheme {
 impl fmt::Display for ButtonScheme {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         Debug::fmt(self, f)
+    }
+}
+
+impl I18nDisplay for ButtonScheme {
+    fn to_i18n_string(&self) -> String {
+        match self {
+            ButtonScheme::Natural => fl!("settings-button-scheme-natural"),
+            ButtonScheme::Inverted => fl!("settings-button-scheme-inverted"),
+        }
     }
 }
 
@@ -470,6 +481,16 @@ impl fmt::Display for FinishedAction {
             FinishedAction::Notify => write!(f, "Notify"),
             FinishedAction::Close => write!(f, "Close"),
             FinishedAction::GoToNext => write!(f, "Go to Next"),
+        }
+    }
+}
+
+impl I18nDisplay for FinishedAction {
+    fn to_i18n_string(&self) -> String {
+        match self {
+            FinishedAction::Notify => fl!("settings-finished-action-notify"),
+            FinishedAction::Close => fl!("settings-finished-action-close"),
+            FinishedAction::GoToNext => fl!("settings-finished-action-goto-next"),
         }
     }
 }

--- a/crates/core/src/view/intermission.rs
+++ b/crates/core/src/view/intermission.rs
@@ -3,9 +3,11 @@ use crate::color::{TEXT_INVERTED_HARD, TEXT_NORMAL};
 use crate::context::Context;
 use crate::device::CURRENT_DEVICE;
 use crate::document::{open, Location};
+use crate::fl;
 use crate::font::{font_from_style, Fonts, DISPLAY_STYLE};
 use crate::framebuffer::Framebuffer;
 use crate::geom::Rectangle;
+use crate::i18n::I18nDisplay;
 use crate::metadata::{sort, BookQuery, SortMethod};
 use crate::settings::{IntermKind, IntermissionDisplay};
 use std::path::PathBuf;
@@ -53,6 +55,16 @@ impl Intermission {
             children: Vec::new(),
             message,
             halt: kind == IntermKind::PowerOff,
+        }
+    }
+}
+
+impl I18nDisplay for IntermissionDisplay {
+    fn to_i18n_string(&self) -> String {
+        match self {
+            IntermissionDisplay::Logo => fl!("settings-intermission-logo"),
+            IntermissionDisplay::Cover => fl!("settings-intermission-cover"),
+            IntermissionDisplay::Image(_) => fl!("settings-intermission-custom"),
         }
     }
 }

--- a/crates/core/src/view/mod.rs
+++ b/crates/core/src/view/mod.rs
@@ -505,6 +505,20 @@ pub enum Event {
     Github(GithubEvent),
     /// Settings-specific events
     Settings(settings_editor::SettingsEvent),
+    /// Request to open a [`NamedInput`](named_input::NamedInput) text overlay.
+    ///
+    /// The handler is responsible for creating the overlay and placing it at the
+    /// correct position in the view hierarchy so it sits at the top of the z-order.
+    OpenNamedInput {
+        /// The `ViewId` used for both the overlay and the resulting `Submit` event.
+        view_id: ViewId,
+        /// Label text displayed inside the input dialog.
+        label: String,
+        /// Maximum number of characters the input field accepts.
+        max_chars: usize,
+        /// Current value pre-populated into the input field.
+        initial_text: String,
+    },
     /// Progress update from a background OTA download thread.
     ///
     /// `OtaView` handles this by updating the status label text and the

--- a/crates/core/src/view/settings_editor/category.rs
+++ b/crates/core/src/view/settings_editor/category.rs
@@ -1,8 +1,16 @@
-use super::setting_row::Kind as RowKind;
+use super::kinds::general::{
+    AutoPowerOff, AutoShare, AutoSuspend, ButtonScheme, KeyboardLayout, Locale, SettingsRetention,
+    SleepCover,
+};
+use super::kinds::intermission::{IntermissionPowerOff, IntermissionShare, IntermissionSuspend};
+use super::kinds::library::LibraryInfo;
+use super::kinds::reader::FinishedActionSetting;
+use super::kinds::telemetry::{LogLevel, LoggingEnabled};
+use super::kinds::SettingKind;
 use crate::context::Context;
 
 /// Categories of settings available in the settings editor.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum Category {
     /// General device settings (auto-suspend, keyboard layout, etc.)
     General,
@@ -28,48 +36,63 @@ impl Category {
         }
     }
 
-    /// Returns the list of setting rows for this category.
-    pub fn settings(&self, context: &Context) -> Vec<RowKind> {
+    /// Returns the list of setting kinds for this category.
+    ///
+    /// Each element is a heap-allocated [`SettingKind`] that fully describes
+    /// the label, current value, widget type, and tap event for one row.
+    pub fn settings(&self, context: &Context) -> Vec<Box<dyn SettingKind>> {
         match self {
             Category::General => vec![
-                RowKind::Locale,
-                RowKind::AutoShare,
-                RowKind::AutoSuspend,
-                RowKind::AutoPowerOff,
-                RowKind::ButtonScheme,
-                RowKind::KeyboardLayout,
-                RowKind::SleepCover,
-                RowKind::SettingsRetention,
+                Box::new(Locale),
+                Box::new(AutoShare),
+                Box::new(AutoSuspend),
+                Box::new(AutoPowerOff),
+                Box::new(ButtonScheme),
+                Box::new(KeyboardLayout),
+                Box::new(SleepCover),
+                Box::new(SettingsRetention),
             ],
-            Category::Reader => vec![RowKind::FinishedAction],
+            Category::Reader => vec![Box::new(FinishedActionSetting)],
             Category::Libraries => (0..context.settings.libraries.len())
-                .map(RowKind::Library)
+                .map(|i| Box::new(LibraryInfo(i)) as Box<dyn SettingKind>)
                 .collect(),
             Category::Intermissions => vec![
-                RowKind::IntermissionSuspend,
-                RowKind::IntermissionPowerOff,
-                RowKind::IntermissionShare,
+                Box::new(IntermissionSuspend),
+                Box::new(IntermissionPowerOff),
+                Box::new(IntermissionShare),
             ],
             Category::Telemetry => {
                 #[cfg(feature = "otel")]
                 {
-                    let rows = vec![
-                        RowKind::LoggingEnabled,
-                        RowKind::LogLevel,
-                        RowKind::OtlpEndpoint,
-                        #[cfg(feature = "test")]
-                        RowKind::EnableKernLog,
+                    use super::kinds::telemetry::OtlpEndpoint;
+                    let rows: Vec<Box<dyn SettingKind>> = vec![
+                        Box::new(LoggingEnabled),
+                        Box::new(LogLevel),
+                        Box::new(OtlpEndpoint),
                     ];
+
+                    #[cfg(feature = "test")]
+                    let mut rows = rows;
+                    #[cfg(feature = "test")]
+                    {
+                        use super::kinds::telemetry::EnableKernLog;
+                        rows.push(Box::new(EnableKernLog));
+                    }
                     rows
                 }
                 #[cfg(not(feature = "otel"))]
                 {
-                    vec![
-                        RowKind::LoggingEnabled,
-                        RowKind::LogLevel,
-                        #[cfg(feature = "test")]
-                        RowKind::EnableKernLog,
-                    ]
+                    let rows: Vec<Box<dyn SettingKind>> =
+                        vec![Box::new(LoggingEnabled), Box::new(LogLevel)];
+
+                    #[cfg(feature = "test")]
+                    let mut rows = rows;
+                    #[cfg(feature = "test")]
+                    {
+                        use super::kinds::telemetry::EnableKernLog;
+                        rows.push(Box::new(EnableKernLog));
+                    }
+                    rows
                 }
             }
         }

--- a/crates/core/src/view/settings_editor/category_editor.rs
+++ b/crates/core/src/view/settings_editor/category_editor.rs
@@ -4,32 +4,29 @@ use crate::device::CURRENT_DEVICE;
 use crate::framebuffer::{Framebuffer, UpdateMode};
 use crate::geom::{halves, Rectangle};
 use crate::gesture::GestureEvent;
-use crate::i18n;
-use crate::settings::{ButtonScheme, FinishedAction, LibrarySettings, Settings};
+use crate::settings::{LibrarySettings, Settings};
 use crate::unit::scale_by_dpi;
 use crate::view::common::locate_by_id;
 use crate::view::filler::Filler;
 use crate::view::menu::{Menu, MenuKind};
 use crate::view::toggleable_keyboard::ToggleableKeyboard;
 use crate::view::{
-    Bus, EntryId, EntryKind, Event, Hub, Id, RenderData, RenderQueue, ToggleEvent, View, ViewId,
-    ID_FEEDER, SMALL_BAR_HEIGHT, THICKNESS_MEDIUM,
+    Bus, EntryId, EntryKind, Event, Hub, Id, RenderData, RenderQueue, View, ViewId, ID_FEEDER,
+    SMALL_BAR_HEIGHT, THICKNESS_MEDIUM,
 };
 
 use super::bottom_bar::{BottomBarVariant, SettingsEditorBottomBar};
 use super::category::Category;
+use super::kinds::library::LibraryInfo;
 use super::library_editor::LibraryEditor;
-use super::setting_row::{Kind as RowKind, SettingRow};
-use super::setting_value::{Kind, SettingsEvent};
-use crate::view::file_chooser::{FileChooser, SelectionMode};
-use crate::view::settings_editor::ToggleSettings;
+use super::setting_row::SettingRow;
 use std::path::PathBuf;
 
 /// A view for editing category-specific settings.
 ///
 /// The `CategoryEditor` manages the UI for editing settings within a specific category
 /// (e.g., Libraries, Intermissions, etc.). It displays setting rows, handles user interactions,
-/// and manages child views such as keyboards, input fields, and file choosers.
+/// and manages child views such as keyboards and input fields.
 ///
 /// All settings changes are applied immediately to `context.settings`, providing instant
 /// feedback without requiring explicit validation.
@@ -44,14 +41,13 @@ use std::path::PathBuf;
 ///   3. BottomSeparator (variable index, only for Libraries category)
 ///   4. BottomBar (variable index, only for Libraries category)
 ///   5. ToggleableKeyboard (at index `keyboard_index`)
-///   6. Plus optional overlay views like LibraryEditor, FileChooser, Menu, and NamedInput fields
+///   6. Plus optional overlay views like LibraryEditor and NamedInput fields
 /// * `category` - The settings category being edited
 /// * `content_rect` - The rectangular area where setting rows are displayed
 /// * `row_height` - The height of each setting row
 /// * `focus` - Currently focused child view, if any
 /// * `first_row_index` - Index in the children vector where setting rows begin (after structural elements)
 /// * `keyboard_index` - Index of the keyboard child view in the children vector
-/// * `active_intermission_edit` - Tracks which intermission type is currently being edited via file chooser
 pub struct CategoryEditor {
     id: Id,
     rect: Rectangle,
@@ -62,7 +58,6 @@ pub struct CategoryEditor {
     focus: Option<ViewId>,
     first_row_index: usize,
     keyboard_index: usize,
-    active_intermission_edit: Option<crate::settings::IntermKind>,
 }
 
 impl CategoryEditor {
@@ -148,8 +143,11 @@ impl CategoryEditor {
             focus: None,
             first_row_index,
             keyboard_index,
-            active_intermission_edit: None,
         }
+    }
+
+    pub fn category(&self) -> Category {
+        self.category
     }
 
     #[inline]
@@ -166,7 +164,7 @@ impl CategoryEditor {
 
     #[inline]
     fn build_setting_row(
-        kind: RowKind,
+        kind: Box<dyn super::kinds::SettingKind>,
         row_rect: Rectangle,
         settings: &Settings,
         fonts: &mut crate::font::Fonts,
@@ -283,7 +281,7 @@ impl CategoryEditor {
             ];
 
             let setting_row = SettingRow::new(
-                RowKind::Library(i),
+                Box::new(LibraryInfo(i)),
                 row_rect,
                 &context.settings,
                 &mut context.fonts,
@@ -399,128 +397,6 @@ impl CategoryEditor {
     }
 
     #[inline]
-    fn handle_set_keyboard_layout(
-        &mut self,
-        layout: &str,
-        hub: &Hub,
-        context: &mut Context,
-    ) -> bool {
-        context.settings.keyboard_layout = layout.to_string();
-        hub.send(Event::Settings(SettingsEvent::UpdateValue {
-            kind: Kind::KeyboardLayout,
-            value: layout.to_string(),
-        }))
-        .ok();
-        true
-    }
-
-    #[inline]
-    fn handle_toggle_sleep_cover(&mut self, context: &mut Context) -> bool {
-        context.settings.sleep_cover = !context.settings.sleep_cover;
-        true
-    }
-
-    #[inline]
-    fn handle_toggle_auto_share(&mut self, context: &mut Context) -> bool {
-        context.settings.auto_share = !context.settings.auto_share;
-        true
-    }
-
-    #[inline]
-    fn handle_toggle_logging_enabled(&mut self, context: &mut Context) -> bool {
-        context.settings.logging.enabled = !context.settings.logging.enabled;
-
-        true
-    }
-
-    #[inline]
-    fn handle_edit_auto_suspend(
-        &mut self,
-        hub: &Hub,
-        rq: &mut RenderQueue,
-        context: &mut Context,
-    ) -> bool {
-        let mut suspend_input = crate::view::named_input::NamedInput::new(
-            "Auto Suspend (minutes, 0 = never)".to_string(),
-            ViewId::AutoSuspendInput,
-            ViewId::AutoSuspendInput,
-            10,
-            context,
-        );
-        let text = if context.settings.auto_suspend == 0.0 {
-            "0".to_string()
-        } else {
-            format!("{:.1}", context.settings.auto_suspend)
-        };
-
-        suspend_input.set_text(&text, rq, context);
-
-        self.children.push(Box::new(suspend_input));
-        hub.send(Event::Focus(Some(ViewId::AutoSuspendInput))).ok();
-
-        rq.add(RenderData::new(self.id, self.rect, UpdateMode::Gui));
-
-        true
-    }
-
-    #[inline]
-    fn handle_edit_auto_power_off(
-        &mut self,
-        hub: &Hub,
-        rq: &mut RenderQueue,
-        context: &mut Context,
-    ) -> bool {
-        let mut power_off_input = crate::view::named_input::NamedInput::new(
-            "Auto Power Off (days, 0 = never)".to_string(),
-            ViewId::AutoPowerOffInput,
-            ViewId::AutoPowerOffInput,
-            10,
-            context,
-        );
-        let text = if context.settings.auto_power_off == 0.0 {
-            "0".to_string()
-        } else {
-            format!("{:.1}", context.settings.auto_power_off)
-        };
-
-        power_off_input.set_text(&text, rq, context);
-
-        self.children.push(Box::new(power_off_input));
-        hub.send(Event::Focus(Some(ViewId::AutoPowerOffInput))).ok();
-        rq.add(RenderData::new(self.id, self.rect, UpdateMode::Gui));
-
-        true
-    }
-
-    #[inline]
-    fn handle_set_button_scheme(
-        &mut self,
-        button_scheme: &ButtonScheme,
-        bus: &mut Bus,
-        context: &mut Context,
-    ) -> bool {
-        context.settings.button_scheme = *button_scheme;
-        bus.push_back(Event::Select(EntryId::SetButtonScheme(*button_scheme)));
-        true
-    }
-
-    #[inline]
-    fn handle_set_finished_action(
-        &mut self,
-        action: FinishedAction,
-        hub: &Hub,
-        context: &mut Context,
-    ) -> bool {
-        context.settings.reader.finished = action;
-        hub.send(Event::Settings(SettingsEvent::UpdateValue {
-            kind: Kind::FinishedAction,
-            value: action.to_string(),
-        }))
-        .ok();
-        true
-    }
-
-    #[inline]
     fn handle_delete_library(
         &mut self,
         index: usize,
@@ -538,83 +414,6 @@ impl CategoryEditor {
             self.children.remove(menu_index);
             rq.add(RenderData::new(self.id, self.rect, UpdateMode::Gui));
         }
-
-        true
-    }
-
-    #[inline]
-    fn handle_set_intermission(
-        &mut self,
-        kind: &crate::settings::IntermKind,
-        display: &crate::settings::IntermissionDisplay,
-        hub: &Hub,
-        context: &mut Context,
-    ) -> bool {
-        use crate::settings::{IntermKind, IntermissionDisplay};
-
-        context.settings.intermissions[*kind] = display.clone();
-
-        let value = match display {
-            IntermissionDisplay::Image(path) => path
-                .file_name()
-                .and_then(|n| n.to_str())
-                .unwrap_or("Custom")
-                .to_string(),
-            _ => display.to_string(),
-        };
-
-        let update_kind = match kind {
-            IntermKind::Suspend => Kind::IntermissionSuspend,
-            IntermKind::PowerOff => Kind::IntermissionPowerOff,
-            IntermKind::Share => Kind::IntermissionShare,
-        };
-
-        hub.send(Event::Settings(SettingsEvent::UpdateValue {
-            kind: update_kind,
-            value,
-        }))
-        .ok();
-
-        true
-    }
-
-    #[inline]
-    fn handle_edit_intermission_image(
-        &mut self,
-        kind: &crate::settings::IntermKind,
-        hub: &Hub,
-        rq: &mut RenderQueue,
-        context: &mut Context,
-    ) -> bool {
-        self.handle_close_view_event(&ViewId::SettingsValueMenu, rq);
-
-        self.active_intermission_edit = Some(*kind);
-
-        #[cfg(not(test))]
-        let initial_path = PathBuf::from("/mnt/onboard");
-        #[cfg(test)]
-        let initial_path = PathBuf::from(
-            tempfile::tempdir()
-                .expect("failed to crete temp dir for test")
-                .path(),
-        );
-
-        let file_chooser = FileChooser::new(
-            rect!(
-                0,
-                0,
-                context.display.dims.0 as i32,
-                context.display.dims.1 as i32
-            ),
-            initial_path,
-            SelectionMode::File,
-            hub,
-            rq,
-            context,
-        );
-
-        self.children.push(Box::new(file_chooser));
-        rq.add(RenderData::new(self.id, self.rect, UpdateMode::Gui));
 
         true
     }
@@ -700,342 +499,59 @@ impl CategoryEditor {
     }
 
     #[inline]
-    fn handle_submit_auto_suspend(&mut self, text: &str, hub: &Hub, context: &mut Context) -> bool {
-        if let Ok(value) = text.parse::<f32>() {
-            context.settings.auto_suspend = value;
-        }
-
-        let display = if context.settings.auto_suspend == 0.0 {
-            "Never".to_string()
-        } else {
-            format!("{:.1}", context.settings.auto_suspend)
-        };
-
-        hub.send(Event::Settings(SettingsEvent::UpdateValue {
-            kind: Kind::AutoSuspend,
-            value: display,
-        }))
-        .ok();
-
-        hub.send(Event::Focus(None)).ok();
-
-        true
-    }
-
-    #[inline]
-    fn handle_submit_auto_power_off(
+    #[allow(clippy::too_many_arguments)]
+    fn handle_open_named_input(
         &mut self,
-        text: &str,
-        hub: &Hub,
-        context: &mut Context,
-    ) -> bool {
-        if let Ok(value) = text.parse::<f32>() {
-            context.settings.auto_power_off = value;
-        }
-
-        let display = if context.settings.auto_power_off == 0.0 {
-            "Never".to_string()
-        } else {
-            format!("{:.1}", context.settings.auto_power_off)
-        };
-
-        hub.send(Event::Settings(SettingsEvent::UpdateValue {
-            kind: Kind::AutoPowerOff,
-            value: display,
-        }))
-        .ok();
-
-        hub.send(Event::Focus(None)).ok();
-
-        true
-    }
-
-    #[inline]
-    fn handle_edit_settings_retention(
-        &mut self,
+        view_id: ViewId,
+        label: String,
+        max_chars: usize,
+        initial_text: String,
         hub: &Hub,
         rq: &mut RenderQueue,
         context: &mut Context,
     ) -> bool {
-        let mut retention_input = crate::view::named_input::NamedInput::new(
-            "Settings Retention".to_string(),
-            ViewId::SettingsRetentionInput,
-            ViewId::SettingsRetentionInput,
-            3,
-            context,
-        );
-        let text = context.settings.settings_retention.to_string();
-
-        retention_input.set_text(&text, rq, context);
-
-        self.children.push(Box::new(retention_input));
-        hub.send(Event::Focus(Some(ViewId::SettingsRetentionInput)))
-            .ok();
-
+        let mut named_input =
+            crate::view::named_input::NamedInput::new(label, view_id, view_id, max_chars, context);
+        named_input.set_text(&initial_text, rq, context);
+        self.children.push(Box::new(named_input));
+        hub.send(Event::Focus(Some(view_id))).ok();
         rq.add(RenderData::new(self.id, self.rect, UpdateMode::Gui));
-
         true
     }
 
     #[inline]
-    fn handle_submit_settings_retention(
+    fn handle_close_view_event(
         &mut self,
-        text: &str,
-        hub: &Hub,
-        context: &mut Context,
-    ) -> bool {
-        if let Ok(value) = text.parse::<usize>() {
-            context.settings.settings_retention = value;
-        }
-
-        hub.send(Event::Settings(SettingsEvent::UpdateValue {
-            kind: Kind::SettingsRetention,
-            value: context.settings.settings_retention.to_string(),
-        }))
-        .ok();
-
-        hub.send(Event::Focus(None)).ok();
-
-        true
-    }
-
-    #[inline]
-    fn handle_set_locale(
-        &mut self,
-        locale: &Option<unic_langid::LanguageIdentifier>,
-        hub: &Hub,
-        context: &mut Context,
-    ) -> bool {
-        context.settings.locale = locale.clone();
-        crate::i18n::init(locale.as_ref());
-
-        let display = locale
-            .as_ref()
-            .map(|l| l.to_string())
-            .unwrap_or_else(|| i18n::DEFAULT_LOCALE.to_string());
-
-        hub.send(Event::Settings(SettingsEvent::UpdateValue {
-            kind: Kind::Locale,
-            value: display,
-        }))
-        .ok();
-
-        true
-    }
-
-    #[inline]
-    fn handle_set_log_level(
-        &mut self,
-        level: &tracing::Level,
+        view_id: &ViewId,
         hub: &Hub,
         rq: &mut RenderQueue,
-        context: &mut Context,
     ) -> bool {
-        context.settings.logging.level = level.to_string();
-        hub.send(Event::Settings(SettingsEvent::UpdateValue {
-            kind: Kind::LogLevel,
-            value: level.to_string(),
-        }))
-        .ok();
-        rq.add(RenderData::new(self.id, self.rect, UpdateMode::Gui));
-        true
-    }
-
-    #[cfg(feature = "otel")]
-    #[inline]
-    fn handle_edit_otlp_endpoint(
-        &mut self,
-        hub: &Hub,
-        rq: &mut RenderQueue,
-        context: &mut Context,
-    ) -> bool {
-        let mut otlp_input = crate::view::named_input::NamedInput::new(
-            "OTLP Endpoint".to_string(),
-            ViewId::OtlpEndpointInput,
-            ViewId::OtlpEndpointInput,
-            50,
-            context,
-        );
-
-        let text = context
-            .settings
-            .logging
-            .otlp_endpoint
-            .clone()
-            .unwrap_or_default();
-        otlp_input.set_text(&text, rq, context);
-
-        self.children.push(Box::new(otlp_input));
-        hub.send(Event::Focus(Some(ViewId::OtlpEndpointInput))).ok();
-
-        rq.add(RenderData::new(self.id, self.rect, UpdateMode::Gui));
-
-        true
-    }
-
-    #[cfg(feature = "otel")]
-    #[inline]
-    fn handle_submit_otlp_endpoint(
-        &mut self,
-        text: &str,
-        hub: &Hub,
-        rq: &mut RenderQueue,
-        context: &mut Context,
-    ) -> bool {
-        let trimmed = text.trim();
-        context.settings.logging.otlp_endpoint = if trimmed.is_empty() {
-            None
-        } else {
-            Some(trimmed.to_string())
-        };
-
-        hub.send(Event::Settings(SettingsEvent::UpdateValue {
-            kind: Kind::OtlpEndpoint,
-            value: context
-                .settings
-                .logging
-                .otlp_endpoint
-                .clone()
-                .unwrap_or_else(|| "Not set".to_string()),
-        }))
-        .ok();
-
-        rq.add(RenderData::new(self.id, self.rect, UpdateMode::Gui));
-
-        hub.send(Event::Focus(None)).ok();
-
-        true
-    }
-
-    /// Handles the `FileChooserClosed` event for intermission image selection.
-    ///
-    /// Updates `context.settings.intermissions` with the selected image path and schedules
-    /// a GUI refresh to reflect the change.
-    ///
-    /// # Returns
-    ///
-    /// Always returns `false` to allow the event to propagate through the view hierarchy.
-    /// Other views in the chain (LibraryEditor, SettingValue) may also need to handle this
-    /// event for their own path selection needs.
-    #[inline]
-    fn handle_file_chooser_closed(
-        &mut self,
-        path: &Option<PathBuf>,
-        hub: &Hub,
-        _rq: &mut RenderQueue,
-        context: &mut Context,
-    ) -> bool {
-        if let Some(kind) = self.active_intermission_edit.take() {
-            if let Some(ref selected_path) = *path {
-                use crate::settings::{IntermKind, IntermissionDisplay};
-                context.settings.intermissions[kind] =
-                    IntermissionDisplay::Image(selected_path.clone());
-
-                let value = selected_path
-                    .file_name()
-                    .and_then(|n| n.to_str())
-                    .unwrap_or("Custom")
-                    .to_string();
-
-                let update_kind = match kind {
-                    IntermKind::Suspend => Kind::IntermissionSuspend,
-                    IntermKind::PowerOff => Kind::IntermissionPowerOff,
-                    IntermKind::Share => Kind::IntermissionShare,
-                };
-
-                hub.send(Event::Settings(SettingsEvent::UpdateValue {
-                    kind: update_kind,
-                    value,
-                }))
-                .ok();
-            }
-        }
-
-        false
-    }
-
-    /// Handles the `Close` event for various child views within the category editor.
-    ///
-    /// This method manages the closure of different overlay and child views:
-    ///
-    /// - **LibraryEditor, AutoSuspendInput, AutoPowerOffInput, SettingsValueMenu**: These overlay
-    ///   views are removed from the children list and a GUI update is scheduled. The event is
-    ///   considered handled.
-    ///
-    /// - **FileChooser**: The file chooser is removed from the children list, the active
-    ///   intermission edit state is cleared, and a GUI update is scheduled.
-    ///
-    /// - **Other view IDs**: Return false as they are not handled by this method.
-    ///
-    /// # Arguments
-    ///
-    /// * `view_id` - The ID of the view being closed
-    /// * `rq` - The render queue for scheduling UI updates
-    ///
-    /// # Returns
-    ///
-    /// `true` if the event was handled, `false` otherwise.
-    #[inline]
-    fn handle_close_view_event(&mut self, view_id: &ViewId, rq: &mut RenderQueue) -> bool {
         match view_id {
-            ViewId::LibraryEditor
-            | ViewId::AutoSuspendInput
+            ViewId::AutoSuspendInput
             | ViewId::AutoPowerOffInput
             | ViewId::SettingsRetentionInput
-            | ViewId::OtlpEndpointInput
-            | ViewId::SettingsValueMenu => {
+            | ViewId::SettingsValueMenu
+            | ViewId::LibraryEditor => {
                 if let Some(index) = locate_by_id(self, *view_id) {
+                    let input_rect = *self.children[index].rect();
                     self.children.remove(index);
-                    rq.add(RenderData::new(self.id, self.rect, UpdateMode::Gui));
+                    rq.add(RenderData::expose(input_rect, UpdateMode::Gui));
                 }
+                hub.send(Event::Focus(None)).ok();
                 true
             }
-            ViewId::FileChooser => {
-                if let Some(index) = locate_by_id(self, ViewId::FileChooser) {
+            #[cfg(feature = "otel")]
+            ViewId::OtlpEndpointInput => {
+                if let Some(index) = locate_by_id(self, *view_id) {
+                    let input_rect = *self.children[index].rect();
                     self.children.remove(index);
-                    rq.add(RenderData::new(self.id, self.rect, UpdateMode::Gui));
+                    rq.add(RenderData::expose(input_rect, UpdateMode::Gui));
                 }
-                self.active_intermission_edit = None;
-                false
+                hub.send(Event::Focus(None)).ok();
+                true
             }
             _ => false,
         }
-    }
-
-    #[inline]
-    #[allow(clippy::too_many_arguments)]
-    fn handle_toggle_event(
-        &mut self,
-        bus: &mut Bus,
-        context: &mut Context,
-        toggle: &ToggleEvent,
-    ) -> bool {
-        match toggle {
-            ToggleEvent::Setting(ref setting) => match setting {
-                ToggleSettings::SleepCover => self.handle_toggle_sleep_cover(context),
-
-                ToggleSettings::AutoShare => self.handle_toggle_auto_share(context),
-                ToggleSettings::ButtonScheme => match context.settings.button_scheme {
-                    ButtonScheme::Natural => {
-                        self.handle_set_button_scheme(&ButtonScheme::Inverted, bus, context)
-                    }
-                    ButtonScheme::Inverted => {
-                        self.handle_set_button_scheme(&ButtonScheme::Natural, bus, context)
-                    }
-                },
-                ToggleSettings::LoggingEnabled => self.handle_toggle_logging_enabled(context),
-                #[cfg(feature = "test")]
-                ToggleSettings::EnableKernLog => self.handle_toggle_enable_kern_log(context),
-            },
-            _ => unreachable!("mismatched toggle event"),
-        }
-    }
-
-    #[cfg(feature = "test")]
-    #[inline]
-    fn handle_toggle_enable_kern_log(&mut self, context: &mut Context) -> bool {
-        context.settings.logging.enable_kern_log = !context.settings.logging.enable_kern_log;
-        true
     }
 }
 
@@ -1057,61 +573,29 @@ impl View for CategoryEditor {
             Event::SubMenu(rect, ref entries) => {
                 self.handle_submenu_event(rect, entries, rq, context)
             }
-            Event::Toggle(ref toggle) if matches!(toggle, ToggleEvent::Setting(_)) => {
-                self.handle_toggle_event(bus, context, toggle)
+            Event::Select(EntryId::DeleteLibrary(index)) => {
+                self.handle_delete_library(*index, rq, context)
             }
-            Event::Select(ref id) => match id {
-                EntryId::SetKeyboardLayout(ref layout) => {
-                    self.handle_set_keyboard_layout(layout, hub, context)
-                }
-                EntryId::SetLocale(ref locale) => self.handle_set_locale(locale, hub, context),
-                EntryId::EditAutoSuspend => self.handle_edit_auto_suspend(hub, rq, context),
-                EntryId::EditAutoPowerOff => self.handle_edit_auto_power_off(hub, rq, context),
-                EntryId::EditSettingsRetention => {
-                    self.handle_edit_settings_retention(hub, rq, context)
-                }
-                EntryId::SetLogLevel(ref level) => {
-                    self.handle_set_log_level(level, hub, rq, context)
-                }
-                #[cfg(feature = "otel")]
-                EntryId::EditOtlpEndpoint => self.handle_edit_otlp_endpoint(hub, rq, context),
-                EntryId::SetButtonScheme(button_scheme) => {
-                    self.handle_set_button_scheme(button_scheme, bus, context)
-                }
-                EntryId::SetFinishedAction(action) => {
-                    self.handle_set_finished_action(*action, hub, context)
-                }
-                EntryId::DeleteLibrary(index) => self.handle_delete_library(*index, rq, context),
-                EntryId::SetIntermission(kind, display) => {
-                    self.handle_set_intermission(kind, display, hub, context)
-                }
-                EntryId::EditIntermissionImage(kind) => {
-                    self.handle_edit_intermission_image(kind, hub, rq, context)
-                }
-                _ => false,
-            },
             Event::AddLibrary => self.handle_add_library_event(hub, rq, context),
             Event::EditLibrary(index) => self.handle_edit_library_event(*index, hub, rq, context),
             Event::UpdateLibrary(index, ref library) => {
                 self.handle_update_library_event(*index, library, rq, context)
             }
-            Event::Submit(ViewId::AutoSuspendInput, ref text) => {
-                self.handle_submit_auto_suspend(text, hub, context)
-            }
-            Event::Submit(ViewId::AutoPowerOffInput, ref text) => {
-                self.handle_submit_auto_power_off(text, hub, context)
-            }
-            Event::Submit(ViewId::SettingsRetentionInput, ref text) => {
-                self.handle_submit_settings_retention(text, hub, context)
-            }
-            #[cfg(feature = "otel")]
-            Event::Submit(ViewId::OtlpEndpointInput, ref text) => {
-                self.handle_submit_otlp_endpoint(text, hub, rq, context)
-            }
-            Event::FileChooserClosed(ref path) => {
-                self.handle_file_chooser_closed(path, hub, rq, context)
-            }
-            Event::Close(view_id) => self.handle_close_view_event(view_id, rq),
+            Event::OpenNamedInput {
+                view_id,
+                ref label,
+                max_chars,
+                ref initial_text,
+            } => self.handle_open_named_input(
+                *view_id,
+                label.clone(),
+                *max_chars,
+                initial_text.clone(),
+                hub,
+                rq,
+                context,
+            ),
+            Event::Close(view_id) => self.handle_close_view_event(view_id, hub, rq),
             _ => false,
         }
     }
@@ -1416,7 +900,8 @@ mod tests {
         let mut bus = VecDeque::new();
         let mut rq = RenderQueue::new();
 
-        let handled = editor.handle_event(
+        let handled = crate::view::handle_event(
+            &mut editor,
             &Event::Select(EntryId::SetIntermission(
                 IntermKind::Suspend,
                 IntermissionDisplay::Logo,
@@ -1444,7 +929,8 @@ mod tests {
         let mut bus = VecDeque::new();
         let mut rq = RenderQueue::new();
 
-        let handled = editor.handle_event(
+        let handled = crate::view::handle_event(
+            &mut editor,
             &Event::Select(EntryId::SetIntermission(
                 IntermKind::PowerOff,
                 IntermissionDisplay::Cover,
@@ -1460,117 +946,5 @@ mod tests {
             context.settings.intermissions[IntermKind::PowerOff],
             IntermissionDisplay::Cover
         ));
-    }
-
-    #[test]
-    fn test_edit_intermission_image_opens_file_chooser() {
-        use crate::settings::IntermKind;
-
-        let mut context = create_test_context();
-        let mut editor = create_test_intermissions_category_editor(&mut context);
-        let (hub, _receiver) = channel();
-        let mut bus = VecDeque::new();
-        let mut rq = RenderQueue::new();
-
-        let initial_children_count = editor.children.len();
-
-        let handled = editor.handle_event(
-            &Event::Select(EntryId::EditIntermissionImage(IntermKind::Share)),
-            &hub,
-            &mut bus,
-            &mut rq,
-            &mut context,
-        );
-
-        assert!(handled);
-        assert_eq!(editor.children.len(), initial_children_count + 1);
-        assert!(editor.active_intermission_edit.is_some());
-        assert_eq!(editor.active_intermission_edit.unwrap(), IntermKind::Share);
-        assert!(!rq.is_empty());
-    }
-
-    #[test]
-    fn test_file_chooser_closed_sets_custom_image() {
-        use crate::settings::{IntermKind, IntermissionDisplay};
-
-        let mut context = create_test_context();
-        let mut editor = create_test_intermissions_category_editor(&mut context);
-        let (hub, _receiver) = channel();
-        let mut bus = VecDeque::new();
-        let mut rq = RenderQueue::new();
-
-        editor.active_intermission_edit = Some(IntermKind::Suspend);
-
-        let test_path = PathBuf::from("/mnt/onboard/test.png");
-        let handled = editor.handle_event(
-            &Event::FileChooserClosed(Some(test_path.clone())),
-            &hub,
-            &mut bus,
-            &mut rq,
-            &mut context,
-        );
-
-        assert!(!handled);
-        assert!(editor.active_intermission_edit.is_none());
-        assert!(matches!(
-            &context.settings.intermissions[IntermKind::Suspend],
-            IntermissionDisplay::Image(path) if path == &test_path
-        ));
-    }
-
-    #[test]
-    fn test_file_chooser_cancelled_clears_active_edit() {
-        use crate::settings::IntermKind;
-
-        let mut context = create_test_context();
-        let mut editor = create_test_intermissions_category_editor(&mut context);
-        let (hub, _receiver) = channel();
-        let mut bus = VecDeque::new();
-        let mut rq = RenderQueue::new();
-
-        editor.active_intermission_edit = Some(IntermKind::Share);
-
-        let handled = editor.handle_event(
-            &Event::FileChooserClosed(None),
-            &hub,
-            &mut bus,
-            &mut rq,
-            &mut context,
-        );
-
-        assert!(!handled);
-        assert!(editor.active_intermission_edit.is_none());
-    }
-
-    #[test]
-    fn test_close_file_chooser_clears_active_edit() {
-        use crate::settings::IntermKind;
-
-        let mut context = create_test_context();
-        let mut editor = create_test_intermissions_category_editor(&mut context);
-        let (hub, _receiver) = channel();
-        let mut bus = VecDeque::new();
-        let mut rq = RenderQueue::new();
-
-        editor.active_intermission_edit = Some(IntermKind::PowerOff);
-        editor
-            .children
-            .push(Box::new(crate::view::filler::Filler::new(
-                rect![0, 0, 100, 100],
-                crate::color::WHITE,
-            )));
-
-        let handled = editor.handle_event(
-            &Event::Close(ViewId::FileChooser),
-            &hub,
-            &mut bus,
-            &mut rq,
-            &mut context,
-        );
-
-        assert!(
-            !handled,
-            "Close event for FileChooser should not capture the event so that settings editor can refresh the whole screen.");
-        assert!(editor.active_intermission_edit.is_none());
     }
 }

--- a/crates/core/src/view/settings_editor/kinds/general.rs
+++ b/crates/core/src/view/settings_editor/kinds/general.rs
@@ -1,0 +1,748 @@
+//! Setting kinds for the General category.
+
+use super::{
+    InputSettingKind, SettingData, SettingIdentity, SettingKind, ToggleSettings, WidgetKind,
+};
+use crate::fl;
+use crate::i18n::I18nDisplay;
+use crate::settings::Settings;
+use crate::view::{Bus, EntryId, EntryKind, Event, ToggleEvent, ViewId};
+use anyhow::Error;
+use std::fs;
+use std::path::Path;
+
+/// Language and locale selection setting
+pub struct Locale;
+
+impl SettingKind for Locale {
+    fn identity(&self) -> SettingIdentity {
+        SettingIdentity::Locale
+    }
+
+    fn label(&self, _settings: &Settings) -> String {
+        fl!("settings-general-language")
+    }
+
+    fn fetch(&self, settings: &Settings) -> SettingData {
+        let current = settings.locale.as_ref().map(|l| l.to_string());
+        let display = current
+            .as_deref()
+            .unwrap_or(crate::i18n::DEFAULT_LOCALE)
+            .to_string();
+
+        let entries = crate::i18n::AVAILABLE_LOCALES
+            .iter()
+            .map(|&tag| {
+                let lang_id: Option<unic_langid::LanguageIdentifier> = tag.parse().ok();
+                EntryKind::RadioButton(
+                    tag.to_string(),
+                    EntryId::SetLocale(lang_id),
+                    current.as_deref() == Some(tag),
+                )
+            })
+            .collect::<Vec<_>>();
+
+        SettingData {
+            value: display,
+            widget: WidgetKind::SubMenu(entries),
+        }
+    }
+
+    fn handle(&self, evt: &Event, settings: &mut Settings, _bus: &mut Bus) -> Option<String> {
+        if let Event::Select(EntryId::SetLocale(ref locale)) = evt {
+            settings.locale = locale.clone();
+            crate::i18n::init(locale.as_ref());
+            let display = locale
+                .as_ref()
+                .map(|l| l.to_string())
+                .unwrap_or_else(|| crate::i18n::DEFAULT_LOCALE.to_string());
+            return Some(display);
+        }
+        None
+    }
+}
+
+/// Keyboard layout selection setting
+pub struct KeyboardLayout;
+
+impl SettingKind for KeyboardLayout {
+    fn identity(&self) -> SettingIdentity {
+        SettingIdentity::KeyboardLayout
+    }
+
+    fn label(&self, _settings: &Settings) -> String {
+        fl!("settings-general-keyboard-layout")
+    }
+
+    fn fetch(&self, settings: &Settings) -> SettingData {
+        let current_layout = settings.keyboard_layout.clone();
+        let available_layouts = get_available_layouts().unwrap_or_default();
+
+        let entries = available_layouts
+            .iter()
+            .map(|layout| {
+                EntryKind::RadioButton(
+                    layout.clone(),
+                    EntryId::SetKeyboardLayout(layout.clone()),
+                    current_layout == *layout,
+                )
+            })
+            .collect::<Vec<_>>();
+
+        SettingData {
+            value: current_layout,
+            widget: WidgetKind::SubMenu(entries),
+        }
+    }
+
+    fn handle(&self, evt: &Event, settings: &mut Settings, _bus: &mut Bus) -> Option<String> {
+        if let Event::Select(EntryId::SetKeyboardLayout(ref layout)) = evt {
+            settings.keyboard_layout = layout.clone();
+            return Some(layout.clone());
+        }
+        None
+    }
+}
+
+/// Auto suspend timeout setting
+pub struct AutoSuspend;
+
+impl SettingKind for AutoSuspend {
+    fn identity(&self) -> SettingIdentity {
+        SettingIdentity::AutoSuspend
+    }
+
+    fn label(&self, _settings: &Settings) -> String {
+        fl!("settings-general-auto-suspend")
+    }
+
+    fn fetch(&self, settings: &Settings) -> SettingData {
+        let value = if settings.auto_suspend == 0.0 {
+            fl!("settings-general-never")
+        } else {
+            format!("{:.1}", settings.auto_suspend)
+        };
+
+        SettingData {
+            value,
+            widget: WidgetKind::ActionLabel(Event::Select(EntryId::EditAutoSuspend)),
+        }
+    }
+
+    fn as_input_kind(&self) -> Option<&dyn InputSettingKind> {
+        Some(self)
+    }
+}
+
+impl InputSettingKind for AutoSuspend {
+    fn submit_view_id(&self) -> ViewId {
+        ViewId::AutoSuspendInput
+    }
+
+    fn open_entry_id(&self) -> EntryId {
+        EntryId::EditAutoSuspend
+    }
+
+    fn input_label(&self) -> String {
+        fl!("settings-general-auto-suspend-input")
+    }
+
+    fn input_max_chars(&self) -> usize {
+        10
+    }
+
+    fn current_text(&self, settings: &Settings) -> String {
+        if settings.auto_suspend == 0.0 {
+            "0".to_string()
+        } else {
+            format!("{:.1}", settings.auto_suspend)
+        }
+    }
+
+    fn apply_text(&self, text: &str, settings: &mut Settings) -> String {
+        if let Ok(value) = text.parse::<f32>() {
+            settings.auto_suspend = value;
+        }
+        if settings.auto_suspend == 0.0 {
+            fl!("settings-general-never")
+        } else {
+            format!("{:.1}", settings.auto_suspend)
+        }
+    }
+}
+
+/// Auto power off timeout setting
+pub struct AutoPowerOff;
+
+impl SettingKind for AutoPowerOff {
+    fn identity(&self) -> SettingIdentity {
+        SettingIdentity::AutoPowerOff
+    }
+
+    fn label(&self, _settings: &Settings) -> String {
+        fl!("settings-general-auto-power-off")
+    }
+
+    fn fetch(&self, settings: &Settings) -> SettingData {
+        let value = if settings.auto_power_off == 0.0 {
+            fl!("settings-general-never")
+        } else {
+            format!("{:.1}", settings.auto_power_off)
+        };
+
+        SettingData {
+            value,
+            widget: WidgetKind::ActionLabel(Event::Select(EntryId::EditAutoPowerOff)),
+        }
+    }
+
+    fn as_input_kind(&self) -> Option<&dyn InputSettingKind> {
+        Some(self)
+    }
+}
+
+impl InputSettingKind for AutoPowerOff {
+    fn submit_view_id(&self) -> ViewId {
+        ViewId::AutoPowerOffInput
+    }
+
+    fn open_entry_id(&self) -> EntryId {
+        EntryId::EditAutoPowerOff
+    }
+
+    fn input_label(&self) -> String {
+        fl!("settings-general-auto-power-off-input")
+    }
+
+    fn input_max_chars(&self) -> usize {
+        10
+    }
+
+    fn current_text(&self, settings: &Settings) -> String {
+        if settings.auto_power_off == 0.0 {
+            "0".to_string()
+        } else {
+            format!("{:.1}", settings.auto_power_off)
+        }
+    }
+
+    fn apply_text(&self, text: &str, settings: &mut Settings) -> String {
+        if let Ok(value) = text.parse::<f32>() {
+            settings.auto_power_off = value;
+        }
+        if settings.auto_power_off == 0.0 {
+            fl!("settings-general-never")
+        } else {
+            format!("{:.1}", settings.auto_power_off)
+        }
+    }
+}
+
+/// Sleep cover enable/disable toggle setting
+pub struct SleepCover;
+
+impl SettingKind for SleepCover {
+    fn identity(&self) -> SettingIdentity {
+        SettingIdentity::SleepCover
+    }
+
+    fn label(&self, _settings: &Settings) -> String {
+        fl!("settings-general-enable-sleep-cover")
+    }
+
+    fn fetch(&self, settings: &Settings) -> SettingData {
+        SettingData {
+            value: settings.sleep_cover.to_string(),
+            widget: WidgetKind::Toggle {
+                left_label: fl!("settings-general-toggle-on"),
+                right_label: fl!("settings-general-toggle-off"),
+                enabled: settings.sleep_cover,
+                tap_event: Event::Toggle(ToggleEvent::Setting(ToggleSettings::SleepCover)),
+            },
+        }
+    }
+
+    fn handle(&self, evt: &Event, settings: &mut Settings, _bus: &mut Bus) -> Option<String> {
+        if let Event::Toggle(ToggleEvent::Setting(ToggleSettings::SleepCover)) = evt {
+            settings.sleep_cover = !settings.sleep_cover;
+            return Some(settings.sleep_cover.to_string());
+        }
+        None
+    }
+}
+
+/// Auto share enable/disable toggle setting
+pub struct AutoShare;
+
+impl SettingKind for AutoShare {
+    fn identity(&self) -> SettingIdentity {
+        SettingIdentity::AutoShare
+    }
+
+    fn label(&self, _settings: &Settings) -> String {
+        fl!("settings-general-enable-auto-share")
+    }
+
+    fn fetch(&self, settings: &Settings) -> SettingData {
+        SettingData {
+            value: settings.auto_share.to_string(),
+            widget: WidgetKind::Toggle {
+                left_label: fl!("settings-general-toggle-on"),
+                right_label: fl!("settings-general-toggle-off"),
+                enabled: settings.auto_share,
+                tap_event: Event::Toggle(ToggleEvent::Setting(ToggleSettings::AutoShare)),
+            },
+        }
+    }
+
+    fn handle(&self, evt: &Event, settings: &mut Settings, _bus: &mut Bus) -> Option<String> {
+        if let Event::Toggle(ToggleEvent::Setting(ToggleSettings::AutoShare)) = evt {
+            settings.auto_share = !settings.auto_share;
+            return Some(settings.auto_share.to_string());
+        }
+        None
+    }
+}
+
+/// Button scheme (natural/inverted) toggle setting
+pub struct ButtonScheme;
+
+impl SettingKind for ButtonScheme {
+    fn identity(&self) -> SettingIdentity {
+        SettingIdentity::ButtonScheme
+    }
+
+    fn label(&self, _settings: &Settings) -> String {
+        fl!("settings-general-button-scheme")
+    }
+
+    fn fetch(&self, settings: &Settings) -> SettingData {
+        let enabled = settings.button_scheme == crate::settings::ButtonScheme::Natural;
+        SettingData {
+            value: settings.button_scheme.to_i18n_string(),
+            widget: WidgetKind::Toggle {
+                left_label: crate::settings::ButtonScheme::Natural.to_i18n_string(),
+                right_label: crate::settings::ButtonScheme::Inverted.to_i18n_string(),
+                enabled,
+                tap_event: Event::Toggle(ToggleEvent::Setting(ToggleSettings::ButtonScheme)),
+            },
+        }
+    }
+
+    fn handle(&self, evt: &Event, settings: &mut Settings, bus: &mut Bus) -> Option<String> {
+        let new_scheme = match evt {
+            Event::Toggle(ToggleEvent::Setting(ToggleSettings::ButtonScheme)) => {
+                match settings.button_scheme {
+                    crate::settings::ButtonScheme::Natural => {
+                        Some(crate::settings::ButtonScheme::Inverted)
+                    }
+                    crate::settings::ButtonScheme::Inverted => {
+                        Some(crate::settings::ButtonScheme::Natural)
+                    }
+                }
+            }
+            Event::Select(EntryId::SetButtonScheme(scheme)) => Some(*scheme),
+            _ => None,
+        };
+
+        if let Some(scheme) = new_scheme {
+            settings.button_scheme = scheme;
+            bus.push_back(Event::Select(EntryId::SetButtonScheme(scheme)));
+            return Some(settings.button_scheme.to_i18n_string());
+        }
+        None
+    }
+}
+
+/// Settings retention count setting
+pub struct SettingsRetention;
+
+impl SettingKind for SettingsRetention {
+    fn identity(&self) -> SettingIdentity {
+        SettingIdentity::SettingsRetention
+    }
+
+    fn label(&self, _settings: &Settings) -> String {
+        fl!("settings-general-settings-retention")
+    }
+
+    fn fetch(&self, settings: &Settings) -> SettingData {
+        SettingData {
+            value: settings.settings_retention.to_string(),
+            widget: WidgetKind::ActionLabel(Event::Select(EntryId::EditSettingsRetention)),
+        }
+    }
+
+    fn as_input_kind(&self) -> Option<&dyn InputSettingKind> {
+        Some(self)
+    }
+}
+
+impl InputSettingKind for SettingsRetention {
+    fn submit_view_id(&self) -> ViewId {
+        ViewId::SettingsRetentionInput
+    }
+
+    fn open_entry_id(&self) -> EntryId {
+        EntryId::EditSettingsRetention
+    }
+
+    fn input_label(&self) -> String {
+        fl!("settings-general-settings-retention")
+    }
+
+    fn input_max_chars(&self) -> usize {
+        3
+    }
+
+    fn current_text(&self, settings: &Settings) -> String {
+        settings.settings_retention.to_string()
+    }
+
+    fn apply_text(&self, text: &str, settings: &mut Settings) -> String {
+        if let Ok(value) = text.parse::<usize>() {
+            settings.settings_retention = value;
+        }
+        settings.settings_retention.to_string()
+    }
+}
+
+/// Scans the keyboard-layouts directory for available keyboard layouts
+fn get_available_layouts() -> Result<Vec<String>, Error> {
+    let layouts_dir = Path::new("keyboard-layouts");
+    let mut layouts = Vec::new();
+
+    if layouts_dir.exists() {
+        for entry in fs::read_dir(layouts_dir)? {
+            let entry = entry?;
+            let path = entry.path();
+
+            if path.extension().and_then(|s| s.to_str()) == Some("json") {
+                if let Some(stem) = path.file_stem().and_then(|s| s.to_str()) {
+                    let layout_name = stem
+                        .chars()
+                        .enumerate()
+                        .map(|(i, c)| {
+                            if i == 0 {
+                                c.to_uppercase().collect::<String>()
+                            } else {
+                                c.to_string()
+                            }
+                        })
+                        .collect::<String>();
+                    layouts.push(layout_name);
+                }
+            }
+        }
+    }
+
+    layouts.sort();
+    Ok(layouts)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::settings::Settings;
+    use crate::view::settings_editor::kinds::{InputSettingKind, ToggleSettings};
+    use crate::view::{Bus, EntryId, Event, ToggleEvent};
+    use std::collections::VecDeque;
+
+    mod locale {
+        use super::*;
+
+        #[test]
+        fn handle_set_locale_updates_settings() {
+            let setting = Locale;
+            let mut settings = Settings::default();
+            let mut bus: Bus = VecDeque::new();
+            let locale: Option<unic_langid::LanguageIdentifier> = Some("de-DE".parse().unwrap());
+            let event = Event::Select(EntryId::SetLocale(locale.clone()));
+
+            let result = setting.handle(&event, &mut settings, &mut bus);
+
+            assert!(result.is_some());
+            assert_eq!(result.unwrap(), "de-DE");
+            assert_eq!(settings.locale, locale);
+        }
+
+        #[test]
+        fn handle_returns_none_for_wrong_event() {
+            let setting = Locale;
+            let mut settings = Settings::default();
+            let mut bus: Bus = VecDeque::new();
+
+            let result = setting.handle(&Event::Select(EntryId::About), &mut settings, &mut bus);
+
+            assert!(result.is_none());
+        }
+    }
+
+    mod keyboard_layout {
+        use super::*;
+
+        #[test]
+        fn handle_set_layout_updates_settings() {
+            let setting = KeyboardLayout;
+            let mut settings = Settings::default();
+            let mut bus: Bus = VecDeque::new();
+            let event = Event::Select(EntryId::SetKeyboardLayout("German".to_string()));
+
+            let result = setting.handle(&event, &mut settings, &mut bus);
+
+            assert!(result.is_some());
+            assert_eq!(result.unwrap(), "German");
+            assert_eq!(settings.keyboard_layout, "German");
+        }
+
+        #[test]
+        fn handle_returns_none_for_wrong_event() {
+            let setting = KeyboardLayout;
+            let mut settings = Settings::default();
+            let mut bus: Bus = VecDeque::new();
+
+            let result = setting.handle(&Event::Select(EntryId::About), &mut settings, &mut bus);
+
+            assert!(result.is_none());
+        }
+    }
+
+    mod auto_suspend {
+        use super::*;
+
+        #[test]
+        fn apply_text_parses_and_updates() {
+            let setting = AutoSuspend;
+            let mut settings = Settings::default();
+
+            let display = setting.apply_text("60.0", &mut settings);
+
+            assert_eq!(display, "60.0");
+            assert_eq!(settings.auto_suspend, 60.0);
+        }
+
+        #[test]
+        fn apply_text_returns_never_for_zero() {
+            let setting = AutoSuspend;
+            let mut settings = Settings::default();
+
+            let display = setting.apply_text("0", &mut settings);
+
+            assert_eq!(display, "Never");
+            assert_eq!(settings.auto_suspend, 0.0);
+        }
+
+        #[test]
+        fn apply_text_ignores_invalid_input() {
+            let setting = AutoSuspend;
+            let mut settings = Settings {
+                auto_suspend: 30.0,
+                ..Default::default()
+            };
+
+            let display = setting.apply_text("invalid", &mut settings);
+
+            assert_eq!(settings.auto_suspend, 30.0);
+            assert_eq!(display, "30.0");
+        }
+    }
+
+    mod auto_power_off {
+        use super::*;
+
+        #[test]
+        fn apply_text_parses_and_updates() {
+            let setting = AutoPowerOff;
+            let mut settings = Settings::default();
+
+            let display = setting.apply_text("14.0", &mut settings);
+
+            assert_eq!(display, "14.0");
+            assert_eq!(settings.auto_power_off, 14.0);
+        }
+
+        #[test]
+        fn apply_text_returns_never_for_zero() {
+            let setting = AutoPowerOff;
+            let mut settings = Settings::default();
+
+            let display = setting.apply_text("0", &mut settings);
+
+            assert_eq!(display, "Never");
+            assert_eq!(settings.auto_power_off, 0.0);
+        }
+
+        #[test]
+        fn apply_text_ignores_invalid_input() {
+            let setting = AutoPowerOff;
+            let mut settings = Settings {
+                auto_power_off: 7.0,
+                ..Default::default()
+            };
+
+            let display = setting.apply_text("invalid", &mut settings);
+
+            assert_eq!(settings.auto_power_off, 7.0);
+            assert_eq!(display, "7.0");
+        }
+    }
+
+    mod sleep_cover {
+        use super::*;
+
+        #[test]
+        fn handle_toggle_event_toggles_value() {
+            let setting = SleepCover;
+            let mut settings = Settings {
+                sleep_cover: true,
+                ..Default::default()
+            };
+            let mut bus: Bus = VecDeque::new();
+            let event = Event::Toggle(ToggleEvent::Setting(ToggleSettings::SleepCover));
+
+            let result = setting.handle(&event, &mut settings, &mut bus);
+
+            assert!(result.is_some());
+            assert_eq!(result.unwrap(), "false");
+            assert!(!settings.sleep_cover);
+        }
+
+        #[test]
+        fn handle_returns_none_for_wrong_event() {
+            let setting = SleepCover;
+            let mut settings = Settings::default();
+            let mut bus: Bus = VecDeque::new();
+
+            let result = setting.handle(&Event::Select(EntryId::About), &mut settings, &mut bus);
+
+            assert!(result.is_none());
+        }
+    }
+
+    mod auto_share {
+        use super::*;
+
+        #[test]
+        fn handle_toggle_event_toggles_value() {
+            let setting = AutoShare;
+            let mut settings = Settings {
+                auto_share: false,
+                ..Default::default()
+            };
+            let mut bus: Bus = VecDeque::new();
+            let event = Event::Toggle(ToggleEvent::Setting(ToggleSettings::AutoShare));
+
+            let result = setting.handle(&event, &mut settings, &mut bus);
+
+            assert!(result.is_some());
+            assert_eq!(result.unwrap(), "true");
+            assert!(settings.auto_share);
+        }
+
+        #[test]
+        fn handle_returns_none_for_wrong_event() {
+            let setting = AutoShare;
+            let mut settings = Settings::default();
+            let mut bus: Bus = VecDeque::new();
+
+            let result = setting.handle(&Event::Select(EntryId::About), &mut settings, &mut bus);
+
+            assert!(result.is_none());
+        }
+    }
+
+    mod button_scheme {
+        use super::*;
+        use crate::settings::ButtonScheme;
+
+        #[test]
+        fn handle_toggle_event_switches_natural_to_inverted() {
+            let setting = ButtonScheme;
+            let mut settings = Settings {
+                button_scheme: ButtonScheme::Natural,
+                ..Default::default()
+            };
+            let mut bus: Bus = VecDeque::new();
+            let event = Event::Toggle(ToggleEvent::Setting(ToggleSettings::ButtonScheme));
+
+            let result = setting.handle(&event, &mut settings, &mut bus);
+
+            assert_eq!(settings.button_scheme, ButtonScheme::Inverted);
+            assert_eq!(bus.len(), 1);
+            assert!(result.is_some());
+        }
+
+        #[test]
+        fn handle_toggle_event_switches_inverted_to_natural() {
+            let setting = ButtonScheme;
+            let mut settings = Settings {
+                button_scheme: ButtonScheme::Inverted,
+                ..Default::default()
+            };
+            let mut bus: Bus = VecDeque::new();
+            let event = Event::Toggle(ToggleEvent::Setting(ToggleSettings::ButtonScheme));
+
+            let result = setting.handle(&event, &mut settings, &mut bus);
+
+            assert_eq!(settings.button_scheme, ButtonScheme::Natural);
+            assert_eq!(bus.len(), 1);
+            assert!(result.is_some());
+        }
+
+        #[test]
+        fn handle_set_scheme_event_applies_directly() {
+            let setting = ButtonScheme;
+            let mut settings = Settings {
+                button_scheme: ButtonScheme::Natural,
+                ..Default::default()
+            };
+            let mut bus: Bus = VecDeque::new();
+            let event = Event::Select(EntryId::SetButtonScheme(ButtonScheme::Inverted));
+
+            let result = setting.handle(&event, &mut settings, &mut bus);
+
+            assert_eq!(settings.button_scheme, ButtonScheme::Inverted);
+            assert!(result.is_some());
+        }
+
+        #[test]
+        fn handle_returns_none_for_wrong_event() {
+            let setting = ButtonScheme;
+            let mut settings = Settings::default();
+            let mut bus: Bus = VecDeque::new();
+
+            let result = setting.handle(&Event::Select(EntryId::About), &mut settings, &mut bus);
+
+            assert!(result.is_none());
+        }
+    }
+
+    mod settings_retention {
+        use super::*;
+
+        #[test]
+        fn apply_text_parses_and_updates() {
+            let setting = SettingsRetention;
+            let mut settings = Settings::default();
+
+            let display = setting.apply_text("10", &mut settings);
+
+            assert_eq!(display, "10");
+            assert_eq!(settings.settings_retention, 10);
+        }
+
+        #[test]
+        fn apply_text_ignores_invalid_input() {
+            let setting = SettingsRetention;
+            let mut settings = Settings {
+                settings_retention: 3,
+                ..Default::default()
+            };
+
+            let display = setting.apply_text("invalid", &mut settings);
+
+            assert_eq!(settings.settings_retention, 3);
+            assert_eq!(display, "3");
+        }
+    }
+}

--- a/crates/core/src/view/settings_editor/kinds/identity.rs
+++ b/crates/core/src/view/settings_editor/kinds/identity.rs
@@ -1,0 +1,39 @@
+//! Single, deduplicated identity enum for all settings.
+//!
+//! This replaces the two parallel `Kind` enums that previously existed in
+//! `setting_row` and `setting_value`.  It is only used to route
+//! [`SettingsEvent::UpdateValue`](crate::view::settings_editor::SettingsEvent)
+//! events to the correct view — the view layer itself contains no per-setting
+//! match arms.
+
+/// Identifies a specific setting value view for targeted updates.
+///
+/// Used in [`SettingsEvent::UpdateValue`](crate::view::settings_editor::SettingsEvent)
+/// so that [`CategoryEditor`](crate::view::settings_editor::CategoryEditor) can tell
+/// exactly which [`SettingValue`](crate::view::settings_editor::SettingValue) to
+/// refresh after a setting changes.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SettingIdentity {
+    KeyboardLayout,
+    Locale,
+    AutoSuspend,
+    AutoPowerOff,
+    SleepCover,
+    AutoShare,
+    ButtonScheme,
+    LoggingEnabled,
+    FinishedAction,
+    LibraryInfo(usize),
+    LibraryName(usize),
+    LibraryPath(usize),
+    LibraryFinishedAction(usize),
+    IntermissionSuspend,
+    IntermissionPowerOff,
+    IntermissionShare,
+    SettingsRetention,
+    LogLevel,
+    #[cfg(feature = "otel")]
+    OtlpEndpoint,
+    #[cfg(feature = "test")]
+    EnableKernLog,
+}

--- a/crates/core/src/view/settings_editor/kinds/intermission.rs
+++ b/crates/core/src/view/settings_editor/kinds/intermission.rs
@@ -1,0 +1,380 @@
+//! Setting kinds for the Intermissions category.
+
+use super::{SettingData, SettingIdentity, SettingKind, WidgetKind};
+use crate::fl;
+use crate::i18n::I18nDisplay;
+use crate::settings::{IntermKind, IntermissionDisplay, Settings};
+use crate::view::{Bus, EntryId, EntryKind, Event};
+
+/// Fetches the intermission display setting data for the given intermission kind
+fn fetch_intermission(kind: IntermKind, settings: &Settings) -> SettingData {
+    let display = &settings.intermissions[kind];
+
+    let (value, is_logo, is_cover) = match display {
+        IntermissionDisplay::Logo => (display.to_i18n_string(), true, false),
+        IntermissionDisplay::Cover => (display.to_i18n_string(), false, true),
+        IntermissionDisplay::Image(path) => {
+            let i18n_display = fl!("settings-intermission-custom");
+            let display_name = path
+                .file_name()
+                .and_then(|n| n.to_str())
+                .unwrap_or(i18n_display.as_str())
+                .to_string();
+            (display_name, false, false)
+        }
+    };
+
+    let entries = vec![
+        EntryKind::RadioButton(
+            IntermissionDisplay::Logo.to_i18n_string(),
+            EntryId::SetIntermission(kind, IntermissionDisplay::Logo),
+            is_logo,
+        ),
+        EntryKind::RadioButton(
+            IntermissionDisplay::Cover.to_i18n_string(),
+            EntryId::SetIntermission(kind, IntermissionDisplay::Cover),
+            is_cover,
+        ),
+        EntryKind::Command(
+            fl!("settings-intermission-custom-image"),
+            EntryId::EditIntermissionImage(kind),
+        ),
+    ];
+
+    SettingData {
+        value,
+        widget: WidgetKind::SubMenu(entries),
+    }
+}
+
+/// Extracts the display name from an [`IntermissionDisplay`] value.
+///
+/// Uses [`IntermissionDisplay`]'s [`I18nDisplay`] implementation for
+/// `Logo` and `Cover`. For `Image`, the filename is used instead of the full path since
+/// the built-in `Display` impl only yields `"Custom"` for that variant.
+fn intermission_display_name(display: &IntermissionDisplay) -> String {
+    let i18n_display = fl!("settings-intermission-custom");
+    match display {
+        IntermissionDisplay::Image(path) => path
+            .file_name()
+            .and_then(|n| n.to_str())
+            .unwrap_or(i18n_display.as_str())
+            .to_string(),
+        _ => display.to_i18n_string(),
+    }
+}
+
+/// Suspend screen display setting
+pub struct IntermissionSuspend;
+
+impl SettingKind for IntermissionSuspend {
+    fn identity(&self) -> SettingIdentity {
+        SettingIdentity::IntermissionSuspend
+    }
+
+    fn label(&self, _settings: &Settings) -> String {
+        fl!("settings-intermission-suspend-screen")
+    }
+
+    fn fetch(&self, settings: &Settings) -> SettingData {
+        fetch_intermission(IntermKind::Suspend, settings)
+    }
+
+    fn handle(&self, evt: &Event, settings: &mut Settings, _bus: &mut Bus) -> Option<String> {
+        if let Event::Select(EntryId::SetIntermission(IntermKind::Suspend, ref display)) = evt {
+            settings.intermissions[IntermKind::Suspend] = display.clone();
+            return Some(intermission_display_name(display));
+        }
+
+        if let Event::FileChooserClosed(Some(ref path)) = evt {
+            let display = IntermissionDisplay::Image(path.clone());
+            settings.intermissions[IntermKind::Suspend] = display.clone();
+            return Some(intermission_display_name(&display));
+        }
+
+        None
+    }
+
+    fn file_chooser_entry_id(&self) -> Option<EntryId> {
+        Some(EntryId::EditIntermissionImage(IntermKind::Suspend))
+    }
+}
+
+/// Power off screen display setting
+pub struct IntermissionPowerOff;
+
+impl SettingKind for IntermissionPowerOff {
+    fn identity(&self) -> SettingIdentity {
+        SettingIdentity::IntermissionPowerOff
+    }
+
+    fn label(&self, _settings: &Settings) -> String {
+        fl!("settings-intermission-power-off-screen")
+    }
+
+    fn fetch(&self, settings: &Settings) -> SettingData {
+        fetch_intermission(IntermKind::PowerOff, settings)
+    }
+
+    fn handle(&self, evt: &Event, settings: &mut Settings, _bus: &mut Bus) -> Option<String> {
+        if let Event::Select(EntryId::SetIntermission(IntermKind::PowerOff, ref display)) = evt {
+            settings.intermissions[IntermKind::PowerOff] = display.clone();
+            return Some(intermission_display_name(display));
+        }
+
+        if let Event::FileChooserClosed(Some(ref path)) = evt {
+            let display = IntermissionDisplay::Image(path.clone());
+            settings.intermissions[IntermKind::PowerOff] = display.clone();
+            return Some(intermission_display_name(&display));
+        }
+
+        None
+    }
+
+    fn file_chooser_entry_id(&self) -> Option<EntryId> {
+        Some(EntryId::EditIntermissionImage(IntermKind::PowerOff))
+    }
+}
+
+/// Share screen display setting
+pub struct IntermissionShare;
+
+impl SettingKind for IntermissionShare {
+    fn identity(&self) -> SettingIdentity {
+        SettingIdentity::IntermissionShare
+    }
+
+    fn label(&self, _settings: &Settings) -> String {
+        fl!("settings-intermission-share-screen")
+    }
+
+    fn fetch(&self, settings: &Settings) -> SettingData {
+        fetch_intermission(IntermKind::Share, settings)
+    }
+
+    fn handle(&self, evt: &Event, settings: &mut Settings, _bus: &mut Bus) -> Option<String> {
+        if let Event::Select(EntryId::SetIntermission(IntermKind::Share, ref display)) = evt {
+            settings.intermissions[IntermKind::Share] = display.clone();
+            return Some(intermission_display_name(display));
+        }
+
+        if let Event::FileChooserClosed(Some(ref path)) = evt {
+            let display = IntermissionDisplay::Image(path.clone());
+            settings.intermissions[IntermKind::Share] = display.clone();
+            return Some(intermission_display_name(&display));
+        }
+
+        None
+    }
+
+    fn file_chooser_entry_id(&self) -> Option<EntryId> {
+        Some(EntryId::EditIntermissionImage(IntermKind::Share))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::settings::{IntermissionDisplay, Settings};
+    use crate::view::{Bus, EntryId, Event};
+    use std::collections::VecDeque;
+    use std::path::PathBuf;
+
+    mod intermission_suspend {
+        use super::*;
+
+        #[test]
+        fn handle_set_intermission_updates_settings() {
+            let setting = IntermissionSuspend;
+            let mut settings = Settings::default();
+            let mut bus: Bus = VecDeque::new();
+            let event = Event::Select(EntryId::SetIntermission(
+                IntermKind::Suspend,
+                IntermissionDisplay::Cover,
+            ));
+
+            let result = setting.handle(&event, &mut settings, &mut bus);
+
+            assert!(result.is_some());
+            assert_eq!(
+                settings.intermissions[IntermKind::Suspend],
+                IntermissionDisplay::Cover
+            );
+        }
+
+        #[test]
+        fn handle_file_chooser_closed_updates_settings() {
+            let setting = IntermissionSuspend;
+            let mut settings = Settings::default();
+            let mut bus: Bus = VecDeque::new();
+            let path = PathBuf::from("/selected/image.jpg");
+            let event = Event::FileChooserClosed(Some(path));
+
+            let result = setting.handle(&event, &mut settings, &mut bus);
+
+            assert!(result.is_some());
+            assert_eq!(
+                settings.intermissions[IntermKind::Suspend],
+                IntermissionDisplay::Image(PathBuf::from("/selected/image.jpg"))
+            );
+        }
+
+        #[test]
+        fn handle_returns_none_for_wrong_kind() {
+            let setting = IntermissionSuspend;
+            let mut settings = Settings::default();
+            let mut bus: Bus = VecDeque::new();
+            let event = Event::Select(EntryId::SetIntermission(
+                IntermKind::PowerOff,
+                IntermissionDisplay::Cover,
+            ));
+
+            let result = setting.handle(&event, &mut settings, &mut bus);
+
+            assert!(result.is_none());
+        }
+
+        #[test]
+        fn handle_returns_none_for_cancelled_file_chooser() {
+            let setting = IntermissionSuspend;
+            let mut settings = Settings::default();
+            let mut bus: Bus = VecDeque::new();
+
+            let result = setting.handle(&Event::FileChooserClosed(None), &mut settings, &mut bus);
+
+            assert!(result.is_none());
+        }
+    }
+
+    mod intermission_power_off {
+        use super::*;
+
+        #[test]
+        fn handle_set_intermission_updates_settings() {
+            let setting = IntermissionPowerOff;
+            let mut settings = Settings::default();
+            let mut bus: Bus = VecDeque::new();
+            let event = Event::Select(EntryId::SetIntermission(
+                IntermKind::PowerOff,
+                IntermissionDisplay::Cover,
+            ));
+
+            let result = setting.handle(&event, &mut settings, &mut bus);
+
+            assert!(result.is_some());
+            assert_eq!(
+                settings.intermissions[IntermKind::PowerOff],
+                IntermissionDisplay::Cover
+            );
+        }
+
+        #[test]
+        fn handle_file_chooser_closed_updates_settings() {
+            let setting = IntermissionPowerOff;
+            let mut settings = Settings::default();
+            let mut bus: Bus = VecDeque::new();
+            let path = PathBuf::from("/selected/poweroff.png");
+            let event = Event::FileChooserClosed(Some(path));
+
+            let result = setting.handle(&event, &mut settings, &mut bus);
+
+            assert!(result.is_some());
+            assert_eq!(
+                settings.intermissions[IntermKind::PowerOff],
+                IntermissionDisplay::Image(PathBuf::from("/selected/poweroff.png"))
+            );
+        }
+
+        #[test]
+        fn handle_returns_none_for_wrong_kind() {
+            let setting = IntermissionPowerOff;
+            let mut settings = Settings::default();
+            let mut bus: Bus = VecDeque::new();
+            let event = Event::Select(EntryId::SetIntermission(
+                IntermKind::Suspend,
+                IntermissionDisplay::Logo,
+            ));
+
+            let result = setting.handle(&event, &mut settings, &mut bus);
+
+            assert!(result.is_none());
+        }
+
+        #[test]
+        fn handle_returns_none_for_cancelled_file_chooser() {
+            let setting = IntermissionPowerOff;
+            let mut settings = Settings::default();
+            let mut bus: Bus = VecDeque::new();
+
+            let result = setting.handle(&Event::FileChooserClosed(None), &mut settings, &mut bus);
+
+            assert!(result.is_none());
+        }
+    }
+
+    mod intermission_share {
+        use super::*;
+
+        #[test]
+        fn handle_set_intermission_updates_settings() {
+            let setting = IntermissionShare;
+            let mut settings = Settings::default();
+            let mut bus: Bus = VecDeque::new();
+            let event = Event::Select(EntryId::SetIntermission(
+                IntermKind::Share,
+                IntermissionDisplay::Cover,
+            ));
+
+            let result = setting.handle(&event, &mut settings, &mut bus);
+
+            assert!(result.is_some());
+            assert_eq!(
+                settings.intermissions[IntermKind::Share],
+                IntermissionDisplay::Cover
+            );
+        }
+
+        #[test]
+        fn handle_file_chooser_closed_updates_settings() {
+            let setting = IntermissionShare;
+            let mut settings = Settings::default();
+            let mut bus: Bus = VecDeque::new();
+            let path = PathBuf::from("/selected/share.jpg");
+            let event = Event::FileChooserClosed(Some(path));
+
+            let result = setting.handle(&event, &mut settings, &mut bus);
+
+            assert!(result.is_some());
+            assert_eq!(
+                settings.intermissions[IntermKind::Share],
+                IntermissionDisplay::Image(PathBuf::from("/selected/share.jpg"))
+            );
+        }
+
+        #[test]
+        fn handle_returns_none_for_wrong_kind() {
+            let setting = IntermissionShare;
+            let mut settings = Settings::default();
+            let mut bus: Bus = VecDeque::new();
+            let event = Event::Select(EntryId::SetIntermission(
+                IntermKind::PowerOff,
+                IntermissionDisplay::Cover,
+            ));
+
+            let result = setting.handle(&event, &mut settings, &mut bus);
+
+            assert!(result.is_none());
+        }
+
+        #[test]
+        fn handle_returns_none_for_cancelled_file_chooser() {
+            let setting = IntermissionShare;
+            let mut settings = Settings::default();
+            let mut bus: Bus = VecDeque::new();
+
+            let result = setting.handle(&Event::FileChooserClosed(None), &mut settings, &mut bus);
+
+            assert!(result.is_none());
+        }
+    }
+}

--- a/crates/core/src/view/settings_editor/kinds/library.rs
+++ b/crates/core/src/view/settings_editor/kinds/library.rs
@@ -1,0 +1,139 @@
+//! Setting kinds for the Libraries category.
+
+use super::{SettingData, SettingIdentity, SettingKind, WidgetKind};
+use crate::fl;
+use crate::i18n::I18nDisplay;
+use crate::settings::{FinishedAction, Settings};
+use crate::view::{EntryId, EntryKind, Event};
+
+/// Shows a summary of a library (path) and opens the library editor on tap.
+pub struct LibraryInfo(pub usize);
+
+impl SettingKind for LibraryInfo {
+    fn identity(&self) -> SettingIdentity {
+        SettingIdentity::LibraryInfo(self.0)
+    }
+
+    fn label(&self, settings: &Settings) -> String {
+        settings
+            .libraries
+            .get(self.0)
+            .map(|lib| lib.name.clone())
+            .unwrap_or_else(|| fl!("settings-general-unknown"))
+    }
+
+    fn fetch(&self, settings: &Settings) -> SettingData {
+        let value = settings
+            .libraries
+            .get(self.0)
+            .map(|lib| lib.path.display().to_string())
+            .unwrap_or_else(|| fl!("settings-general-unknown"));
+
+        SettingData {
+            value,
+            widget: WidgetKind::ActionLabel(Event::EditLibrary(self.0)),
+        }
+    }
+}
+
+/// Library name editing setting
+pub struct LibraryName(pub usize);
+
+impl SettingKind for LibraryName {
+    fn identity(&self) -> SettingIdentity {
+        SettingIdentity::LibraryName(self.0)
+    }
+
+    fn label(&self, _settings: &Settings) -> String {
+        fl!("settings-library-name")
+    }
+
+    fn fetch(&self, settings: &Settings) -> SettingData {
+        let value = settings
+            .libraries
+            .get(self.0)
+            .map(|lib| lib.name.clone())
+            .unwrap_or_else(|| fl!("settings-general-unknown"));
+
+        SettingData {
+            value,
+            widget: WidgetKind::ActionLabel(Event::Select(EntryId::EditLibraryName)),
+        }
+    }
+}
+
+/// Library path editing setting
+pub struct LibraryPath(pub usize);
+
+impl SettingKind for LibraryPath {
+    fn identity(&self) -> SettingIdentity {
+        SettingIdentity::LibraryPath(self.0)
+    }
+
+    fn label(&self, _settings: &Settings) -> String {
+        fl!("settings-library-path")
+    }
+
+    fn fetch(&self, settings: &Settings) -> SettingData {
+        let value = settings
+            .libraries
+            .get(self.0)
+            .map(|lib| lib.path.display().to_string())
+            .unwrap_or_else(|| fl!("settings-general-unknown"));
+
+        SettingData {
+            value,
+            widget: WidgetKind::ActionLabel(Event::Select(EntryId::EditLibraryPath)),
+        }
+    }
+}
+
+/// Library finished action setting
+pub struct LibraryFinishedAction(pub usize);
+
+impl SettingKind for LibraryFinishedAction {
+    fn identity(&self) -> SettingIdentity {
+        SettingIdentity::LibraryFinishedAction(self.0)
+    }
+
+    fn label(&self, _settings: &Settings) -> String {
+        fl!("settings-library-end-of-book-action")
+    }
+
+    fn fetch(&self, settings: &Settings) -> SettingData {
+        let index = self.0;
+        let current = settings.libraries.get(index).and_then(|lib| lib.finished);
+
+        let value = current
+            .map(|action| action.to_i18n_string())
+            .unwrap_or_else(|| fl!("settings-library-inherit"));
+
+        let entries = vec![
+            EntryKind::RadioButton(
+                fl!("settings-library-inherit"),
+                EntryId::ClearLibraryFinishedAction(index),
+                current.is_none(),
+            ),
+            EntryKind::RadioButton(
+                FinishedAction::Notify.to_i18n_string(),
+                EntryId::SetLibraryFinishedAction(index, FinishedAction::Notify),
+                current == Some(FinishedAction::Notify),
+            ),
+            EntryKind::RadioButton(
+                FinishedAction::Close.to_i18n_string(),
+                EntryId::SetLibraryFinishedAction(index, FinishedAction::Close),
+                current == Some(FinishedAction::Close),
+            ),
+            EntryKind::RadioButton(
+                FinishedAction::GoToNext.to_i18n_string(),
+                EntryId::SetLibraryFinishedAction(index, FinishedAction::GoToNext),
+                current == Some(FinishedAction::GoToNext),
+            ),
+        ];
+
+        SettingData {
+            value,
+            widget: WidgetKind::SubMenu(entries),
+        }
+    }
+}

--- a/crates/core/src/view/settings_editor/kinds/mod.rs
+++ b/crates/core/src/view/settings_editor/kinds/mod.rs
@@ -1,0 +1,198 @@
+//! Trait and supporting types for defining individual settings.
+//!
+//! Each setting is a small struct that implements [`SettingKind`]. The trait
+//! encapsulates everything a [`SettingRow`](crate::view::settings_editor::SettingRow)
+//! needs to know: the row label, the current display value, which widget to
+//! render (`ActionLabel`, `Toggle`, or `SubMenu`), and which event to fire on tap.
+//!
+//! [`SettingIdentity`] is the single, deduplicated identity enum used by
+//! [`SettingsEvent::UpdateValue`](crate::view::settings_editor::SettingsEvent) to
+//! target the correct [`SettingValue`](crate::view::settings_editor::SettingValue) view.
+
+pub mod general;
+pub mod identity;
+pub mod intermission;
+pub mod library;
+pub mod reader;
+pub mod telemetry;
+
+pub use identity::SettingIdentity;
+
+use crate::settings::Settings;
+use crate::view::{Bus, EntryId, EntryKind, Event, ViewId};
+
+/// Identifies which boolean setting a toggle widget controls.
+///
+/// Used in [`ToggleEvent::Setting`](crate::view::ToggleEvent) so that
+/// [`CategoryEditor`](crate::view::settings_editor::CategoryEditor) can dispatch
+/// to the correct toggle handler without coupling to UI view IDs.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ToggleSettings {
+    /// Sleep cover enable/disable setting
+    SleepCover,
+    /// Auto-share enable/disable setting
+    AutoShare,
+    /// Button scheme selection (natural or inverted)
+    ButtonScheme,
+    /// Logging enabled setting
+    LoggingEnabled,
+    /// Kernel logging enabled setting (test builds only)
+    #[cfg(feature = "test")]
+    EnableKernLog,
+}
+
+/// Describes how the value side of a setting row should be rendered.
+///
+/// Each variant is fully self-contained: it carries everything needed to build
+/// the widget, including the tap event or sub-menu entries.
+pub enum WidgetKind {
+    /// A tappable label that opens a free-form editor (e.g. a text input dialog).
+    ///
+    /// The inner event is fired when the label is tapped.
+    ActionLabel(Event),
+    /// A two-state toggle switch.
+    Toggle {
+        /// Label shown on the left (the "on" side).
+        left_label: String,
+        /// Label shown on the right (the "off" side).
+        right_label: String,
+        /// Whether the toggle is currently in the left/enabled state.
+        enabled: bool,
+        /// Event fired when the toggle is tapped.
+        tap_event: Event,
+    },
+    /// A tappable label that opens a sub-menu with the given entries.
+    ///
+    /// The entries (e.g. radio buttons) are stored here so that the widget is
+    /// fully self-contained.
+    SubMenu(Vec<EntryKind>),
+}
+
+/// All data needed to build and update the value side of a setting row.
+pub struct SettingData {
+    /// Text representation of the current value (shown in the widget).
+    pub value: String,
+    /// Which widget type to render, including all tap/event data for that widget.
+    pub widget: WidgetKind,
+}
+
+/// A self-contained description of a single setting.
+///
+/// Implementing this trait is sufficient to add a new setting to the editor.
+pub trait SettingKind {
+    /// Unique identity used to route [`SettingsEvent::UpdateValue`](crate::view::settings_editor::SettingsEvent::UpdateValue) to the
+    /// correct [`SettingValue`](crate::view::settings_editor::SettingValue) view.
+    fn identity(&self) -> SettingIdentity;
+
+    /// Human-readable label shown on the left side of the setting row.
+    ///
+    /// `settings` is provided for dynamic labels (e.g. library names).
+    fn label(&self, settings: &Settings) -> String;
+
+    /// Fetch the current display value and widget configuration from `settings`.
+    fn fetch(&self, settings: &Settings) -> SettingData;
+
+    /// Handle an incoming event that may apply a change to this setting.
+    ///
+    /// Mutates `settings` if the event is relevant and returns the updated
+    /// display string. Returns `None` if this event does not apply to this setting.
+    /// `bus` is available for settings that need to propagate side-effects.
+    fn handle(&self, _evt: &Event, _settings: &mut Settings, _bus: &mut Bus) -> Option<String> {
+        None
+    }
+
+    /// Returns this setting as an [`InputSettingKind`] if it supports text input.
+    ///
+    /// [`InputSettingKind`] implementors override this to return `Some(self)`.
+    /// All other settings inherit the default `None`.
+    fn as_input_kind(&self) -> Option<&dyn InputSettingKind> {
+        None
+    }
+
+    /// Returns the [`EntryId`] that triggers opening a file chooser for this setting.
+    ///
+    /// Default `None`. Implement on settings that offer a "Custom Image..." option
+    /// (currently the three intermission kinds).
+    fn file_chooser_entry_id(&self) -> Option<EntryId> {
+        None
+    }
+}
+
+impl<T: SettingKind + ?Sized> SettingKind for &T {
+    fn identity(&self) -> SettingIdentity {
+        (**self).identity()
+    }
+
+    fn label(&self, settings: &Settings) -> String {
+        (**self).label(settings)
+    }
+
+    fn fetch(&self, settings: &Settings) -> SettingData {
+        (**self).fetch(settings)
+    }
+
+    fn handle(&self, evt: &Event, settings: &mut Settings, bus: &mut Bus) -> Option<String> {
+        (**self).handle(evt, settings, bus)
+    }
+
+    fn as_input_kind(&self) -> Option<&dyn InputSettingKind> {
+        (**self).as_input_kind()
+    }
+
+    fn file_chooser_entry_id(&self) -> Option<EntryId> {
+        (**self).file_chooser_entry_id()
+    }
+}
+
+impl<T: SettingKind + ?Sized> SettingKind for Box<T> {
+    fn identity(&self) -> SettingIdentity {
+        (**self).identity()
+    }
+
+    fn label(&self, settings: &Settings) -> String {
+        (**self).label(settings)
+    }
+
+    fn fetch(&self, settings: &Settings) -> SettingData {
+        (**self).fetch(settings)
+    }
+
+    fn handle(&self, evt: &Event, settings: &mut Settings, bus: &mut Bus) -> Option<String> {
+        (**self).handle(evt, settings, bus)
+    }
+
+    fn as_input_kind(&self) -> Option<&dyn InputSettingKind> {
+        (**self).as_input_kind()
+    }
+
+    fn file_chooser_entry_id(&self) -> Option<EntryId> {
+        (**self).file_chooser_entry_id()
+    }
+}
+
+/// Extended trait for settings that accept free-form text input via a [`NamedInput`] overlay.
+///
+/// [`NamedInput`]: crate::view::named_input::NamedInput
+pub trait InputSettingKind: SettingKind {
+    /// The [`ViewId`] used by this setting's [`NamedInput`] and its submit event.
+    ///
+    /// [`NamedInput`]: crate::view::named_input::NamedInput
+    fn submit_view_id(&self) -> ViewId;
+
+    /// The [`EntryId`] event that opens this setting's input dialog when tapped.
+    fn open_entry_id(&self) -> EntryId;
+
+    /// Label shown inside the [`NamedInput`] dialog.
+    ///
+    /// [`NamedInput`]: crate::view::named_input::NamedInput
+    fn input_label(&self) -> String;
+
+    /// Maximum number of characters the input accepts.
+    fn input_max_chars(&self) -> usize;
+
+    /// The current value as a string to pre-populate the input field.
+    fn current_text(&self, settings: &Settings) -> String;
+
+    /// Parse `text` from the input, mutate `settings`, and return the display string.
+    fn apply_text(&self, text: &str, settings: &mut Settings) -> String;
+}

--- a/crates/core/src/view/settings_editor/kinds/reader.rs
+++ b/crates/core/src/view/settings_editor/kinds/reader.rs
@@ -1,0 +1,121 @@
+//! Setting kinds for the Reader category.
+
+use super::{SettingData, SettingIdentity, SettingKind, WidgetKind};
+use crate::fl;
+use crate::i18n::I18nDisplay;
+use crate::settings::{FinishedAction, Settings};
+use crate::view::{Bus, EntryId, EntryKind, Event};
+
+/// Reader finished action setting
+pub struct FinishedActionSetting;
+
+impl SettingKind for FinishedActionSetting {
+    fn identity(&self) -> SettingIdentity {
+        SettingIdentity::FinishedAction
+    }
+
+    fn label(&self, _settings: &Settings) -> String {
+        fl!("settings-reader-end-of-book-action")
+    }
+
+    fn fetch(&self, settings: &Settings) -> SettingData {
+        let current = settings.reader.finished;
+
+        let entries = vec![
+            EntryKind::RadioButton(
+                FinishedAction::Notify.to_i18n_string(),
+                EntryId::SetFinishedAction(FinishedAction::Notify),
+                current == FinishedAction::Notify,
+            ),
+            EntryKind::RadioButton(
+                FinishedAction::Close.to_i18n_string(),
+                EntryId::SetFinishedAction(FinishedAction::Close),
+                current == FinishedAction::Close,
+            ),
+            EntryKind::RadioButton(
+                FinishedAction::GoToNext.to_i18n_string(),
+                EntryId::SetFinishedAction(FinishedAction::GoToNext),
+                current == FinishedAction::GoToNext,
+            ),
+        ];
+
+        SettingData {
+            value: current.to_i18n_string(),
+            widget: WidgetKind::SubMenu(entries),
+        }
+    }
+
+    fn handle(&self, evt: &Event, settings: &mut Settings, _bus: &mut Bus) -> Option<String> {
+        if let Event::Select(EntryId::SetFinishedAction(action)) = evt {
+            settings.reader.finished = *action;
+            return Some(action.to_i18n_string());
+        }
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::settings::{FinishedAction, Settings};
+    use crate::view::{Bus, EntryId, Event};
+    use std::collections::VecDeque;
+
+    mod finished_action_setting {
+        use super::*;
+
+        #[test]
+        fn handle_set_action_updates_settings() {
+            let setting = FinishedActionSetting;
+            let mut settings = Settings::default();
+            settings.reader.finished = FinishedAction::Close;
+            let mut bus: Bus = VecDeque::new();
+            let event = Event::Select(EntryId::SetFinishedAction(FinishedAction::GoToNext));
+
+            let result = setting.handle(&event, &mut settings, &mut bus);
+
+            assert!(result.is_some());
+            assert_eq!(settings.reader.finished, FinishedAction::GoToNext);
+        }
+
+        #[test]
+        fn handle_can_set_all_actions() {
+            let setting = FinishedActionSetting;
+            let mut settings = Settings::default();
+            let mut bus: Bus = VecDeque::new();
+
+            for action in [
+                FinishedAction::Notify,
+                FinishedAction::Close,
+                FinishedAction::GoToNext,
+            ] {
+                let event = Event::Select(EntryId::SetFinishedAction(action));
+                setting.handle(&event, &mut settings, &mut bus);
+                assert_eq!(settings.reader.finished, action);
+            }
+        }
+
+        #[test]
+        fn handle_returns_none_for_wrong_event() {
+            let setting = FinishedActionSetting;
+            let mut settings = Settings::default();
+            let mut bus: Bus = VecDeque::new();
+
+            let result = setting.handle(&Event::Select(EntryId::About), &mut settings, &mut bus);
+
+            assert!(result.is_none());
+        }
+
+        #[test]
+        fn handle_returns_none_for_per_library_entry_id() {
+            let setting = FinishedActionSetting;
+            let mut settings = Settings::default();
+            let mut bus: Bus = VecDeque::new();
+            let event = Event::Select(EntryId::SetLibraryFinishedAction(0, FinishedAction::Notify));
+
+            let result = setting.handle(&event, &mut settings, &mut bus);
+
+            assert!(result.is_none());
+        }
+    }
+}

--- a/crates/core/src/view/settings_editor/kinds/telemetry.rs
+++ b/crates/core/src/view/settings_editor/kinds/telemetry.rs
@@ -1,0 +1,452 @@
+//! Setting kinds for the Telemetry category.
+
+use super::{SettingData, SettingIdentity, SettingKind, ToggleSettings, WidgetKind};
+use crate::fl;
+use crate::settings::Settings;
+use crate::view::{Bus, EntryId, EntryKind, Event, ToggleEvent};
+
+#[cfg(feature = "otel")]
+use super::InputSettingKind;
+#[cfg(feature = "otel")]
+use crate::view::ViewId;
+use std::str::FromStr;
+
+/// Logging enabled toggle setting
+pub struct LoggingEnabled;
+
+impl SettingKind for LoggingEnabled {
+    fn identity(&self) -> SettingIdentity {
+        SettingIdentity::LoggingEnabled
+    }
+
+    fn label(&self, _settings: &Settings) -> String {
+        fl!("settings-telemetry-enable-logging")
+    }
+
+    fn fetch(&self, settings: &Settings) -> SettingData {
+        SettingData {
+            value: settings.logging.enabled.to_string(),
+            widget: WidgetKind::Toggle {
+                left_label: fl!("settings-general-toggle-on"),
+                right_label: fl!("settings-general-toggle-off"),
+                enabled: settings.logging.enabled,
+                tap_event: Event::Toggle(ToggleEvent::Setting(ToggleSettings::LoggingEnabled)),
+            },
+        }
+    }
+
+    fn handle(&self, evt: &Event, settings: &mut Settings, _bus: &mut Bus) -> Option<String> {
+        if let Event::Toggle(ToggleEvent::Setting(ToggleSettings::LoggingEnabled)) = evt {
+            settings.logging.enabled = !settings.logging.enabled;
+            return Some(settings.logging.enabled.to_string());
+        }
+        None
+    }
+}
+
+/// Log level selection setting
+pub struct LogLevel;
+
+impl LogLevel {
+    fn level_to_i18n(level: &tracing::Level) -> String {
+        match *level {
+            tracing::Level::TRACE => fl!("settings-log-level-trace"),
+            tracing::Level::DEBUG => fl!("settings-log-level-debug"),
+            tracing::Level::INFO => fl!("settings-log-level-info"),
+            tracing::Level::WARN => fl!("settings-log-level-warn"),
+            tracing::Level::ERROR => fl!("settings-log-level-error"),
+        }
+    }
+}
+
+impl SettingKind for LogLevel {
+    fn identity(&self) -> SettingIdentity {
+        SettingIdentity::LogLevel
+    }
+
+    fn label(&self, _settings: &Settings) -> String {
+        fl!("settings-telemetry-log-level")
+    }
+
+    fn fetch(&self, settings: &Settings) -> SettingData {
+        let current = tracing::Level::from_str(settings.logging.level.as_str())
+            .unwrap_or(tracing::Level::INFO);
+
+        let entries = vec![
+            EntryKind::RadioButton(
+                Self::level_to_i18n(&tracing::Level::TRACE),
+                EntryId::SetLogLevel(tracing::Level::TRACE),
+                current == tracing::Level::TRACE,
+            ),
+            EntryKind::RadioButton(
+                Self::level_to_i18n(&tracing::Level::DEBUG),
+                EntryId::SetLogLevel(tracing::Level::DEBUG),
+                current == tracing::Level::DEBUG,
+            ),
+            EntryKind::RadioButton(
+                Self::level_to_i18n(&tracing::Level::INFO),
+                EntryId::SetLogLevel(tracing::Level::INFO),
+                current == tracing::Level::INFO,
+            ),
+            EntryKind::RadioButton(
+                Self::level_to_i18n(&tracing::Level::WARN),
+                EntryId::SetLogLevel(tracing::Level::WARN),
+                current == tracing::Level::WARN,
+            ),
+            EntryKind::RadioButton(
+                Self::level_to_i18n(&tracing::Level::ERROR),
+                EntryId::SetLogLevel(tracing::Level::ERROR),
+                current == tracing::Level::ERROR,
+            ),
+        ];
+
+        SettingData {
+            value: Self::level_to_i18n(&current),
+            widget: WidgetKind::SubMenu(entries),
+        }
+    }
+
+    fn handle(&self, evt: &Event, settings: &mut Settings, _bus: &mut Bus) -> Option<String> {
+        if let Event::Select(EntryId::SetLogLevel(ref level)) = evt {
+            settings.logging.level = level.to_string();
+            return Some(Self::level_to_i18n(level));
+        }
+        None
+    }
+}
+
+/// OTLP endpoint configuration setting (otel feature)
+#[cfg(feature = "otel")]
+pub struct OtlpEndpoint;
+
+#[cfg(feature = "otel")]
+impl SettingKind for OtlpEndpoint {
+    fn identity(&self) -> SettingIdentity {
+        SettingIdentity::OtlpEndpoint
+    }
+
+    fn label(&self, _settings: &Settings) -> String {
+        fl!("settings-telemetry-otlp-endpoint")
+    }
+
+    fn fetch(&self, settings: &Settings) -> SettingData {
+        let value = settings
+            .logging
+            .otlp_endpoint
+            .clone()
+            .unwrap_or_else(|| fl!("settings-general-not-set"));
+
+        SettingData {
+            value,
+            widget: WidgetKind::ActionLabel(Event::Select(EntryId::EditOtlpEndpoint)),
+        }
+    }
+
+    fn as_input_kind(&self) -> Option<&dyn InputSettingKind> {
+        Some(self)
+    }
+}
+
+#[cfg(feature = "otel")]
+impl InputSettingKind for OtlpEndpoint {
+    fn submit_view_id(&self) -> ViewId {
+        ViewId::OtlpEndpointInput
+    }
+
+    fn open_entry_id(&self) -> EntryId {
+        EntryId::EditOtlpEndpoint
+    }
+
+    fn input_label(&self) -> String {
+        fl!("settings-telemetry-otlp-endpoint")
+    }
+
+    fn input_max_chars(&self) -> usize {
+        50
+    }
+
+    fn current_text(&self, settings: &Settings) -> String {
+        settings.logging.otlp_endpoint.clone().unwrap_or_default()
+    }
+
+    fn apply_text(&self, text: &str, settings: &mut Settings) -> String {
+        let trimmed = text.trim();
+        settings.logging.otlp_endpoint = if trimmed.is_empty() {
+            None
+        } else {
+            Some(trimmed.to_string())
+        };
+        settings
+            .logging
+            .otlp_endpoint
+            .clone()
+            .unwrap_or_else(|| fl!("settings-general-not-set"))
+    }
+}
+
+/// Kernel logging toggle setting (test feature)
+#[cfg(feature = "test")]
+pub struct EnableKernLog;
+
+#[cfg(feature = "test")]
+impl SettingKind for EnableKernLog {
+    fn identity(&self) -> SettingIdentity {
+        SettingIdentity::EnableKernLog
+    }
+
+    fn label(&self, _settings: &Settings) -> String {
+        fl!("settings-telemetry-enable-kernel-log")
+    }
+
+    fn fetch(&self, settings: &Settings) -> SettingData {
+        SettingData {
+            value: settings.logging.enable_kern_log.to_string(),
+            widget: WidgetKind::Toggle {
+                left_label: fl!("settings-general-toggle-on"),
+                right_label: fl!("settings-general-toggle-off"),
+                enabled: settings.logging.enable_kern_log,
+                tap_event: Event::Toggle(ToggleEvent::Setting(ToggleSettings::EnableKernLog)),
+            },
+        }
+    }
+
+    fn handle(&self, evt: &Event, settings: &mut Settings, _bus: &mut Bus) -> Option<String> {
+        if let Event::Toggle(ToggleEvent::Setting(ToggleSettings::EnableKernLog)) = evt {
+            settings.logging.enable_kern_log = !settings.logging.enable_kern_log;
+            return Some(settings.logging.enable_kern_log.to_string());
+        }
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::settings::Settings;
+    use crate::view::settings_editor::kinds::ToggleSettings;
+    use crate::view::{Bus, EntryId, Event, ToggleEvent};
+    use std::collections::VecDeque;
+
+    mod logging_enabled {
+        use super::*;
+
+        #[test]
+        fn handle_toggle_disables_when_enabled() {
+            let setting = LoggingEnabled;
+            let mut settings = Settings::default();
+            settings.logging.enabled = true;
+            let mut bus: Bus = VecDeque::new();
+            let event = Event::Toggle(ToggleEvent::Setting(ToggleSettings::LoggingEnabled));
+
+            let result = setting.handle(&event, &mut settings, &mut bus);
+
+            assert!(result.is_some());
+            assert!(!settings.logging.enabled);
+        }
+
+        #[test]
+        fn handle_toggle_enables_when_disabled() {
+            let setting = LoggingEnabled;
+            let mut settings = Settings::default();
+            settings.logging.enabled = false;
+            let mut bus: Bus = VecDeque::new();
+            let event = Event::Toggle(ToggleEvent::Setting(ToggleSettings::LoggingEnabled));
+
+            let result = setting.handle(&event, &mut settings, &mut bus);
+
+            assert!(result.is_some());
+            assert!(settings.logging.enabled);
+        }
+
+        #[test]
+        fn handle_returns_none_for_wrong_event() {
+            let setting = LoggingEnabled;
+            let mut settings = Settings::default();
+            let mut bus: Bus = VecDeque::new();
+
+            let result = setting.handle(&Event::Select(EntryId::About), &mut settings, &mut bus);
+
+            assert!(result.is_none());
+        }
+
+        #[test]
+        fn handle_returns_none_for_wrong_toggle() {
+            let setting = LoggingEnabled;
+            let mut settings = Settings::default();
+            let mut bus: Bus = VecDeque::new();
+
+            let result = setting.handle(
+                &Event::Toggle(ToggleEvent::Setting(ToggleSettings::SleepCover)),
+                &mut settings,
+                &mut bus,
+            );
+
+            assert!(result.is_none());
+        }
+    }
+
+    mod log_level {
+        use super::*;
+
+        #[test]
+        fn handle_set_level_updates_settings() {
+            let setting = LogLevel;
+            let mut settings = Settings::default();
+            settings.logging.level = "INFO".to_string();
+            let mut bus: Bus = VecDeque::new();
+            let event = Event::Select(EntryId::SetLogLevel(tracing::Level::WARN));
+
+            let result = setting.handle(&event, &mut settings, &mut bus);
+
+            assert!(result.is_some());
+            assert_eq!(settings.logging.level, "WARN");
+        }
+
+        #[test]
+        fn handle_can_set_all_levels() {
+            let setting = LogLevel;
+            let mut settings = Settings::default();
+            let mut bus: Bus = VecDeque::new();
+
+            for level in [
+                tracing::Level::TRACE,
+                tracing::Level::DEBUG,
+                tracing::Level::INFO,
+                tracing::Level::WARN,
+                tracing::Level::ERROR,
+            ] {
+                let event = Event::Select(EntryId::SetLogLevel(level));
+                setting.handle(&event, &mut settings, &mut bus);
+                assert_eq!(settings.logging.level, level.to_string());
+            }
+        }
+
+        #[test]
+        fn handle_returns_none_for_wrong_event() {
+            let setting = LogLevel;
+            let mut settings = Settings::default();
+            let mut bus: Bus = VecDeque::new();
+
+            let result = setting.handle(&Event::Select(EntryId::About), &mut settings, &mut bus);
+
+            assert!(result.is_none());
+        }
+    }
+
+    #[cfg(feature = "otel")]
+    mod otlp_endpoint {
+        use super::*;
+        use crate::view::settings_editor::kinds::InputSettingKind;
+
+        #[test]
+        fn apply_text_sets_endpoint() {
+            let setting = OtlpEndpoint;
+            let mut settings = Settings::default();
+
+            let display = setting.apply_text("http://otel:4317", &mut settings);
+
+            assert_eq!(display, "http://otel:4317");
+            assert_eq!(
+                settings.logging.otlp_endpoint,
+                Some("http://otel:4317".to_string())
+            );
+        }
+
+        #[test]
+        fn apply_text_trims_whitespace() {
+            let setting = OtlpEndpoint;
+            let mut settings = Settings::default();
+
+            let display = setting.apply_text("  http://otel:4317  ", &mut settings);
+
+            assert_eq!(display, "http://otel:4317");
+            assert_eq!(
+                settings.logging.otlp_endpoint,
+                Some("http://otel:4317".to_string())
+            );
+        }
+
+        #[test]
+        fn apply_text_empty_clears_endpoint() {
+            let setting = OtlpEndpoint;
+            let mut settings = Settings::default();
+            settings.logging.otlp_endpoint = Some("http://old:4317".to_string());
+
+            let display = setting.apply_text("", &mut settings);
+
+            assert_eq!(display, "Not set");
+            assert_eq!(settings.logging.otlp_endpoint, None);
+        }
+
+        #[test]
+        fn apply_text_whitespace_only_clears_endpoint() {
+            let setting = OtlpEndpoint;
+            let mut settings = Settings::default();
+            settings.logging.otlp_endpoint = Some("http://old:4317".to_string());
+
+            let display = setting.apply_text("   ", &mut settings);
+
+            assert_eq!(display, "Not set");
+            assert_eq!(settings.logging.otlp_endpoint, None);
+        }
+    }
+
+    #[cfg(feature = "test")]
+    mod enable_kern_log {
+        use super::*;
+
+        #[test]
+        fn handle_toggle_enables_when_disabled() {
+            let setting = EnableKernLog;
+            let mut settings = Settings::default();
+            settings.logging.enable_kern_log = false;
+            let mut bus: Bus = VecDeque::new();
+            let event = Event::Toggle(ToggleEvent::Setting(ToggleSettings::EnableKernLog));
+
+            let result = setting.handle(&event, &mut settings, &mut bus);
+
+            assert!(result.is_some());
+            assert!(settings.logging.enable_kern_log);
+        }
+
+        #[test]
+        fn handle_toggle_disables_when_enabled() {
+            let setting = EnableKernLog;
+            let mut settings = Settings::default();
+            settings.logging.enable_kern_log = true;
+            let mut bus: Bus = VecDeque::new();
+            let event = Event::Toggle(ToggleEvent::Setting(ToggleSettings::EnableKernLog));
+
+            let result = setting.handle(&event, &mut settings, &mut bus);
+
+            assert!(result.is_some());
+            assert!(!settings.logging.enable_kern_log);
+        }
+
+        #[test]
+        fn handle_returns_none_for_wrong_event() {
+            let setting = EnableKernLog;
+            let mut settings = Settings::default();
+            let mut bus: Bus = VecDeque::new();
+
+            let result = setting.handle(&Event::Select(EntryId::About), &mut settings, &mut bus);
+
+            assert!(result.is_none());
+        }
+
+        #[test]
+        fn handle_returns_none_for_wrong_toggle() {
+            let setting = EnableKernLog;
+            let mut settings = Settings::default();
+            let mut bus: Bus = VecDeque::new();
+
+            let result = setting.handle(
+                &Event::Toggle(ToggleEvent::Setting(ToggleSettings::LoggingEnabled)),
+                &mut settings,
+                &mut bus,
+            );
+
+            assert!(result.is_none());
+        }
+    }
+}

--- a/crates/core/src/view/settings_editor/library_editor.rs
+++ b/crates/core/src/view/settings_editor/library_editor.rs
@@ -1,9 +1,12 @@
 use super::bottom_bar::{BottomBarVariant, SettingsEditorBottomBar};
-use super::setting_row::{Kind as RowKind, SettingRow};
-use super::setting_value::{Kind as ValueKind, SettingsEvent};
+use super::kinds::library::{LibraryFinishedAction, LibraryName, LibraryPath};
+use super::kinds::SettingIdentity;
+use super::setting_row::SettingRow;
+use super::setting_value::SettingsEvent;
 use crate::color::{BLACK, WHITE};
 use crate::context::Context;
 use crate::device::CURRENT_DEVICE;
+use crate::fl;
 use crate::font::Fonts;
 use crate::framebuffer::{Framebuffer, UpdateMode};
 use crate::geom::{halves, Rectangle};
@@ -189,7 +192,7 @@ impl LibraryEditor {
         fonts: &mut crate::font::Fonts,
     ) -> Box<dyn View> {
         Box::new(SettingRow::new(
-            RowKind::LibraryName(library_index),
+            Box::new(LibraryName(library_index)),
             rect,
             settings,
             fonts,
@@ -203,7 +206,7 @@ impl LibraryEditor {
         fonts: &mut crate::font::Fonts,
     ) -> Box<dyn View> {
         Box::new(SettingRow::new(
-            RowKind::LibraryPath(library_index),
+            Box::new(LibraryPath(library_index)),
             rect,
             settings,
             fonts,
@@ -218,7 +221,7 @@ impl LibraryEditor {
         fonts: &mut crate::font::Fonts,
     ) -> Box<dyn View> {
         Box::new(SettingRow::new(
-            RowKind::LibraryFinishedAction(library_index),
+            Box::new(LibraryFinishedAction(library_index)),
             rect,
             settings,
             fonts,
@@ -386,7 +389,7 @@ impl LibraryEditor {
     fn handle_submit_name_event(&mut self, text: &str, bus: &mut Bus) -> bool {
         self.library.name = text.to_string();
         bus.push_back(Event::Settings(SettingsEvent::UpdateValue {
-            kind: ValueKind::LibraryName(self.library_index),
+            kind: SettingIdentity::LibraryName(self.library_index),
             value: text.to_string(),
         }));
         false
@@ -404,7 +407,7 @@ impl LibraryEditor {
         }
         self.library.finished = Some(action);
         bus.push_back(Event::Settings(SettingsEvent::UpdateValue {
-            kind: ValueKind::LibraryFinishedAction(self.library_index),
+            kind: SettingIdentity::LibraryFinishedAction(self.library_index),
             value: action.to_string(),
         }));
         true
@@ -417,8 +420,8 @@ impl LibraryEditor {
         }
         self.library.finished = None;
         bus.push_back(Event::Settings(SettingsEvent::UpdateValue {
-            kind: ValueKind::LibraryFinishedAction(self.library_index),
-            value: "Inherit".to_string(),
+            kind: SettingIdentity::LibraryFinishedAction(self.library_index),
+            value: fl!("settings-library-inherit"),
         }));
         true
     }
@@ -432,7 +435,7 @@ impl LibraryEditor {
         if let Some(path) = path {
             self.library.path = path.clone();
             bus.push_back(Event::Settings(SettingsEvent::UpdateValue {
-                kind: ValueKind::LibraryPath(self.library_index),
+                kind: SettingIdentity::LibraryPath(self.library_index),
                 value: path.display().to_string(),
             }));
         }

--- a/crates/core/src/view/settings_editor/mod.rs
+++ b/crates/core/src/view/settings_editor/mod.rs
@@ -27,6 +27,102 @@
 //! When a setting is modified, the CategoryEditor directly updates `context.settings`,
 //! providing immediate feedback. Settings are persisted to disk when the settings editor
 //! is closed.
+//!
+//! ## Adding a new setting
+//!
+//! Each setting is a small self-contained struct that implements [`SettingKind`].
+//! The trait carries everything the UI needs.
+//!
+//! ### 1. Add a variant to `SettingIdentity`
+//!
+//! Open `kinds/identity.rs` and add a variant for the new setting:
+//!
+//! ```rust,no_run
+//! pub enum SettingIdentity {
+//!     // ... existing variants
+//!     MyNewSetting,
+//! }
+//! ```
+//!
+//! ### 2. Implement `SettingKind`
+//!
+//! Add a struct in the appropriate `kinds/*.rs` file and implement the trait:
+//!
+//! ```rust,ignore
+//! // This example uses hypothetical types (MyNewSetting, EntryId::EditMyNewSetting)
+//! // that do not exist in the codebase — it illustrates the pattern to follow.
+//! pub struct MyNewSetting;
+//!
+//! impl SettingKind for MyNewSetting {
+//!     fn identity(&self) -> SettingIdentity {
+//!         SettingIdentity::MyNewSetting
+//!     }
+//!
+//!     fn label(&self, _settings: &Settings) -> String {
+//!         "My New Setting".to_string()
+//!     }
+//!
+//!     fn fetch(&self, settings: &Settings) -> SettingData {
+//!         SettingData {
+//!             value: settings.my_new_setting.to_string(),
+//!             widget: WidgetKind::ActionLabel(Event::Select(EntryId::EditMyNewSetting)),
+//!         }
+//!     }
+//! }
+//! ```
+//!
+//! For a **toggle** widget, use `WidgetKind::Toggle { ..., tap_event }` where
+//! `tap_event` is `Event::Toggle(ToggleEvent::Setting(ToggleSettings::MyNewSetting))`
+//! (adding the corresponding `ToggleSettings` variant in `kinds/mod.rs`).
+//!
+//! For a **sub-menu** (radio buttons), use `WidgetKind::SubMenu(entries)` where
+//! `entries` is a `Vec<`[`EntryKind`](crate::view::EntryKind)`>` — the sub-menu
+//! event is built automatically from the entries when the row is tapped.
+//!
+//! ### 3. Register the setting in `Category::settings()`
+//!
+//! Open `category.rs` and add the new kind to the relevant category arm:
+//!
+//! ```rust,ignore
+//! // This example shows a match arm inside Category::settings() — it is a
+//! // partial snippet and cannot compile standalone.
+//! Category::General => vec![
+//!     // ... existing kinds
+//!     Box::new(MyNewSetting),
+//! ],
+//! ```
+//!
+//! ### 4. Handle mutations (usually automatic)
+//!
+//! Most settings do **not** require any changes to `CategoryEditor`. The framework
+//! handles mutations automatically:
+//!
+//! - **Sub-menu / toggle / file-chooser settings**: [`SettingKind::handle`] is called
+//!   when the user makes a selection. Implement `handle` on your struct to mutate
+//!   `context.settings` and return the updated display string.
+//! - **Text-input settings**: Implement [`InputSettingKind`] and its `apply_text`
+//!   method. The overlay and submission flow are handled by [`SettingValue`].
+//!
+//! A `CategoryEditor` handler is only needed for settings with **custom event flows**
+//! not covered by the traits above — for example, library management actions that
+//! must coordinate multiple views or emit side-effect events. In that case, add a
+//! handler method in `category_editor.rs` and dispatch it from `handle_event`. After
+//! mutating `context.settings`, send `SettingsEvent::UpdateValue` so the corresponding
+//! [`SettingValue`] view refreshes its displayed text:
+//!
+//! ```rust,ignore
+//! // This example shows a method inside a CategoryEditor impl block — it is a
+//! // partial snippet and cannot compile standalone.
+//! fn handle_my_new_setting(&mut self, value: f32, hub: &Hub, context: &mut Context) -> bool {
+//!     context.settings.my_new_setting = value;
+//!     hub.send(Event::Settings(SettingsEvent::UpdateValue {
+//!         kind: SettingIdentity::MyNewSetting,
+//!         value: value.to_string(),
+//!     }))
+//!     .ok();
+//!     true
+//! }
+//! ```
 
 use crate::color::BLACK;
 use crate::context::Context;
@@ -40,6 +136,9 @@ use crate::view::navigation::stack_navigation_bar::StackNavigationBar;
 use crate::view::top_bar::{TopBar, TopBarVariant};
 use crate::view::{Bus, Event, Hub, Id, RenderData, RenderQueue, View, ViewId, ID_FEEDER};
 use crate::view::{SMALL_BAR_HEIGHT, THICKNESS_MEDIUM};
+use fxhash::FxHashMap;
+
+pub mod kinds;
 
 mod bottom_bar;
 mod category;
@@ -59,7 +158,8 @@ pub use self::category_button::CategoryButton;
 pub use self::category_editor::CategoryEditor;
 pub use self::category_navigation_bar::CategoryNavigationBar;
 pub use self::category_provider::SettingsCategoryProvider;
-pub use self::setting_row::{Kind as RowKind, SettingRow};
+pub use self::kinds::{InputSettingKind, SettingIdentity, SettingKind};
+pub use self::setting_row::SettingRow;
 pub use self::setting_value::SettingValue;
 
 /// Main settings editor view.
@@ -75,12 +175,18 @@ pub use self::setting_value::SettingValue;
 /// - `children`: Child views including the top bar, separators, navigation bar, and category editor
 /// - `nav_bar_index`: Index of the StackNavigationBar in the children vector
 /// - `editor_index`: Index of the CategoryEditor in the children vector
+/// - `editors`: Pre-built [`CategoryEditor`] instances for all inactive categories, keyed by
+///   [`Category`]. On tab switch the active editor is returned here and the target is pulled
+///   out, avoiding a full view-tree rebuild on every navigation. The [`Category::Libraries`]
+///   editor is included and stays current because every library mutation calls
+///   `rebuild_library_rows` before returning.
 pub struct SettingsEditor {
     id: Id,
     rect: Rectangle,
     children: Vec<Box<dyn View>>,
     nav_bar_index: usize,
     editor_index: usize,
+    editors: FxHashMap<Category, Box<dyn View>>,
 }
 
 impl SettingsEditor {
@@ -133,6 +239,17 @@ impl SettingsEditor {
         let editor_index = children.len();
         children.push(Box::new(category_editor));
 
+        let mut editors: FxHashMap<Category, Box<dyn View>> = FxHashMap::default();
+
+        for category in Category::all() {
+            if category == Category::General {
+                continue;
+            }
+
+            let editor = CategoryEditor::new(content_rect, category, rq, context);
+            editors.insert(category, Box::new(editor));
+        }
+
         rq.add(RenderData::new(id, rect, UpdateMode::Gui));
 
         SettingsEditor {
@@ -141,6 +258,7 @@ impl SettingsEditor {
             children,
             nav_bar_index,
             editor_index,
+            editors,
         }
     }
 
@@ -218,12 +336,19 @@ impl View for SettingsEditor {
                     let nav_bar = self.children[self.nav_bar_index]
                         .downcast_mut::<StackNavigationBar<SettingsCategoryProvider>>()
                         .unwrap();
-
                     nav_bar.set_selected(*category, rq, context);
                     nav_bar.rect.max.y
                 };
 
-                self.children.remove(self.editor_index);
+                let current_category = self.children[self.editor_index]
+                    .downcast_ref::<CategoryEditor>()
+                    .map(|e| e.category());
+
+                let outgoing = self.children.remove(self.editor_index);
+
+                if let Some(cat) = current_category {
+                    self.editors.insert(cat, outgoing);
+                }
 
                 let content_rect = rect![
                     self.rect.min.x,
@@ -232,12 +357,14 @@ impl View for SettingsEditor {
                     self.rect.max.y
                 ];
 
-                let new_editor = CategoryEditor::new(content_rect, *category, rq, context);
-                self.children
-                    .insert(self.editor_index, Box::new(new_editor));
+                let incoming = self.editors.remove(category).unwrap_or_else(|| {
+                    Box::new(CategoryEditor::new(content_rect, *category, rq, context))
+                        as Box<dyn View>
+                });
+
+                self.children.insert(self.editor_index, incoming);
 
                 rq.add(RenderData::new(self.id, self.rect, UpdateMode::Gui));
-
                 true
             }
             Event::NavigationBarResized(_) => {

--- a/crates/core/src/view/settings_editor/setting_row.rs
+++ b/crates/core/src/view/settings_editor/setting_row.rs
@@ -1,106 +1,12 @@
 use super::super::label::Label;
 use super::super::Align;
 use super::super::{Bus, Event, Hub, Id, RenderQueue, View, ID_FEEDER};
-use super::setting_value::{Kind as ValueKind, SettingValue};
+use super::kinds::{SettingIdentity, SettingKind};
+use super::setting_value::SettingValue;
 use crate::context::Context;
 use crate::framebuffer::Framebuffer;
 use crate::geom::Rectangle;
 use crate::settings::Settings;
-use crate::view::settings_editor::ToggleSettings;
-
-pub enum Kind {
-    Locale,
-    KeyboardLayout,
-    SleepCover,
-    AutoShare,
-    AutoSuspend,
-    AutoPowerOff,
-    ButtonScheme,
-    FinishedAction,
-    Library(usize),
-    LibraryName(usize),
-    LibraryPath(usize),
-    LibraryFinishedAction(usize),
-    IntermissionSuspend,
-    IntermissionPowerOff,
-    IntermissionShare,
-    SettingsRetention,
-    LoggingEnabled,
-    LogLevel,
-    #[cfg(feature = "otel")]
-    OtlpEndpoint,
-    #[cfg(feature = "test")]
-    EnableKernLog,
-}
-
-impl Kind {
-    /// Returns the human-readable label for this setting kind.
-    ///
-    /// # Arguments
-    ///
-    /// * `settings` - The current settings, used to look up dynamic labels (e.g., library names)
-    ///
-    /// # Returns
-    ///
-    /// A `String` containing the display label for this setting
-    pub fn label(&self, settings: &Settings) -> String {
-        match self {
-            Kind::Locale => "Language".to_string(),
-            Kind::KeyboardLayout => "Keyboard Layout".to_string(),
-            Kind::SleepCover => "Enable Sleep Cover".to_string(),
-            Kind::AutoShare => "Enable Auto Share".to_string(),
-            Kind::AutoSuspend => "Auto Suspend (minutes)".to_string(),
-            Kind::AutoPowerOff => "Auto Power Off (days)".to_string(),
-            Kind::ButtonScheme => "Button Scheme".to_string(),
-            Kind::FinishedAction => "End of Book Action".to_string(),
-            Kind::Library(index) => settings
-                .libraries
-                .get(*index)
-                .map(|lib| lib.name.clone())
-                .unwrap_or_else(|| "Unknown".to_string()),
-            Kind::LibraryName(_) => "Name".to_string(),
-            Kind::LibraryPath(_) => "Path".to_string(),
-            Kind::LibraryFinishedAction(_) => "End of Book Action".to_string(),
-            Kind::IntermissionSuspend => "Suspend Screen".to_string(),
-            Kind::IntermissionPowerOff => "Power Off Screen".to_string(),
-            Kind::IntermissionShare => "Share Screen".to_string(),
-            Kind::SettingsRetention => "Settings Retention".to_string(),
-            Kind::LoggingEnabled => "Enable Logging".to_string(),
-            Kind::LogLevel => "Log Level".to_string(),
-            #[cfg(feature = "otel")]
-            Kind::OtlpEndpoint => "OTLP Endpoint".to_string(),
-            #[cfg(feature = "test")]
-            Kind::EnableKernLog => "Enable Kernel Log".to_string(),
-        }
-    }
-
-    fn value_kind(&self) -> ValueKind {
-        match self {
-            Kind::Locale => ValueKind::Locale,
-            Kind::KeyboardLayout => ValueKind::KeyboardLayout,
-            Kind::SleepCover => ValueKind::Toggle(ToggleSettings::SleepCover),
-            Kind::AutoShare => ValueKind::Toggle(ToggleSettings::AutoShare),
-            Kind::AutoSuspend => ValueKind::AutoSuspend,
-            Kind::AutoPowerOff => ValueKind::AutoPowerOff,
-            Kind::ButtonScheme => ValueKind::Toggle(ToggleSettings::ButtonScheme),
-            Kind::FinishedAction => ValueKind::FinishedAction,
-            Kind::Library(index) => ValueKind::LibraryInfo(*index),
-            Kind::LibraryName(index) => ValueKind::LibraryName(*index),
-            Kind::LibraryPath(index) => ValueKind::LibraryPath(*index),
-            Kind::LibraryFinishedAction(index) => ValueKind::LibraryFinishedAction(*index),
-            Kind::IntermissionSuspend => ValueKind::IntermissionSuspend,
-            Kind::IntermissionPowerOff => ValueKind::IntermissionPowerOff,
-            Kind::IntermissionShare => ValueKind::IntermissionShare,
-            Kind::SettingsRetention => ValueKind::SettingsRetention,
-            Kind::LoggingEnabled => ValueKind::Toggle(ToggleSettings::LoggingEnabled),
-            Kind::LogLevel => ValueKind::LogLevel,
-            #[cfg(feature = "otel")]
-            Kind::OtlpEndpoint => ValueKind::OtlpEndpoint,
-            #[cfg(feature = "test")]
-            Kind::EnableKernLog => ValueKind::Toggle(ToggleSettings::EnableKernLog),
-        }
-    }
-}
 
 /// A row in the settings UI that displays a setting label and its corresponding value.
 ///
@@ -108,22 +14,19 @@ impl Kind {
 /// - A `Label` displaying the human-readable name of the setting
 /// - A `SettingValue` displaying the current value and allowing modifications
 ///
-/// # Fields
-///
-/// * `id` - Unique identifier for this view
-/// * `rect` - The rectangular area occupied by this row
-/// * `children` - Vector containing the label and value child views
-/// * `kind` - The type of setting this row represents
+/// The row is completely driven by a [`SettingKind`] implementation — no match arms
+/// are needed here.
 pub struct SettingRow {
     id: Id,
     rect: Rectangle,
     children: Vec<Box<dyn View>>,
-    kind: Kind,
+    /// Kept for the `UpdateLibrary` special case that relabels library rows.
+    identity: SettingIdentity,
 }
 
 impl SettingRow {
     pub fn new(
-        kind: Kind,
+        kind: impl SettingKind + 'static,
         rect: Rectangle,
         settings: &Settings,
         fonts: &mut crate::font::Fonts,
@@ -135,17 +38,18 @@ impl SettingRow {
         let value_rect = rect![rect.min.x + half_width, rect.min.y, rect.max.x, rect.max.y];
 
         let label_text = kind.label(settings);
+        let identity = kind.identity();
         let label = Label::new(label_rect, label_text, Align::Left(50));
         children.push(Box::new(label) as Box<dyn View>);
 
-        let setting_value = SettingValue::new(kind.value_kind(), value_rect, settings, fonts);
+        let setting_value = SettingValue::new(kind, value_rect, settings, fonts);
         children.push(Box::new(setting_value) as Box<dyn View>);
 
         SettingRow {
             id: ID_FEEDER.next(),
             rect,
             children,
-            kind,
+            identity,
         }
     }
 }
@@ -161,9 +65,9 @@ impl View for SettingRow {
         _context: &mut Context,
     ) -> bool {
         match evt {
-            Event::UpdateLibrary(index, ref library) => match &self.kind {
-                Kind::Library(our_index) => {
-                    if index == our_index {
+            Event::UpdateLibrary(index, ref library) => {
+                if let SettingIdentity::LibraryInfo(our_index) = self.identity {
+                    if *index == our_index {
                         if let Some(name_view) = self.children.get_mut(0) {
                             if let Some(name_label) = name_view.as_any_mut().downcast_mut::<Label>()
                             {
@@ -172,10 +76,9 @@ impl View for SettingRow {
                             }
                         }
                     }
-                    false
                 }
-                _ => false,
-            },
+                false
+            }
             _ => false,
         }
     }
@@ -210,6 +113,7 @@ mod tests {
     use super::*;
     use crate::context::test_helpers::create_test_context;
     use crate::settings::LibrarySettings;
+    use crate::view::settings_editor::kinds::library::LibraryInfo;
     use std::collections::VecDeque;
     use std::path::PathBuf;
     use std::sync::mpsc::channel;
@@ -236,7 +140,7 @@ mod tests {
         let settings = create_test_settings();
         let rect = rect![0, 0, 400, 60];
 
-        let mut row = SettingRow::new(Kind::Library(0), rect, &settings, &mut context.fonts);
+        let mut row = SettingRow::new(LibraryInfo(0), rect, &settings, &mut context.fonts);
 
         let (hub, _receiver) = channel();
         let mut bus = VecDeque::new();
@@ -248,7 +152,7 @@ mod tests {
             ..Default::default()
         };
 
-        let event = Event::UpdateLibrary(0, Box::new(updated_library.clone()));
+        let event = Event::UpdateLibrary(0, Box::new(updated_library));
         let handled = row.handle_event(&event, &hub, &mut bus, &mut rq, &mut context);
 
         assert!(handled);
@@ -261,7 +165,7 @@ mod tests {
         let settings = create_test_settings();
         let rect = rect![0, 0, 400, 60];
 
-        let mut row = SettingRow::new(Kind::Library(0), rect, &settings, &mut context.fonts);
+        let mut row = SettingRow::new(LibraryInfo(0), rect, &settings, &mut context.fonts);
 
         let (hub, _receiver) = channel();
         let mut bus = VecDeque::new();

--- a/crates/core/src/view/settings_editor/setting_value.rs
+++ b/crates/core/src/view/settings_editor/setting_value.rs
@@ -1,626 +1,152 @@
 use super::super::action_label::ActionLabel;
-use super::super::EntryKind;
-use super::super::{Align, Bus, Event, Hub, Id, RenderQueue, View, ID_FEEDER};
+use super::super::{Align, Bus, Event, Hub, Id, RenderQueue, View, ViewId, ID_FEEDER};
+use super::kinds::{SettingIdentity, SettingKind, WidgetKind};
 use crate::context::Context;
-use crate::framebuffer::Framebuffer;
+use crate::framebuffer::{Framebuffer, UpdateMode};
 use crate::geom::Rectangle;
-use crate::i18n;
-use crate::settings::{ButtonScheme, FinishedAction, IntermKind, Settings};
-use crate::view::{toggle::Toggle, EntryId, ToggleEvent};
-use anyhow::Error;
-use std::fs;
-use std::path::Path;
-use std::str::FromStr;
+use crate::settings::Settings;
+use crate::view::common::locate_by_id;
+use crate::view::file_chooser::{FileChooser, SelectionMode};
+use crate::view::toggle::Toggle;
+use crate::view::{EntryKind, RenderData};
+
+/// Re-exported for use in `ToggleEvent::Setting` and `CategoryEditor`.
+pub use super::kinds::ToggleSettings;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum SettingsEvent {
-    /// Updates a SettingValue view by its Kind with a new value.
+    /// Updates a SettingValue view by its identity with a new value.
     ///
-    /// Each SettingValue checks if the kind matches its own kind, and updates
-    /// itself if there's a match. This allows targeted updates without needing
+    /// Each SettingValue checks if the identity matches its own, and updates
+    /// itself if there is a match. This allows targeted updates without needing
     /// to know the specific view ID.
     UpdateValue {
-        /// The Kind of SettingValue to update (matches against self.kind)
-        kind: Kind,
+        /// The identity of the SettingValue to update (matches against self.identity)
+        kind: SettingIdentity,
         /// The new value to display
         value: String,
     },
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum ToggleSettings {
-    /// Sleep cover enable/disable setting
-    SleepCover,
-    /// Auto-share enable/disable setting
-    AutoShare,
-    /// Button scheme selection (natural or inverted)
-    ButtonScheme,
-    /// Logging enabled setting
-    LoggingEnabled,
-    /// Kernel logging enabled setting (test builds only)
-    #[cfg(feature = "test")]
-    EnableKernLog,
-}
-
-/// Represents the type of setting value being displayed.
-///
-/// This enum categorizes different settings that can be configured in the application,
-/// including keyboard layout, power management, button schemes, and library settings.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum Kind {
-    /// Keyboard layout selection setting
-    KeyboardLayout,
-    /// Locale selection setting
-    Locale,
-    /// Auto-suspend timeout setting (in minutes)
-    AutoSuspend,
-    /// Auto power-off timeout setting (in minutes)
-    AutoPowerOff,
-
-    /// Generic toggle setting
-    Toggle(ToggleSettings),
-
-    /// Global finished action setting (what to do when a book is finished)
-    FinishedAction,
-    /// Library info display for the library at the given index
-    LibraryInfo(usize),
-    /// Library name setting for the library at the given index
-    LibraryName(usize),
-    /// Library path setting for the library at the given index
-    LibraryPath(usize),
-    /// Per-library finished action override for the library at the given index
-    LibraryFinishedAction(usize),
-    /// Intermission display setting for suspend screen
-    IntermissionSuspend,
-    /// Intermission display setting for power-off screen
-    IntermissionPowerOff,
-    /// Intermission display setting for share screen
-    IntermissionShare,
-    /// Settings retention setting (how many old versions to keep)
-    SettingsRetention,
-    /// Log level setting
-    LogLevel,
-    /// OTLP endpoint setting (only available with otel feature)
-    #[cfg(feature = "otel")]
-    OtlpEndpoint,
-}
-
-impl Kind {
-    pub fn matches_interm_kind(&self, interm_kind: &IntermKind) -> bool {
-        matches!(
-            (self, interm_kind),
-            (Kind::IntermissionSuspend, IntermKind::Suspend)
-                | (Kind::IntermissionPowerOff, IntermKind::PowerOff)
-                | (Kind::IntermissionShare, IntermKind::Share)
-        )
-    }
-}
-
 /// Represents a single setting value display in the settings UI.
 ///
-/// This struct manages the display and interaction of a setting value, including
-/// the current value, available options (entries), and associated UI components.
-/// It acts as a View that can be rendered and handle events related to setting changes.
-#[derive(Debug)]
+/// This struct manages the display and interaction of a setting value and its
+/// associated UI widget (an [`ActionLabel`], a sub-menu label, or a [`Toggle`]).
+/// It acts as a View that handles events via the [`SettingKind`] trait, updating the
+/// displayed text and sub-menu checked state when the underlying setting changes.
 pub struct SettingValue {
     /// Unique identifier for this setting value view
     id: Id,
-    /// The type of setting this value represents
-    kind: Kind,
     /// The rectangular area occupied by this view
     rect: Rectangle,
-    /// Child views, typically containing an ActionLabel for display
+    /// Child views — a single ActionLabel or Toggle widget, plus any active NamedInput overlay
     children: Vec<Box<dyn View>>,
-    /// Available options/entries for this setting (e.g., radio buttons, checkboxes)
-    ///
-    /// # Important
-    /// Whenever this field is modified, the underlying ActionLabel's event must be updated
-    /// by calling `create_tap_event()` and setting it via `action_label.set_event()`.
-    /// This ensures the tap behavior reflects the current entries state.
+    /// Retained so that SubMenu entries can be rebuilt with updated checked
+    /// state each time UpdateValue is received, and to provide identity for
+    /// routing [`SettingsEvent::UpdateValue`] without a separate field.
+    kind: Box<dyn SettingKind>,
+    /// Current SubMenu entries, exposed for test inspection.
+    #[cfg(test)]
+    pub entries: Vec<EntryKind>,
+    #[cfg(not(test))]
     entries: Vec<EntryKind>,
+    /// Tracks the ViewId of an active NamedInput child, if one is open.
+    active_input: Option<ViewId>,
+    /// Whether a FileChooser overlay is currently open as a child.
+    active_file_chooser: bool,
+    /// Keeps the temporary directory alive for the duration of the FileChooser session.
+    /// Without this, the directory would be deleted before FileChooser can use it.
+    #[cfg(test)]
+    _temp_dir: Option<tempfile::TempDir>,
+}
+
+impl std::fmt::Debug for SettingValue {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SettingValue")
+            .field("id", &self.id)
+            .field("identity", &self.kind.identity())
+            .field("rect", &self.rect)
+            .finish_non_exhaustive()
+    }
 }
 
 impl SettingValue {
+    /// Creates a new `SettingValue` for the given `kind`.
+    ///
+    /// `kind` accepts any owned value that implements [`SettingKind`], including references
+    /// (`&T`), boxes (`Box<T>`), and concrete types directly. The value is erased into a
+    /// `Box<dyn SettingKind>` internally, so the caller does not need to box it beforehand.
     pub fn new(
-        kind: Kind,
+        kind: impl SettingKind + 'static,
         rect: Rectangle,
         settings: &Settings,
         fonts: &mut crate::font::Fonts,
     ) -> SettingValue {
-        let (value, entries, enabled_toggle) = Self::fetch_data_for_kind(&kind, settings);
+        let kind: Box<dyn SettingKind> = Box::new(kind);
+        let data = kind.fetch(settings);
+
+        let entries = if let WidgetKind::SubMenu(ref e) = data.widget {
+            e.clone()
+        } else {
+            Vec::new()
+        };
 
         let mut setting_value = SettingValue {
             id: ID_FEEDER.next(),
-            kind,
             rect,
             children: vec![],
+            kind,
             entries,
+            active_input: None,
+            active_file_chooser: false,
+            #[cfg(test)]
+            _temp_dir: None,
         };
 
         setting_value.children =
-            vec![setting_value.kind_to_child_view(value, enabled_toggle, fonts)];
+            vec![setting_value.build_child_view(data.value, data.widget, fonts)];
 
         setting_value
     }
 
-    fn kind_to_child_view(
+    fn build_child_view(
         &self,
         value: String,
-        enabled_toggle: Option<bool>,
+        widget: WidgetKind,
         fonts: &mut crate::font::Fonts,
     ) -> Box<dyn View> {
-        let event = self.create_tap_event();
-
-        match self.kind {
-            Kind::Toggle(ref toggle) => match toggle {
-                ToggleSettings::AutoShare => Box::new(Toggle::new(
-                    self.rect,
-                    "on",
-                    "off",
-                    enabled_toggle.expect("enabled bool should be Some for toggle settings"),
-                    event.expect("Event should not be None for toggle"),
-                    fonts,
-                    Align::Right(10),
-                )),
-                ToggleSettings::ButtonScheme => Box::new(Toggle::new(
-                    self.rect,
-                    ButtonScheme::Natural.to_string().as_str(),
-                    ButtonScheme::Inverted.to_string().as_str(),
-                    enabled_toggle.expect("enabled bool should be Some for toggle settings"),
-                    event.expect("Event should not be None for toggle"),
-                    fonts,
-                    Align::Right(10),
-                )),
-                ToggleSettings::SleepCover => Box::new(Toggle::new(
-                    self.rect,
-                    "on",
-                    "off",
-                    enabled_toggle.expect("enabled bool should be Some for toggle settings"),
-                    event.expect("Event should not be None for toggle"),
-                    fonts,
-                    Align::Right(10),
-                )),
-                ToggleSettings::LoggingEnabled => Box::new(Toggle::new(
-                    self.rect,
-                    "on",
-                    "off",
-                    enabled_toggle.expect("enabled bool should be Some for toggle settings"),
-                    event.expect("Event should not be None for toggle"),
-                    fonts,
-                    Align::Right(10),
-                )),
-                #[cfg(feature = "test")]
-                ToggleSettings::EnableKernLog => Box::new(Toggle::new(
-                    self.rect,
-                    "on",
-                    "off",
-                    enabled_toggle.expect("enabled bool should be Some for toggle settings"),
-                    event.expect("Event should not be None for toggle"),
-                    fonts,
-                    Align::Right(10),
-                )),
-            },
-            _ => Box::new(ActionLabel::new(self.rect, value, Align::Right(10)).event(event)),
-        }
-    }
-
-    /// Refreshes the displayed value by re-reading from context.settings.
-    ///
-    /// This method updates the ActionLabel text to reflect the current state of the setting
-    /// in context.settings. It should be called whenever the underlying setting changes.
-    ///
-    /// # Deprecated
-    /// This method relies on context.settings which may not reflect the current
-    /// editing state. Use `Event::Settings(SettingsEvent::UpdateValue { kind, value })`
-    /// instead to directly update SettingValue views during editing.
-    #[deprecated(note = "use Event::Settings(SettingsEvent::UpdateValue { kind, value }) instead")]
-    pub fn refresh_from_context(&mut self, context: &Context, rq: &mut RenderQueue) {
-        let (value, entries, _enabled_toggle) =
-            Self::fetch_data_for_kind(&self.kind, &context.settings);
-        self.entries = entries;
-        let event = self.create_tap_event();
-
-        if let Some(action_label) = self.children.get_mut(0) {
-            if let Some(label) = action_label.as_any_mut().downcast_mut::<ActionLabel>() {
-                label.update(&value, rq);
-                label.set_event(event);
+        match widget {
+            WidgetKind::Toggle {
+                left_label,
+                right_label,
+                enabled,
+                tap_event,
+            } => Box::new(Toggle::new(
+                self.rect,
+                &left_label,
+                &right_label,
+                enabled,
+                tap_event,
+                fonts,
+                Align::Right(10),
+            )),
+            WidgetKind::ActionLabel(tap_event) => Box::new(
+                ActionLabel::new(self.rect, value, Align::Right(10)).event(Some(tap_event)),
+            ),
+            WidgetKind::SubMenu(entries) => {
+                let event = Some(Event::SubMenu(self.rect, entries));
+                Box::new(ActionLabel::new(self.rect, value, Align::Right(10)).event(event))
             }
         }
     }
 
-    fn fetch_data_for_kind(
-        kind: &Kind,
-        settings: &Settings,
-    ) -> (String, Vec<EntryKind>, Option<bool>) {
-        match kind {
-            Kind::KeyboardLayout => Self::fetch_keyboard_layout_data(settings),
-            Kind::Locale => Self::fetch_locale_data(settings),
-            Kind::AutoSuspend => Self::fetch_auto_suspend_data(settings),
-            Kind::AutoPowerOff => Self::fetch_auto_power_off_data(settings),
-            Kind::FinishedAction => Self::fetch_finished_action_data(settings),
-            Kind::LibraryInfo(index) => Self::fetch_library_info_data(*index, settings),
-            Kind::LibraryName(index) => Self::fetch_library_name_data(*index, settings),
-            Kind::LibraryPath(index) => Self::fetch_library_path_data(*index, settings),
-            Kind::LibraryFinishedAction(index) => {
-                Self::fetch_library_finished_action_data(*index, settings)
-            }
-            Kind::IntermissionSuspend => {
-                Self::fetch_intermission_data(crate::settings::IntermKind::Suspend, settings)
-            }
-            Kind::IntermissionPowerOff => {
-                Self::fetch_intermission_data(crate::settings::IntermKind::PowerOff, settings)
-            }
-            Kind::IntermissionShare => {
-                Self::fetch_intermission_data(crate::settings::IntermKind::Share, settings)
-            }
-            Kind::SettingsRetention => Self::fetch_settings_retention_data(settings),
-            Kind::LogLevel => Self::fetch_log_level_data(settings),
-            #[cfg(feature = "otel")]
-            Kind::OtlpEndpoint => Self::fetch_otlp_endpoint_data(settings),
-            Kind::Toggle(toggle) => match toggle {
-                ToggleSettings::SleepCover => Self::fetch_sleep_cover_data(settings),
-                ToggleSettings::AutoShare => Self::fetch_auto_share_data(settings),
-                ToggleSettings::ButtonScheme => Self::fetch_button_scheme_data(settings),
-                ToggleSettings::LoggingEnabled => Self::fetch_logging_enabled_data(settings),
-                #[cfg(feature = "test")]
-                ToggleSettings::EnableKernLog => Self::fetch_enable_kern_log_data(settings),
-            },
-        }
-    }
-
-    fn fetch_locale_data(settings: &Settings) -> (String, Vec<EntryKind>, Option<bool>) {
-        let current = settings.locale.as_ref().map(|l| l.to_string());
-
-        let display = current
-            .as_deref()
-            .unwrap_or(i18n::DEFAULT_LOCALE)
-            .to_string();
-
-        let entries = crate::i18n::AVAILABLE_LOCALES
-            .iter()
-            .map(|&tag| {
-                let lang_id: Option<unic_langid::LanguageIdentifier> = tag.parse().ok();
-                EntryKind::RadioButton(
-                    tag.to_string(),
-                    EntryId::SetLocale(lang_id),
-                    current.as_deref() == Some(tag),
-                )
-            })
-            .collect();
-
-        (display, entries, None)
-    }
-
-    fn fetch_keyboard_layout_data(settings: &Settings) -> (String, Vec<EntryKind>, Option<bool>) {
-        let current_layout = settings.keyboard_layout.clone();
-        let available_layouts = Self::get_available_layouts().unwrap_or_default();
-
-        let entries: Vec<EntryKind> = available_layouts
-            .iter()
-            .map(|layout| {
-                EntryKind::RadioButton(
-                    layout.clone(),
-                    EntryId::SetKeyboardLayout(layout.clone()),
-                    current_layout == *layout,
-                )
-            })
-            .collect();
-
-        (current_layout, entries, None)
-    }
-
-    fn fetch_sleep_cover_data(settings: &Settings) -> (String, Vec<EntryKind>, Option<bool>) {
-        let enabled = settings.sleep_cover;
-        let value = if enabled {
-            "Enabled".to_string()
-        } else {
-            "Disabled".to_string()
-        };
-
-        (value, vec![], Some(settings.sleep_cover))
-    }
-
-    fn fetch_auto_share_data(settings: &Settings) -> (String, Vec<EntryKind>, Option<bool>) {
-        let enabled = settings.auto_share;
-        let value = if enabled {
-            "Enabled".to_string()
-        } else {
-            "Disabled".to_string()
-        };
-
-        (value, vec![], Some(settings.auto_share))
-    }
-
-    fn fetch_button_scheme_data(settings: &Settings) -> (String, Vec<EntryKind>, Option<bool>) {
-        let current_scheme = settings.button_scheme;
-        let value = format!("{:?}", current_scheme);
-
-        (
-            value,
-            vec![],
-            Some(settings.button_scheme == ButtonScheme::Natural),
-        )
-    }
-
-    fn fetch_auto_suspend_data(settings: &Settings) -> (String, Vec<EntryKind>, Option<bool>) {
-        let value = if settings.auto_suspend == 0.0 {
-            "Never".to_string()
-        } else {
-            format!("{:.1}", settings.auto_suspend)
-        };
-
-        (value, vec![], None)
-    }
-
-    fn fetch_auto_power_off_data(settings: &Settings) -> (String, Vec<EntryKind>, Option<bool>) {
-        let value = if settings.auto_power_off == 0.0 {
-            "Never".to_string()
-        } else {
-            format!("{:.1}", settings.auto_power_off)
-        };
-
-        (value, vec![], None)
-    }
-
-    #[inline]
-    fn fetch_settings_retention_data(
-        settings: &Settings,
-    ) -> (String, Vec<EntryKind>, Option<bool>) {
-        let value = settings.settings_retention.to_string();
-
-        (value, vec![], None)
-    }
-
-    #[inline]
-    fn fetch_logging_enabled_data(settings: &Settings) -> (String, Vec<EntryKind>, Option<bool>) {
-        let toggle = settings.logging.enabled;
-        (toggle.to_string(), vec![], Some(settings.logging.enabled))
-    }
-
-    #[cfg(feature = "test")]
-    #[inline]
-    fn fetch_enable_kern_log_data(settings: &Settings) -> (String, Vec<EntryKind>, Option<bool>) {
-        let toggle = settings.logging.enable_kern_log;
-        (
-            toggle.to_string(),
-            vec![],
-            Some(settings.logging.enable_kern_log),
-        )
-    }
-
-    #[inline]
-    fn fetch_log_level_data(settings: &Settings) -> (String, Vec<EntryKind>, Option<bool>) {
-        let current = tracing::Level::from_str(settings.logging.level.as_str())
-            .unwrap_or(tracing::Level::INFO);
-
-        let entries = vec![
-            EntryKind::RadioButton(
-                tracing::Level::TRACE.to_string(),
-                EntryId::SetLogLevel(tracing::Level::TRACE),
-                current == tracing::Level::TRACE,
-            ),
-            EntryKind::RadioButton(
-                tracing::Level::DEBUG.to_string(),
-                EntryId::SetLogLevel(tracing::Level::DEBUG),
-                current == tracing::Level::DEBUG,
-            ),
-            EntryKind::RadioButton(
-                tracing::Level::INFO.to_string(),
-                EntryId::SetLogLevel(tracing::Level::INFO),
-                current == tracing::Level::INFO,
-            ),
-            EntryKind::RadioButton(
-                tracing::Level::WARN.to_string(),
-                EntryId::SetLogLevel(tracing::Level::WARN),
-                current == tracing::Level::WARN,
-            ),
-            EntryKind::RadioButton(
-                tracing::Level::ERROR.to_string(),
-                EntryId::SetLogLevel(tracing::Level::ERROR),
-                current == tracing::Level::ERROR,
-            ),
-        ];
-
-        (current.to_string(), entries, None)
-    }
-
-    #[cfg(feature = "otel")]
-    #[inline]
-    fn fetch_otlp_endpoint_data(settings: &Settings) -> (String, Vec<EntryKind>, Option<bool>) {
-        let value = settings
-            .logging
-            .otlp_endpoint
-            .clone()
-            .unwrap_or_else(|| "Not set".to_string());
-
-        (value, vec![], None)
-    }
-
-    #[inline]
-    fn fetch_finished_action_data(settings: &Settings) -> (String, Vec<EntryKind>, Option<bool>) {
-        let current = settings.reader.finished;
-
-        let value = current.to_string();
-
-        let entries = vec![
-            EntryKind::RadioButton(
-                FinishedAction::Notify.to_string(),
-                EntryId::SetFinishedAction(FinishedAction::Notify),
-                current == FinishedAction::Notify,
-            ),
-            EntryKind::RadioButton(
-                FinishedAction::Close.to_string(),
-                EntryId::SetFinishedAction(FinishedAction::Close),
-                current == FinishedAction::Close,
-            ),
-            EntryKind::RadioButton(
-                FinishedAction::GoToNext.to_string(),
-                EntryId::SetFinishedAction(FinishedAction::GoToNext),
-                current == FinishedAction::GoToNext,
-            ),
-        ];
-
-        (value, entries, None)
-    }
-
-    #[inline]
-    fn fetch_library_finished_action_data(
-        index: usize,
-        settings: &Settings,
-    ) -> (String, Vec<EntryKind>, Option<bool>) {
-        let current = settings.libraries.get(index).and_then(|lib| lib.finished);
-
-        let value = current
-            .map(|action| action.to_string())
-            .unwrap_or_else(|| "Inherit".to_string());
-
-        let entries = vec![
-            EntryKind::RadioButton(
-                "Inherit".to_string(),
-                EntryId::ClearLibraryFinishedAction(index),
-                current.is_none(),
-            ),
-            EntryKind::RadioButton(
-                FinishedAction::Notify.to_string(),
-                EntryId::SetLibraryFinishedAction(index, FinishedAction::Notify),
-                current == Some(FinishedAction::Notify),
-            ),
-            EntryKind::RadioButton(
-                FinishedAction::Close.to_string(),
-                EntryId::SetLibraryFinishedAction(index, FinishedAction::Close),
-                current == Some(FinishedAction::Close),
-            ),
-            EntryKind::RadioButton(
-                FinishedAction::GoToNext.to_string(),
-                EntryId::SetLibraryFinishedAction(index, FinishedAction::GoToNext),
-                current == Some(FinishedAction::GoToNext),
-            ),
-        ];
-
-        (value, entries, None)
-    }
-
-    fn fetch_library_info_data(
-        index: usize,
-        settings: &Settings,
-    ) -> (String, Vec<EntryKind>, Option<bool>) {
-        if let Some(library) = settings.libraries.get(index) {
-            let value = library.path.display().to_string();
-
-            (value, vec![], None)
-        } else {
-            ("Unknown".to_string(), vec![], None)
-        }
-    }
-
-    fn fetch_library_name_data(
-        index: usize,
-        settings: &Settings,
-    ) -> (String, Vec<EntryKind>, Option<bool>) {
-        if let Some(library) = settings.libraries.get(index) {
-            (library.name.clone(), vec![], None)
-        } else {
-            ("Unknown".to_string(), vec![], None)
-        }
-    }
-
-    fn fetch_library_path_data(
-        index: usize,
-        settings: &Settings,
-    ) -> (String, Vec<EntryKind>, Option<bool>) {
-        if let Some(library) = settings.libraries.get(index) {
-            (library.path.display().to_string(), vec![], None)
-        } else {
-            ("Unknown".to_string(), vec![], None)
-        }
-    }
-
-    fn get_available_layouts() -> Result<Vec<String>, Error> {
-        let layouts_dir = Path::new("keyboard-layouts");
-        let mut layouts = Vec::new();
-
-        if layouts_dir.exists() {
-            for entry in fs::read_dir(layouts_dir)? {
-                let entry = entry?;
-                let path = entry.path();
-
-                if path.extension().and_then(|s| s.to_str()) == Some("json") {
-                    if let Some(stem) = path.file_stem().and_then(|s| s.to_str()) {
-                        let layout_name = stem
-                            .chars()
-                            .enumerate()
-                            .map(|(i, c)| {
-                                if i == 0 {
-                                    c.to_uppercase().collect::<String>()
-                                } else {
-                                    c.to_string()
-                                }
-                            })
-                            .collect::<String>();
-                        layouts.push(layout_name);
-                    }
-                }
-            }
-        }
-
-        layouts.sort();
-        Ok(layouts)
-    }
-
-    fn fetch_intermission_data(
-        kind: IntermKind,
-        settings: &Settings,
-    ) -> (String, Vec<EntryKind>, Option<bool>) {
-        use crate::settings::IntermissionDisplay;
-
-        let display = &settings.intermissions[kind];
-
-        let (value, is_logo, is_cover) = match display {
-            IntermissionDisplay::Logo => ("Logo".to_string(), true, false),
-            IntermissionDisplay::Cover => ("Cover".to_string(), false, true),
-            IntermissionDisplay::Image(path) => {
-                let display_name = path
-                    .file_name()
-                    .and_then(|n| n.to_str())
-                    .unwrap_or("Custom")
-                    .to_string();
-                (display_name, false, false)
-            }
-        };
-
-        let entries = vec![
-            EntryKind::RadioButton(
-                "Logo".to_string(),
-                EntryId::SetIntermission(kind, IntermissionDisplay::Logo),
-                is_logo,
-            ),
-            EntryKind::RadioButton(
-                "Cover".to_string(),
-                EntryId::SetIntermission(kind, IntermissionDisplay::Cover),
-                is_cover,
-            ),
-            EntryKind::Command(
-                "Custom Image...".to_string(),
-                EntryId::EditIntermissionImage(kind),
-            ),
-        ];
-
-        (value, entries, None)
-    }
-
-    pub fn update(&mut self, value: String, context: &Context, rq: &mut RenderQueue) {
+    pub fn update(&mut self, value: String, settings: &Settings, rq: &mut RenderQueue) {
         if let Some(action_label) = self.children[0].downcast_mut::<ActionLabel>() {
             action_label.update(&value, rq);
-        }
 
-        if !self.entries.is_empty() {
-            let (_, entries, _) = Self::fetch_data_for_kind(&self.kind, &context.settings);
-            self.entries = entries;
-
-            if let Some(event) = self.create_tap_event() {
-                if let Some(action_label) = self.children[0].downcast_mut::<ActionLabel>() {
-                    action_label.set_event(Some(event));
-                }
+            if let WidgetKind::SubMenu(entries) = self.kind.fetch(settings).widget {
+                self.entries = entries.clone();
+                action_label.set_event(Some(Event::SubMenu(self.rect, entries)));
             }
         }
     }
@@ -632,65 +158,137 @@ impl SettingValue {
             String::new()
         }
     }
-
-    /// Generates the appropriate event to be triggered when this setting value is tapped.
-    ///
-    /// This method determines what event should be emitted based on the type of setting.
-    /// It's used during initialization (in `new()`) and after updates (in various `handle_*` methods)
-    /// to ensure the ActionLabel always has the correct tap behavior.
-    ///
-    /// The behavior varies by setting type:
-    /// - **Direct edit settings** (LibraryInfo, LibraryName, LibraryPath, AutoSuspend, AutoPowerOff):
-    ///   Return specific edit events that trigger their corresponding input dialogs.
-    /// - **Settings with multiple options** (KeyboardLayout, SleepCover, AutoShare, ButtonScheme, Intermission*):
-    ///   Return a SubMenu event that displays all available entries as radio buttons or checkboxes.
-    ///
-    /// # Returns
-    /// An Option containing:
-    /// - `Some(Event)` - the event to emit on tap
-    /// - `None`
-    ///
-    /// # Important
-    /// **This method must be called every time `self.entries` is updated** to ensure the tap event
-    /// reflects the current state of available entries.
-    fn create_tap_event(&self) -> Option<Event> {
-        match self.kind {
-            Kind::LibraryInfo(index) => Some(Event::EditLibrary(index)),
-            Kind::LibraryName(_) => Some(Event::Select(EntryId::EditLibraryName)),
-            Kind::LibraryPath(_) => Some(Event::Select(EntryId::EditLibraryPath)),
-            Kind::AutoSuspend => Some(Event::Select(EntryId::EditAutoSuspend)),
-            Kind::AutoPowerOff => Some(Event::Select(EntryId::EditAutoPowerOff)),
-            Kind::SettingsRetention => Some(Event::Select(EntryId::EditSettingsRetention)),
-            #[cfg(feature = "otel")]
-            Kind::OtlpEndpoint => Some(Event::Select(EntryId::EditOtlpEndpoint)),
-            Kind::Toggle(ref toggle) => Some(Event::Toggle(ToggleEvent::Setting(toggle.clone()))),
-            _ if !self.entries.is_empty() => Some(Event::SubMenu(self.rect, self.entries.clone())),
-            _ => None,
-        }
-    }
 }
 
 impl View for SettingValue {
-    #[cfg_attr(feature = "otel", tracing::instrument(skip(self, _hub, _bus, rq, _context), fields(event = ?evt), ret(level=tracing::Level::TRACE)))]
+    /// Handles events in three passes.
+    ///
+    /// 1. Delegates to [`SettingKind::handle`] for direct mutation events such as
+    ///    submenu selections and toggle taps. When the kind handles the event it
+    ///    returns the updated display string, which is applied immediately.
+    ///
+    /// 2. For [`InputSettingKind`](crate::view::settings_editor::InputSettingKind) settings, opens a [`NamedInput`] overlay on the
+    ///    matching [`EntryId`](crate::view::EntryId) tap, applies the submitted text on [`Event::Submit`],
+    ///    and closes the overlay on [`Event::Close`] or after submission.
+    ///
+    /// 3. Falls back to [`SettingsEvent::UpdateValue`] routing so that
+    ///    `LibraryEditor` and other callers can push targeted display updates
+    ///    without going through the event bus.
+    ///
+    /// [`NamedInput`]: crate::view::named_input::NamedInput
+    #[cfg_attr(feature = "otel", tracing::instrument(skip(self, hub, bus, rq, context), fields(event = ?evt), ret(level=tracing::Level::TRACE)))]
     fn handle_event(
         &mut self,
         evt: &Event,
-        _hub: &Hub,
-        _bus: &mut Bus,
+        hub: &Hub,
+        bus: &mut Bus,
         rq: &mut RenderQueue,
-        _context: &mut Context,
+        context: &mut Context,
     ) -> bool {
-        match evt {
-            Event::Settings(SettingsEvent::UpdateValue { kind, value }) => {
-                if self.kind == *kind {
-                    self.update(value.clone(), _context, rq);
-                    true
-                } else {
-                    false
+        if let Event::Select(ref entry_id) = evt {
+            if Some(entry_id) == self.kind.file_chooser_entry_id().as_ref()
+                && !self.active_file_chooser
+            {
+                #[cfg(not(test))]
+                let initial_path = std::path::PathBuf::from("/mnt/onboard");
+                #[cfg(test)]
+                let initial_path = {
+                    let temp_dir = tempfile::tempdir().expect("failed to create temp dir for test");
+                    let path = temp_dir.path().to_path_buf();
+                    self._temp_dir = Some(temp_dir);
+                    path
+                };
+
+                let file_chooser = FileChooser::new(
+                    rect!(
+                        0,
+                        0,
+                        context.display.dims.0 as i32,
+                        context.display.dims.1 as i32
+                    ),
+                    initial_path,
+                    SelectionMode::File,
+                    hub,
+                    rq,
+                    context,
+                );
+                rq.add(RenderData::new(self.id, self.rect, UpdateMode::Gui));
+                self.children.push(Box::new(file_chooser));
+                self.active_file_chooser = true;
+                return true;
+            }
+        }
+
+        if let Event::FileChooserClosed(_) = evt {
+            if self.active_file_chooser {
+                if let Some(display) = self.kind.handle(evt, &mut context.settings, bus) {
+                    self.update(display, &context.settings, rq);
+                }
+                return false;
+            }
+            return false;
+        }
+
+        if let Event::Close(ViewId::FileChooser) = evt {
+            if self.active_file_chooser {
+                if let Some(idx) = locate_by_id(self, ViewId::FileChooser) {
+                    self.children.remove(idx);
+                }
+                self.active_file_chooser = false;
+                #[cfg(test)]
+                {
+                    self._temp_dir = None;
+                }
+                rq.add(RenderData::new(self.id, self.rect, UpdateMode::Gui));
+                return false;
+            }
+        }
+
+        if let Some(display) = self.kind.handle(evt, &mut context.settings, bus) {
+            self.update(display, &context.settings, rq);
+            bus.push_back(Event::Close(ViewId::SettingsValueMenu));
+            return true;
+        }
+
+        if let Some(input_kind) = self.kind.as_input_kind() {
+            let view_id = input_kind.submit_view_id();
+            let open_entry = input_kind.open_entry_id();
+
+            if let Event::Select(ref id) = evt {
+                if *id == open_entry && self.active_input.is_none() {
+                    bus.push_back(Event::OpenNamedInput {
+                        view_id,
+                        label: input_kind.input_label(),
+                        max_chars: input_kind.input_max_chars(),
+                        initial_text: input_kind.current_text(&context.settings),
+                    });
+                    self.active_input = Some(view_id);
+                    return true;
                 }
             }
-            _ => false,
+
+            if let Event::Submit(submitted_id, ref text) = evt {
+                if Some(*submitted_id) == self.active_input {
+                    let display = self
+                        .kind
+                        .as_input_kind()
+                        .unwrap()
+                        .apply_text(text, &mut context.settings);
+                    self.active_input = None;
+                    self.update(display, &context.settings, rq);
+                    return true;
+                }
+            }
         }
+
+        if let Event::Settings(SettingsEvent::UpdateValue { kind, value }) = evt {
+            if self.kind.identity() == *kind {
+                self.update(value.clone(), &context.settings, rq);
+                return true;
+            }
+        }
+
+        false
     }
 
     #[cfg_attr(feature = "otel", tracing::instrument(skip(self, _fb, _fonts), fields(rect = ?_rect)))]
@@ -724,6 +322,14 @@ mod tests {
     use crate::context::test_helpers::create_test_context;
     use crate::gesture::GestureEvent;
     use crate::settings::Settings;
+    use crate::view::settings_editor::kinds::general::{
+        AutoPowerOff, AutoSuspend, KeyboardLayout, SettingsRetention,
+    };
+    use crate::view::settings_editor::kinds::intermission::{
+        IntermissionPowerOff, IntermissionShare, IntermissionSuspend,
+    };
+    use crate::view::settings_editor::kinds::library::{LibraryInfo, LibraryName, LibraryPath};
+    use crate::view::settings_editor::kinds::telemetry::LogLevel;
     use crate::view::RenderQueue;
     use std::collections::VecDeque;
     use std::path::PathBuf;
@@ -735,20 +341,12 @@ mod tests {
         let settings = Settings::default();
         let rect = rect![0, 0, 200, 50];
 
-        let mut suspend_value = SettingValue::new(
-            Kind::IntermissionSuspend,
-            rect,
-            &settings,
-            &mut context.fonts,
-        );
-        let mut power_off_value = SettingValue::new(
-            Kind::IntermissionPowerOff,
-            rect,
-            &settings,
-            &mut context.fonts,
-        );
+        let mut suspend_value =
+            SettingValue::new(&IntermissionSuspend, rect, &settings, &mut context.fonts);
+        let mut power_off_value =
+            SettingValue::new(&IntermissionPowerOff, rect, &settings, &mut context.fonts);
         let mut share_value =
-            SettingValue::new(Kind::IntermissionShare, rect, &settings, &mut context.fonts);
+            SettingValue::new(&IntermissionShare, rect, &settings, &mut context.fonts);
 
         let (hub, _receiver) = channel();
         let mut bus = VecDeque::new();
@@ -758,19 +356,11 @@ mod tests {
         let initial_power_off = power_off_value.value().clone();
         let initial_share = share_value.value().clone();
 
-        let test_path = PathBuf::from("/mnt/onboard/test_image.png");
-        let event = Event::FileChooserClosed(Some(test_path.clone()));
+        let event = Event::FileChooserClosed(None);
 
         suspend_value.handle_event(&event, &hub, &mut bus, &mut rq, &mut context);
         power_off_value.handle_event(&event, &hub, &mut bus, &mut rq, &mut context);
         share_value.handle_event(&event, &hub, &mut bus, &mut rq, &mut context);
-
-        println!("Initial suspend value: {}", initial_suspend);
-        println!("After event suspend value: {}", suspend_value.value());
-        println!("Initial power_off value: {}", initial_power_off);
-        println!("After event power_off value: {}", power_off_value.value());
-        println!("Initial share value: {}", initial_share);
-        println!("After event share value: {}", share_value.value());
 
         assert_eq!(suspend_value.value(), initial_suspend);
         assert_eq!(power_off_value.value(), initial_power_off);
@@ -778,40 +368,56 @@ mod tests {
     }
 
     #[test]
-    fn test_intermission_values_update_via_submit_event() {
-        use crate::settings::IntermKind;
+    fn test_intermission_values_update_via_update_value_event() {
         let mut context = create_test_context();
         let settings = Settings::default();
         let rect = rect![0, 0, 200, 50];
 
-        let mut suspend_value = SettingValue::new(
-            Kind::IntermissionSuspend,
-            rect,
-            &settings,
-            &mut context.fonts,
-        );
-        let mut power_off_value = SettingValue::new(
-            Kind::IntermissionPowerOff,
-            rect,
-            &settings,
-            &mut context.fonts,
-        );
+        let mut suspend_value =
+            SettingValue::new(&IntermissionSuspend, rect, &settings, &mut context.fonts);
+        let mut power_off_value =
+            SettingValue::new(&IntermissionPowerOff, rect, &settings, &mut context.fonts);
         let mut share_value =
-            SettingValue::new(Kind::IntermissionShare, rect, &settings, &mut context.fonts);
+            SettingValue::new(&IntermissionShare, rect, &settings, &mut context.fonts);
 
+        let (hub, _receiver) = channel();
+        let mut bus = VecDeque::new();
         let mut rq = RenderQueue::new();
 
-        context.settings.intermissions[IntermKind::Suspend] =
-            crate::settings::IntermissionDisplay::Image(PathBuf::from("suspend_image.png"));
-        context.settings.intermissions[IntermKind::PowerOff] =
-            crate::settings::IntermissionDisplay::Image(PathBuf::from("poweroff_image.png"));
-        context.settings.intermissions[IntermKind::Share] =
-            crate::settings::IntermissionDisplay::Image(PathBuf::from("share_image.png"));
+        let handled_suspend = suspend_value.handle_event(
+            &Event::Settings(SettingsEvent::UpdateValue {
+                kind: SettingIdentity::IntermissionSuspend,
+                value: "suspend_image.png".to_string(),
+            }),
+            &hub,
+            &mut bus,
+            &mut rq,
+            &mut context,
+        );
+        let handled_power_off = power_off_value.handle_event(
+            &Event::Settings(SettingsEvent::UpdateValue {
+                kind: SettingIdentity::IntermissionPowerOff,
+                value: "poweroff_image.png".to_string(),
+            }),
+            &hub,
+            &mut bus,
+            &mut rq,
+            &mut context,
+        );
+        let handled_share = share_value.handle_event(
+            &Event::Settings(SettingsEvent::UpdateValue {
+                kind: SettingIdentity::IntermissionShare,
+                value: "share_image.png".to_string(),
+            }),
+            &hub,
+            &mut bus,
+            &mut rq,
+            &mut context,
+        );
 
-        suspend_value.refresh_from_context(&context, &mut rq);
-        power_off_value.refresh_from_context(&context, &mut rq);
-        share_value.refresh_from_context(&context, &mut rq);
-
+        assert!(handled_suspend);
+        assert!(handled_power_off);
+        assert!(handled_share);
         assert_eq!(suspend_value.value(), "suspend_image.png");
         assert_eq!(power_off_value.value(), "poweroff_image.png");
         assert_eq!(share_value.value(), "share_image.png");
@@ -826,12 +432,16 @@ mod tests {
         };
         let rect = rect![0, 0, 200, 50];
 
-        let mut value =
-            SettingValue::new(Kind::KeyboardLayout, rect, &settings, &mut context.fonts);
+        let mut value = SettingValue::new(&KeyboardLayout, rect, &settings, &mut context.fonts);
         let mut rq = RenderQueue::new();
 
-        context.settings.keyboard_layout = "French".to_string();
-        value.refresh_from_context(&context, &mut rq);
+        let update_event = Event::Settings(SettingsEvent::UpdateValue {
+            kind: SettingIdentity::KeyboardLayout,
+            value: "French".to_string(),
+        });
+        let (hub, _receiver) = channel();
+        let mut bus = VecDeque::new();
+        value.handle_event(&update_event, &hub, &mut bus, &mut rq, &mut context);
 
         assert_eq!(value.value(), "French");
         assert!(!rq.is_empty());
@@ -843,11 +453,16 @@ mod tests {
         let settings = Settings::default();
         let rect = rect![0, 0, 200, 50];
 
-        let mut value = SettingValue::new(Kind::AutoSuspend, rect, &settings, &mut context.fonts);
+        let mut value = SettingValue::new(&AutoSuspend, rect, &settings, &mut context.fonts);
         let mut rq = RenderQueue::new();
+        let (hub, _receiver) = channel();
+        let mut bus = VecDeque::new();
 
-        context.settings.auto_suspend = 15.0;
-        value.refresh_from_context(&context, &mut rq);
+        let update_event = Event::Settings(SettingsEvent::UpdateValue {
+            kind: SettingIdentity::AutoSuspend,
+            value: "15.0".to_string(),
+        });
+        value.handle_event(&update_event, &hub, &mut bus, &mut rq, &mut context);
 
         assert_eq!(value.value(), "15.0");
         assert!(!rq.is_empty());
@@ -859,11 +474,16 @@ mod tests {
         let settings = Settings::default();
         let rect = rect![0, 0, 200, 50];
 
-        let mut value = SettingValue::new(Kind::AutoPowerOff, rect, &settings, &mut context.fonts);
+        let mut value = SettingValue::new(&AutoPowerOff, rect, &settings, &mut context.fonts);
         let mut rq = RenderQueue::new();
+        let (hub, _receiver) = channel();
+        let mut bus = VecDeque::new();
 
-        context.settings.auto_power_off = 7.0;
-        value.refresh_from_context(&context, &mut rq);
+        let update_event = Event::Settings(SettingsEvent::UpdateValue {
+            kind: SettingIdentity::AutoPowerOff,
+            value: "7.0".to_string(),
+        });
+        value.handle_event(&update_event, &hub, &mut bus, &mut rq, &mut context);
 
         assert_eq!(value.value(), "7.0");
         assert!(!rq.is_empty());
@@ -881,12 +501,16 @@ mod tests {
         let rect = rect![0, 0, 200, 50];
 
         let mut context = create_test_context();
-        let mut value =
-            SettingValue::new(Kind::LibraryName(0), rect, &settings, &mut context.fonts);
+        let mut value = SettingValue::new(LibraryName(0), rect, &settings, &mut context.fonts);
         let mut rq = RenderQueue::new();
+        let (hub, _receiver) = channel();
+        let mut bus = VecDeque::new();
 
-        context.settings.libraries[0].name = "New Name".to_string();
-        value.refresh_from_context(&context, &mut rq);
+        let update_event = Event::Settings(SettingsEvent::UpdateValue {
+            kind: SettingIdentity::LibraryName(0),
+            value: "New Name".to_string(),
+        });
+        value.handle_event(&update_event, &hub, &mut bus, &mut rq, &mut context);
 
         assert_eq!(value.value(), "New Name");
         assert!(!rq.is_empty());
@@ -904,13 +528,17 @@ mod tests {
         let rect = rect![0, 0, 200, 50];
 
         let mut context = create_test_context();
-        let mut value =
-            SettingValue::new(Kind::LibraryPath(0), rect, &settings, &mut context.fonts);
+        let mut value = SettingValue::new(LibraryPath(0), rect, &settings, &mut context.fonts);
         let mut rq = RenderQueue::new();
+        let (hub, _receiver) = channel();
+        let mut bus = VecDeque::new();
 
         let new_path = PathBuf::from("/mnt/onboard/new_library");
-        context.settings.libraries[0].path = new_path.clone();
-        value.refresh_from_context(&context, &mut rq);
+        let update_event = Event::Settings(SettingsEvent::UpdateValue {
+            kind: SettingIdentity::LibraryPath(0),
+            value: new_path.display().to_string(),
+        });
+        value.handle_event(&update_event, &hub, &mut bus, &mut rq, &mut context);
 
         assert_eq!(value.value(), new_path.display().to_string());
         assert!(!rq.is_empty());
@@ -928,7 +556,7 @@ mod tests {
         let rect = rect![0, 0, 200, 50];
 
         let mut context = create_test_context();
-        let value = SettingValue::new(Kind::LibraryInfo(0), rect, &settings, &mut context.fonts);
+        let value = SettingValue::new(LibraryInfo(0), rect, &settings, &mut context.fonts);
         let (hub, _receiver) = channel();
         let mut bus = VecDeque::new();
         let mut rq = RenderQueue::new();
@@ -966,12 +594,8 @@ mod tests {
         });
         let rect = rect![0, 0, 200, 50];
 
-        let mut value = SettingValue::new(
-            Kind::LibraryName(0),
-            rect,
-            &context.settings,
-            &mut context.fonts,
-        );
+        let mut value =
+            SettingValue::new(LibraryName(0), rect, &context.settings, &mut context.fonts);
         let (hub, _receiver) = channel();
         let mut bus = VecDeque::new();
         let mut rq = RenderQueue::new();
@@ -979,7 +603,7 @@ mod tests {
         assert_eq!(value.value(), "Old Name");
 
         let update_event = Event::Settings(SettingsEvent::UpdateValue {
-            kind: Kind::LibraryName(0),
+            kind: SettingIdentity::LibraryName(0),
             value: "New Name".to_string(),
         });
         let handled = value.handle_event(&update_event, &hub, &mut bus, &mut rq, &mut context);
@@ -1003,12 +627,8 @@ mod tests {
         });
         let rect = rect![0, 0, 200, 50];
 
-        let mut value = SettingValue::new(
-            Kind::LibraryPath(0),
-            rect,
-            &context.settings,
-            &mut context.fonts,
-        );
+        let mut value =
+            SettingValue::new(LibraryPath(0), rect, &context.settings, &mut context.fonts);
         let (hub, _receiver) = channel();
         let mut bus = VecDeque::new();
         let mut rq = RenderQueue::new();
@@ -1016,7 +636,7 @@ mod tests {
         assert_eq!(value.value(), "/old/path");
 
         let update_event = Event::Settings(SettingsEvent::UpdateValue {
-            kind: Kind::LibraryPath(0),
+            kind: SettingIdentity::LibraryPath(0),
             value: "/new/path".to_string(),
         });
         let handled = value.handle_event(&update_event, &hub, &mut bus, &mut rq, &mut context);
@@ -1040,12 +660,8 @@ mod tests {
         });
         let rect = rect![0, 0, 200, 50];
 
-        let mut value = SettingValue::new(
-            Kind::LibraryName(0),
-            rect,
-            &context.settings,
-            &mut context.fonts,
-        );
+        let mut value =
+            SettingValue::new(LibraryName(0), rect, &context.settings, &mut context.fonts);
         let (hub, _receiver) = channel();
         let mut bus = VecDeque::new();
         let mut rq = RenderQueue::new();
@@ -1053,7 +669,7 @@ mod tests {
         assert_eq!(value.value(), "Test Library");
 
         let update_event = Event::Settings(SettingsEvent::UpdateValue {
-            kind: Kind::LibraryPath(0),
+            kind: SettingIdentity::LibraryPath(0),
             value: "Some Path".to_string(),
         });
         let handled = value.handle_event(&update_event, &hub, &mut bus, &mut rq, &mut context);
@@ -1086,12 +702,8 @@ mod tests {
         });
         let rect = rect![0, 0, 200, 50];
 
-        let mut value = SettingValue::new(
-            Kind::LibraryName(0),
-            rect,
-            &context.settings,
-            &mut context.fonts,
-        );
+        let mut value =
+            SettingValue::new(LibraryName(0), rect, &context.settings, &mut context.fonts);
         let (hub, _receiver) = channel();
         let mut bus = VecDeque::new();
         let mut rq = RenderQueue::new();
@@ -1099,7 +711,7 @@ mod tests {
         assert_eq!(value.value(), "Library 0");
 
         let update_event = Event::Settings(SettingsEvent::UpdateValue {
-            kind: Kind::LibraryName(1),
+            kind: SettingIdentity::LibraryName(1),
             value: "Updated Library 1".to_string(),
         });
         let handled = value.handle_event(&update_event, &hub, &mut bus, &mut rq, &mut context);
@@ -1118,14 +730,9 @@ mod tests {
     #[test]
     fn test_update_value_event_updates_auto_suspend() {
         let rect = rect![0, 0, 200, 50];
-
         let mut context = create_test_context();
-        let mut value = SettingValue::new(
-            Kind::AutoSuspend,
-            rect,
-            &context.settings,
-            &mut context.fonts,
-        );
+        let mut value =
+            SettingValue::new(&AutoSuspend, rect, &context.settings, &mut context.fonts);
         let (hub, _receiver) = channel();
         let mut bus = VecDeque::new();
         let mut rq = RenderQueue::new();
@@ -1133,7 +740,7 @@ mod tests {
         assert_eq!(value.value(), "30.0");
 
         let update_event = Event::Settings(SettingsEvent::UpdateValue {
-            kind: Kind::AutoSuspend,
+            kind: SettingIdentity::AutoSuspend,
             value: "60.0".to_string(),
         });
         let handled = value.handle_event(&update_event, &hub, &mut bus, &mut rq, &mut context);
@@ -1148,14 +755,9 @@ mod tests {
     #[test]
     fn test_update_value_event_updates_auto_power_off() {
         let rect = rect![0, 0, 200, 50];
-
         let mut context = create_test_context();
-        let mut value = SettingValue::new(
-            Kind::AutoPowerOff,
-            rect,
-            &context.settings,
-            &mut context.fonts,
-        );
+        let mut value =
+            SettingValue::new(&AutoPowerOff, rect, &context.settings, &mut context.fonts);
         let (hub, _receiver) = channel();
         let mut bus = VecDeque::new();
         let mut rq = RenderQueue::new();
@@ -1163,7 +765,7 @@ mod tests {
         assert_eq!(value.value(), "3.0");
 
         let update_event = Event::Settings(SettingsEvent::UpdateValue {
-            kind: Kind::AutoPowerOff,
+            kind: SettingIdentity::AutoPowerOff,
             value: "60.0".to_string(),
         });
         let handled = value.handle_event(&update_event, &hub, &mut bus, &mut rq, &mut context);
@@ -1178,10 +780,9 @@ mod tests {
     #[test]
     fn test_update_value_event_updates_settings_retention() {
         let rect = rect![0, 0, 200, 50];
-
         let mut context = create_test_context();
         let mut value = SettingValue::new(
-            Kind::SettingsRetention,
+            &SettingsRetention,
             rect,
             &context.settings,
             &mut context.fonts,
@@ -1193,7 +794,7 @@ mod tests {
         assert_eq!(value.value(), "3");
 
         let update_event = Event::Settings(SettingsEvent::UpdateValue {
-            kind: Kind::SettingsRetention,
+            kind: SettingIdentity::SettingsRetention,
             value: "5".to_string(),
         });
         let handled = value.handle_event(&update_event, &hub, &mut bus, &mut rq, &mut context);
@@ -1208,12 +809,10 @@ mod tests {
     #[test]
     fn test_update_value_event_regenerates_log_level_radio_buttons() {
         let rect = rect![0, 0, 200, 50];
-
         let mut context = create_test_context();
         context.settings.logging.level = "INFO".to_string();
 
-        let mut value =
-            SettingValue::new(Kind::LogLevel, rect, &context.settings, &mut context.fonts);
+        let mut value = SettingValue::new(&LogLevel, rect, &context.settings, &mut context.fonts);
         let (hub, _receiver) = channel();
         let mut bus = VecDeque::new();
         let mut rq = RenderQueue::new();
@@ -1235,7 +834,7 @@ mod tests {
 
         context.settings.logging.level = "DEBUG".to_string();
         let update_event = Event::Settings(SettingsEvent::UpdateValue {
-            kind: Kind::LogLevel,
+            kind: SettingIdentity::LogLevel,
             value: "DEBUG".to_string(),
         });
         let handled = value.handle_event(&update_event, &hub, &mut bus, &mut rq, &mut context);
@@ -1245,30 +844,5 @@ mod tests {
             "UpdateValue event should be handled when kind matches"
         );
         assert_eq!(value.value(), "DEBUG");
-
-        let updated_entries = &value.entries;
-        let debug_entry = updated_entries.iter().find(|e| {
-            if let EntryKind::RadioButton(label, _, _) = e {
-                label == "DEBUG"
-            } else {
-                false
-            }
-        });
-        assert!(
-            matches!(debug_entry, Some(EntryKind::RadioButton(_, _, true))),
-            "DEBUG should be checked after update"
-        );
-
-        let info_entry_after = updated_entries.iter().find(|e| {
-            if let EntryKind::RadioButton(label, _, _) = e {
-                label == "INFO"
-            } else {
-                false
-            }
-        });
-        assert!(
-            matches!(info_entry_after, Some(EntryKind::RadioButton(_, _, false))),
-            "INFO should be unchecked after update"
-        );
     }
 }


### PR DESCRIPTION
This pull request introduces internationalization (i18n) support for settings-related UI strings, adds a trait for localized display of settings enums, and refactors the settings editor to use a more extensible and type-safe approach for representing settings. The changes also add a unified identity enum for settings, which simplifies targeted updates in the settings editor. Below are the most important changes:

**Internationalization and Localization Improvements:**

* Added new i18n strings for all settings-related UI labels and options in the `cadmus_core.ftl` file, enabling proper localization of the settings interface.
* Introduced the `I18nDisplay` trait in `i18n.rs` for types that can provide localized string representations, and implemented this trait for several settings enums (`ButtonScheme`, `FinishedAction`, `IntermissionDisplay`). [[1]](diffhunk://#diff-21ca797d4b2a6c795f25f15e5e0fb6084d367525df9de404d3557ca6562bbd2bR17-R22) [[2]](diffhunk://#diff-22ab21715d2b6235b163233bedb56d236445d7ed4942de27c365aca34694aec7R114-R122) [[3]](diffhunk://#diff-22ab21715d2b6235b163233bedb56d236445d7ed4942de27c365aca34694aec7R488-R497) [[4]](diffhunk://#diff-84d4f55e9f61ec501382f4dd583f93fa1df915579d294535c7358c27268044dbR62-R71)

**Settings Editor Refactor:**

* Refactored the settings editor to use boxed trait objects (`Box<dyn SettingKind>`) instead of enum variants for representing setting rows, improving extensibility and maintainability. [[1]](diffhunk://#diff-f74e857ca61dfc27e71a5abb35f504cba975b9f0e928307a85bb760bade010d1L1-R13) [[2]](diffhunk://#diff-f74e857ca61dfc27e71a5abb35f504cba975b9f0e928307a85bb760bade010d1L31-R95)

**Settings Identity and Targeted Updates:**

* Introduced a single, deduplicated `SettingIdentity` enum in a new module, replacing parallel enums and enabling precise routing of update events for individual settings in the editor UI.

**Event Handling:**

* Added a new `OpenNamedInput` variant to the main `Event` enum, allowing the UI to request a named text input overlay, which can be used for settings that require user text input.

These changes collectively improve the localization, extensibility, and maintainability of the settings UI and its underlying logic.

---

Change-Id: 481dc2a3cf5bda97a2ea7e2119ce8374
Change-Id-Short: vrymnxpwnkuo
Ref: https://github.com/OGKevin/cadmus/issues/291 https://github.com/OGKevin/cadmus/issues/296
Ref: CAD-13 CAD-15
