### PR TITLE
feat(dictionaries): add native monolingual dictionary support

### DIFF
--- a/.sqlx/query-1eddbdfda3c0556c7febf527001cd0151a61902313dbb9c4dcb43e3d387c28ea.json
+++ b/.sqlx/query-1eddbdfda3c0556c7febf527001cd0151a61902313dbb9c4dcb43e3d387c28ea.json
@@ -1,0 +1,28 @@
+{
+  "db_name": "SQLite",
+  "query": "SELECT formats, updated as \"updated: UnixTimestamp\", words\n                   FROM dictionary_monolingual_metadata\n                   WHERE lang = ?",
+  "describe": {
+    "columns": [
+      {
+        "name": "formats",
+        "ordinal": 0,
+        "type_info": "Text"
+      },
+      {
+        "name": "updated: UnixTimestamp",
+        "ordinal": 1,
+        "type_info": "Integer"
+      },
+      {
+        "name": "words",
+        "ordinal": 2,
+        "type_info": "Integer"
+      }
+    ],
+    "parameters": {
+      "Right": 1
+    },
+    "nullable": [false, false, false]
+  },
+  "hash": "1eddbdfda3c0556c7febf527001cd0151a61902313dbb9c4dcb43e3d387c28ea"
+}

--- a/.sqlx/query-426509510c78e31ee8ca666fdffa59b967971a7fe2332c5668b1d8143b19334d.json
+++ b/.sqlx/query-426509510c78e31ee8ca666fdffa59b967971a7fe2332c5668b1d8143b19334d.json
@@ -1,0 +1,33 @@
+{
+  "db_name": "SQLite",
+  "query": "SELECT lang, formats, updated as \"updated: UnixTimestamp\", words\n                   FROM dictionary_monolingual_metadata",
+  "describe": {
+    "columns": [
+      {
+        "name": "lang",
+        "ordinal": 0,
+        "type_info": "Text"
+      },
+      {
+        "name": "formats",
+        "ordinal": 1,
+        "type_info": "Text"
+      },
+      {
+        "name": "updated: UnixTimestamp",
+        "ordinal": 2,
+        "type_info": "Integer"
+      },
+      {
+        "name": "words",
+        "ordinal": 3,
+        "type_info": "Integer"
+      }
+    ],
+    "parameters": {
+      "Right": 0
+    },
+    "nullable": [false, false, false, false]
+  },
+  "hash": "426509510c78e31ee8ca666fdffa59b967971a7fe2332c5668b1d8143b19334d"
+}

--- a/.sqlx/query-94584443c1d766a629e0b1a1884182fc896044563b5712abf8ff9684bfc9816b.json
+++ b/.sqlx/query-94584443c1d766a629e0b1a1884182fc896044563b5712abf8ff9684bfc9816b.json
@@ -1,0 +1,12 @@
+{
+  "db_name": "SQLite",
+  "query": "INSERT INTO dictionary_monolingual_metadata\n                       (lang, formats, updated, words, cached_at)\n                   VALUES (?, ?, ?, ?, ?)\n                   ON CONFLICT(lang) DO UPDATE SET\n                       formats   = excluded.formats,\n                       updated   = excluded.updated,\n                       words     = excluded.words,\n                       cached_at = excluded.cached_at",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Right": 5
+    },
+    "nullable": []
+  },
+  "hash": "94584443c1d766a629e0b1a1884182fc896044563b5712abf8ff9684bfc9816b"
+}

--- a/crates/core/i18n/en-GB/cadmus_core.ftl
+++ b/crates/core/i18n/en-GB/cadmus_core.ftl
@@ -6,6 +6,12 @@ english = English
 
 startup-loading = Cadmus starting up…
 
+# Notifications
+
+notification-downloading-dictionary = Downloading dictionary for "{ $lang }"
+notification-downloading-dictionary-completed = Downloading dictionary for "{ $lang }" completed
+notification-not-online = WiFi must be connected for this action.
+
 # Common
 delete = Delete
 
@@ -78,3 +84,10 @@ settings-telemetry-log-level = Log Level
 settings-telemetry-otlp-endpoint = OTLP Endpoint
 settings-telemetry-enable-kernel-log = Enable Kernel Log
 settings-telemetry-enable-dbus-log = Enable D-Bus Log
+
+# Settings - Dictionaries
+settings-dictionaries-downloading = Downloading
+settings-dictionaries-re-download = Re-download
+settings-dictionaries-delete = {delete}
+settings-dictionaries-installed = Installed
+settings-dictionaries-download = Download

--- a/crates/core/migrations/005_monolingual_metadata.sql
+++ b/crates/core/migrations/005_monolingual_metadata.sql
@@ -1,0 +1,7 @@
+CREATE TABLE IF NOT EXISTS dictionary_monolingual_metadata (
+    lang      TEXT    PRIMARY KEY NOT NULL,
+    formats   TEXT    NOT NULL,
+    updated   INTEGER NOT NULL,
+    words     INTEGER NOT NULL,
+    cached_at INTEGER NOT NULL
+) STRICT;

--- a/crates/core/src/context.rs
+++ b/crates/core/src/context.rs
@@ -27,7 +27,7 @@ use tracing::error;
 use walkdir::WalkDir;
 
 const KEYBOARD_LAYOUTS_DIRNAME: &str = "keyboard-layouts";
-const DICTIONARIES_DIRNAME: &str = "dictionaries";
+pub(crate) const DICTIONARIES_DIRNAME: &str = "dictionaries";
 const INPUT_HISTORY_SIZE: usize = 32;
 
 pub struct Context {
@@ -148,6 +148,8 @@ impl Context {
 
     #[cfg_attr(feature = "otel", tracing::instrument(skip_all))]
     pub fn load_dictionaries(&mut self) {
+        self.dictionaries.clear();
+
         let glob = Glob::new("**/*.index").unwrap().compile_matcher();
 
         #[cfg(test)]

--- a/crates/core/src/dictionary/mod.rs
+++ b/crates/core/src/dictionary/mod.rs
@@ -2,6 +2,8 @@
 //!
 //! This crate can read dictionaries in the dict format, as used by dictd. It supports both
 //! uncompressed and compressed dictionaries.
+//!
+//! It also provides support for downloading dictionaries from the monolingual project.
 
 mod dictreader;
 mod errors;
@@ -9,6 +11,10 @@ mod errors;
 pub mod indexing;
 #[cfg(not(feature = "bench"))]
 mod indexing;
+
+mod monolingual;
+
+pub(crate) use monolingual::MonolingualDictionaryService;
 
 use std::path::Path;
 

--- a/crates/core/src/dictionary/monolingual/client.rs
+++ b/crates/core/src/dictionary/monolingual/client.rs
@@ -1,0 +1,289 @@
+//! HTTP client for monolingual dictionary API operations.
+//!
+//! Only monolingual dictionaries (source language == target language) are
+//! supported. Bilingual pairs present in the API response are ignored.
+
+use super::db::Db;
+use super::errors::MonolingualError;
+use super::metadata::{DictionariesResponse, DictionaryEntry};
+use crate::db::Database;
+use crate::http::Client;
+
+const MONOLINGUAL_API_URL: &str = "https://www.reader-dict.com/api/v1/dictionaries";
+
+/// Monolingual dictionary HTTP client.
+///
+/// This client queries the monolingual API and manages a SQLite cache of
+/// dictionary metadata. It composes the base [`crate::http::Client`] for all
+/// network requests.
+#[derive(Clone)]
+pub(super) struct MonolingualClient {
+    http: Client,
+    db: Db,
+}
+
+impl std::fmt::Debug for MonolingualClient {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("MonolingualClient")
+            .field("db", &self.db)
+            .finish_non_exhaustive()
+    }
+}
+
+impl MonolingualClient {
+    /// Creates a new monolingual client backed by the given database.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the underlying HTTP client fails to build.
+    #[cfg_attr(feature = "otel", tracing::instrument(skip_all))]
+    pub(super) fn new(database: &Database) -> Result<Self, MonolingualError> {
+        tracing::debug!("Building monolingual client");
+
+        let http = Client::new()?;
+        let db = Db::new(database);
+
+        tracing::debug!("Monolingual client built successfully");
+        Ok(Self { http, db })
+    }
+
+    /// Fetches dictionary metadata from the API and caches the response.
+    ///
+    /// If the metadata is already cached, this will overwrite it with the
+    /// latest from the API. For offline availability, use
+    /// [`Self::get_cached_metadata`] instead.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the HTTP request fails or the response cannot be
+    /// parsed.
+    #[cfg_attr(feature = "otel", tracing::instrument(skip(self)))]
+    fn fetch_metadata(&self) -> Result<DictionariesResponse, MonolingualError> {
+        tracing::debug!("Fetching monolingual metadata from API");
+
+        let text = self
+            .http
+            .get(MONOLINGUAL_API_URL)
+            .send()
+            .map_err(|e| MonolingualError::Request(e.to_string()))?
+            .error_for_status()
+            .map_err(|e| MonolingualError::Request(e.to_string()))?
+            .text()
+            .map_err(|e| MonolingualError::Request(e.to_string()))?;
+
+        let metadata: DictionariesResponse = serde_json::from_str(&text)?;
+
+        for (source_lang, targets) in &metadata {
+            if let Some(entry) = targets.get(source_lang.as_str()) {
+                self.db.upsert_entry(source_lang, entry)?;
+            }
+        }
+
+        tracing::debug!("Cached monolingual metadata to database");
+        Ok(metadata)
+    }
+
+    /// Gets cached dictionary metadata if available.
+    ///
+    /// This does not make any network requests and is suitable for offline
+    /// use. Returns `None` if no entries have been cached yet.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the database read fails.
+    #[cfg_attr(feature = "otel", tracing::instrument(skip(self)))]
+    fn get_cached_metadata(&self) -> Result<Option<DictionariesResponse>, MonolingualError> {
+        let entries = self.db.get_all_entries()?;
+
+        if entries.is_empty() {
+            tracing::debug!("No cached metadata found in database");
+            return Ok(None);
+        }
+
+        let mut response = DictionariesResponse::new();
+        for (lang, entry) in entries {
+            response
+                .entry(lang.clone())
+                .or_default()
+                .insert(lang, entry);
+        }
+
+        tracing::debug!("Loaded cached metadata from database");
+        Ok(Some(response))
+    }
+
+    #[cfg_attr(feature = "otel", tracing::instrument(skip(self)))]
+    fn load_metadata(&self) -> Result<DictionariesResponse, MonolingualError> {
+        match self.get_cached_metadata()? {
+            Some(metadata) => Ok(metadata),
+            None => {
+                tracing::debug!("Cache miss, fetching from API");
+                self.fetch_metadata()
+            }
+        }
+    }
+
+    /// Returns all available monolingual dictionaries.
+    ///
+    /// Only entries where source language equals target language are returned.
+    /// Bilingual pairs present in the API response are ignored.
+    ///
+    /// First tries to load from cache, falls back to an API fetch if not
+    /// cached.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if metadata cannot be loaded.
+    #[cfg_attr(feature = "otel", tracing::instrument(skip(self)))]
+    pub(super) fn get_available_dictionaries(
+        &self,
+    ) -> Result<Vec<(String, DictionaryEntry)>, MonolingualError> {
+        let metadata = self.load_metadata()?;
+
+        let monolingual = metadata
+            .into_iter()
+            .filter_map(|(lang, mut targets)| targets.remove(&lang).map(|entry| (lang, entry)))
+            .collect();
+
+        Ok(monolingual)
+    }
+
+    /// Downloads raw bytes from `url`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the HTTP request fails.
+    #[cfg_attr(feature = "otel", tracing::instrument(skip(self), fields(url = %url)))]
+    pub(super) fn download_bytes(&self, url: &str) -> Result<Vec<u8>, MonolingualError> {
+        tracing::debug!(url = %url, "Downloading bytes");
+
+        let bytes = self
+            .http
+            .get(url)
+            .send()
+            .map_err(|e| MonolingualError::Request(e.to_string()))?
+            .error_for_status()
+            .map_err(|e| MonolingualError::Request(e.to_string()))?
+            .bytes()
+            .map_err(|e| MonolingualError::Request(e.to_string()))?;
+
+        tracing::debug!(url = %url, bytes = bytes.len(), "Download complete");
+
+        Ok(bytes.to_vec())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::db::Database;
+
+    fn create_test_client() -> (MonolingualClient, Database) {
+        crate::crypto::init_crypto_provider();
+        let database = Database::new(":memory:").expect("failed to create in-memory database");
+        database.migrate().expect("failed to run migrations");
+        let client = MonolingualClient::new(&database).expect("failed to create client");
+        (client, database)
+    }
+
+    fn make_response_json() -> String {
+        r#"{
+            "en": {
+                "en": { "formats": "df,dic,dictorg,kobo,mobi,stardict", "updated": "2026-04-01", "words": 1381375 },
+                "fr": { "formats": "df,dic,dictorg,kobo,mobi,stardict", "updated": "2026-04-01", "words": 50000 }
+            },
+            "fr": {
+                "fr": { "formats": "df,dic,dictorg,kobo,mobi,stardict", "updated": "2026-03-01", "words": 2050655 }
+            }
+        }"#.to_string()
+    }
+
+    #[test]
+    fn test_client_creation() {
+        let (_client, _database) = create_test_client();
+    }
+
+    #[test]
+    fn test_no_cache_initially() {
+        let (client, _database) = create_test_client();
+        let result = client.get_cached_metadata().expect("should not error");
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_cache_roundtrip() {
+        let (client, _database) = create_test_client();
+
+        let json = make_response_json();
+        let metadata: DictionariesResponse = serde_json::from_str(&json).unwrap();
+        for (source_lang, targets) in &metadata {
+            if let Some(entry) = targets.get(source_lang.as_str()) {
+                client.db.upsert_entry(source_lang, entry).unwrap();
+            }
+        }
+
+        let cached = client.get_cached_metadata().expect("should load cache");
+        assert!(cached.is_some());
+        let cached = cached.unwrap();
+        assert!(cached.contains_key("en"));
+        assert!(cached["en"].contains_key("en"));
+        assert_eq!(cached["en"]["en"].words, 1_381_375);
+    }
+
+    #[test]
+    fn test_get_available_dictionaries_filters_bilingual() {
+        let (client, _database) = create_test_client();
+
+        let json = make_response_json();
+        let metadata: DictionariesResponse = serde_json::from_str(&json).unwrap();
+        for (source_lang, targets) in &metadata {
+            if let Some(entry) = targets.get(source_lang.as_str()) {
+                client.db.upsert_entry(source_lang, entry).unwrap();
+            }
+        }
+
+        let available = client.get_available_dictionaries().unwrap();
+        // "en→fr" bilingual entry must be excluded; only "en→en" and "fr→fr" returned
+        assert_eq!(available.len(), 2);
+        let langs: Vec<&str> = available.iter().map(|(l, _)| l.as_str()).collect();
+        assert!(langs.contains(&"en"));
+        assert!(langs.contains(&"fr"));
+    }
+
+    /// Fetches live metadata from the monolingual API.
+    ///
+    /// Run with: `cargo test -- --ignored`
+    #[test]
+    #[ignore = "requires network access to www.reader-dict.com"]
+    fn test_fetch_metadata_live() {
+        let (client, _database) = create_test_client();
+        let result = client.fetch_metadata();
+        assert!(result.is_ok(), "fetch_metadata failed: {:?}", result.err());
+        let metadata = result.unwrap();
+        assert!(
+            !metadata.is_empty(),
+            "Expected at least one language in response"
+        );
+        assert!(
+            metadata.get("en").and_then(|m| m.get("en")).is_some(),
+            "Expected English monolingual dictionary in response"
+        );
+    }
+
+    /// Fetches metadata and verifies the entry is written to the database.
+    ///
+    /// Run with: `cargo test -- --ignored`
+    #[test]
+    #[ignore = "requires network access to www.reader-dict.com"]
+    fn test_fetch_metadata_writes_cache() {
+        let (client, _database) = create_test_client();
+        client.fetch_metadata().expect("fetch_metadata failed");
+        let cached = client
+            .get_cached_metadata()
+            .expect("get_cached_metadata failed");
+        assert!(
+            cached.is_some(),
+            "Expected cache to be populated after fetch"
+        );
+    }
+}

--- a/crates/core/src/dictionary/monolingual/db.rs
+++ b/crates/core/src/dictionary/monolingual/db.rs
@@ -1,0 +1,206 @@
+//! Database access layer for monolingual dictionary metadata.
+//!
+//! Manages the `dictionary_monolingual_metadata` table, which caches the
+//! API response from `https://www.reader-dict.com/api/v1/dictionaries`.
+//! Only monolingual entries (source language == target language) are stored.
+
+use super::metadata::DictionaryEntry;
+use crate::db::runtime::RUNTIME;
+use crate::db::types::UnixTimestamp;
+use crate::db::Database;
+use anyhow::Error;
+use chrono::NaiveDate;
+use sqlx::SqlitePool;
+
+/// Database handle for `dictionary_monolingual_metadata`.
+#[derive(Clone, Debug)]
+pub(super) struct Db {
+    pool: SqlitePool,
+}
+
+impl Db {
+    pub(super) fn new(database: &Database) -> Self {
+        Self {
+            pool: database.pool().clone(),
+        }
+    }
+
+    /// Inserts or replaces a single monolingual metadata entry.
+    ///
+    /// The `updated` date string (e.g. `"2026-04-01"`) is parsed as midnight
+    /// UTC and stored as a Unix epoch integer.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the date string cannot be parsed or the database
+    /// write fails.
+    #[cfg_attr(feature = "otel", tracing::instrument(skip(self, entry), fields(lang = %lang)))]
+    pub(super) fn upsert_entry(&self, lang: &str, entry: &DictionaryEntry) -> Result<(), Error> {
+        let updated = parse_date_to_timestamp(&entry.updated)?;
+        let cached_at = UnixTimestamp::now();
+        let formats = &entry.formats;
+        let words = entry.words as i64;
+
+        RUNTIME.block_on(async {
+            sqlx::query!(
+                r#"INSERT INTO dictionary_monolingual_metadata
+                       (lang, formats, updated, words, cached_at)
+                   VALUES (?, ?, ?, ?, ?)
+                   ON CONFLICT(lang) DO UPDATE SET
+                       formats   = excluded.formats,
+                       updated   = excluded.updated,
+                       words     = excluded.words,
+                       cached_at = excluded.cached_at"#,
+                lang,
+                formats,
+                updated,
+                words,
+                cached_at,
+            )
+            .execute(&self.pool)
+            .await?;
+
+            tracing::debug!(lang, "upserted monolingual metadata entry");
+            Ok(())
+        })
+    }
+
+    /// Retrieves all cached monolingual metadata entries.
+    ///
+    /// Returns an empty `Vec` if no entries have been cached yet.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the database query fails or any stored `updated`
+    /// timestamp cannot be formatted as a date string.
+    #[cfg_attr(feature = "otel", tracing::instrument(skip(self)))]
+    pub(super) fn get_all_entries(&self) -> Result<Vec<(String, DictionaryEntry)>, Error> {
+        RUNTIME.block_on(async {
+            let rows = sqlx::query!(
+                r#"SELECT lang, formats, updated as "updated: UnixTimestamp", words
+                   FROM dictionary_monolingual_metadata"#,
+            )
+            .fetch_all(&self.pool)
+            .await?;
+
+            rows.into_iter()
+                .map(|r| {
+                    Ok((
+                        r.lang,
+                        DictionaryEntry {
+                            formats: r.formats,
+                            updated: format_timestamp_to_date(r.updated)?,
+                            words: r.words as u64,
+                        },
+                    ))
+                })
+                .collect()
+        })
+    }
+}
+
+/// Parses an ISO 8601 date string (e.g. `"2026-04-01"`) to midnight UTC as a
+/// `UnixTimestamp`.
+fn parse_date_to_timestamp(date_str: &str) -> Result<UnixTimestamp, Error> {
+    let date = NaiveDate::parse_from_str(date_str, "%Y-%m-%d")
+        .map_err(|e| anyhow::anyhow!("invalid date '{}': {}", date_str, e))?;
+    let dt: chrono::NaiveDateTime = date.and_hms_opt(0, 0, 0).unwrap();
+    Ok(UnixTimestamp::from(dt))
+}
+
+/// Formats a `UnixTimestamp` back to an ISO 8601 date string (e.g. `"2026-04-01"`).
+fn format_timestamp_to_date(ts: UnixTimestamp) -> Result<String, Error> {
+    let dt: chrono::NaiveDateTime = ts.into();
+    Ok(dt.format("%Y-%m-%d").to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn create_test_db() -> (Database, Db) {
+        let database = Database::new(":memory:").expect("failed to create in-memory database");
+        database.migrate().expect("failed to run migrations");
+        let db = Db::new(&database);
+        (database, db)
+    }
+
+    fn make_entry(updated: &str, words: u64) -> DictionaryEntry {
+        DictionaryEntry {
+            formats: "df,dic,dictorg,kobo,mobi,stardict".to_string(),
+            updated: updated.to_string(),
+            words,
+        }
+    }
+
+    #[test]
+    fn test_upsert_and_get_roundtrip() {
+        let (_database, db) = create_test_db();
+        let entry = make_entry("2026-04-01", 1_381_375);
+
+        db.upsert_entry("en", &entry)
+            .expect("upsert should succeed");
+
+        let all = db.get_all_entries().expect("get_all should not fail");
+        assert_eq!(all.len(), 1);
+        let (lang, fetched) = &all[0];
+        assert_eq!(lang, "en");
+        assert_eq!(fetched.formats, entry.formats);
+        assert_eq!(fetched.updated, "2026-04-01");
+        assert_eq!(fetched.words, 1_381_375);
+    }
+
+    #[test]
+    fn test_upsert_overwrites_existing_entry() {
+        let (_database, db) = create_test_db();
+
+        db.upsert_entry("en", &make_entry("2026-01-01", 100))
+            .expect("upsert should succeed");
+        db.upsert_entry("en", &make_entry("2026-04-01", 1_381_375))
+            .expect("upsert should succeed");
+
+        let all = db.get_all_entries().expect("get_all should not fail");
+        assert_eq!(all.len(), 1);
+        let (_, fetched) = &all[0];
+        assert_eq!(fetched.updated, "2026-04-01");
+        assert_eq!(fetched.words, 1_381_375);
+    }
+
+    #[test]
+    fn test_get_all_entries_returns_all() {
+        let (_database, db) = create_test_db();
+
+        db.upsert_entry("en", &make_entry("2026-04-01", 1_381_375))
+            .expect("upsert should succeed");
+        db.upsert_entry("fr", &make_entry("2026-03-01", 2_050_655))
+            .expect("upsert should succeed");
+
+        let all = db.get_all_entries().expect("get_all should not fail");
+        assert_eq!(all.len(), 2);
+
+        let langs: Vec<&str> = all.iter().map(|(l, _)| l.as_str()).collect();
+        assert!(langs.contains(&"en"));
+        assert!(langs.contains(&"fr"));
+    }
+
+    #[test]
+    fn test_get_all_entries_empty() {
+        let (_database, db) = create_test_db();
+        let all = db.get_all_entries().expect("get_all should not fail");
+        assert!(all.is_empty());
+    }
+
+    #[test]
+    fn test_parse_date_to_timestamp_roundtrip() {
+        let date_str = "2026-04-01";
+        let ts = parse_date_to_timestamp(date_str).expect("parse should succeed");
+        let formatted = format_timestamp_to_date(ts).expect("format should succeed");
+        assert_eq!(formatted, date_str);
+    }
+
+    #[test]
+    fn test_parse_date_invalid_returns_error() {
+        assert!(parse_date_to_timestamp("not-a-date").is_err());
+        assert!(parse_date_to_timestamp("2026/04/01").is_err());
+    }
+}

--- a/crates/core/src/dictionary/monolingual/errors.rs
+++ b/crates/core/src/dictionary/monolingual/errors.rs
@@ -1,0 +1,30 @@
+//! Error types for monolingual dictionary operations.
+
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum MonolingualError {
+    #[error("HTTP request failed: {0}")]
+    Http(#[from] crate::http::HttpError),
+
+    #[error("Failed to deserialize API response: {0}")]
+    Deserialization(#[from] serde_json::Error),
+
+    #[error("Database error: {0}")]
+    Database(#[from] anyhow::Error),
+
+    #[error("I/O error: {0}")]
+    Io(#[from] std::io::Error),
+
+    #[error("Dictionary not found for language: {0}")]
+    NotFound(String),
+
+    #[error("Request failed: {0}")]
+    Request(String),
+
+    #[error("Failed to extract dictionary archive: {0}")]
+    Extraction(String),
+
+    #[error("Installation already in progress for language: {0}")]
+    InstallationInProgress(String),
+}

--- a/crates/core/src/dictionary/monolingual/metadata.rs
+++ b/crates/core/src/dictionary/monolingual/metadata.rs
@@ -1,0 +1,135 @@
+//! API response types for the monolingual dictionary metadata endpoint.
+//!
+//! The `GET https://www.reader-dict.com/api/v1/dictionaries` endpoint returns
+//! a unified bilingual + monolingual registry. This module only models and
+//! exposes the **monolingual** subset (entries where source language equals
+//! target language, e.g. `en → en`). Bilingual pairs are ignored.
+
+use std::collections::HashMap;
+
+use serde::{Deserialize, Serialize};
+
+/// Top-level response from `GET https://www.reader-dict.com/api/v1/dictionaries`.
+///
+/// The API returns a nested map of source language → target language → entry.
+/// Both monolingual (src == tgt) and bilingual (src != tgt) entries are present,
+/// but only the monolingual subset is used by this module.
+pub type DictionariesResponse = HashMap<String, HashMap<String, DictionaryEntry>>;
+
+/// A single dictionary entry returned by the API.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct DictionaryEntry {
+    /// Comma-separated list of available download formats
+    /// (e.g. `"df,dic,dictorg,kobo,mobi,stardict"`).
+    pub formats: String,
+
+    /// ISO 8601 date of the last release (e.g. `"2026-04-01"`).
+    pub updated: String,
+
+    /// Number of headword entries in the dictionary.
+    pub words: u64,
+}
+
+/// Returns the download URL for the DICT.org format archive (includes etymologies).
+///
+/// Pattern: `https://www.reader-dict.com/file/{lang}/dictorg-{lang}-{lang}.zip`
+pub(super) fn download_url(lang: &str) -> String {
+    format!(
+        "https://www.reader-dict.com/file/{lang}/dictorg-{lang}-{lang}.zip",
+        lang = lang
+    )
+}
+
+/// Returns the download URL for the DICT.org format archive **without** etymologies.
+///
+/// Pattern: `https://www.reader-dict.com/file/{lang}/dictorg-{lang}-{lang}-noetym.zip`
+pub(super) fn download_url_no_etym(lang: &str) -> String {
+    format!(
+        "https://www.reader-dict.com/file/{lang}/dictorg-{lang}-{lang}-noetym.zip",
+        lang = lang
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_entry() -> DictionaryEntry {
+        DictionaryEntry {
+            formats: "df,dic,dictorg,kobo,mobi,stardict".to_string(),
+            updated: "2026-04-01".to_string(),
+            words: 1_381_375,
+        }
+    }
+
+    #[test]
+    fn test_download_url_english() {
+        assert_eq!(
+            download_url("en"),
+            "https://www.reader-dict.com/file/en/dictorg-en-en.zip"
+        );
+    }
+
+    #[test]
+    fn test_download_url_no_etym_english() {
+        assert_eq!(
+            download_url_no_etym("en"),
+            "https://www.reader-dict.com/file/en/dictorg-en-en-noetym.zip"
+        );
+    }
+
+    #[test]
+    fn test_download_url_french() {
+        assert_eq!(
+            download_url("fr"),
+            "https://www.reader-dict.com/file/fr/dictorg-fr-fr.zip"
+        );
+    }
+
+    #[test]
+    fn test_deserialize_response() {
+        let json = r#"{
+            "en": {
+                "en": { "formats": "df,dic,dictorg,kobo,mobi,stardict", "updated": "2026-04-01", "words": 1381375 },
+                "fr": { "formats": "df,dic,dictorg,kobo,mobi,stardict", "updated": "2026-04-01", "words": 50000 }
+            },
+            "fr": {
+                "fr": { "formats": "df,dic,dictorg,kobo,mobi,stardict", "updated": "2026-03-01", "words": 2050655 }
+            }
+        }"#;
+
+        let resp: DictionariesResponse = serde_json::from_str(json).unwrap();
+
+        let en_entry = resp.get("en").and_then(|m| m.get("en")).unwrap();
+        assert_eq!(en_entry.words, 1_381_375);
+        assert_eq!(en_entry.updated, "2026-04-01");
+
+        let fr_entry = resp.get("fr").and_then(|m| m.get("fr")).unwrap();
+        assert_eq!(fr_entry.words, 2_050_655);
+
+        assert_eq!(*en_entry, make_entry());
+    }
+
+    #[test]
+    fn test_monolingual_filter() {
+        let json = r#"{
+            "en": {
+                "en": { "formats": "df,dic,dictorg,kobo,mobi,stardict", "updated": "2026-04-01", "words": 1381375 },
+                "fr": { "formats": "df,dic,dictorg,kobo,mobi,stardict", "updated": "2026-04-01", "words": 50000 }
+            },
+            "af": {
+                "en": { "formats": "df,dic,dictorg,kobo,mobi,stardict", "updated": "2026-04-01", "words": 8934 }
+            }
+        }"#;
+
+        let resp: DictionariesResponse = serde_json::from_str(json).unwrap();
+
+        let monolingual: Vec<(&str, &DictionaryEntry)> = resp
+            .iter()
+            .filter_map(|(lang, targets)| targets.get(lang.as_str()).map(|e| (lang.as_str(), e)))
+            .collect();
+
+        assert_eq!(monolingual.len(), 1);
+        assert_eq!(monolingual[0].0, "en");
+    }
+}

--- a/crates/core/src/dictionary/monolingual/mod.rs
+++ b/crates/core/src/dictionary/monolingual/mod.rs
@@ -1,0 +1,19 @@
+//! Monolingual dictionary support.
+//!
+//! The single entry point for callers is [`MonolingualDictionaryService`],
+//! which exposes:
+//!
+//! - [`MonolingualDictionaryService::get_available_dictionaries`] – remote catalogue
+//! - [`MonolingualDictionaryService::get_installed_dictionaries`] – locally installed
+//! - [`MonolingualDictionaryService::install_dictionary`] – download and extract
+//!
+//! All internal modules (`client`, `db`, `metadata`) are private implementation
+//! details and are not accessible outside this module.
+
+mod client;
+mod db;
+mod errors;
+mod metadata;
+mod service;
+
+pub(crate) use service::MonolingualDictionaryService;

--- a/crates/core/src/dictionary/monolingual/service.rs
+++ b/crates/core/src/dictionary/monolingual/service.rs
@@ -1,0 +1,511 @@
+//! High-level service for monolingual dictionary management.
+//!
+//! [`MonolingualDictionaryService`] is the single public entry point for all
+//! monolingual dictionary operations: querying the remote catalogue, listing
+//! installed dictionaries, and installing a new one.
+
+use super::client::MonolingualClient;
+use super::errors::MonolingualError;
+use super::metadata::{download_url, download_url_no_etym, DictionaryEntry};
+use crate::db::Database;
+use std::collections::HashSet;
+use std::fs;
+use std::io::{self, Cursor};
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
+use zip::ZipArchive;
+
+/// Subdirectory inside the dictionaries root where reader-dict downloads live.
+const READER_DICT_SUBDIR: &str = "reader-dict";
+
+/// Provides monolingual dictionary management: querying available dictionaries,
+/// listing installed ones, and downloading + extracting new ones.
+///
+/// All network metadata is cached in the application SQLite database.
+/// Downloaded dictionaries are extracted to
+/// `<dict_dir>/reader-dict/<lang>/`.
+///
+/// The service is cheaply cloneable (`Arc`-backed). All clones share the same
+/// `pending_installs` set, so concurrent-download guards work correctly across
+/// the UI thread (which holds the original) and background threads (which hold
+/// clones).
+#[derive(Clone, Debug)]
+pub struct MonolingualDictionaryService {
+    client: MonolingualClient,
+    dict_dir: PathBuf,
+    pending_installs: Arc<Mutex<HashSet<String>>>,
+}
+
+impl MonolingualDictionaryService {
+    /// Creates a new service.
+    ///
+    /// # Arguments
+    ///
+    /// * `database` - Application SQLite database used for metadata caching.
+    /// * `dict_dir` - Root directory where dictionaries are stored. Downloads
+    ///   are placed in `<dict_dir>/reader-dict/<lang>/`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the HTTP client cannot be built.
+    #[cfg_attr(feature = "otel", tracing::instrument(skip(database), fields(dict_dir = %dict_dir.display())))]
+    pub fn new(database: &Database, dict_dir: &Path) -> Result<Self, MonolingualError> {
+        let client = MonolingualClient::new(database)?;
+        Ok(Self {
+            client,
+            dict_dir: dict_dir.to_path_buf(),
+            pending_installs: Arc::new(Mutex::new(HashSet::new())),
+        })
+    }
+
+    /// Returns all dictionaries available for download from the remote API.
+    ///
+    /// Metadata is served from the SQLite cache when available; otherwise a
+    /// network request is made and the result is cached.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the metadata cannot be loaded from cache or network.
+    #[cfg_attr(feature = "otel", tracing::instrument(skip(self)))]
+    pub fn get_available_dictionaries(
+        &self,
+    ) -> Result<Vec<(String, DictionaryEntry)>, MonolingualError> {
+        self.client.get_available_dictionaries()
+    }
+
+    /// Returns the language codes of all locally installed dictionaries.
+    ///
+    /// A dictionary is considered installed when its language directory exists
+    /// inside `<dict_dir>/reader-dict/` and contains at least one `.index`
+    /// file paired with a `.dict` or `.dict.dz` file.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the directory cannot be read.
+    #[cfg_attr(feature = "otel", tracing::instrument(skip(self)))]
+    pub fn get_installed_dictionaries(&self) -> Result<Vec<String>, MonolingualError> {
+        let root = self.reader_dict_dir();
+
+        if !root.exists() {
+            return Ok(Vec::new());
+        }
+
+        let mut installed = Vec::new();
+
+        for entry in fs::read_dir(&root)? {
+            let entry = entry?;
+            let path = entry.path();
+
+            if !path.is_dir() {
+                continue;
+            }
+
+            if has_dict_pair(&path) {
+                if let Some(lang) = path.file_name().and_then(|n| n.to_str()) {
+                    installed.push(lang.to_string());
+                }
+            }
+        }
+
+        Ok(installed)
+    }
+
+    /// Returns `true` if a download is already in progress for `lang`.
+    ///
+    /// This can be used by callers to suppress duplicate install requests before
+    /// spawning a background thread.
+    #[cfg_attr(feature = "otel", tracing::instrument(skip(self), ret(level=tracing::Level::TRACE)))]
+    pub fn is_installing(&self, lang: &str) -> bool {
+        #[cfg(feature = "otel")]
+        let _span = tracing::info_span!("lock").entered();
+        self.pending_installs.lock().unwrap().contains(lang)
+    }
+
+    /// Downloads and installs a dictionary for the given language.
+    ///
+    /// The archive is extracted into `<dict_dir>/reader-dict/<lang>/` and the
+    /// files are renamed to `<lang>.index` and `<lang>.dict[.dz]`. Any
+    /// existing files in that directory are overwritten.
+    ///
+    /// Returns [`MonolingualError::InstallationInProgress`] immediately if a
+    /// download for the same language is already running. The caller should
+    /// check [`Self::is_installing`] on the UI thread before spawning a thread
+    /// to get a user-visible early exit; this check inside `install_dictionary`
+    /// provides a safety net against races.
+    ///
+    /// # Arguments
+    ///
+    /// * `lang` - ISO 639-1 language code (e.g. `"en"`, `"fr"`).
+    /// * `include_etymologies` - When `true`, the full archive (with
+    ///   etymologies) is downloaded; when `false`, the smaller no-etymology
+    ///   variant is used.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if a download for `lang` is already in progress, if
+    /// the download fails, if the archive cannot be parsed, or if files cannot
+    /// be written to disk.
+    #[cfg_attr(feature = "otel", tracing::instrument(skip(self), fields(lang = %lang, include_etymologies)))]
+    pub fn install_dictionary(
+        &self,
+        lang: &str,
+        include_etymologies: bool,
+    ) -> Result<(), MonolingualError> {
+        {
+            #[cfg(feature = "otel")]
+            let _span = tracing::info_span!("lock").entered();
+
+            let mut pending = self.pending_installs.lock().unwrap();
+            if pending.contains(lang) {
+                return Err(MonolingualError::InstallationInProgress(lang.to_string()));
+            }
+            pending.insert(lang.to_string());
+        }
+
+        let result = self.do_install(lang, include_etymologies);
+
+        {
+            #[cfg(feature = "otel")]
+            let _span = tracing::info_span!("lock").entered();
+            self.pending_installs.lock().unwrap().remove(lang);
+        }
+
+        result
+    }
+
+    #[cfg_attr(feature = "otel", tracing::instrument(skip(self)))]
+    fn do_install(&self, lang: &str, include_etymologies: bool) -> Result<(), MonolingualError> {
+        let url = if include_etymologies {
+            download_url(lang)
+        } else {
+            download_url_no_etym(lang)
+        };
+
+        tracing::info!(lang, url = %url, "Downloading dictionary");
+
+        let bytes = self
+            .client
+            .download_bytes(&url)
+            .map_err(|e| MonolingualError::Request(e.to_string()))?;
+
+        let dest = self.lang_dir(lang);
+        fs::create_dir_all(&dest)?;
+
+        tracing::debug!(lang, dest = %dest.display(), "Extracting dictionary archive");
+
+        extract_zip_renamed(&bytes, &dest, lang)?;
+
+        tracing::info!(lang, dest = %dest.display(), "Dictionary installed");
+
+        Ok(())
+    }
+
+    fn reader_dict_dir(&self) -> PathBuf {
+        self.dict_dir.join(READER_DICT_SUBDIR)
+    }
+
+    fn lang_dir(&self, lang: &str) -> PathBuf {
+        self.reader_dict_dir().join(lang)
+    }
+}
+
+/// Returns `true` when `dir` contains at least one `.index` file that is
+/// paired with a `.dict` or `.dict.dz` file sharing the same stem.
+fn has_dict_pair(dir: &Path) -> bool {
+    let Ok(entries) = fs::read_dir(dir) else {
+        return false;
+    };
+
+    for entry in entries.flatten() {
+        let path = entry.path();
+        let name = match path.file_name().and_then(|n| n.to_str()) {
+            Some(n) => n.to_string(),
+            None => continue,
+        };
+
+        if !name.ends_with(".index") {
+            continue;
+        }
+
+        let stem = &name[..name.len() - ".index".len()];
+        let dict = dir.join(format!("{stem}.dict"));
+        let dict_dz = dir.join(format!("{stem}.dict.dz"));
+
+        if dict.exists() || dict_dz.exists() {
+            return true;
+        }
+    }
+
+    false
+}
+
+/// Extracts all entries from a ZIP archive `bytes` into `dest`, renaming each
+/// file to `<lang>.<ext>` where `<ext>` is `.index`, `.dict`, or `.dict.dz`.
+///
+/// Files with unrecognised extensions are skipped. Directories inside the ZIP
+/// are ignored because all output files land flat in `dest`.
+#[cfg_attr(feature = "otel", tracing::instrument(skip(bytes)))]
+fn extract_zip_renamed(bytes: &[u8], dest: &Path, lang: &str) -> Result<(), MonolingualError> {
+    let cursor = Cursor::new(bytes);
+    let mut archive = ZipArchive::new(cursor)
+        .map_err(|e| MonolingualError::Extraction(format!("failed to open zip archive: {e}")))?;
+
+    for i in 0..archive.len() {
+        let mut file = archive.by_index(i).map_err(|e| {
+            MonolingualError::Extraction(format!("failed to read zip entry {i}: {e}"))
+        })?;
+
+        if file.is_dir() {
+            continue;
+        }
+
+        let original_name = match file.enclosed_name() {
+            Some(p) => p
+                .file_name()
+                .and_then(|n| n.to_str())
+                .unwrap_or("")
+                .to_string(),
+            None => {
+                tracing::warn!(index = i, "Skipping zip entry with unsafe path");
+                continue;
+            }
+        };
+
+        let target_name = dict_file_target_name(&original_name, lang);
+        let Some(target_name) = target_name else {
+            tracing::debug!(
+                original_name,
+                "Skipping zip entry with unrecognised extension"
+            );
+            continue;
+        };
+
+        let out_path = dest.join(&target_name);
+        let mut out_file = fs::File::create(&out_path)?;
+        io::copy(&mut file, &mut out_file)?;
+        tracing::debug!(path = %out_path.display(), "Extracted file");
+    }
+
+    Ok(())
+}
+
+/// Maps a ZIP entry filename to its renamed output filename `<lang>.<ext>`.
+///
+/// Recognised extensions (in priority order):
+/// - `.dict.dz` → `Reader-Dict-<lang>.dict.dz`
+/// - `.dict`    → `Reader-Dict-<lang>.dict`
+/// - `.index`   → `Reader-Dict-<lang>.index`
+///
+/// Returns `None` for any other extension.
+fn dict_file_target_name(original: &str, lang: &str) -> Option<String> {
+    for ext in &[".dict.dz", ".dict", ".index"] {
+        if original.ends_with(ext) {
+            return Some(format!("Reader-Dict-{lang}{ext}"));
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::db::Database;
+    use std::io::Write;
+    use tempfile::TempDir;
+
+    fn create_test_service() -> (MonolingualDictionaryService, TempDir) {
+        crate::crypto::init_crypto_provider();
+        let dir = TempDir::new().expect("failed to create temp dir");
+        let database = Database::new(":memory:").expect("failed to create in-memory database");
+        database.migrate().expect("failed to run migrations");
+        let service = MonolingualDictionaryService::new(&database, dir.path())
+            .expect("failed to create service");
+        (service, dir)
+    }
+
+    #[test]
+    fn test_get_installed_empty_when_no_dir() {
+        let (service, _dir) = create_test_service();
+        let installed = service.get_installed_dictionaries().unwrap();
+        assert!(installed.is_empty());
+    }
+
+    #[test]
+    fn test_get_installed_empty_when_dir_exists_but_empty() {
+        let (service, dir) = create_test_service();
+        fs::create_dir_all(dir.path().join(READER_DICT_SUBDIR)).unwrap();
+        let installed = service.get_installed_dictionaries().unwrap();
+        assert!(installed.is_empty());
+    }
+
+    #[test]
+    fn test_get_installed_detects_dict_pair() {
+        let (service, dir) = create_test_service();
+        let lang_dir = dir.path().join(READER_DICT_SUBDIR).join("en");
+        fs::create_dir_all(&lang_dir).unwrap();
+        fs::File::create(lang_dir.join("dict.index")).unwrap();
+        fs::File::create(lang_dir.join("dict.dict")).unwrap();
+
+        let installed = service.get_installed_dictionaries().unwrap();
+        assert_eq!(installed, vec!["en".to_string()]);
+    }
+
+    #[test]
+    fn test_get_installed_detects_dict_dz_pair() {
+        let (service, dir) = create_test_service();
+        let lang_dir = dir.path().join(READER_DICT_SUBDIR).join("fr");
+        fs::create_dir_all(&lang_dir).unwrap();
+        fs::File::create(lang_dir.join("dict.index")).unwrap();
+        fs::File::create(lang_dir.join("dict.dict.dz")).unwrap();
+
+        let installed = service.get_installed_dictionaries().unwrap();
+        assert_eq!(installed, vec!["fr".to_string()]);
+    }
+
+    #[test]
+    fn test_get_installed_ignores_index_without_dict() {
+        let (service, dir) = create_test_service();
+        let lang_dir = dir.path().join(READER_DICT_SUBDIR).join("de");
+        fs::create_dir_all(&lang_dir).unwrap();
+        fs::File::create(lang_dir.join("dict.index")).unwrap();
+
+        let installed = service.get_installed_dictionaries().unwrap();
+        assert!(installed.is_empty());
+    }
+
+    #[test]
+    fn test_install_dictionary_extracts_zip_renamed() {
+        let (_service, dir) = create_test_service();
+
+        let zip_bytes = make_test_zip(&[
+            ("dictorg-en-en.index", b"index content"),
+            ("dictorg-en-en.dict", b"dict content"),
+        ]);
+
+        let dest = dir.path().join(READER_DICT_SUBDIR).join("en");
+        fs::create_dir_all(&dest).unwrap();
+        extract_zip_renamed(&zip_bytes, &dest, "en").unwrap();
+
+        assert!(dest.join("Reader-Dict-en.index").exists());
+        assert!(dest.join("Reader-Dict-en.dict").exists());
+    }
+
+    fn make_test_zip(entries: &[(&str, &[u8])]) -> Vec<u8> {
+        let mut buf = Vec::new();
+        {
+            let cursor = Cursor::new(&mut buf);
+            let mut zip = zip::ZipWriter::new(cursor);
+            let options = zip::write::SimpleFileOptions::default();
+            for (name, content) in entries {
+                zip.start_file(*name, options).unwrap();
+                zip.write_all(content).unwrap();
+            }
+            zip.finish().unwrap();
+        }
+        buf
+    }
+
+    #[test]
+    fn test_is_installing_false_initially() {
+        let (service, _dir) = create_test_service();
+        assert!(!service.is_installing("en"));
+    }
+
+    #[test]
+    fn test_is_installing_true_while_pending() {
+        let (service, _dir) = create_test_service();
+        service
+            .pending_installs
+            .lock()
+            .unwrap()
+            .insert("fr".to_string());
+        assert!(service.is_installing("fr"));
+        assert!(!service.is_installing("en"));
+    }
+
+    #[test]
+    fn test_is_installing_false_after_removal() {
+        let (service, _dir) = create_test_service();
+        service
+            .pending_installs
+            .lock()
+            .unwrap()
+            .insert("en".to_string());
+        service.pending_installs.lock().unwrap().remove("en");
+        assert!(!service.is_installing("en"));
+    }
+
+    #[test]
+    fn test_concurrent_install_same_lang_returns_error() {
+        let (service, _dir) = create_test_service();
+        service
+            .pending_installs
+            .lock()
+            .unwrap()
+            .insert("de".to_string());
+
+        let err = service
+            .install_dictionary("de", false)
+            .expect_err("expected InstallationInProgress error");
+
+        assert!(
+            matches!(err, MonolingualError::InstallationInProgress(_)),
+            "unexpected error variant: {err}"
+        );
+    }
+
+    #[test]
+    fn test_pending_cleared_after_failed_install() {
+        let (service, _dir) = create_test_service();
+
+        // A missing URL will cause a network error; verify pending is cleared.
+        let _ = service.install_dictionary("zz", false);
+        assert!(!service.is_installing("zz"));
+    }
+
+    #[test]
+    fn test_is_installing_shared_across_clones() {
+        let (service, _dir) = create_test_service();
+        let clone = service.clone();
+
+        service
+            .pending_installs
+            .lock()
+            .unwrap()
+            .insert("ja".to_string());
+
+        assert!(clone.is_installing("ja"));
+    }
+
+    /// Downloads and installs the English dictionary from the live API, then
+    /// verifies that at least one `.index` + `.dict`/`.dict.dz` pair is present.
+    ///
+    /// Run with: `cargo test -- --ignored`
+    #[test]
+    #[ignore = "requires network access to www.reader-dict.com"]
+    fn test_install_dictionary_live() {
+        let (service, dir) = create_test_service();
+
+        service
+            .install_dictionary("en", false)
+            .expect("install_dictionary failed");
+
+        let lang_dir = dir.path().join(READER_DICT_SUBDIR).join("en");
+        assert!(
+            lang_dir.exists(),
+            "language directory should exist after install"
+        );
+        assert!(
+            has_dict_pair(&lang_dir),
+            "expected .index + .dict/.dict.dz pair in {lang_dir:?}"
+        );
+
+        let installed = service
+            .get_installed_dictionaries()
+            .expect("get_installed_dictionaries failed");
+        assert!(
+            installed.contains(&"en".to_string()),
+            "expected 'en' in installed list, got {installed:?}"
+        );
+    }
+}

--- a/crates/core/src/view/mod.rs
+++ b/crates/core/src/view/mod.rs
@@ -532,6 +532,15 @@ pub enum Event {
     /// This event is sent from the version check thread when the remote version
     /// is newer than the current version, triggering the actual download to begin.
     StartStableReleaseDownload,
+    /// Result of a background dictionary install spawned by `CategoryEditor`.
+    ///
+    /// Sent from the download thread when the install completes (success or
+    /// failure). `CategoryEditor` handles this by rebuilding the rows list so
+    /// the newly-installed dictionary appears immediately.
+    DictionaryInstallComplete {
+        lang: String,
+        result: Result<(), String>,
+    },
 }
 
 #[derive(Debug, Clone, Eq, PartialEq)]
@@ -774,6 +783,9 @@ pub enum EntryId {
     SetPenColor(Color),
     TogglePenDynamism,
     ReloadDictionaries,
+    DownloadDictionary(String),
+    RedownloadDictionary(String),
+    DeleteDictionary(String),
     New,
     Refresh,
     TakeScreenshot,

--- a/crates/core/src/view/ota.rs
+++ b/crates/core/src/view/ota.rs
@@ -12,6 +12,7 @@ use super::{
 use crate::color::WHITE;
 use crate::context::Context;
 use crate::device::CURRENT_DEVICE;
+use crate::fl;
 use crate::font::{font_from_style, Fonts, NORMAL_STYLE};
 use crate::framebuffer::Framebuffer;
 use crate::geom::Rectangle;
@@ -79,7 +80,7 @@ pub fn show_ota_view(
     if !context.online {
         let notif = Notification::new(
             None,
-            "WiFi must be connected to check for updates.".to_string(),
+            fl!("notification-not-online"),
             false,
             hub,
             rq,

--- a/crates/core/src/view/settings_editor/category.rs
+++ b/crates/core/src/view/settings_editor/category.rs
@@ -1,3 +1,4 @@
+use super::kinds::dictionary::DictionaryInfo;
 use super::kinds::general::{
     AutoPowerOff, AutoShare, AutoSuspend, ButtonScheme, KeyboardLayout, Locale, SettingsRetention,
     SleepCover,
@@ -9,6 +10,8 @@ use super::kinds::reader::FinishedActionSetting;
 use super::kinds::telemetry::{LogLevel, LoggingEnabled};
 use super::kinds::SettingKind;
 use crate::context::Context;
+use crate::dictionary::MonolingualDictionaryService;
+use std::collections::BTreeSet;
 
 /// Categories of settings available in the settings editor.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -25,6 +28,8 @@ pub enum Category {
     Import,
     /// Telemetry and logging settings
     Telemetry,
+    /// Monolingual dictionary download and management
+    Dictionaries,
 }
 
 impl Category {
@@ -37,6 +42,7 @@ impl Category {
             Category::Intermissions => "Intermission Screens".to_string(),
             Category::Import => "Import".to_string(),
             Category::Telemetry => "Telemetry".to_string(),
+            Category::Dictionaries => "Dictionaries".to_string(),
         }
     }
 
@@ -44,7 +50,16 @@ impl Category {
     ///
     /// Each element is a heap-allocated [`SettingKind`] that fully describes
     /// the label, current value, widget type, and tap event for one row.
-    pub fn settings(&self, context: &Context) -> Vec<Box<dyn SettingKind>> {
+    ///
+    /// `dict_service` is used only by the [`Category::Dictionaries`] variant.
+    /// All other categories ignore it. Passing `None` for a `Dictionaries`
+    /// category produces an empty list and logs a warning.
+    #[cfg_attr(feature = "otel", tracing::instrument(skip(context, dict_service)))]
+    pub fn settings(
+        &self,
+        context: &Context,
+        dict_service: Option<&MonolingualDictionaryService>,
+    ) -> Vec<Box<dyn SettingKind>> {
         match self {
             Category::General => vec![
                 Box::new(Locale),
@@ -104,6 +119,42 @@ impl Category {
                     rows
                 }
             }
+            Category::Dictionaries => {
+                let Some(service) = dict_service else {
+                    tracing::warn!(
+                        "No MonolingualDictionaryService provided for Dictionaries category"
+                    );
+                    return Vec::new();
+                };
+
+                let available: BTreeSet<String> = if context.online {
+                    service
+                        .get_available_dictionaries()
+                        .unwrap_or_default()
+                        .into_iter()
+                        .map(|(lang, _)| lang)
+                        .collect()
+                } else {
+                    BTreeSet::new()
+                };
+
+                let installed: BTreeSet<String> = service
+                    .get_installed_dictionaries()
+                    .unwrap_or_default()
+                    .into_iter()
+                    .collect();
+
+                let mut all_langs: Vec<String> = available.union(&installed).cloned().collect();
+                all_langs.sort();
+
+                all_langs
+                    .into_iter()
+                    .map(|lang| {
+                        let is_installed = installed.contains(&lang);
+                        Box::new(DictionaryInfo { lang, is_installed }) as Box<dyn SettingKind>
+                    })
+                    .collect()
+            }
         }
     }
 
@@ -112,6 +163,7 @@ impl Category {
         vec![
             Category::General,
             Category::Reader,
+            Category::Dictionaries,
             Category::Libraries,
             Category::Intermissions,
             Category::Import,

--- a/crates/core/src/view/settings_editor/category_editor.rs
+++ b/crates/core/src/view/settings_editor/category_editor.rs
@@ -1,6 +1,8 @@
 use crate::color::{BLACK, WHITE};
-use crate::context::Context;
+use crate::context::{Context, DICTIONARIES_DIRNAME};
 use crate::device::CURRENT_DEVICE;
+use crate::dictionary::MonolingualDictionaryService;
+use crate::fl;
 use crate::framebuffer::{Framebuffer, UpdateMode};
 use crate::geom::{halves, CycleDir, Rectangle};
 use crate::settings::{LibrarySettings, Settings};
@@ -10,15 +12,16 @@ use crate::view::filler::Filler;
 use crate::view::menu::{Menu, MenuKind};
 use crate::view::toggleable_keyboard::ToggleableKeyboard;
 use crate::view::{
-    Bus, EntryId, EntryKind, Event, Hub, Id, RenderData, RenderQueue, View, ViewId, ID_FEEDER,
-    SMALL_BAR_HEIGHT, THICKNESS_MEDIUM,
+    Bus, EntryId, EntryKind, Event, Hub, Id, NotificationEvent, RenderData, RenderQueue, View,
+    ViewId, ID_FEEDER, SMALL_BAR_HEIGHT, THICKNESS_MEDIUM,
 };
 
 use super::bottom_bar::{BottomBarVariant, SettingsEditorBottomBar};
 use super::category::Category;
 use super::library_editor::LibraryEditor;
 use super::setting_row::SettingRow;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
+use std::thread;
 
 /// A view for editing category-specific settings.
 ///
@@ -62,6 +65,7 @@ pub struct CategoryEditor {
     keyboard_index: usize,
     current_page: usize,
     pages_count: usize,
+    dict_service: Option<MonolingualDictionaryService>,
 }
 
 impl CategoryEditor {
@@ -112,6 +116,21 @@ impl CategoryEditor {
         let separator_index = first_row_index;
         let keyboard_index = children.len() - 1;
 
+        let dict_service = if category == Category::Dictionaries {
+            match MonolingualDictionaryService::new(
+                &context.database,
+                std::path::Path::new(DICTIONARIES_DIRNAME),
+            ) {
+                Ok(service) => Some(service),
+                Err(e) => {
+                    tracing::warn!(error = %e, "Failed to create MonolingualDictionaryService");
+                    None
+                }
+            }
+        } else {
+            None
+        };
+
         let mut editor = CategoryEditor {
             id,
             rect,
@@ -125,6 +144,7 @@ impl CategoryEditor {
             keyboard_index,
             current_page: 0,
             pages_count: 1,
+            dict_service,
         };
 
         editor.update_rows_list(rq, context);
@@ -235,7 +255,7 @@ impl CategoryEditor {
         let available_height = self.content_rect.height() as i32;
         let max_rows = (available_height / self.row_height).max(1) as usize;
 
-        let all_kinds = self.category.settings(context);
+        let all_kinds = self.category.settings(context, self.dict_service.as_ref());
         let total_rows = all_kinds.len();
 
         self.pages_count = total_rows.div_ceil(max_rows).max(1);
@@ -484,6 +504,90 @@ impl CategoryEditor {
         true
     }
 
+    /// Spawns a background thread to download and install a dictionary for the
+    /// given language code.
+    ///
+    /// Uses `include_etymologies = false` to prefer the smaller no-etymology
+    /// variant. On completion the thread sends `Event::DictionaryInstallComplete`
+    /// via the hub so the UI can rebuild the rows on the main thread.
+    ///
+    /// If a download is already in progress for `lang` the request is silently
+    /// ignored to prevent duplicate background threads racing to write the same
+    /// files.
+    #[inline]
+    #[cfg_attr(feature = "otel", tracing::instrument(skip(self, hub)))]
+    fn handle_download_dictionary(&mut self, lang: &str, hub: &Hub) -> bool {
+        let Some(service) = self.dict_service.clone() else {
+            tracing::warn!(
+                lang,
+                "No MonolingualDictionaryService available to download dictionary"
+            );
+            return true;
+        };
+
+        if service.is_installing(lang) {
+            return true;
+        }
+
+        let lang_owned = lang.to_string();
+        let hub2 = hub.clone();
+        let parent_span = tracing::Span::current();
+
+        hub.send(crate::view::Event::Notification(NotificationEvent::Show(
+            fl!("notification-downloading-dictionary", lang = lang),
+        )))
+        .ok();
+
+        thread::spawn(move || {
+            let _span =
+                tracing::info_span!(parent: &parent_span, "dictionary_install_async").entered();
+
+            let result = service
+                .install_dictionary(&lang_owned, false)
+                .map_err(|e| e.to_string());
+
+            hub2.send(crate::view::Event::DictionaryInstallComplete {
+                lang: lang_owned,
+                result,
+            })
+            .ok();
+        });
+
+        true
+    }
+
+    /// Removes the installed dictionary directory for the given language code, then rebuilds the rows.
+    ///
+    /// The directory `<DICTIONARIES_DIRNAME>/reader-dict/<lang>/` is removed. Any open
+    /// `SettingsValueMenu` is closed before rebuilding. Logs a warning on failure.
+    #[inline]
+    fn handle_delete_dictionary(
+        &mut self,
+        lang: &str,
+        rq: &mut RenderQueue,
+        context: &mut Context,
+    ) -> bool {
+        let lang_dir = Path::new(DICTIONARIES_DIRNAME)
+            .join("reader-dict")
+            .join(lang);
+
+        if lang_dir.exists() {
+            if let Err(e) = std::fs::remove_dir_all(&lang_dir) {
+                tracing::warn!(lang, error = %e, "Failed to delete dictionary directory");
+            }
+        }
+
+        if let Some(menu_index) = locate_by_id(self, ViewId::SettingsValueMenu) {
+            self.children.remove(menu_index);
+            rq.add(RenderData::new(self.id, self.rect, UpdateMode::Gui));
+        }
+
+        self.current_page = 0;
+        self.update_rows_list(rq, context);
+        context.load_dictionaries();
+        true
+    }
+
     #[inline]
     fn handle_close_view_event(
         &mut self,
@@ -538,6 +642,21 @@ impl View for CategoryEditor {
             Event::Select(EntryId::DeleteLibrary(index)) => {
                 self.handle_delete_library(*index, rq, context)
             }
+            Event::Select(EntryId::DownloadDictionary(lang))
+            | Event::Select(EntryId::RedownloadDictionary(lang)) => {
+                if !context.online {
+                    hub.send(Event::Notification(NotificationEvent::Show(fl!(
+                        "notification-not-online"
+                    ))))
+                    .ok();
+
+                    return true;
+                }
+                self.handle_download_dictionary(lang, hub)
+            }
+            Event::Select(EntryId::DeleteDictionary(lang)) => {
+                self.handle_delete_dictionary(lang, rq, context)
+            }
             Event::AddLibrary => self.handle_add_library_event(hub, rq, context),
             Event::EditLibrary(index) => self.handle_edit_library_event(*index, hub, rq, context),
             Event::UpdateLibrary(index, ref library) => {
@@ -558,6 +677,26 @@ impl View for CategoryEditor {
                 context,
             ),
             Event::Close(view_id) => self.handle_close_view_event(view_id, hub, rq),
+            Event::DictionaryInstallComplete { lang, result } => {
+                match result {
+                    Ok(()) => {
+                        tracing::info!(lang, "Dictionary installed");
+
+                        self.current_page = 0;
+                        self.update_rows_list(rq, context);
+                        context.load_dictionaries();
+
+                        hub.send(Event::Notification(NotificationEvent::Show(fl!(
+                            "notification-downloading-dictionary-completed",
+                            lang = lang
+                        ))))
+                        .ok();
+                    }
+                    Err(e) => tracing::warn!(lang, error = %e, "Failed to install dictionary"),
+                }
+
+                true
+            }
             Event::Page(dir) => {
                 let new_page = match dir {
                     CycleDir::Previous => self.current_page.saturating_sub(1),

--- a/crates/core/src/view/settings_editor/kinds/dictionary.rs
+++ b/crates/core/src/view/settings_editor/kinds/dictionary.rs
@@ -1,0 +1,74 @@
+//! Setting kinds for the Dictionaries category.
+
+use super::{SettingData, SettingIdentity, SettingKind, WidgetKind};
+use crate::fl;
+use crate::settings::Settings;
+use crate::view::{EntryId, EntryKind, Event};
+
+/// Represents a single monolingual dictionary row in the Dictionaries settings category.
+///
+/// Each row shows a lang code as the label and "Installed" or "Download" as the
+/// value. Installed dictionaries show a sub-menu with "Re-download" and "Delete"
+/// options; uninstalled ones show an `ActionLabel` that fires the download event on tap.
+pub struct DictionaryInfo {
+    /// ISO 639-1 language code, e.g. `"en"` or `"fr"`.
+    pub lang: String,
+    /// Whether this dictionary is currently installed on the device.
+    pub is_installed: bool,
+}
+
+impl SettingKind for DictionaryInfo {
+    fn identity(&self) -> SettingIdentity {
+        SettingIdentity::DictionaryInfo(self.lang.clone())
+    }
+
+    fn label(&self, _settings: &Settings) -> String {
+        self.lang.clone()
+    }
+
+    fn handle(
+        &self,
+        evt: &Event,
+        _settings: &mut Settings,
+        _bus: &mut crate::view::Bus,
+    ) -> (Option<String>, bool) {
+        match evt {
+            Event::Select(entry) => match entry {
+                EntryId::DownloadDictionary(lang) | EntryId::RedownloadDictionary(lang)
+                    if lang == &self.lang =>
+                {
+                    (Some(fl!("settings-dictionaries-downloading")), false)
+                }
+                _ => (None, false),
+            },
+            _ => (None, false),
+        }
+    }
+
+    fn fetch(&self, _settings: &Settings) -> SettingData {
+        if self.is_installed {
+            let entries = vec![
+                EntryKind::Command(
+                    fl!("settings-dictionaries-re-download"),
+                    EntryId::RedownloadDictionary(self.lang.clone()),
+                ),
+                EntryKind::Command(
+                    fl!("settings-dictionaries-delete"),
+                    EntryId::DeleteDictionary(self.lang.clone()),
+                ),
+            ];
+
+            SettingData {
+                value: fl!("settings-dictionaries-installed"),
+                widget: WidgetKind::SubMenu(entries),
+            }
+        } else {
+            SettingData {
+                value: fl!("settings-dictionaries-download"),
+                widget: WidgetKind::ActionLabel(Event::Select(EntryId::DownloadDictionary(
+                    self.lang.clone(),
+                ))),
+            }
+        }
+    }
+}

--- a/crates/core/src/view/settings_editor/kinds/general.rs
+++ b/crates/core/src/view/settings_editor/kinds/general.rs
@@ -48,7 +48,12 @@ impl SettingKind for Locale {
         }
     }
 
-    fn handle(&self, evt: &Event, settings: &mut Settings, _bus: &mut Bus) -> Option<String> {
+    fn handle(
+        &self,
+        evt: &Event,
+        settings: &mut Settings,
+        _bus: &mut Bus,
+    ) -> (Option<String>, bool) {
         if let Event::Select(EntryId::SetLocale(ref locale)) = evt {
             settings.locale = locale.clone();
             crate::i18n::init(locale.as_ref());
@@ -56,9 +61,9 @@ impl SettingKind for Locale {
                 .as_ref()
                 .map(|l| l.to_string())
                 .unwrap_or_else(|| crate::i18n::DEFAULT_LOCALE.to_string());
-            return Some(display);
+            return (Some(display), true);
         }
-        None
+        (None, false)
     }
 }
 
@@ -95,12 +100,17 @@ impl SettingKind for KeyboardLayout {
         }
     }
 
-    fn handle(&self, evt: &Event, settings: &mut Settings, _bus: &mut Bus) -> Option<String> {
+    fn handle(
+        &self,
+        evt: &Event,
+        settings: &mut Settings,
+        _bus: &mut Bus,
+    ) -> (Option<String>, bool) {
         if let Event::Select(EntryId::SetKeyboardLayout(ref layout)) = evt {
             settings.keyboard_layout = layout.clone();
-            return Some(layout.clone());
+            return (Some(layout.clone()), true);
         }
-        None
+        (None, false)
     }
 }
 
@@ -262,12 +272,17 @@ impl SettingKind for SleepCover {
         }
     }
 
-    fn handle(&self, evt: &Event, settings: &mut Settings, _bus: &mut Bus) -> Option<String> {
+    fn handle(
+        &self,
+        evt: &Event,
+        settings: &mut Settings,
+        _bus: &mut Bus,
+    ) -> (Option<String>, bool) {
         if let Event::Toggle(ToggleEvent::Setting(ToggleSettings::SleepCover)) = evt {
             settings.sleep_cover = !settings.sleep_cover;
-            return Some(settings.sleep_cover.to_string());
+            return (Some(settings.sleep_cover.to_string()), true);
         }
-        None
+        (None, false)
     }
 }
 
@@ -295,12 +310,17 @@ impl SettingKind for AutoShare {
         }
     }
 
-    fn handle(&self, evt: &Event, settings: &mut Settings, _bus: &mut Bus) -> Option<String> {
+    fn handle(
+        &self,
+        evt: &Event,
+        settings: &mut Settings,
+        _bus: &mut Bus,
+    ) -> (Option<String>, bool) {
         if let Event::Toggle(ToggleEvent::Setting(ToggleSettings::AutoShare)) = evt {
             settings.auto_share = !settings.auto_share;
-            return Some(settings.auto_share.to_string());
+            return (Some(settings.auto_share.to_string()), true);
         }
-        None
+        (None, false)
     }
 }
 
@@ -329,7 +349,12 @@ impl SettingKind for ButtonScheme {
         }
     }
 
-    fn handle(&self, evt: &Event, settings: &mut Settings, bus: &mut Bus) -> Option<String> {
+    fn handle(
+        &self,
+        evt: &Event,
+        settings: &mut Settings,
+        bus: &mut Bus,
+    ) -> (Option<String>, bool) {
         let new_scheme = match evt {
             Event::Toggle(ToggleEvent::Setting(ToggleSettings::ButtonScheme)) => {
                 match settings.button_scheme {
@@ -348,9 +373,9 @@ impl SettingKind for ButtonScheme {
         if let Some(scheme) = new_scheme {
             settings.button_scheme = scheme;
             bus.push_back(Event::Select(EntryId::SetButtonScheme(scheme)));
-            return Some(settings.button_scheme.to_i18n_string());
+            return (Some(settings.button_scheme.to_i18n_string()), true);
         }
-        None
+        (None, false)
     }
 }
 
@@ -461,8 +486,8 @@ mod tests {
 
             let result = setting.handle(&event, &mut settings, &mut bus);
 
-            assert!(result.is_some());
-            assert_eq!(result.unwrap(), "de-DE");
+            assert!(result.0.is_some());
+            assert_eq!(result.0.unwrap(), "de-DE");
             assert_eq!(settings.locale, locale);
         }
 
@@ -474,7 +499,7 @@ mod tests {
 
             let result = setting.handle(&Event::Select(EntryId::About), &mut settings, &mut bus);
 
-            assert!(result.is_none());
+            assert!(result.0.is_none());
         }
     }
 
@@ -490,8 +515,8 @@ mod tests {
 
             let result = setting.handle(&event, &mut settings, &mut bus);
 
-            assert!(result.is_some());
-            assert_eq!(result.unwrap(), "German");
+            assert!(result.0.is_some());
+            assert_eq!(result.0.unwrap(), "German");
             assert_eq!(settings.keyboard_layout, "German");
         }
 
@@ -503,7 +528,7 @@ mod tests {
 
             let result = setting.handle(&Event::Select(EntryId::About), &mut settings, &mut bus);
 
-            assert!(result.is_none());
+            assert!(result.0.is_none());
         }
     }
 
@@ -602,8 +627,8 @@ mod tests {
 
             let result = setting.handle(&event, &mut settings, &mut bus);
 
-            assert!(result.is_some());
-            assert_eq!(result.unwrap(), "false");
+            assert!(result.0.is_some());
+            assert_eq!(result.0.unwrap(), "false");
             assert!(!settings.sleep_cover);
         }
 
@@ -615,7 +640,7 @@ mod tests {
 
             let result = setting.handle(&Event::Select(EntryId::About), &mut settings, &mut bus);
 
-            assert!(result.is_none());
+            assert!(result.0.is_none());
         }
     }
 
@@ -634,8 +659,8 @@ mod tests {
 
             let result = setting.handle(&event, &mut settings, &mut bus);
 
-            assert!(result.is_some());
-            assert_eq!(result.unwrap(), "true");
+            assert!(result.0.is_some());
+            assert_eq!(result.0.unwrap(), "true");
             assert!(settings.auto_share);
         }
 
@@ -647,7 +672,7 @@ mod tests {
 
             let result = setting.handle(&Event::Select(EntryId::About), &mut settings, &mut bus);
 
-            assert!(result.is_none());
+            assert!(result.0.is_none());
         }
     }
 
@@ -669,7 +694,7 @@ mod tests {
 
             assert_eq!(settings.button_scheme, ButtonScheme::Inverted);
             assert_eq!(bus.len(), 1);
-            assert!(result.is_some());
+            assert!(result.0.is_some());
         }
 
         #[test]
@@ -686,7 +711,7 @@ mod tests {
 
             assert_eq!(settings.button_scheme, ButtonScheme::Natural);
             assert_eq!(bus.len(), 1);
-            assert!(result.is_some());
+            assert!(result.0.is_some());
         }
 
         #[test]
@@ -702,7 +727,7 @@ mod tests {
             let result = setting.handle(&event, &mut settings, &mut bus);
 
             assert_eq!(settings.button_scheme, ButtonScheme::Inverted);
-            assert!(result.is_some());
+            assert!(result.0.is_some());
         }
 
         #[test]
@@ -713,7 +738,7 @@ mod tests {
 
             let result = setting.handle(&Event::Select(EntryId::About), &mut settings, &mut bus);
 
-            assert!(result.is_none());
+            assert!(result.0.is_none());
         }
     }
 

--- a/crates/core/src/view/settings_editor/kinds/identity.rs
+++ b/crates/core/src/view/settings_editor/kinds/identity.rs
@@ -40,4 +40,6 @@ pub enum SettingIdentity {
     EnableKernLog,
     #[cfg(all(feature = "test", feature = "kobo"))]
     EnableDbusLog,
+    /// Identity for a monolingual dictionary row, keyed by ISO 639-1 language code.
+    DictionaryInfo(String),
 }

--- a/crates/core/src/view/settings_editor/kinds/import.rs
+++ b/crates/core/src/view/settings_editor/kinds/import.rs
@@ -31,12 +31,17 @@ impl SettingKind for ImportStartupTrigger {
         }
     }
 
-    fn handle(&self, evt: &Event, settings: &mut Settings, _bus: &mut Bus) -> Option<String> {
+    fn handle(
+        &self,
+        evt: &Event,
+        settings: &mut Settings,
+        _bus: &mut Bus,
+    ) -> (Option<String>, bool) {
         if let Event::Toggle(ToggleEvent::Setting(ToggleSettings::ImportStartupTrigger)) = evt {
             settings.import.startup_trigger = !settings.import.startup_trigger;
-            return Some(settings.import.startup_trigger.to_string());
+            return (Some(settings.import.startup_trigger.to_string()), true);
         }
-        None
+        (None, false)
     }
 }
 
@@ -64,12 +69,17 @@ impl SettingKind for ImportSyncMetadata {
         }
     }
 
-    fn handle(&self, evt: &Event, settings: &mut Settings, _bus: &mut Bus) -> Option<String> {
+    fn handle(
+        &self,
+        evt: &Event,
+        settings: &mut Settings,
+        _bus: &mut Bus,
+    ) -> (Option<String>, bool) {
         if let Event::Toggle(ToggleEvent::Setting(ToggleSettings::ImportSyncMetadata)) = evt {
             settings.import.sync_metadata = !settings.import.sync_metadata;
-            return Some(settings.import.sync_metadata.to_string());
+            return (Some(settings.import.sync_metadata.to_string()), true);
         }
-        None
+        (None, false)
     }
 }
 
@@ -94,7 +104,7 @@ mod tests {
 
             let result = setting.handle(&event, &mut settings, &mut bus);
 
-            assert!(result.is_some());
+            assert!(result.0.is_some());
             assert!(!settings.import.startup_trigger);
         }
 
@@ -108,7 +118,7 @@ mod tests {
 
             let result = setting.handle(&event, &mut settings, &mut bus);
 
-            assert!(result.is_some());
+            assert!(result.0.is_some());
             assert!(settings.import.startup_trigger);
         }
 
@@ -121,7 +131,7 @@ mod tests {
 
             let result = setting.handle(&Event::Select(EntryId::About), &mut settings, &mut bus);
 
-            assert!(result.is_none());
+            assert!(result.0.is_none());
         }
 
         #[test]
@@ -136,7 +146,7 @@ mod tests {
                 &mut bus,
             );
 
-            assert!(result.is_none());
+            assert!(result.0.is_none());
         }
     }
 
@@ -153,7 +163,7 @@ mod tests {
 
             let result = setting.handle(&event, &mut settings, &mut bus);
 
-            assert!(result.is_some());
+            assert!(result.0.is_some());
             assert!(!settings.import.sync_metadata);
         }
 
@@ -167,7 +177,7 @@ mod tests {
 
             let result = setting.handle(&event, &mut settings, &mut bus);
 
-            assert!(result.is_some());
+            assert!(result.0.is_some());
             assert!(settings.import.sync_metadata);
         }
 
@@ -180,7 +190,7 @@ mod tests {
 
             let result = setting.handle(&Event::Select(EntryId::About), &mut settings, &mut bus);
 
-            assert!(result.is_none());
+            assert!(result.0.is_none());
         }
 
         #[test]
@@ -195,7 +205,7 @@ mod tests {
                 &mut bus,
             );
 
-            assert!(result.is_none());
+            assert!(result.0.is_none());
         }
     }
 }

--- a/crates/core/src/view/settings_editor/kinds/intermission.rs
+++ b/crates/core/src/view/settings_editor/kinds/intermission.rs
@@ -80,19 +80,24 @@ impl SettingKind for IntermissionSuspend {
         fetch_intermission(IntermKind::Suspend, settings)
     }
 
-    fn handle(&self, evt: &Event, settings: &mut Settings, _bus: &mut Bus) -> Option<String> {
+    fn handle(
+        &self,
+        evt: &Event,
+        settings: &mut Settings,
+        _bus: &mut Bus,
+    ) -> (Option<String>, bool) {
         if let Event::Select(EntryId::SetIntermission(IntermKind::Suspend, ref display)) = evt {
             settings.intermissions[IntermKind::Suspend] = display.clone();
-            return Some(intermission_display_name(display));
+            return (Some(intermission_display_name(display)), true);
         }
 
         if let Event::FileChooserClosed(Some(ref path)) = evt {
             let display = IntermissionDisplay::Image(path.clone());
             settings.intermissions[IntermKind::Suspend] = display.clone();
-            return Some(intermission_display_name(&display));
+            return (Some(intermission_display_name(&display)), true);
         }
 
-        None
+        (None, false)
     }
 
     fn file_chooser_entry_id(&self) -> Option<EntryId> {
@@ -116,19 +121,24 @@ impl SettingKind for IntermissionPowerOff {
         fetch_intermission(IntermKind::PowerOff, settings)
     }
 
-    fn handle(&self, evt: &Event, settings: &mut Settings, _bus: &mut Bus) -> Option<String> {
+    fn handle(
+        &self,
+        evt: &Event,
+        settings: &mut Settings,
+        _bus: &mut Bus,
+    ) -> (Option<String>, bool) {
         if let Event::Select(EntryId::SetIntermission(IntermKind::PowerOff, ref display)) = evt {
             settings.intermissions[IntermKind::PowerOff] = display.clone();
-            return Some(intermission_display_name(display));
+            return (Some(intermission_display_name(display)), true);
         }
 
         if let Event::FileChooserClosed(Some(ref path)) = evt {
             let display = IntermissionDisplay::Image(path.clone());
             settings.intermissions[IntermKind::PowerOff] = display.clone();
-            return Some(intermission_display_name(&display));
+            return (Some(intermission_display_name(&display)), true);
         }
 
-        None
+        (None, false)
     }
 
     fn file_chooser_entry_id(&self) -> Option<EntryId> {
@@ -152,19 +162,24 @@ impl SettingKind for IntermissionShare {
         fetch_intermission(IntermKind::Share, settings)
     }
 
-    fn handle(&self, evt: &Event, settings: &mut Settings, _bus: &mut Bus) -> Option<String> {
+    fn handle(
+        &self,
+        evt: &Event,
+        settings: &mut Settings,
+        _bus: &mut Bus,
+    ) -> (Option<String>, bool) {
         if let Event::Select(EntryId::SetIntermission(IntermKind::Share, ref display)) = evt {
             settings.intermissions[IntermKind::Share] = display.clone();
-            return Some(intermission_display_name(display));
+            return (Some(intermission_display_name(display)), true);
         }
 
         if let Event::FileChooserClosed(Some(ref path)) = evt {
             let display = IntermissionDisplay::Image(path.clone());
             settings.intermissions[IntermKind::Share] = display.clone();
-            return Some(intermission_display_name(&display));
+            return (Some(intermission_display_name(&display)), true);
         }
 
-        None
+        (None, false)
     }
 
     fn file_chooser_entry_id(&self) -> Option<EntryId> {
@@ -195,7 +210,7 @@ mod tests {
 
             let result = setting.handle(&event, &mut settings, &mut bus);
 
-            assert!(result.is_some());
+            assert!(result.0.is_some());
             assert_eq!(
                 settings.intermissions[IntermKind::Suspend],
                 IntermissionDisplay::Cover
@@ -212,7 +227,7 @@ mod tests {
 
             let result = setting.handle(&event, &mut settings, &mut bus);
 
-            assert!(result.is_some());
+            assert!(result.0.is_some());
             assert_eq!(
                 settings.intermissions[IntermKind::Suspend],
                 IntermissionDisplay::Image(PathBuf::from("/selected/image.jpg"))
@@ -231,7 +246,7 @@ mod tests {
 
             let result = setting.handle(&event, &mut settings, &mut bus);
 
-            assert!(result.is_none());
+            assert!(result.0.is_none());
         }
 
         #[test]
@@ -242,7 +257,7 @@ mod tests {
 
             let result = setting.handle(&Event::FileChooserClosed(None), &mut settings, &mut bus);
 
-            assert!(result.is_none());
+            assert!(result.0.is_none());
         }
     }
 
@@ -261,7 +276,7 @@ mod tests {
 
             let result = setting.handle(&event, &mut settings, &mut bus);
 
-            assert!(result.is_some());
+            assert!(result.0.is_some());
             assert_eq!(
                 settings.intermissions[IntermKind::PowerOff],
                 IntermissionDisplay::Cover
@@ -278,7 +293,7 @@ mod tests {
 
             let result = setting.handle(&event, &mut settings, &mut bus);
 
-            assert!(result.is_some());
+            assert!(result.0.is_some());
             assert_eq!(
                 settings.intermissions[IntermKind::PowerOff],
                 IntermissionDisplay::Image(PathBuf::from("/selected/poweroff.png"))
@@ -297,7 +312,7 @@ mod tests {
 
             let result = setting.handle(&event, &mut settings, &mut bus);
 
-            assert!(result.is_none());
+            assert!(result.0.is_none());
         }
 
         #[test]
@@ -308,7 +323,7 @@ mod tests {
 
             let result = setting.handle(&Event::FileChooserClosed(None), &mut settings, &mut bus);
 
-            assert!(result.is_none());
+            assert!(result.0.is_none());
         }
     }
 
@@ -327,7 +342,7 @@ mod tests {
 
             let result = setting.handle(&event, &mut settings, &mut bus);
 
-            assert!(result.is_some());
+            assert!(result.0.is_some());
             assert_eq!(
                 settings.intermissions[IntermKind::Share],
                 IntermissionDisplay::Cover
@@ -344,7 +359,7 @@ mod tests {
 
             let result = setting.handle(&event, &mut settings, &mut bus);
 
-            assert!(result.is_some());
+            assert!(result.0.is_some());
             assert_eq!(
                 settings.intermissions[IntermKind::Share],
                 IntermissionDisplay::Image(PathBuf::from("/selected/share.jpg"))
@@ -363,7 +378,7 @@ mod tests {
 
             let result = setting.handle(&event, &mut settings, &mut bus);
 
-            assert!(result.is_none());
+            assert!(result.0.is_none());
         }
 
         #[test]
@@ -374,7 +389,7 @@ mod tests {
 
             let result = setting.handle(&Event::FileChooserClosed(None), &mut settings, &mut bus);
 
-            assert!(result.is_none());
+            assert!(result.0.is_none());
         }
     }
 }

--- a/crates/core/src/view/settings_editor/kinds/mod.rs
+++ b/crates/core/src/view/settings_editor/kinds/mod.rs
@@ -9,6 +9,7 @@
 //! [`SettingsEvent::UpdateValue`](crate::view::settings_editor::SettingsEvent) to
 //! target the correct [`SettingValue`](crate::view::settings_editor::SettingValue) view.
 
+pub mod dictionary;
 pub mod general;
 pub mod identity;
 pub mod import;
@@ -106,8 +107,13 @@ pub trait SettingKind {
     /// Mutates `settings` if the event is relevant and returns the updated
     /// display string. Returns `None` if this event does not apply to this setting.
     /// `bus` is available for settings that need to propagate side-effects.
-    fn handle(&self, _evt: &Event, _settings: &mut Settings, _bus: &mut Bus) -> Option<String> {
-        None
+    fn handle(
+        &self,
+        _evt: &Event,
+        _settings: &mut Settings,
+        _bus: &mut Bus,
+    ) -> (Option<String>, bool) {
+        (None, false)
     }
 
     /// Returns this setting as an [`InputSettingKind`] if it supports text input.
@@ -145,7 +151,12 @@ impl<T: SettingKind + ?Sized> SettingKind for &T {
         (**self).fetch(settings)
     }
 
-    fn handle(&self, evt: &Event, settings: &mut Settings, bus: &mut Bus) -> Option<String> {
+    fn handle(
+        &self,
+        evt: &Event,
+        settings: &mut Settings,
+        bus: &mut Bus,
+    ) -> (Option<String>, bool) {
         (**self).handle(evt, settings, bus)
     }
 
@@ -175,7 +186,12 @@ impl<T: SettingKind + ?Sized> SettingKind for Box<T> {
         (**self).fetch(settings)
     }
 
-    fn handle(&self, evt: &Event, settings: &mut Settings, bus: &mut Bus) -> Option<String> {
+    fn handle(
+        &self,
+        evt: &Event,
+        settings: &mut Settings,
+        bus: &mut Bus,
+    ) -> (Option<String>, bool) {
         (**self).handle(evt, settings, bus)
     }
 

--- a/crates/core/src/view/settings_editor/kinds/reader.rs
+++ b/crates/core/src/view/settings_editor/kinds/reader.rs
@@ -45,12 +45,17 @@ impl SettingKind for FinishedActionSetting {
         }
     }
 
-    fn handle(&self, evt: &Event, settings: &mut Settings, _bus: &mut Bus) -> Option<String> {
+    fn handle(
+        &self,
+        evt: &Event,
+        settings: &mut Settings,
+        _bus: &mut Bus,
+    ) -> (Option<String>, bool) {
         if let Event::Select(EntryId::SetFinishedAction(action)) = evt {
             settings.reader.finished = *action;
-            return Some(action.to_i18n_string());
+            return (Some(action.to_i18n_string()), true);
         }
-        None
+        (None, false)
     }
 }
 
@@ -74,7 +79,7 @@ mod tests {
 
             let result = setting.handle(&event, &mut settings, &mut bus);
 
-            assert!(result.is_some());
+            assert!(result.0.is_some());
             assert_eq!(settings.reader.finished, FinishedAction::GoToNext);
         }
 
@@ -103,7 +108,7 @@ mod tests {
 
             let result = setting.handle(&Event::Select(EntryId::About), &mut settings, &mut bus);
 
-            assert!(result.is_none());
+            assert!(result.0.is_none());
         }
 
         #[test]
@@ -115,7 +120,7 @@ mod tests {
 
             let result = setting.handle(&event, &mut settings, &mut bus);
 
-            assert!(result.is_none());
+            assert!(result.0.is_none());
         }
     }
 }

--- a/crates/core/src/view/settings_editor/kinds/telemetry.rs
+++ b/crates/core/src/view/settings_editor/kinds/telemetry.rs
@@ -35,12 +35,17 @@ impl SettingKind for LoggingEnabled {
         }
     }
 
-    fn handle(&self, evt: &Event, settings: &mut Settings, _bus: &mut Bus) -> Option<String> {
+    fn handle(
+        &self,
+        evt: &Event,
+        settings: &mut Settings,
+        _bus: &mut Bus,
+    ) -> (Option<String>, bool) {
         if let Event::Toggle(ToggleEvent::Setting(ToggleSettings::LoggingEnabled)) = evt {
             settings.logging.enabled = !settings.logging.enabled;
-            return Some(settings.logging.enabled.to_string());
+            return (Some(settings.logging.enabled.to_string()), true);
         }
-        None
+        (None, false)
     }
 }
 
@@ -106,12 +111,17 @@ impl SettingKind for LogLevel {
         }
     }
 
-    fn handle(&self, evt: &Event, settings: &mut Settings, _bus: &mut Bus) -> Option<String> {
+    fn handle(
+        &self,
+        evt: &Event,
+        settings: &mut Settings,
+        _bus: &mut Bus,
+    ) -> (Option<String>, bool) {
         if let Event::Select(EntryId::SetLogLevel(ref level)) = evt {
             settings.logging.level = level.to_string();
-            return Some(Self::level_to_i18n(level));
+            return (Some(Self::level_to_i18n(level)), true);
         }
-        None
+        (None, false)
     }
 }
 
@@ -210,12 +220,17 @@ impl SettingKind for EnableKernLog {
         }
     }
 
-    fn handle(&self, evt: &Event, settings: &mut Settings, _bus: &mut Bus) -> Option<String> {
+    fn handle(
+        &self,
+        evt: &Event,
+        settings: &mut Settings,
+        _bus: &mut Bus,
+    ) -> (Option<String>, bool) {
         if let Event::Toggle(ToggleEvent::Setting(ToggleSettings::EnableKernLog)) = evt {
             settings.logging.enable_kern_log = !settings.logging.enable_kern_log;
-            return Some(settings.logging.enable_kern_log.to_string());
+            return (Some(settings.logging.enable_kern_log.to_string()), true);
         }
-        None
+        (None, false)
     }
 }
 
@@ -245,12 +260,17 @@ impl SettingKind for EnableDbusLog {
         }
     }
 
-    fn handle(&self, evt: &Event, settings: &mut Settings, _bus: &mut Bus) -> Option<String> {
+    fn handle(
+        &self,
+        evt: &Event,
+        settings: &mut Settings,
+        _bus: &mut Bus,
+    ) -> (Option<String>, bool) {
         if let Event::Toggle(ToggleEvent::Setting(ToggleSettings::EnableDbusLog)) = evt {
             settings.logging.enable_dbus_log = !settings.logging.enable_dbus_log;
-            return Some(settings.logging.enable_dbus_log.to_string());
+            return (Some(settings.logging.enable_dbus_log.to_string()), true);
         }
-        None
+        (None, false)
     }
 }
 
@@ -275,7 +295,7 @@ mod tests {
 
             let result = setting.handle(&event, &mut settings, &mut bus);
 
-            assert!(result.is_some());
+            assert!(result.0.is_some());
             assert!(!settings.logging.enabled);
         }
 
@@ -289,7 +309,7 @@ mod tests {
 
             let result = setting.handle(&event, &mut settings, &mut bus);
 
-            assert!(result.is_some());
+            assert!(result.0.is_some());
             assert!(settings.logging.enabled);
         }
 
@@ -301,7 +321,7 @@ mod tests {
 
             let result = setting.handle(&Event::Select(EntryId::About), &mut settings, &mut bus);
 
-            assert!(result.is_none());
+            assert!(result.0.is_none());
         }
 
         #[test]
@@ -316,7 +336,7 @@ mod tests {
                 &mut bus,
             );
 
-            assert!(result.is_none());
+            assert!(result.0.is_none());
         }
     }
 
@@ -333,7 +353,7 @@ mod tests {
 
             let result = setting.handle(&event, &mut settings, &mut bus);
 
-            assert!(result.is_some());
+            assert!(result.0.is_some());
             assert_eq!(settings.logging.level, "WARN");
         }
 
@@ -364,7 +384,7 @@ mod tests {
 
             let result = setting.handle(&Event::Select(EntryId::About), &mut settings, &mut bus);
 
-            assert!(result.is_none());
+            assert!(result.0.is_none());
         }
     }
 
@@ -440,7 +460,7 @@ mod tests {
 
             let result = setting.handle(&event, &mut settings, &mut bus);
 
-            assert!(result.is_some());
+            assert!(result.0.is_some());
             assert!(settings.logging.enable_kern_log);
         }
 
@@ -454,7 +474,7 @@ mod tests {
 
             let result = setting.handle(&event, &mut settings, &mut bus);
 
-            assert!(result.is_some());
+            assert!(result.0.is_some());
             assert!(!settings.logging.enable_kern_log);
         }
 
@@ -466,7 +486,7 @@ mod tests {
 
             let result = setting.handle(&Event::Select(EntryId::About), &mut settings, &mut bus);
 
-            assert!(result.is_none());
+            assert!(result.0.is_none());
         }
 
         #[test]
@@ -481,7 +501,7 @@ mod tests {
                 &mut bus,
             );
 
-            assert!(result.is_none());
+            assert!(result.0.is_none());
         }
     }
 
@@ -499,7 +519,7 @@ mod tests {
 
             let result = setting.handle(&event, &mut settings, &mut bus);
 
-            assert!(result.is_some());
+            assert!(result.0.is_some());
             assert!(settings.logging.enable_dbus_log);
         }
 
@@ -513,7 +533,7 @@ mod tests {
 
             let result = setting.handle(&event, &mut settings, &mut bus);
 
-            assert!(result.is_some());
+            assert!(result.0.is_some());
             assert!(!settings.logging.enable_dbus_log);
         }
 
@@ -525,7 +545,7 @@ mod tests {
 
             let result = setting.handle(&Event::Select(EntryId::About), &mut settings, &mut bus);
 
-            assert!(result.is_none());
+            assert!(result.0.is_none());
         }
 
         #[test]
@@ -540,7 +560,7 @@ mod tests {
                 &mut bus,
             );
 
-            assert!(result.is_none());
+            assert!(result.0.is_none());
         }
     }
 }

--- a/crates/core/src/view/settings_editor/setting_value.rs
+++ b/crates/core/src/view/settings_editor/setting_value.rs
@@ -230,7 +230,7 @@ impl View for SettingValue {
 
         if let Event::FileChooserClosed(_) = evt {
             if self.active_file_chooser {
-                if let Some(display) = self.kind.handle(evt, &mut context.settings, bus) {
+                if let (Some(display), _) = self.kind.handle(evt, &mut context.settings, bus) {
                     self.update(display, &context.settings, rq);
                 }
                 return false;
@@ -253,10 +253,10 @@ impl View for SettingValue {
             }
         }
 
-        if let Some(display) = self.kind.handle(evt, &mut context.settings, bus) {
+        if let (Some(display), handled) = self.kind.handle(evt, &mut context.settings, bus) {
             self.update(display, &context.settings, rq);
             bus.push_back(Event::Close(ViewId::SettingsValueMenu));
-            return true;
+            return handled;
         }
 
         if let Some(input_kind) = self.kind.as_input_kind() {


### PR DESCRIPTION
What is missing is a way to invalidate the cache. My initial thinking is to invalidate it on each new release of Cadmus. Would also be nice to know if new versions of a dictionary is available. 

But for now, this implementation gets the initial version out, can discuss with upstream to see what would be the best way to:
- invalidate the cache
- notify the user that a new version of an installed dictionary is available.

---

This pull request introduces support for downloading and caching monolingual dictionaries from the Monolingual project API. It adds a new database table to cache dictionary metadata, implements a dedicated HTTP client and database access layer, and exposes a new service for managing monolingual dictionaries. Additionally, it updates the English localization with relevant user notifications.

**Monolingual Dictionary Download and Caching**

* Added a new module `monolingual` in `crates/core/src/dictionary/` that provides the `MonolingualDictionaryService` for downloading, caching, and managing monolingual dictionaries.
* Implemented `MonolingualClient` for interacting with the remote API and local cache, including methods for fetching metadata, retrieving cached data, and downloading dictionary files. Comprehensive tests are included.
* Added a database access layer (`db.rs`) for the new `dictionary_monolingual_metadata` table, with methods to upsert and retrieve entries, and proper date handling. Includes thorough tests.
* Defined error types specific to monolingual dictionary operations in `errors.rs`.

**Database and Query Changes**

* Added a migration to create the `dictionary_monolingual_metadata` table, which stores metadata for each language's monolingual dictionary.
* Added SQLx query definitions for inserting and selecting monolingual dictionary metadata. [[1]](diffhunk://#diff-d5e7e37852cd1ed5d877f4474b9d2d23fb53c37f042c2e8104a8a82536c54a7eR1-R12) [[2]](diffhunk://#diff-1d9271191232bf550eabf816a0eb96fe5845337f54a21dc14b641e0b967aeac8R1-R28) [[3]](diffhunk://#diff-67ba8e99576bd4ea01ab5f2401f2e9e9f92233cfa339853ba45923dc0230acd9R1-R33)

**Localization and Miscellaneous**

* Updated English localization with notifications for dictionary download status and connectivity requirements.
* Made `DICTIONARIES_DIRNAME` public within the crate for use in the new module.
* Updated crate-level documentation to mention support for downloading monolingual dictionaries.

---

 - [x] Use sticky notification for downloading progress
   - [x] check if the API supports chunked downloads

---

Closes: https://github.com/reader-dict/monolingual/issues/2663