### PR TITLE
chore(xtask): run bench via xtask

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -327,7 +327,6 @@ dependencies = [
  "arc-swap",
  "bitflags 2.11.0",
  "byteorder",
- "cadmus-core",
  "chrono",
  "criterion",
  "ctor",

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -93,7 +93,6 @@ procfs = { version = "0.18", optional = true }
 [dev-dependencies]
 criterion = { version = "0.8", features = ["html_reports"] }
 tempfile = "3.14"
-cadmus-core = { path = ".", features = ["bench"] } 
 
 [[bench]]
 name = "dictionary_bench"

--- a/crates/core/benches/dictionary_bench.rs
+++ b/crates/core/benches/dictionary_bench.rs
@@ -1,9 +1,14 @@
+#[cfg(feature = "bench")]
 use std::time::Duration;
 
+#[cfg(feature = "bench")]
 use cadmus_core::dictionary::indexing::{normalize, Entry};
+#[cfg(feature = "bench")]
 use cadmus_core::dictionary::Metadata;
+#[cfg(feature = "bench")]
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
 
+#[cfg(feature = "bench")]
 fn make_sorted_entries(n: usize) -> Vec<Entry> {
     (0..n)
         .map(|i| Entry {
@@ -15,12 +20,14 @@ fn make_sorted_entries(n: usize) -> Vec<Entry> {
         .collect()
 }
 
+#[cfg(feature = "bench")]
 fn make_unsorted_entries(n: usize) -> Vec<Entry> {
     let mut entries = make_sorted_entries(n);
     entries.reverse();
     entries
 }
 
+#[cfg(feature = "bench")]
 fn make_entries_needing_transform(n: usize, sorted: bool) -> Vec<Entry> {
     let mut entries: Vec<Entry> = (0..n)
         .map(|i| Entry {
@@ -38,6 +45,7 @@ fn make_entries_needing_transform(n: usize, sorted: bool) -> Vec<Entry> {
     entries
 }
 
+#[cfg(feature = "bench")]
 fn bench_normalize(c: &mut Criterion) {
     let metadata_no_transform = Metadata {
         all_chars: true,
@@ -84,9 +92,14 @@ fn bench_normalize(c: &mut Criterion) {
     group.finish();
 }
 
+#[cfg(feature = "bench")]
 criterion_group!(
     name = benches;
     config = Criterion::default().measurement_time(Duration::from_secs(10)).sample_size(10);
     targets = bench_normalize
 );
+#[cfg(feature = "bench")]
 criterion_main!(benches);
+
+#[cfg(not(feature = "bench"))]
+fn main() {}

--- a/xtask/src/lib.rs
+++ b/xtask/src/lib.rs
@@ -20,6 +20,7 @@
 //! | [`fmt`](tasks::fmt) | Check (or apply) `rustfmt` formatting |
 //! | [`clippy`](tasks::clippy) | Run `cargo clippy` across the feature matrix |
 //! | [`test`](tasks::test) | Run `cargo test` across the feature matrix |
+//! | [`bench`](tasks::bench) | Run benchmarks with the `bench` feature enabled |
 //! | [`build-kobo`](tasks::build_kobo) | Cross-compile for Kobo (ARM, Linux only) |
 //! | [`setup-native`](tasks::setup_native) | Build MuPDF and the C wrapper for native dev |
 //! | [`run-emulator`](tasks::run_emulator) | Run the Cadmus emulator (ensures prereqs are built) |
@@ -44,9 +45,10 @@ pub use anyhow::Result;
 pub use clap::Parser;
 
 pub use tasks::{
-    build_kobo::BuildKoboArgs, bundle::BundleArgs, ci::CiArgs, clippy::ClippyArgs, dist::DistArgs,
-    docs::DocsArgs, fmt::FmtArgs, install_importer::InstallImporterArgs,
-    run_emulator::RunEmulatorArgs, setup_native::SetupNativeArgs, test::TestArgs,
+    bench::BenchArgs, build_kobo::BuildKoboArgs, bundle::BundleArgs, ci::CiArgs,
+    clippy::ClippyArgs, dist::DistArgs, docs::DocsArgs, fmt::FmtArgs,
+    install_importer::InstallImporterArgs, run_emulator::RunEmulatorArgs,
+    setup_native::SetupNativeArgs, test::TestArgs,
 };
 
 /// Cadmus build automation.
@@ -67,6 +69,8 @@ pub enum Command {
     Clippy(ClippyArgs),
     /// Run cargo test across the full feature matrix.
     Test(TestArgs),
+    /// Run benchmarks with the bench feature enabled.
+    Bench(BenchArgs),
     /// Cross-compile Cadmus for Kobo devices (Linux only).
     BuildKobo(BuildKoboArgs),
     /// Build MuPDF and the C wrapper for native development.
@@ -98,6 +102,7 @@ pub fn run() -> Result<()> {
         Command::Fmt(args) => tasks::fmt::run(args),
         Command::Clippy(args) => tasks::clippy::run(args),
         Command::Test(args) => tasks::test::run(args),
+        Command::Bench(args) => tasks::bench::run(args),
         Command::BuildKobo(args) => tasks::build_kobo::run(args),
         Command::SetupNative(args) => tasks::setup_native::run(args),
         Command::RunEmulator(args) => tasks::run_emulator::run(args),

--- a/xtask/src/tasks/bench.rs
+++ b/xtask/src/tasks/bench.rs
@@ -1,0 +1,24 @@
+//! `cargo xtask bench` — run benchmarks with the `bench` feature enabled.
+//!
+//! Runs `cargo bench --features bench` for the workspace, activating the
+//! `bench` feature flag that exposes internal module visibility required by
+//! the criterion benchmark targets.
+
+use anyhow::Result;
+use clap::Args;
+
+use super::util::{cmd, workspace};
+
+/// Arguments for `cargo xtask bench`.
+#[derive(Debug, Args)]
+pub struct BenchArgs {}
+
+/// Runs `cargo bench --features bench` from the workspace root.
+///
+/// # Errors
+///
+/// Returns an error if the benchmark process exits non-zero.
+pub fn run(_args: BenchArgs) -> Result<()> {
+    let root = workspace::root()?;
+    cmd::run("cargo", &["bench", "--features", "bench"], &root, &[])
+}

--- a/xtask/src/tasks/mod.rs
+++ b/xtask/src/tasks/mod.rs
@@ -3,6 +3,7 @@
 //! Each sub-module corresponds to one top-level subcommand.  Shared utilities
 //! live in [`util`].
 
+pub mod bench;
 pub mod build_kobo;
 pub mod bundle;
 pub mod ci;


### PR DESCRIPTION
The cadmus-core dev-dependency on itself with features=["bench"] was making release please fail due to circular dependencies.

- Remove self-referential cadmus-core dev-dependency from crates/core
- Add `cargo xtask bench` command that runs `cargo bench --features bench`

Change-Id: 66fc49fb6fc81f60aef60ec9dd4afc0f
Change-Id-Short: ttknvqkotknr