### PR TITLE
chore(docs): add deepwiki link for auto-indexing

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,14 @@
 
 <p align="center">
     <a href="https://github.com/ogkevin/cadmus/releases" alt="GitHub release">
-        <img src="https://img.shields.io/github/release/ogkevin/cadmus.svg?style=for-the-badge" /></a>
+        <img src="https://img.shields.io/github/release/ogkevin/cadmus.svg?style=for-the-badge"/></a>
     <img src="https://img.shields.io/github/actions/workflow/status/ogkevin/cadmus/cargo.yml?style=for-the-badge" />
     <a href="https://discord.gg/3AJHp6rV5a" alt="Discord">
         <img src="https://img.shields.io/discord/1459138935203565741?style=for-the-badge" /></a>
+    <img alt="GitHub Downloads (all assets, latest release)" src="https://img.shields.io/github/downloads/OGKevin/cadmus/latest/total?style=for-the-badge">
+    <a href="https://deepwiki.com/OGKevin/cadmus">
+    <img alt="Static Badge" src="https://img.shields.io/badge/Ask_DeepWiki-blue?style=for-the-badge">
+    </a>
 </p>
 
 <div align="center">
@@ -19,7 +23,9 @@ Cadmus is a document reader for Kobo e-readers.
 </div>
 
 Documentation is available at:
-https://ogkevin.github.io/cadmus/
+<https://ogkevin.github.io/cadmus/>
+
+AI maintained docs at: <https://deepwiki.com/OGKevin/cadmus>
 
 ## Acknowledgments
 


### PR DESCRIPTION
Adding a link to deepwiki, ensures that cadmus deepwiki entry is indexed every week.

Change-Id: c3419cc5e7e338f37ca28fcac33b38e4
Change-Id-Short: nwvyqnnulslw