### PR TITLE
feat(library): switch fingerprints to BLAKE3 content hash

### DIFF
--- a/.sqlx/query-4bc378635ca2074547afbe4d42914ba8c60bde10be219fbc941437e6af3d0342.json
+++ b/.sqlx/query-4bc378635ca2074547afbe4d42914ba8c60bde10be219fbc941437e6af3d0342.json
@@ -1,0 +1,12 @@
+{
+  "db_name": "SQLite",
+  "query": "\n            INSERT INTO toc_entries (\n                id, book_fingerprint, parent_id, position, title, location_kind, location_exact, location_uri\n            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)\n            ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Right": 8
+    },
+    "nullable": []
+  },
+  "hash": "4bc378635ca2074547afbe4d42914ba8c60bde10be219fbc941437e6af3d0342"
+}

--- a/.sqlx/query-57ce3d841b58db1b0d4d59b33eacbe0b32fa7fb5d6b389b875cd380f6fd5e92f.json
+++ b/.sqlx/query-57ce3d841b58db1b0d4d59b33eacbe0b32fa7fb5d6b389b875cd380f6fd5e92f.json
@@ -1,0 +1,12 @@
+{
+  "db_name": "SQLite",
+  "query": "INSERT OR IGNORE INTO thumbnails (fingerprint, thumbnail_data)\n         SELECT ?, thumbnail_data\n         FROM thumbnails\n         WHERE fingerprint = ?",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Right": 2
+    },
+    "nullable": []
+  },
+  "hash": "57ce3d841b58db1b0d4d59b33eacbe0b32fa7fb5d6b389b875cd380f6fd5e92f"
+}

--- a/.sqlx/query-5900b60857582a7ed69018147b4afa143c2b3d025640ff12c64b913a954e8fb7.json
+++ b/.sqlx/query-5900b60857582a7ed69018147b4afa143c2b3d025640ff12c64b913a954e8fb7.json
@@ -1,0 +1,12 @@
+{
+  "db_name": "SQLite",
+  "query": "UPDATE reading_states SET fingerprint = ? WHERE fingerprint = ?",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Right": 2
+    },
+    "nullable": []
+  },
+  "hash": "5900b60857582a7ed69018147b4afa143c2b3d025640ff12c64b913a954e8fb7"
+}

--- a/.sqlx/query-9395239b2adb3ed9f2850645d1e3672926884141b78c15479a77d17b0e858d1c.json
+++ b/.sqlx/query-9395239b2adb3ed9f2850645d1e3672926884141b78c15479a77d17b0e858d1c.json
@@ -1,0 +1,20 @@
+{
+  "db_name": "SQLite",
+  "query": "SELECT COUNT(*) FROM toc_entries WHERE book_fingerprint = ?",
+  "describe": {
+    "columns": [
+      {
+        "name": "COUNT(*)",
+        "ordinal": 0,
+        "type_info": "Integer"
+      }
+    ],
+    "parameters": {
+      "Right": 1
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "9395239b2adb3ed9f2850645d1e3672926884141b78c15479a77d17b0e858d1c"
+}

--- a/.sqlx/query-954589b09eba6b9f00ab120f2a004644302d7cae569213e601a6e7da8e7c990e.json
+++ b/.sqlx/query-954589b09eba6b9f00ab120f2a004644302d7cae569213e601a6e7da8e7c990e.json
@@ -1,0 +1,20 @@
+{
+  "db_name": "SQLite",
+  "query": "SELECT fingerprint FROM books WHERE fingerprint = ?",
+  "describe": {
+    "columns": [
+      {
+        "name": "fingerprint",
+        "ordinal": 0,
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Right": 1
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "954589b09eba6b9f00ab120f2a004644302d7cae569213e601a6e7da8e7c990e"
+}

--- a/.sqlx/query-95dc4c5573d17df287d11fa2bb04d375ec3689144d1b05002b2e87f851011790.json
+++ b/.sqlx/query-95dc4c5573d17df287d11fa2bb04d375ec3689144d1b05002b2e87f851011790.json
@@ -1,0 +1,12 @@
+{
+  "db_name": "SQLite",
+  "query": "UPDATE library_books SET book_fingerprint = ? WHERE book_fingerprint = ?",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Right": 2
+    },
+    "nullable": []
+  },
+  "hash": "95dc4c5573d17df287d11fa2bb04d375ec3689144d1b05002b2e87f851011790"
+}

--- a/.sqlx/query-a80311c0868623486865d1cbe4719fa3c5c3002ad05db94ce5867f3798ef3f99.json
+++ b/.sqlx/query-a80311c0868623486865d1cbe4719fa3c5c3002ad05db94ce5867f3798ef3f99.json
@@ -1,0 +1,12 @@
+{
+  "db_name": "SQLite",
+  "query": "UPDATE toc_entries SET book_fingerprint = ? WHERE book_fingerprint = ?",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Right": 2
+    },
+    "nullable": []
+  },
+  "hash": "a80311c0868623486865d1cbe4719fa3c5c3002ad05db94ce5867f3798ef3f99"
+}

--- a/.sqlx/query-b2393302c1d25ac2e691b5e27a05b95feb36d5ef234a6316a30e5e3c8ae7b056.json
+++ b/.sqlx/query-b2393302c1d25ac2e691b5e27a05b95feb36d5ef234a6316a30e5e3c8ae7b056.json
@@ -1,0 +1,12 @@
+{
+  "db_name": "SQLite",
+  "query": "UPDATE book_categories SET book_fingerprint = ? WHERE book_fingerprint = ?",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Right": 2
+    },
+    "nullable": []
+  },
+  "hash": "b2393302c1d25ac2e691b5e27a05b95feb36d5ef234a6316a30e5e3c8ae7b056"
+}

--- a/.sqlx/query-b3155aa05713960e9f78479984358a752ec7b117f268acd9093e6caa1b9cecea.json
+++ b/.sqlx/query-b3155aa05713960e9f78479984358a752ec7b117f268acd9093e6caa1b9cecea.json
@@ -1,0 +1,12 @@
+{
+  "db_name": "SQLite",
+  "query": "INSERT OR IGNORE INTO book_categories (book_fingerprint, category_id)\n         SELECT ?, category_id\n         FROM book_categories\n         WHERE book_fingerprint = ?",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Right": 2
+    },
+    "nullable": []
+  },
+  "hash": "b3155aa05713960e9f78479984358a752ec7b117f268acd9093e6caa1b9cecea"
+}

--- a/.sqlx/query-be0ef2e2d0e4d3bd55a67fc7a977c6a8c23df80191707dbba61623f25e1042b4.json
+++ b/.sqlx/query-be0ef2e2d0e4d3bd55a67fc7a977c6a8c23df80191707dbba61623f25e1042b4.json
@@ -1,0 +1,12 @@
+{
+  "db_name": "SQLite",
+  "query": "\n        INSERT OR IGNORE INTO reading_states (\n            fingerprint, opened, current_page, pages_count, finished, dithered,\n            zoom_mode, scroll_mode, page_offset_x, page_offset_y, rotation,\n            cropping_margins_json, margin_width, screen_margin_width,\n            font_family, font_size, text_align, line_height,\n            contrast_exponent, contrast_gray,\n            page_names_json, bookmarks_json, annotations_json\n        )\n        SELECT\n            ?, opened, current_page, pages_count, finished, dithered,\n            zoom_mode, scroll_mode, page_offset_x, page_offset_y, rotation,\n            cropping_margins_json, margin_width, screen_margin_width,\n            font_family, font_size, text_align, line_height,\n            contrast_exponent, contrast_gray,\n            page_names_json, bookmarks_json, annotations_json\n        FROM reading_states\n        WHERE fingerprint = ?\n        ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Right": 2
+    },
+    "nullable": []
+  },
+  "hash": "be0ef2e2d0e4d3bd55a67fc7a977c6a8c23df80191707dbba61623f25e1042b4"
+}

--- a/.sqlx/query-c96cd5e53aeed977262aba51c37e79f974e58b26b94904223295ec7819a1eec5.json
+++ b/.sqlx/query-c96cd5e53aeed977262aba51c37e79f974e58b26b94904223295ec7819a1eec5.json
@@ -1,0 +1,12 @@
+{
+  "db_name": "SQLite",
+  "query": "UPDATE book_authors SET book_fingerprint = ? WHERE book_fingerprint = ?",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Right": 2
+    },
+    "nullable": []
+  },
+  "hash": "c96cd5e53aeed977262aba51c37e79f974e58b26b94904223295ec7819a1eec5"
+}

--- a/.sqlx/query-d4aff3705b9fa541d388d2e48efc894a14f58c5481841c45d4e96b51713d2c66.json
+++ b/.sqlx/query-d4aff3705b9fa541d388d2e48efc894a14f58c5481841c45d4e96b51713d2c66.json
@@ -1,0 +1,12 @@
+{
+  "db_name": "SQLite",
+  "query": "INSERT OR IGNORE INTO book_authors (book_fingerprint, author_id, position)\n         SELECT ?, author_id, position\n         FROM book_authors\n         WHERE book_fingerprint = ?",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Right": 2
+    },
+    "nullable": []
+  },
+  "hash": "d4aff3705b9fa541d388d2e48efc894a14f58c5481841c45d4e96b51713d2c66"
+}

--- a/.sqlx/query-e686ad2131d9929f759d16cb96371b9644c155240fc4d533185c984e2f80a43e.json
+++ b/.sqlx/query-e686ad2131d9929f759d16cb96371b9644c155240fc4d533185c984e2f80a43e.json
@@ -1,0 +1,62 @@
+{
+  "db_name": "SQLite",
+  "query": "\n        SELECT\n            book_fingerprint,\n            id                as \"id: Uuid7\",\n            parent_id         as \"parent_id!: OptionalUuid7\",\n            position,\n            title,\n            location_kind,\n            location_exact,\n            location_uri\n        FROM toc_entries\n        WHERE book_fingerprint = ?\n        ORDER BY id ASC\n        ",
+  "describe": {
+    "columns": [
+      {
+        "name": "book_fingerprint",
+        "ordinal": 0,
+        "type_info": "Text"
+      },
+      {
+        "name": "id: Uuid7",
+        "ordinal": 1,
+        "type_info": "Text"
+      },
+      {
+        "name": "parent_id!: OptionalUuid7",
+        "ordinal": 2,
+        "type_info": "Text"
+      },
+      {
+        "name": "position",
+        "ordinal": 3,
+        "type_info": "Integer"
+      },
+      {
+        "name": "title",
+        "ordinal": 4,
+        "type_info": "Text"
+      },
+      {
+        "name": "location_kind",
+        "ordinal": 5,
+        "type_info": "Text"
+      },
+      {
+        "name": "location_exact",
+        "ordinal": 6,
+        "type_info": "Integer"
+      },
+      {
+        "name": "location_uri",
+        "ordinal": 7,
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Right": 1
+    },
+    "nullable": [
+      false,
+      false,
+      true,
+      false,
+      false,
+      false,
+      true,
+      true
+    ]
+  },
+  "hash": "e686ad2131d9929f759d16cb96371b9644c155240fc4d533185c984e2f80a43e"
+}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -148,6 +148,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "arrayref"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
+
+[[package]]
 name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -302,6 +308,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "blake3"
+version = "1.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d2d5991425dfd0785aed03aedcf0b321d61975c9b5b3689c774a2610ae0b51e"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "cc",
+ "cfg-if",
+ "constant_time_eq",
+ "cpufeatures 0.3.0",
+ "memmap2 0.9.10",
+ "rayon-core",
+]
+
+[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -372,6 +394,7 @@ dependencies = [
  "anyhow",
  "arc-swap",
  "bitflags 2.11.0",
+ "blake3",
  "byteorder",
  "chrono",
  "criterion",

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -104,6 +104,10 @@ tempfile = "3.14"
 name = "dictionary_bench"
 harness = false
 
+[[bench]]
+name = "fingerprint_bench"
+harness = false
+
 [build-dependencies]
 uuid = { version = "1.20.0", features = ["v7"] }
 

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -12,6 +12,7 @@ crate-type = ["rlib"]
 
 [dependencies]
 bitflags = "2.10.0"
+blake3 = { version = "1", features = ["mmap", "rayon"] }
 downcast-rs = "2.0.2"
 lazy_static = "1.5.0"
 libc = "0.2.180"

--- a/crates/core/benches/fingerprint_bench.rs
+++ b/crates/core/benches/fingerprint_bench.rs
@@ -1,0 +1,75 @@
+#[cfg(feature = "bench")]
+use std::io::Write;
+#[cfg(feature = "bench")]
+use std::time::Duration;
+
+#[cfg(feature = "bench")]
+use cadmus_core::helpers::{Fingerprint, Fp};
+#[cfg(feature = "bench")]
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+#[cfg(feature = "bench")]
+use tempfile::NamedTempFile;
+
+/// Creates a temporary file filled with `size` bytes of repeating pattern data.
+#[cfg(feature = "bench")]
+fn create_temp_file(size: usize) -> NamedTempFile {
+    let mut file = NamedTempFile::new().expect("failed to create temp file");
+    let chunk: Vec<u8> = (0..256u16).map(|i| i as u8).cycle().take(size).collect();
+    file.write_all(&chunk).expect("failed to write temp file");
+    file.flush().expect("failed to flush temp file");
+    file
+}
+
+#[cfg(feature = "bench")]
+fn bench_fingerprint(c: &mut Criterion) {
+    let sizes: &[(usize, &str)] = &[
+        (1_024, "1KB"),
+        (10_240, "10KB"),
+        (102_400, "100KB"),
+        (204_800, "200KB"),
+        (512_000, "500KB"),
+        (716_800, "700KB"),
+        (1_048_576, "1MB"),
+        (209_715_200, "200MB"),
+        (524_288_000, "500MB"),
+        (734_003_200, "700MB"),
+        (1_073_741_824, "1GB"),
+    ];
+
+    let mut group = c.benchmark_group("fingerprint");
+
+    for (size, label) in sizes {
+        let file = create_temp_file(*size);
+        let path = file.path().to_path_buf();
+
+        // Set a fixed mtime so the bench is deterministic across runs.
+        let mtime = std::time::UNIX_EPOCH + Duration::from_secs(315_532_800);
+        file.as_file()
+            .set_modified(mtime)
+            .expect("failed to set mtime");
+
+        // The fat32 epoch anchor used by the current implementation.
+        let fat32_epoch = mtime;
+
+        group.bench_with_input(BenchmarkId::new("size", label), label, |b, _| {
+            b.iter(|| {
+                let md = std::fs::metadata(&path).expect("metadata failed");
+                let _fp: Fp = md.fingerprint(fat32_epoch).expect("fingerprint failed");
+            });
+        });
+    }
+
+    group.finish();
+}
+
+#[cfg(feature = "bench")]
+criterion_group!(
+    name = benches;
+    config = Criterion::default().measurement_time(Duration::from_secs(10)).sample_size(50);
+    targets = bench_fingerprint
+);
+#[cfg(feature = "bench")]
+criterion_main!(benches);
+
+#[cfg(not(feature = "bench"))]
+fn main() {}

--- a/crates/core/benches/fingerprint_bench.rs
+++ b/crates/core/benches/fingerprint_bench.rs
@@ -4,7 +4,7 @@ use std::io::Write;
 use std::time::Duration;
 
 #[cfg(feature = "bench")]
-use cadmus_core::helpers::{Fingerprint, Fp};
+use cadmus_core::helpers::Fingerprint;
 #[cfg(feature = "bench")]
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
 #[cfg(feature = "bench")]
@@ -42,19 +42,9 @@ fn bench_fingerprint(c: &mut Criterion) {
         let file = create_temp_file(*size);
         let path = file.path().to_path_buf();
 
-        // Set a fixed mtime so the bench is deterministic across runs.
-        let mtime = std::time::UNIX_EPOCH + Duration::from_secs(315_532_800);
-        file.as_file()
-            .set_modified(mtime)
-            .expect("failed to set mtime");
-
-        // The fat32 epoch anchor used by the current implementation.
-        let fat32_epoch = mtime;
-
         group.bench_with_input(BenchmarkId::new("size", label), label, |b, _| {
             b.iter(|| {
-                let md = std::fs::metadata(&path).expect("metadata failed");
-                let _fp: Fp = md.fingerprint(fat32_epoch).expect("fingerprint failed");
+                let _fp = path.fingerprint().expect("fingerprint failed");
             });
         });
     }

--- a/crates/core/src/helpers.rs
+++ b/crates/core/src/helpers.rs
@@ -7,13 +7,11 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::borrow::Cow;
 use std::char;
 use std::fmt;
-use std::fs::{self, File, Metadata};
+use std::fs::{self, File};
 use std::io::{self, BufReader, BufWriter};
-use std::num::ParseIntError;
-use std::ops::{Deref, DerefMut};
+use std::ops::Deref;
 use std::path::{Component, Path, PathBuf};
 use std::str::FromStr;
-use std::time::SystemTime;
 use walkdir::DirEntry;
 
 lazy_static! {
@@ -138,48 +136,146 @@ where
     }
 }
 
+/// Computes a content-based fingerprint for a file.
+///
+/// Implemented on [`Path`] to hash the full file contents using BLAKE3,
+/// producing a stable 32-byte digest that is independent of filesystem
+/// metadata such as modification time or file size.
+///
+/// # Hashing strategy
+///
+/// The implementation selects between two BLAKE3 strategies based on file size:
+///
+/// - **< 10 MiB** — [`update_reader`](blake3::Hasher::update_reader): plain
+///   buffered sequential read. Avoids both mmap syscall overhead and rayon
+///   thread-spawn cost. On slow storage, a
+///   single sequential `read()` into a buffer is faster than taking page
+///   faults through a memory mapping for small files. Benchmarks
+///   showed that `update_mmap_rayon` regressed by +125% at
+///   100 KiB and +76% at 200 KiB vs a plain read, confirming the pattern.
+///   The typical e-book (100 KiB–500 KiB) falls into this range.
+///
+/// - **≥ 10 MiB** — [`update_mmap_rayon`](blake3::Hasher::update_mmap_rayon):
+///   memory-mapped parallel hashing across rayon threads. Benchmarks showed
+///   −35% at 1 MiB, −70% at 200 MiB, and −79% at 1 GiB vs the
+///   single-threaded path. Reserved for large PDFs and similar files where
+///   the parallelism benefit clearly outweighs the mmap overhead.
+///
+/// The 10 MiB threshold is a conservative estimate that has not yet been
+/// measured on hardware directly.
 pub trait Fingerprint {
-    fn fingerprint(&self, epoch: SystemTime) -> io::Result<Fp>;
+    fn fingerprint(&self) -> io::Result<Fp>;
 }
 
-impl Fingerprint for Metadata {
-    fn fingerprint(&self, epoch: SystemTime) -> io::Result<Fp> {
-        let m = self
-            .modified()?
-            .duration_since(epoch)
-            .map_or_else(|e| e.duration().as_secs(), |v| v.as_secs());
-        Ok(Fp(m.rotate_left(32) ^ self.len()))
+/// Files at or above this size are hashed with `update_mmap_rayon`; smaller
+/// files use `update_reader` to avoid mmap and rayon thread-spawn overhead.
+const RAYON_THRESHOLD: u64 = 10 * 1024 * 1024;
+
+impl Fingerprint for Path {
+    #[cfg_attr(feature = "tracing", tracing::instrument(ret(level=tracing::Level::TRACE)))]
+    fn fingerprint(&self) -> io::Result<Fp> {
+        let mut hasher = blake3::Hasher::new();
+        if std::fs::metadata(self)?.len() >= RAYON_THRESHOLD {
+            hasher.update_mmap_rayon(self)?;
+        } else {
+            let file = std::fs::File::open(self)?;
+            hasher.update_reader(file)?;
+        }
+        Ok(Fp(*hasher.finalize().as_bytes()))
     }
 }
 
+/// A 32-byte BLAKE3 content fingerprint used as the primary key for books.
+///
+/// Serialized as a 64-character lowercase hex string (e.g.
+/// `"af1349b9f5f9a1a6a0404dea36dcc949..."`).
 #[derive(Debug, Copy, Clone, Hash, Eq, PartialEq)]
-pub struct Fp(u64);
+pub struct Fp([u8; 32]);
+
+impl Fp {
+    /// Constructs an `Fp` from a `u64` seed for use in tests.
+    ///
+    /// The seed is written into the last 8 bytes (big-endian); the remaining
+    /// 24 bytes are zero. This guarantees uniqueness for distinct seeds while
+    /// producing a valid 32-byte fingerprint.
+    #[cfg(test)]
+    pub fn from_u64(seed: u64) -> Self {
+        let mut bytes = [0u8; 32];
+        bytes[24..].copy_from_slice(&seed.to_be_bytes());
+        Fp(bytes)
+    }
+
+    /// Parses a legacy 16-character uppercase hex fingerprint (mtime + size
+    /// metadata format) into an `Fp`.
+    ///
+    /// The `u64` value is stored in the last 8 bytes (big-endian); the
+    /// remaining 24 bytes are zero. This matches the `from_u64` layout so
+    /// that legacy entries round-trip consistently. V2 migration will
+    /// re-key these to real BLAKE3 hashes once the files are found on disk.
+    pub(crate) fn from_legacy_str(s: &str) -> Result<Self, FpParseError> {
+        if s.len() != 16 {
+            return Err(FpParseError);
+        }
+        let seed = u64::from_str_radix(s, 16).map_err(|_| FpParseError)?;
+        let mut bytes = [0u8; 32];
+        bytes[24..].copy_from_slice(&seed.to_be_bytes());
+        Ok(Fp(bytes))
+    }
+}
 
 impl Deref for Fp {
-    type Target = u64;
+    type Target = [u8; 32];
 
     fn deref(&self) -> &Self::Target {
         &self.0
     }
 }
 
-impl DerefMut for Fp {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.0
+/// Error returned when a hex string cannot be decoded into an [`Fp`].
+#[derive(Debug)]
+pub struct FpParseError;
+
+impl fmt::Display for FpParseError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(
+            "invalid fingerprint: expected 64 hex characters or 16 hex characters (legacy format)",
+        )
     }
 }
 
+impl std::error::Error for FpParseError {}
+
 impl FromStr for Fp {
-    type Err = ParseIntError;
+    type Err = FpParseError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        u64::from_str_radix(s, 16).map(Fp)
+        if !s.is_ascii() {
+            return Err(FpParseError);
+        }
+
+        if s.len() == 16 {
+            return Self::from_legacy_str(s);
+        }
+
+        if s.len() != 64 {
+            return Err(FpParseError);
+        }
+
+        let mut bytes = [0u8; 32];
+        for (i, byte) in bytes.iter_mut().enumerate() {
+            *byte = u8::from_str_radix(&s[i * 2..i * 2 + 2], 16).map_err(|_| FpParseError)?;
+        }
+
+        Ok(Fp(bytes))
     }
 }
 
 impl fmt::Display for Fp {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{:016X}", self.0)
+        for byte in &self.0 {
+            write!(f, "{:02x}", byte)?;
+        }
+        Ok(())
     }
 }
 
@@ -198,14 +294,15 @@ impl<'de> Visitor<'de> for FpVisitor {
     type Value = Fp;
 
     fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-        formatter.write_str("a string")
+        formatter.write_str("a 64-character hex string or a 16-character legacy hex string")
     }
 
     fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
     where
         E: de::Error,
     {
-        Self::Value::from_str(value)
+        Fp::from_str(value)
+            .or_else(|_| Fp::from_legacy_str(value))
             .map_err(|e| E::custom(format!("can't parse fingerprint: {}", e)))
     }
 }
@@ -293,6 +390,7 @@ impl IsHidden for DirEntry {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::str::FromStr;
 
     #[test]
     fn test_entities() {
@@ -302,5 +400,48 @@ mod tests {
         assert_eq!(decode_entities("a &#x003E; b"), "a > b");
         assert_eq!(decode_entities("a &#38; b"), "a & b");
         assert_eq!(decode_entities("a &lt; b &gt; c"), "a < b > c");
+    }
+
+    #[test]
+    fn fp_from_str_rejects_non_ascii_input() {
+        let invalid = format!("a€{}", "0".repeat(60));
+
+        assert_eq!(invalid.len(), 64);
+        assert!(Fp::from_str(&invalid).is_err());
+    }
+
+    #[test]
+    fn fp_from_str_parses_valid_legacy_hex() {
+        let input = "0123456789ABCDEF";
+        let fp = Fp::from_str(input).expect("legacy fingerprint should parse");
+
+        assert_eq!(
+            fp.to_string(),
+            "0000000000000000000000000000000000000000000000000123456789abcdef"
+        );
+    }
+
+    #[test]
+    fn fp_from_str_rejects_invalid_legacy_hex() {
+        assert!(Fp::from_str("0123456789ABCDEG").is_err());
+    }
+
+    #[test]
+    fn fp_from_str_parses_valid_hex() {
+        let input = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+        let fp = Fp::from_str(input).expect("valid fingerprint should parse");
+
+        assert_eq!(fp.to_string(), input);
+    }
+
+    #[test]
+    fn fp_from_str_accepts_uppercase_hex() {
+        let input = "0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF";
+        let fp = Fp::from_str(input).expect("uppercase fingerprint should parse");
+
+        assert_eq!(
+            fp.to_string(),
+            "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+        );
     }
 }

--- a/crates/core/src/library/db/conversion.rs
+++ b/crates/core/src/library/db/conversion.rs
@@ -242,7 +242,7 @@ mod tests {
 
     #[test]
     fn test_info_to_book_row_roundtrip() {
-        let fp = Fp::from_str("0000000000000001").unwrap();
+        let fp = Fp::from_u64(1);
         let info = Info {
             title: "Test Book".to_string(),
             author: "Test Author".to_string(),
@@ -257,7 +257,7 @@ mod tests {
 
         let row = info_to_book_row(fp, &info);
 
-        assert_eq!(row.fingerprint, "0000000000000001");
+        assert_eq!(row.fingerprint, fp.to_string());
         assert_eq!(row.title, "Test Book");
         assert_eq!(row.file_path, "/tmp/test.pdf");
         assert_eq!(row.absolute_path, "/mnt/onboard/tmp/test.pdf");

--- a/crates/core/src/library/db/mod.rs
+++ b/crates/core/src/library/db/mod.rs
@@ -2793,7 +2793,7 @@ mod tests {
     #[test]
     fn test_insert_and_get_book() {
         let (_db, libdb) = create_test_db();
-        let fp = Fp::from_str("0000000000000001").unwrap();
+        let fp = Fp::from_u64(1);
 
         let info = Info {
             title: "Test Book".to_string(),
@@ -2845,7 +2845,7 @@ mod tests {
     #[test]
     fn test_insert_book_with_reading_state() {
         let (_db, libdb) = create_test_db();
-        let fp = Fp::from_str("0000000000000002").unwrap();
+        let fp = Fp::from_u64(2);
 
         let reader_info = ReaderInfo {
             current_page: 42,
@@ -2893,7 +2893,7 @@ mod tests {
     #[test]
     fn test_delete_book() {
         let (_db, libdb) = create_test_db();
-        let fp = Fp::from_str("0000000000000003").unwrap();
+        let fp = Fp::from_u64(3);
 
         let info = Info {
             title: "Book to Delete".to_string(),
@@ -2939,7 +2939,7 @@ mod tests {
         let library_id = register_test_library(&libdb, "/tmp/test_library4", "Test Library 4");
 
         for i in 1..=5 {
-            let fp = Fp::from_str(&format!("{:016X}", i)).unwrap();
+            let fp = Fp::from_u64(i as u64);
             let info = Info {
                 title: format!("Book {}", i),
                 author: format!("Author {}", i),
@@ -2961,7 +2961,7 @@ mod tests {
             .get_all_books(library_id)
             .expect("failed to get books");
         for i in 1..=5 {
-            let fp = Fp::from_str(&format!("{:016X}", i)).unwrap();
+            let fp = Fp::from_u64(i as u64);
             let retrieved = books
                 .iter()
                 .find(|info| info.fp == Some(fp))
@@ -2975,7 +2975,7 @@ mod tests {
     #[test]
     fn test_update_book() {
         let (_db, libdb) = create_test_db();
-        let fp = Fp::from_str("0000000000000004").unwrap();
+        let fp = Fp::from_u64(4);
 
         let mut info = Info {
             title: "Original Title".to_string(),
@@ -3021,7 +3021,7 @@ mod tests {
         let library_id = register_test_library(&libdb, "/tmp/test_library6", "Test Library 6");
 
         for i in 1..=3 {
-            let fp = Fp::from_str(&format!("{:016X}", i)).unwrap();
+            let fp = Fp::from_u64(i as u64);
             let info = Info {
                 title: format!("Book {}", i),
                 author: format!("Author {}", i),
@@ -3270,7 +3270,7 @@ mod tests {
     #[test]
     fn test_reading_state_crud() {
         let (_db, libdb) = create_test_db();
-        let fp = Fp::from_str("0000000000000005").unwrap();
+        let fp = Fp::from_u64(5);
 
         let info = Info {
             title: "Book with State".to_string(),
@@ -3340,7 +3340,7 @@ mod tests {
 
         let mut books = Vec::new();
         for i in 1..=5 {
-            let fp = Fp::from_str(&format!("{:016X}", i + 100)).unwrap();
+            let fp = Fp::from_u64((i + 100) as u64);
             let info = Info {
                 title: format!("Batch Book {}", i),
                 author: format!("Batch Author {}, Co-Author {}", i, i + 1),
@@ -3389,7 +3389,7 @@ mod tests {
 
         let mut books = Vec::new();
         for i in 1..=3 {
-            let fp = Fp::from_str(&format!("{:016X}", i + 200)).unwrap();
+            let fp = Fp::from_u64((i + 200) as u64);
             let mut info = Info {
                 title: format!("Original Book {}", i),
                 author: format!("Original Author {}", i),
@@ -3784,7 +3784,7 @@ mod tests {
 
         let mut fps = Vec::new();
         for i in 1..=4 {
-            let fp = Fp::from_str(&format!("{:016X}", i + 300)).unwrap();
+            let fp = Fp::from_u64((i + 300) as u64);
             let info = Info {
                 title: format!("Delete Book {}", i),
                 author: format!("Delete Author {}", i),
@@ -3843,7 +3843,7 @@ mod tests {
     #[test]
     fn test_categories_round_trip() {
         let (_db, libdb) = create_test_db();
-        let fp = Fp::from_str("0000000000000099").unwrap();
+        let fp = Fp::from_u64(0x99);
 
         let info = Info {
             title: "Categorized Book".to_string(),
@@ -3883,7 +3883,7 @@ mod tests {
     #[test]
     fn test_categories_updated_on_update_book() {
         let (_db, libdb) = create_test_db();
-        let fp = Fp::from_str("000000000000009A").unwrap();
+        let fp = Fp::from_u64(0x9A);
 
         let mut info = Info {
             title: "Updateable Book".to_string(),
@@ -4457,7 +4457,7 @@ mod tests {
 
         let mut books = Vec::new();
         for i in 1..=3 {
-            let fp = Fp::from_str(&format!("{:016X}", i + 400)).unwrap();
+            let fp = Fp::from_u64((i + 400) as u64);
             let reader_info = ReaderInfo {
                 current_page: i * 10,
                 pages_count: i * 100,

--- a/crates/core/src/library/migrations.rs
+++ b/crates/core/src/library/migrations.rs
@@ -8,12 +8,18 @@
 //! | Module | Migration ID |
 //! |---|---|
 //! | [`import_legacy_filesystem_data::MIGRATION_ID`] | `v1_import_legacy_filesystem_data` |
+//! | [`rehash_fingerprints::MIGRATION_ID`] | `v2_rehash_fingerprints` |
 
+use crate::db::types::OptionalUuid7;
 use crate::db::types::UnixTimestamp;
-use crate::helpers::Fp;
+use crate::db::types::Uuid7;
+use crate::document::SimpleTocEntry;
+use crate::helpers::{Fingerprint, Fp};
 use crate::library::db::conversion::{
-    extract_authors, info_to_book_row, reader_info_to_reading_state_row,
+    encode_location, extract_authors, info_to_book_row, reader_info_to_reading_state_row,
+    rows_to_toc_entries,
 };
+use crate::library::db::models::TocEntryRow;
 #[cfg(not(feature = "test"))]
 use crate::library::THUMBNAIL_PREVIEWS_DIRNAME;
 use crate::library::{METADATA_FILENAME, READING_STATES_DIRNAME};
@@ -22,9 +28,9 @@ use crate::settings::versioned::SettingsManager;
 use crate::version::get_current_version;
 use fxhash::FxBuildHasher;
 use indexmap::IndexMap;
-use sqlx::{Sqlite, Transaction};
+use sqlx::{Row, Sqlite, Transaction};
 use std::collections::HashSet;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::str::FromStr;
 use tokio::fs;
 use tracing::{error, info, warn};
@@ -79,6 +85,485 @@ crate::migration!(
         Ok(())
     }
 );
+
+crate::migration!(
+    /// Re-fingerprints every book in all libraries using BLAKE3 content hashing.
+    ///
+    /// The old fingerprint was derived from file metadata (mtime + size relative to
+    /// the FAT32 epoch), which was unstable across timestamp changes. This migration
+    /// computes a new content-based fingerprint for each file that is still present
+    /// on disk and re-keys all associated database rows (reading states, thumbnails,
+    /// TOC entries, authors, categories) to the new fingerprint, preserving user
+    /// progress data.
+    ///
+    /// Files that are no longer present on disk keep a canonicalized legacy
+    /// fingerprint in the database so their data remains readable until the next
+    /// `import()` scan removes them as orphans.
+    "v2_rehash_fingerprints",
+    async fn rehash_fingerprints(pool: &SqlitePool) {
+        let books: Vec<(String, Option<String>)> = sqlx::query(
+                r#"
+                SELECT
+                    b.fingerprint,
+                    (
+                        SELECT lb.absolute_path
+                        FROM library_books lb
+                        WHERE lb.book_fingerprint = b.fingerprint
+                          AND lb.absolute_path != ''
+                        ORDER BY lb.absolute_path ASC, lb.library_id ASC
+                        LIMIT 1
+                    ) AS "absolute_path?: String"
+                FROM books b
+                "#
+            )
+            .fetch_all(pool)
+            .await?
+            .into_iter()
+            .map(|row| {
+                (
+                    row.get::<String, _>("fingerprint"),
+                    row.get::<Option<String>, _>("absolute_path?: String"),
+                )
+            })
+            .collect();
+
+        for (old_fp_str, absolute_path) in &books {
+            let Some(absolute_path) = absolute_path.as_ref() else {
+                continue;
+            };
+
+            let abs_path = PathBuf::from(absolute_path);
+
+            if !abs_path.exists() {
+                continue;
+            }
+
+            let new_fp = match abs_path.fingerprint() {
+                Ok(fp) => fp,
+                Err(e) => {
+                    error!(path = ?abs_path, error = %e, "failed to compute BLAKE3 fingerprint, skipping");
+                    continue;
+                }
+            };
+
+            let new_fp_str = new_fp.to_string();
+
+            if new_fp_str == *old_fp_str {
+                continue;
+            }
+
+            if let Err(e) = rekey_book(pool, old_fp_str, &new_fp_str).await {
+                error!(
+                    old_fp = %old_fp_str,
+                    new_fp = %new_fp_str,
+                    error = %e,
+                    "failed to re-key book, skipping"
+                );
+            }
+        }
+
+        canonicalize_legacy_fingerprints(pool, &books).await?;
+
+        Ok(())
+    }
+);
+
+#[cfg_attr(feature = "tracing", tracing::instrument(skip(pool, books)))]
+async fn canonicalize_legacy_fingerprints(
+    pool: &sqlx::SqlitePool,
+    books: &[(String, Option<String>)],
+) -> Result<(), anyhow::Error> {
+    for (old_fp_str, _) in books {
+        if old_fp_str.len() == 64 {
+            continue;
+        }
+
+        let canonical_fp = match Fp::from_legacy_str(old_fp_str) {
+            Ok(fp) => fp.to_string(),
+            Err(_) => {
+                warn!(
+                    fingerprint = %old_fp_str,
+                    "deleting malformed legacy fingerprint that cannot be canonicalized"
+                );
+
+                sqlx::query!("DELETE FROM books WHERE fingerprint = ?", old_fp_str)
+                    .execute(pool)
+                    .await?;
+
+                continue;
+            }
+        };
+
+        if let Err(e) = rekey_book(pool, old_fp_str, &canonical_fp).await {
+            error!(
+                old_fp = %old_fp_str,
+                new_fp = %canonical_fp,
+                error = %e,
+                "failed to canonicalize legacy fingerprint"
+            );
+        }
+    }
+
+    Ok(())
+}
+
+/// Re-keys a single book row from `old_fp` to `new_fp`, preserving all
+/// associated data (reading state, thumbnails, TOC, authors, categories).
+///
+/// All child tables use `ON DELETE CASCADE`, so deleting the old `books` row
+/// at the end cascades cleanly. We update each child table explicitly first
+/// to transfer data to the new fingerprint before the cascade fires.
+///
+/// The `library_books` UPDATE is intentionally global (not scoped to a single
+/// library) because the subsequent DELETE cascades globally — scoping the
+/// UPDATE would silently drop other libraries' associations.
+#[cfg_attr(feature = "tracing", tracing::instrument(skip(pool), fields(old_fp = %old_fp, new_fp = %new_fp)))]
+async fn rekey_book(
+    pool: &sqlx::SqlitePool,
+    old_fp: &str,
+    new_fp: &str,
+) -> Result<(), anyhow::Error> {
+    let mut tx = pool.begin().await?;
+
+    let already_exists: Option<String> = sqlx::query_scalar!(
+        "SELECT fingerprint FROM books WHERE fingerprint = ?",
+        new_fp
+    )
+    .fetch_optional(&mut *tx)
+    .await?;
+
+    if already_exists.is_some() {
+        merge_duplicate_book_data(&mut tx, old_fp, new_fp).await?;
+
+        sqlx::query!("DELETE FROM books WHERE fingerprint = ?", old_fp)
+            .execute(&mut *tx)
+            .await?;
+
+        tx.commit().await?;
+        return Ok(());
+    }
+
+    insert_rekeyed_book(&mut tx, old_fp, new_fp).await?;
+    move_rekeyed_book_data(&mut tx, old_fp, new_fp).await?;
+
+    sqlx::query!("DELETE FROM books WHERE fingerprint = ?", old_fp)
+        .execute(&mut *tx)
+        .await?;
+
+    tx.commit().await?;
+
+    Ok(())
+}
+
+#[cfg_attr(feature = "tracing", tracing::instrument(skip(tx), fields(old_fp = %old_fp, new_fp = %new_fp)))]
+async fn merge_duplicate_book_data(
+    tx: &mut Transaction<'_, Sqlite>,
+    old_fp: &str,
+    new_fp: &str,
+) -> Result<(), anyhow::Error> {
+    merge_library_books(tx, old_fp, new_fp).await?;
+    merge_reading_states(tx, old_fp, new_fp).await?;
+    merge_thumbnails(tx, old_fp, new_fp).await?;
+    merge_toc_entries(tx, old_fp, new_fp).await?;
+    merge_book_authors(tx, old_fp, new_fp).await?;
+    merge_book_categories(tx, old_fp, new_fp).await?;
+
+    Ok(())
+}
+
+#[cfg_attr(feature = "tracing", tracing::instrument(skip(tx), fields(old_fp = %old_fp, new_fp = %new_fp)))]
+async fn merge_library_books(
+    tx: &mut Transaction<'_, Sqlite>,
+    old_fp: &str,
+    new_fp: &str,
+) -> Result<(), anyhow::Error> {
+    sqlx::query(
+        "INSERT OR IGNORE INTO library_books (library_id, book_fingerprint, added_to_library_at, file_path, absolute_path)
+         SELECT library_id, ?, added_to_library_at, file_path, absolute_path
+         FROM library_books
+         WHERE book_fingerprint = ?",
+    )
+    .bind(new_fp)
+    .bind(old_fp)
+    .execute(&mut **tx)
+    .await?;
+
+    Ok(())
+}
+
+#[cfg_attr(feature = "tracing", tracing::instrument(skip(tx), fields(old_fp = %old_fp, new_fp = %new_fp)))]
+async fn merge_reading_states(
+    tx: &mut Transaction<'_, Sqlite>,
+    old_fp: &str,
+    new_fp: &str,
+) -> Result<(), anyhow::Error> {
+    sqlx::query!(
+        r#"
+        INSERT OR IGNORE INTO reading_states (
+            fingerprint, opened, current_page, pages_count, finished, dithered,
+            zoom_mode, scroll_mode, page_offset_x, page_offset_y, rotation,
+            cropping_margins_json, margin_width, screen_margin_width,
+            font_family, font_size, text_align, line_height,
+            contrast_exponent, contrast_gray,
+            page_names_json, bookmarks_json, annotations_json
+        )
+        SELECT
+            ?, opened, current_page, pages_count, finished, dithered,
+            zoom_mode, scroll_mode, page_offset_x, page_offset_y, rotation,
+            cropping_margins_json, margin_width, screen_margin_width,
+            font_family, font_size, text_align, line_height,
+            contrast_exponent, contrast_gray,
+            page_names_json, bookmarks_json, annotations_json
+        FROM reading_states
+        WHERE fingerprint = ?
+        "#,
+        new_fp,
+        old_fp,
+    )
+    .execute(&mut **tx)
+    .await?;
+
+    Ok(())
+}
+
+#[cfg_attr(feature = "tracing", tracing::instrument(skip(tx), fields(old_fp = %old_fp, new_fp = %new_fp)))]
+async fn merge_thumbnails(
+    tx: &mut Transaction<'_, Sqlite>,
+    old_fp: &str,
+    new_fp: &str,
+) -> Result<(), anyhow::Error> {
+    sqlx::query!(
+        "INSERT OR IGNORE INTO thumbnails (fingerprint, thumbnail_data)
+         SELECT ?, thumbnail_data
+         FROM thumbnails
+         WHERE fingerprint = ?",
+        new_fp,
+        old_fp,
+    )
+    .execute(&mut **tx)
+    .await?;
+
+    Ok(())
+}
+
+#[cfg_attr(feature = "tracing", tracing::instrument(skip(tx), fields(old_fp = %old_fp, new_fp = %new_fp)))]
+async fn merge_toc_entries(
+    tx: &mut Transaction<'_, Sqlite>,
+    old_fp: &str,
+    new_fp: &str,
+) -> Result<(), anyhow::Error> {
+    let existing_count: i64 = sqlx::query_scalar!(
+        "SELECT COUNT(*) FROM toc_entries WHERE book_fingerprint = ?",
+        new_fp,
+    )
+    .fetch_one(&mut **tx)
+    .await?;
+
+    if existing_count > 0 {
+        return Ok(());
+    }
+
+    let old_rows = sqlx::query_as!(
+        TocEntryRow,
+        r#"
+        SELECT
+            book_fingerprint,
+            id                as "id: Uuid7",
+            parent_id         as "parent_id!: OptionalUuid7",
+            position,
+            title,
+            location_kind,
+            location_exact,
+            location_uri
+        FROM toc_entries
+        WHERE book_fingerprint = ?
+        ORDER BY id ASC
+        "#,
+        old_fp,
+    )
+    .fetch_all(&mut **tx)
+    .await?;
+
+    if old_rows.is_empty() {
+        return Ok(());
+    }
+
+    let toc_entries = rows_to_toc_entries(&old_rows)?;
+    insert_toc_entries(tx, new_fp, &toc_entries, None).await?;
+
+    Ok(())
+}
+
+#[cfg_attr(feature = "tracing", tracing::instrument(skip(tx, entries), fields(book_fingerprint = %book_fingerprint)))]
+async fn insert_toc_entries(
+    tx: &mut Transaction<'_, Sqlite>,
+    book_fingerprint: &str,
+    entries: &[SimpleTocEntry],
+    parent_id: Option<Uuid7>,
+) -> Result<(), anyhow::Error> {
+    for (position, entry) in entries.iter().enumerate() {
+        let (title, location, children) = match entry {
+            SimpleTocEntry::Leaf(title, location) => (title.as_str(), location, [].as_slice()),
+            SimpleTocEntry::Container(title, location, children) => {
+                (title.as_str(), location, children.as_slice())
+            }
+        };
+
+        let (location_kind, location_exact, location_uri) = encode_location(location);
+        let id = Uuid7::now();
+        let position = position as i64;
+        let parent_id_str = parent_id.as_ref().map(ToString::to_string);
+
+        sqlx::query!(
+            r#"
+            INSERT INTO toc_entries (
+                id, book_fingerprint, parent_id, position, title, location_kind, location_exact, location_uri
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            "#,
+            id,
+            book_fingerprint,
+            parent_id_str,
+            position,
+            title,
+            location_kind,
+            location_exact,
+            location_uri,
+        )
+        .execute(&mut **tx)
+        .await?;
+
+        if !children.is_empty() {
+            Box::pin(insert_toc_entries(tx, book_fingerprint, children, Some(id))).await?;
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg_attr(feature = "tracing", tracing::instrument(skip(tx), fields(old_fp = %old_fp, new_fp = %new_fp)))]
+async fn merge_book_authors(
+    tx: &mut Transaction<'_, Sqlite>,
+    old_fp: &str,
+    new_fp: &str,
+) -> Result<(), anyhow::Error> {
+    sqlx::query!(
+        "INSERT OR IGNORE INTO book_authors (book_fingerprint, author_id, position)
+         SELECT ?, author_id, position
+         FROM book_authors
+         WHERE book_fingerprint = ?",
+        new_fp,
+        old_fp,
+    )
+    .execute(&mut **tx)
+    .await?;
+
+    Ok(())
+}
+
+#[cfg_attr(feature = "tracing", tracing::instrument(skip(tx), fields(old_fp = %old_fp, new_fp = %new_fp)))]
+async fn merge_book_categories(
+    tx: &mut Transaction<'_, Sqlite>,
+    old_fp: &str,
+    new_fp: &str,
+) -> Result<(), anyhow::Error> {
+    sqlx::query!(
+        "INSERT OR IGNORE INTO book_categories (book_fingerprint, category_id)
+         SELECT ?, category_id
+         FROM book_categories
+         WHERE book_fingerprint = ?",
+        new_fp,
+        old_fp,
+    )
+    .execute(&mut **tx)
+    .await?;
+
+    Ok(())
+}
+
+#[cfg_attr(feature = "tracing", tracing::instrument(skip(tx), fields(old_fp = %old_fp, new_fp = %new_fp)))]
+async fn insert_rekeyed_book(
+    tx: &mut Transaction<'_, Sqlite>,
+    old_fp: &str,
+    new_fp: &str,
+) -> Result<(), anyhow::Error> {
+    sqlx::query(
+        r#"
+        INSERT INTO books (
+            fingerprint, title, subtitle, year, language, publisher,
+            series, edition, volume, number, identifier,
+            file_kind, file_size, added_at
+        )
+        SELECT
+            ?, title, subtitle, year, language, publisher,
+            series, edition, volume, number, identifier,
+            file_kind, file_size, added_at
+        FROM books WHERE fingerprint = ?
+        "#,
+    )
+    .bind(new_fp)
+    .bind(old_fp)
+    .execute(&mut **tx)
+    .await?;
+
+    Ok(())
+}
+
+#[cfg_attr(feature = "tracing", tracing::instrument(skip(tx), fields(old_fp = %old_fp, new_fp = %new_fp)))]
+async fn move_rekeyed_book_data(
+    tx: &mut Transaction<'_, Sqlite>,
+    old_fp: &str,
+    new_fp: &str,
+) -> Result<(), anyhow::Error> {
+    sqlx::query!(
+        "UPDATE reading_states SET fingerprint = ? WHERE fingerprint = ?",
+        new_fp,
+        old_fp,
+    )
+    .execute(&mut **tx)
+    .await?;
+
+    sqlx::query!(
+        "UPDATE thumbnails SET fingerprint = ? WHERE fingerprint = ?",
+        new_fp,
+        old_fp,
+    )
+    .execute(&mut **tx)
+    .await?;
+
+    sqlx::query!(
+        "UPDATE toc_entries SET book_fingerprint = ? WHERE book_fingerprint = ?",
+        new_fp,
+        old_fp,
+    )
+    .execute(&mut **tx)
+    .await?;
+
+    sqlx::query!(
+        "UPDATE book_authors SET book_fingerprint = ? WHERE book_fingerprint = ?",
+        new_fp,
+        old_fp,
+    )
+    .execute(&mut **tx)
+    .await?;
+
+    sqlx::query!(
+        "UPDATE book_categories SET book_fingerprint = ? WHERE book_fingerprint = ?",
+        new_fp,
+        old_fp,
+    )
+    .execute(&mut **tx)
+    .await?;
+
+    sqlx::query!(
+        "UPDATE library_books SET book_fingerprint = ? WHERE book_fingerprint = ?",
+        new_fp,
+        old_fp,
+    )
+    .execute(&mut **tx)
+    .await?;
+
+    Ok(())
+}
 
 /// Ensures the library row exists and returns its id.
 #[cfg_attr(feature = "tracing", tracing::instrument(skip(pool), fields(path = %path, name = %name), ret(level = tracing::Level::TRACE)))]
@@ -242,7 +727,7 @@ async fn import_orphan_reading_states(
         let fp = match path
             .file_stem()
             .and_then(|s| s.to_str())
-            .and_then(|s| Fp::from_str(s).ok())
+            .and_then(|s| Fp::from_str(s).ok().or_else(|| Fp::from_legacy_str(s).ok()))
         {
             Some(fp) => fp,
             None => {
@@ -547,4 +1032,383 @@ async fn insert_reading_state(
     .await?;
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::db::runtime::RUNTIME;
+    use crate::db::Database;
+    use crate::document::{SimpleTocEntry, TocLocation};
+    use crate::library::db::Db;
+    use crate::metadata::{FileInfo, ReaderInfo};
+    use chrono::Local;
+    use std::collections::BTreeSet;
+    use std::path::PathBuf;
+    use tempfile::tempdir;
+
+    fn create_test_db() -> (Database, Db) {
+        let db = Database::new(":memory:").expect("failed to create in-memory database");
+        db.migrate().expect("failed to run migrations");
+        let libdb = Db::new(&db);
+
+        (db, libdb)
+    }
+
+    fn create_info(
+        title: &str,
+        author: &str,
+        categories: &[&str],
+        path: &str,
+        reader_info: Option<ReaderInfo>,
+    ) -> Info {
+        Info {
+            title: title.to_string(),
+            author: author.to_string(),
+            categories: categories
+                .iter()
+                .map(|category| category.to_string())
+                .collect::<BTreeSet<_>>(),
+            file: FileInfo {
+                path: PathBuf::from(path),
+                absolute_path: PathBuf::from(path),
+                kind: "epub".to_string(),
+                size: 1024,
+            },
+            reader_info,
+            added: Local::now().naive_local(),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn rekey_book_merges_duplicate_content_data() {
+        let (db, libdb) = create_test_db();
+        let library_a = libdb
+            .register_library("/tmp/library-a", "Library A")
+            .expect("failed to register library A");
+        let library_b = libdb
+            .register_library("/tmp/library-b", "Library B")
+            .expect("failed to register library B");
+
+        let old_fp = Fp::from_u64(1);
+        let new_fp = Fp::from_u64(2);
+        let old_reader = ReaderInfo {
+            current_page: 42,
+            pages_count: 100,
+            ..Default::default()
+        };
+        let old_toc = vec![SimpleTocEntry::Leaf(
+            "Chapter 1".to_string(),
+            TocLocation::Exact(1),
+        )];
+
+        let old_info = create_info(
+            "Old Copy",
+            "Old Author",
+            &["History"],
+            "/tmp/library-a/book.epub",
+            Some(old_reader.clone()),
+        );
+        let new_info = create_info("New Copy", "", &[], "/tmp/library-b/book.epub", None);
+
+        libdb
+            .insert_book(library_a, old_fp, &old_info)
+            .expect("failed to insert old book");
+        libdb
+            .insert_book(library_b, new_fp, &new_info)
+            .expect("failed to insert new book");
+        libdb
+            .save_toc(old_fp, &old_toc)
+            .expect("failed to save old toc");
+        libdb
+            .save_thumbnail(old_fp, b"old-thumbnail")
+            .expect("failed to save old thumbnail");
+
+        RUNTIME.block_on(async {
+            rekey_book(db.pool(), &old_fp.to_string(), &new_fp.to_string())
+                .await
+                .expect("failed to rekey duplicate book");
+        });
+
+        let books_a = libdb
+            .get_all_books(library_a)
+            .expect("failed to load library A books");
+        let books_b = libdb
+            .get_all_books(library_b)
+            .expect("failed to load library B books");
+
+        assert_eq!(books_a.len(), 1);
+        assert_eq!(books_b.len(), 1);
+        assert_eq!(books_a[0].fp, Some(new_fp));
+        assert_eq!(books_b[0].fp, Some(new_fp));
+
+        let merged = &books_a[0];
+        let merged_reader = merged
+            .reader_info
+            .as_ref()
+            .expect("reading state should be preserved");
+
+        assert_eq!(merged.author, "Old Author");
+        assert!(merged.categories.contains("History"));
+        assert_eq!(merged_reader.current_page, old_reader.current_page);
+        assert_eq!(merged_reader.pages_count, old_reader.pages_count);
+        assert!(matches!(
+            merged.toc.as_ref(),
+            Some(toc) if matches!(toc.first(), Some(SimpleTocEntry::Leaf(title, TocLocation::Exact(1))) if title == "Chapter 1")
+        ));
+        assert_eq!(
+            libdb
+                .get_thumbnail(new_fp)
+                .expect("failed to read thumbnail"),
+            Some(b"old-thumbnail".to_vec())
+        );
+        assert_eq!(
+            libdb
+                .get_thumbnail(old_fp)
+                .expect("failed to read old thumbnail"),
+            None
+        );
+    }
+
+    #[test]
+    fn rekey_book_keeps_existing_duplicate_data() {
+        let (db, libdb) = create_test_db();
+        let library_a = libdb
+            .register_library("/tmp/library-c", "Library C")
+            .expect("failed to register library C");
+        let library_b = libdb
+            .register_library("/tmp/library-d", "Library D")
+            .expect("failed to register library D");
+
+        let old_fp = Fp::from_u64(3);
+        let new_fp = Fp::from_u64(4);
+        let old_toc = vec![SimpleTocEntry::Leaf(
+            "Old Chapter".to_string(),
+            TocLocation::Exact(1),
+        )];
+        let new_toc = vec![SimpleTocEntry::Leaf(
+            "New Chapter".to_string(),
+            TocLocation::Exact(2),
+        )];
+
+        let old_info = create_info(
+            "Old Copy",
+            "Old Author",
+            &["History"],
+            "/tmp/library-c/book.epub",
+            Some(ReaderInfo {
+                current_page: 12,
+                pages_count: 100,
+                ..Default::default()
+            }),
+        );
+        let new_info = create_info(
+            "New Copy",
+            "",
+            &[],
+            "/tmp/library-d/book.epub",
+            Some(ReaderInfo {
+                current_page: 88,
+                pages_count: 200,
+                ..Default::default()
+            }),
+        );
+
+        libdb
+            .insert_book(library_a, old_fp, &old_info)
+            .expect("failed to insert old book");
+        libdb
+            .insert_book(library_b, new_fp, &new_info)
+            .expect("failed to insert new book");
+        libdb
+            .save_toc(old_fp, &old_toc)
+            .expect("failed to save old toc");
+        libdb
+            .save_toc(new_fp, &new_toc)
+            .expect("failed to save new toc");
+        libdb
+            .save_thumbnail(old_fp, b"old-thumbnail")
+            .expect("failed to save old thumbnail");
+        libdb
+            .save_thumbnail(new_fp, b"new-thumbnail")
+            .expect("failed to save new thumbnail");
+
+        RUNTIME.block_on(async {
+            rekey_book(db.pool(), &old_fp.to_string(), &new_fp.to_string())
+                .await
+                .expect("failed to rekey duplicate book");
+        });
+
+        let merged = libdb
+            .get_all_books(library_a)
+            .expect("failed to load merged books")
+            .into_iter()
+            .next()
+            .expect("merged book should exist");
+        let merged_reader = merged
+            .reader_info
+            .as_ref()
+            .expect("reading state should exist");
+
+        assert_eq!(merged_reader.current_page, 88);
+        assert!(matches!(
+            merged.toc.as_ref(),
+            Some(toc) if matches!(toc.first(), Some(SimpleTocEntry::Leaf(title, TocLocation::Exact(2))) if title == "New Chapter")
+        ));
+        assert_eq!(
+            libdb
+                .get_thumbnail(new_fp)
+                .expect("failed to read thumbnail"),
+            Some(b"new-thumbnail".to_vec())
+        );
+    }
+
+    #[test]
+    fn rehash_fingerprints_canonicalizes_unrekeyed_legacy_fingerprints() {
+        let (db, libdb) = create_test_db();
+        let library_id = libdb
+            .register_library("/tmp/library-legacy", "Legacy Library")
+            .expect("failed to register legacy library");
+        let legacy_fp = "0000000000000001";
+        let legacy_fp_value =
+            Fp::from_legacy_str(legacy_fp).expect("legacy fingerprint should parse");
+        let canonical_fp = legacy_fp_value.to_string();
+
+        RUNTIME.block_on(async {
+            let mut tx = db
+                .pool()
+                .begin()
+                .await
+                .expect("failed to begin legacy insert transaction");
+
+            ensure_stub_book(&mut tx, library_id, legacy_fp_value)
+                .await
+                .expect("failed to insert legacy book");
+
+            tx.commit()
+                .await
+                .expect("failed to commit legacy insert transaction");
+
+            rehash_fingerprints(db.pool())
+                .await
+                .expect("failed to run rehash migration");
+        });
+
+        let books = libdb
+            .get_all_books(library_id)
+            .expect("canonicalized legacy books should load");
+
+        assert_eq!(books.len(), 1);
+        assert_eq!(
+            books[0].fp.map(|fp| fp.to_string()).as_deref(),
+            Some(canonical_fp.as_str())
+        );
+
+        RUNTIME.block_on(async {
+            let old_row = sqlx::query_scalar!(
+                "SELECT fingerprint FROM books WHERE fingerprint = ?",
+                legacy_fp
+            )
+            .fetch_optional(db.pool())
+            .await
+            .expect("failed to query old fingerprint");
+            let new_row = sqlx::query_scalar!(
+                "SELECT fingerprint FROM books WHERE fingerprint = ?",
+                canonical_fp
+            )
+            .fetch_optional(db.pool())
+            .await
+            .expect("failed to query canonical fingerprint");
+
+            assert!(old_row.is_none());
+            assert_eq!(new_row.as_deref(), Some(canonical_fp.as_str()));
+        });
+    }
+
+    #[test]
+    fn rehash_fingerprints_reads_absolute_path_from_library_books() {
+        let temp = tempdir().expect("failed to create temp dir");
+        let library_root = temp.path().join("library");
+        std::fs::create_dir(&library_root).expect("failed to create library root");
+        let book_path = library_root.join("book.epub");
+        std::fs::write(&book_path, b"rehash me").expect("failed to write book file");
+
+        let (db, libdb) = create_test_db();
+        let library_id = libdb
+            .register_library(library_root.to_string_lossy().as_ref(), "Rehash Library")
+            .expect("failed to register library");
+        let legacy_fp = "00000000000000aa";
+        let expected_fp = book_path.fingerprint().expect("failed to fingerprint file");
+        let now = UnixTimestamp::now();
+
+        RUNTIME.block_on(async {
+            sqlx::query(
+                r#"
+                INSERT INTO books (
+                    fingerprint, title, subtitle, year, language, publisher,
+                    series, edition, volume, number, identifier,
+                    file_kind, file_size, added_at
+                ) VALUES (?, ?, '', '', '', '', '', '', '', '', '', ?, ?, ?)
+                "#,
+            )
+            .bind(legacy_fp)
+            .bind("Legacy Book")
+            .bind("epub")
+            .bind(9_i64)
+            .bind(now)
+            .execute(db.pool())
+            .await
+            .expect("failed to insert legacy book");
+
+            sqlx::query(
+                r#"
+                INSERT INTO library_books (
+                    library_id, book_fingerprint, added_to_library_at, file_path, absolute_path
+                ) VALUES (?, ?, ?, ?, ?)
+                "#,
+            )
+            .bind(library_id)
+            .bind(legacy_fp)
+            .bind(now)
+            .bind("book.epub")
+            .bind(book_path.to_string_lossy().as_ref())
+            .execute(db.pool())
+            .await
+            .expect("failed to insert library book row");
+
+            rehash_fingerprints(db.pool())
+                .await
+                .expect("failed to run rehash migration");
+        });
+
+        let books = libdb
+            .get_all_books(library_id)
+            .expect("rehash results should load");
+
+        assert_eq!(books.len(), 1);
+        assert_eq!(books[0].fp, Some(expected_fp));
+        assert_eq!(books[0].file.absolute_path, book_path);
+
+        RUNTIME.block_on(async {
+            let expected_fp_str = expected_fp.to_string();
+            let old_row = sqlx::query_scalar!(
+                "SELECT fingerprint FROM books WHERE fingerprint = ?",
+                legacy_fp
+            )
+            .fetch_optional(db.pool())
+            .await
+            .expect("failed to query legacy row");
+            let new_row = sqlx::query_scalar!(
+                "SELECT fingerprint FROM books WHERE fingerprint = ?",
+                expected_fp_str
+            )
+            .fetch_optional(db.pool())
+            .await
+            .expect("failed to query rehashed row");
+
+            assert!(old_row.is_none());
+            assert_eq!(new_row.as_deref(), Some(expected_fp_str.as_str()));
+        });
+    }
 }

--- a/crates/core/src/library/mod.rs
+++ b/crates/core/src/library/mod.rs
@@ -13,15 +13,13 @@ use anyhow::{bail, format_err, Error};
 use chrono::Local;
 use fxhash::FxHashMap;
 use std::collections::BTreeSet;
-use std::fs::{self, File};
+use std::fs;
 use std::io::ErrorKind;
 use std::path::{Path, PathBuf};
-use std::time::{Duration, SystemTime};
 use tracing::{debug, error, info};
 use walkdir::WalkDir;
 
 const METADATA_FILENAME: &str = ".metadata.json";
-const FAT32_EPOCH_FILENAME: &str = ".fat32-epoch";
 const READING_STATES_DIRNAME: &str = ".reading-states";
 #[cfg(not(feature = "test"))]
 const THUMBNAIL_PREVIEWS_DIRNAME: &str = ".thumbnail-previews";
@@ -34,14 +32,6 @@ enum PendingRelocation {
         old_fp: Fp,
         file_size: u64,
     },
-    /// Fingerprint drifted by ±1 FAT32 epoch second.
-    /// The book entry is migrated to the new fingerprint and path.
-    EpochDrift {
-        new_fp: Fp,
-        old_fp: Fp,
-        new_relat: PathBuf,
-        new_abs: PathBuf,
-    },
 }
 
 impl PendingRelocation {
@@ -49,7 +39,6 @@ impl PendingRelocation {
     fn old_fp(&self) -> Fp {
         match self {
             PendingRelocation::FingerprintChanged { old_fp, .. } => *old_fp,
-            PendingRelocation::EpochDrift { old_fp, .. } => *old_fp,
         }
     }
 }
@@ -64,7 +53,6 @@ pub struct Library {
     pub home: PathBuf,
     pub db: LibraryDb,
     pub library_id: i64,
-    pub fat32_epoch: SystemTime,
     pub sort_method: SortMethod,
     pub reverse_order: bool,
     pub show_hidden: bool,
@@ -97,21 +85,12 @@ impl Library {
             id
         };
 
-        let path = home.as_ref().join(FAT32_EPOCH_FILENAME);
-        if !path.exists() {
-            let file = File::create(&path)?;
-            file.set_modified(std::time::UNIX_EPOCH + Duration::from_secs(315_532_800))?;
-        }
-
-        let fat32_epoch = path.metadata()?.modified()?;
-
         let sort_method = SortMethod::Opened;
 
         Ok(Library {
             home: home.as_ref().to_path_buf(),
             db,
             library_id,
-            fat32_epoch,
             sort_method,
             reverse_order: sort_method.reverse_order(),
             show_hidden: false,
@@ -350,15 +329,30 @@ impl Library {
         let mut books_to_delete: Vec<Fp> = Vec::new();
         let mut pending_relocations: Vec<PendingRelocation> = Vec::new();
         let mut thumbnails_to_delete: Vec<Fp> = Vec::new();
-        let mut thumbnails_to_move: Vec<(Fp, Fp)> = Vec::new();
 
         #[cfg(feature = "tracing")]
         let _walk_span = tracing::info_span!("walk_directory").entered();
 
+        #[cfg(feature = "emulator")]
+        const IGNORED_TOP_LEVEL_DIRS: &[&str] = &["target", "node_modules", "thirdparty"];
+
         let walk_entries: Vec<_> = WalkDir::new(&self.home)
             .min_depth(1)
             .into_iter()
-            .filter_entry(|e| !e.is_hidden())
+            .filter_entry(|e| {
+                if e.is_hidden() {
+                    return false;
+                }
+                #[cfg(feature = "emulator")]
+                if e.depth() == 1 && e.file_type().is_dir() {
+                    if let Some(name) = e.file_name().to_str() {
+                        if IGNORED_TOP_LEVEL_DIRS.contains(&name) {
+                            return false;
+                        }
+                    }
+                }
+                true
+            })
             .filter_map(|e| e.ok())
             .filter(|e| !e.file_type().is_dir())
             .collect();
@@ -370,19 +364,30 @@ impl Library {
         let _process_span =
             tracing::info_span!("process_entries", count = walk_entries.len()).entered();
 
-        for entry in walk_entries {
+        for entry in &walk_entries {
+            #[cfg(feature = "tracing")]
+            let _span =
+                tracing::info_span!(parent: &_process_span, "process_entry", entry = entry.path().to_str())
+                    .entered();
+
             let path = entry.path();
             let relat = path.strip_prefix(&self.home).unwrap_or(path);
-            let md = entry.metadata().unwrap();
-            let fp = md.fingerprint(self.fat32_epoch).unwrap();
+
+            let fp = match path.fingerprint() {
+                Ok(fp) => fp,
+                Err(e) => {
+                    error!(path = ?path, error = %e, "failed to compute fingerprint, skipping");
+                    continue;
+                }
+            };
 
             if handles_by_fp.contains_key(&fp) {
                 if relat != handles_by_fp[&fp] {
                     debug!(
-                        "Update path for {}: {} → {}.",
-                        fp,
-                        handles_by_fp[&fp].display(),
-                        relat.display()
+                        fp = %fp,
+                        old_path = %handles_by_fp[&fp].display(),
+                        new_path = %relat.display(),
+                        "updated book path"
                     );
                     let old_path = handles_by_fp.remove(&fp).unwrap();
                     handles_by_path.remove(&old_path);
@@ -390,97 +395,56 @@ impl Library {
                     handles_by_path.insert(relat.to_path_buf(), fp);
                     path_updates.push((fp, relat.to_path_buf(), path.to_path_buf()));
                 }
-            } else if let Some(fp2) = handles_by_path.get(relat).cloned() {
+                continue;
+            }
+
+            if let Some(old_fp) = handles_by_path.get(relat).cloned() {
                 debug!(
-                    "Update fingerprint for {}: {} → {}.",
-                    relat.display(),
-                    fp2,
-                    fp
+                    path = %relat.display(),
+                    old_fp = %old_fp,
+                    new_fp = %fp,
+                    "updated book fingerprint"
                 );
 
-                handles_by_fp.remove(&fp2);
+                handles_by_fp.remove(&old_fp);
                 handles_by_path.remove(relat);
                 handles_by_fp.insert(fp, relat.to_path_buf());
                 handles_by_path.insert(relat.to_path_buf(), fp);
-                books_to_delete.push(fp2);
+                books_to_delete.push(old_fp);
 
                 pending_relocations.push(PendingRelocation::FingerprintChanged {
                     new_fp: fp,
-                    old_fp: fp2,
-                    file_size: md.len(),
+                    old_fp,
+                    file_size: entry.metadata().map(|m| m.len()).unwrap_or(0),
                 });
 
-                thumbnails_to_delete.push(fp2);
-            } else {
-                let fp1 = self
-                    .fat32_epoch
-                    .checked_sub(Duration::from_secs(1))
-                    .and_then(|epoch| md.fingerprint(epoch).ok())
-                    .unwrap_or(fp);
-                let fp2 = self
-                    .fat32_epoch
-                    .checked_add(Duration::from_secs(1))
-                    .and_then(|epoch| md.fingerprint(epoch).ok())
-                    .unwrap_or(fp);
+                thumbnails_to_delete.push(old_fp);
+                continue;
+            }
 
-                let nfp = if fp1 != fp && handles_by_fp.contains_key(&fp1) {
-                    Some(fp1)
-                } else if fp2 != fp && handles_by_fp.contains_key(&fp2) {
-                    Some(fp2)
-                } else {
-                    None
-                };
-
-                if let Some(nfp) = nfp {
-                    debug!(
-                        "Update fingerprint for {}: {} → {}.",
-                        handles_by_fp
-                            .get(&nfp)
-                            .map_or_else(|| relat.display(), |p| p.display()),
-                        nfp,
-                        fp
-                    );
-
-                    let old_path = handles_by_fp.remove(&nfp).unwrap_or_default();
-                    handles_by_path.remove(&old_path);
-                    handles_by_fp.insert(fp, relat.to_path_buf());
-                    handles_by_path.insert(relat.to_path_buf(), fp);
-                    books_to_delete.push(nfp);
-
-                    pending_relocations.push(PendingRelocation::EpochDrift {
-                        new_fp: fp,
-                        old_fp: nfp,
-                        new_relat: relat.to_path_buf(),
-                        new_abs: path.to_path_buf(),
-                    });
-
-                    thumbnails_to_move.push((nfp, fp));
-                } else {
-                    let kind = file_kind(path).unwrap_or_default();
-                    if !settings.allowed_kinds.contains(&kind) {
-                        continue;
-                    }
-                    info!("Add new entry: {}, {}.", fp, relat.display());
-                    let size = md.len();
-                    let file = FileInfo {
-                        path: relat.to_path_buf(),
-                        absolute_path: path.to_path_buf(),
-                        kind,
-                        size,
-                    };
-                    let mut info = Info {
-                        file,
-                        ..Default::default()
-                    };
-
-                    if settings.metadata_kinds.contains(&info.file.kind) {
-                        extract_metadata_from_document(&self.home, &mut info);
-                    }
-
-                    handles_by_fp.insert(fp, relat.to_path_buf());
-                    handles_by_path.insert(relat.to_path_buf(), fp);
-                    books_to_insert.push((fp, info));
+            {
+                let kind = file_kind(path).unwrap_or_default();
+                if !settings.allowed_kinds.contains(&kind) {
+                    continue;
                 }
+                info!(fp = %fp, path = %relat.display(), "added new entry");
+                let size = entry.metadata().map(|m| m.len()).unwrap_or(0);
+                let file = FileInfo {
+                    path: relat.to_path_buf(),
+                    absolute_path: path.to_path_buf(),
+                    kind,
+                    size,
+                };
+                let mut info = Info {
+                    file,
+                    ..Default::default()
+                };
+                if settings.metadata_kinds.contains(&info.file.kind) {
+                    extract_metadata_from_document(&self.home, &mut info);
+                }
+                handles_by_fp.insert(fp, relat.to_path_buf());
+                handles_by_path.insert(relat.to_path_buf(), fp);
+                books_to_insert.push((fp, info));
             }
         }
 
@@ -534,36 +498,8 @@ impl Library {
                             books_to_insert.push((new_fp, info));
                         }
                     }
-                    PendingRelocation::EpochDrift {
-                        new_fp,
-                        old_fp,
-                        new_relat,
-                        new_abs,
-                    } => {
-                        if let Some(mut info) = fetched.remove(&old_fp) {
-                            if new_relat != info.file.path {
-                                debug!(
-                                    "Update path for {}: {} → {}.",
-                                    new_fp,
-                                    info.file.path.display(),
-                                    new_relat.display()
-                                );
-                                info.file.path = new_relat;
-                                info.file.absolute_path = new_abs;
-                            }
-                            books_to_insert.push((new_fp, info));
-                        }
-                    }
                 }
             }
-        }
-
-        if let Err(e) = self.db.batch_move_thumbnails(&thumbnails_to_move) {
-            error!(
-                error = %e,
-                count = thumbnails_to_move.len(),
-                "batch move thumbnails failed"
-            );
         }
 
         if let Err(e) = self.db.batch_delete_thumbnails(&thumbnails_to_delete) {
@@ -620,8 +556,13 @@ impl Library {
 
     pub fn add_document(&mut self, info: Info) {
         let path = self.home.join(&info.file.path);
-        let md = path.metadata().unwrap();
-        let fp = md.fingerprint(self.fat32_epoch).unwrap();
+        let fp = match path.fingerprint() {
+            Ok(fp) => fp,
+            Err(e) => {
+                error!(path = %path.display(), error = %e, "failed to fingerprint document");
+                return;
+            }
+        };
 
         if let Err(e) = self.db.insert_book(self.library_id, fp, &info) {
             error!(fp = %fp, error = %e, "failed to insert book into database");
@@ -639,16 +580,7 @@ impl Library {
         let src = self.home.join(path.as_ref());
 
         let fp = self
-            .db
-            .get_book_by_path(self.library_id, path.as_ref())
-            .ok()
-            .flatten()
-            .and_then(|info| info.fp)
-            .or_else(|| {
-                src.metadata()
-                    .ok()
-                    .and_then(|md| md.fingerprint(self.fat32_epoch).ok())
-            })
+            .resolve_fingerprint(path.as_ref())
             .ok_or_else(|| format_err!("can't get fingerprint of {}", path.as_ref().display()))?;
 
         let mut dest = src.clone();
@@ -679,17 +611,7 @@ impl Library {
         let full_path = self.home.join(path.as_ref());
 
         let fp = self
-            .db
-            .get_book_by_path(self.library_id, path.as_ref())
-            .ok()
-            .flatten()
-            .and_then(|info| info.fp)
-            .or_else(|| {
-                full_path
-                    .metadata()
-                    .ok()
-                    .and_then(|md| md.fingerprint(self.fat32_epoch).ok())
-            })
+            .resolve_fingerprint(path.as_ref())
             .ok_or_else(|| format_err!("can't get fingerprint of {}", path.as_ref().display()))?;
 
         if full_path.exists() {
@@ -723,14 +645,8 @@ impl Library {
             ));
         }
 
-        let md = src.metadata()?;
         let fp = self
-            .db
-            .get_book_by_path(self.library_id, path.as_ref())
-            .ok()
-            .flatten()
-            .and_then(|info| info.fp)
-            .or_else(|| md.fingerprint(self.fat32_epoch).ok())
+            .resolve_fingerprint(path.as_ref())
             .ok_or_else(|| format_err!("can't get fingerprint of {}", path.as_ref().display()))?;
 
         let mut dest = other.home.join(path.as_ref());
@@ -749,10 +665,6 @@ impl Library {
         }
 
         fs::copy(&src, &dest)?;
-        {
-            let fdest = File::open(&dest)?;
-            fdest.set_modified(md.modified()?)?;
-        }
 
         if let Ok(Some(thumbnail_data)) = self.db.get_thumbnail(fp) {
             other.db.save_thumbnail(fp, &thumbnail_data).ok();
@@ -787,14 +699,8 @@ impl Library {
             ));
         }
 
-        let md = src.metadata()?;
         let fp = self
-            .db
-            .get_book_by_path(self.library_id, path.as_ref())
-            .ok()
-            .flatten()
-            .and_then(|info| info.fp)
-            .or_else(|| md.fingerprint(self.fat32_epoch).ok())
+            .resolve_fingerprint(path.as_ref())
             .ok_or_else(|| format_err!("can't get fingerprint of {}", path.as_ref().display()))?;
 
         let src = self.home.join(path.as_ref());
@@ -884,12 +790,9 @@ impl Library {
     }
 
     pub fn sync_reader_info<P: AsRef<Path>>(&mut self, path: P, reader: &ReaderInfo) {
-        let fp = match self.fingerprint_for_path(path.as_ref()) {
-            Some(fp) => fp,
-            None => {
-                error!(path = %path.as_ref().display(), "failed to resolve fingerprint for sync_reader_info");
-                return;
-            }
+        let path = path.as_ref();
+        let Some(fp) = self.resolve_fingerprint(path) else {
+            return;
         };
 
         if let Err(e) = self.db.save_reading_state(fp, reader) {
@@ -904,12 +807,9 @@ impl Library {
     /// Call this when a TOC has been parsed from a document for the first time
     /// so subsequent opens can serve it from the database without re-parsing.
     pub fn sync_toc<P: AsRef<Path>>(&mut self, path: P, toc: Vec<SimpleTocEntry>) {
-        let fp = match self.fingerprint_for_path(path.as_ref()) {
-            Some(fp) => fp,
-            None => {
-                error!(path = %path.as_ref().display(), "failed to resolve fingerprint for sync_toc");
-                return;
-            }
+        let path = path.as_ref();
+        let Some(fp) = self.resolve_fingerprint(path) else {
+            return;
         };
 
         if let Err(e) = self.db.save_toc(fp, &toc) {
@@ -938,12 +838,9 @@ impl Library {
     }
 
     pub fn set_status<P: AsRef<Path>>(&mut self, path: P, status: SimpleStatus) {
-        let fp = match self.fingerprint_for_path(path.as_ref()) {
-            Some(fp) => fp,
-            None => {
-                error!(path = %path.as_ref().display(), "failed to resolve fingerprint for set_status");
-                return;
-            }
+        let path = path.as_ref();
+        let Some(fp) = self.resolve_fingerprint(path) else {
+            return;
         };
 
         match status {
@@ -1012,21 +909,6 @@ impl Library {
         books.into_iter().nth(current_index + 1)
     }
 
-    fn fingerprint_for_path(&self, path: &Path) -> Option<Fp> {
-        self.db
-            .get_book_by_path(self.library_id, path)
-            .ok()
-            .flatten()
-            .and_then(|info| info.fp)
-            .or_else(|| {
-                self.home
-                    .join(path)
-                    .metadata()
-                    .ok()
-                    .and_then(|md| md.fingerprint(self.fat32_epoch).ok())
-            })
-    }
-
     pub fn most_recently_opened_reading_book(&self) -> Option<Info> {
         self.db
             .most_recently_opened_reading_book(self.library_id)
@@ -1035,6 +917,34 @@ impl Library {
             })
             .ok()
             .flatten()
+    }
+
+    fn resolve_fingerprint(&self, path: &Path) -> Option<Fp> {
+        match self.db.get_book_by_path(self.library_id, path) {
+            Ok(Some(info)) => {
+                if let Some(fp) = info.fp {
+                    return Some(fp);
+                }
+            }
+            Ok(None) => {}
+            Err(e) => {
+                error!(
+                    path = %path.display(),
+                    error = %e,
+                    "failed to resolve fingerprint from database"
+                );
+            }
+        }
+
+        let full_path = self.home.join(path);
+
+        match full_path.fingerprint() {
+            Ok(fp) => Some(fp),
+            Err(e) => {
+                error!(path = %full_path.display(), error = %e, "failed to fingerprint path");
+                None
+            }
+        }
     }
 }
 
@@ -1993,7 +1903,7 @@ mod tests {
     }
 
     #[test]
-    fn fingerprint_for_path_prefers_db_and_falls_back_to_filesystem() {
+    fn resolve_fingerprint_prefers_db_and_falls_back_to_filesystem() {
         let dir = tempfile::tempdir().expect("failed to create temp dir");
         let db = Database::new(":memory:").expect("failed to create in-memory database");
         db.migrate().expect("failed to run migrations");
@@ -2008,22 +1918,20 @@ mod tests {
             .expect("failed to insert stored book");
 
         assert_eq!(
-            lib.fingerprint_for_path(Path::new("stored.pdf")),
+            lib.resolve_fingerprint(Path::new("stored.pdf")),
             Some(stored_fp)
         );
 
         let fallback_path = dir.path().join("fallback.pdf");
         fs::write(&fallback_path, b"fallback content").expect("failed to write fallback file");
         let expected_fallback_fp = fallback_path
-            .metadata()
-            .expect("failed to stat fallback file")
-            .fingerprint(lib.fat32_epoch)
+            .fingerprint()
             .expect("failed to fingerprint fallback file");
 
         assert_eq!(
-            lib.fingerprint_for_path(Path::new("fallback.pdf")),
+            lib.resolve_fingerprint(Path::new("fallback.pdf")),
             Some(expected_fallback_fp)
         );
-        assert_eq!(lib.fingerprint_for_path(Path::new("missing.pdf")), None);
+        assert_eq!(lib.resolve_fingerprint(Path::new("missing.pdf")), None);
     }
 }

--- a/crates/core/src/telemetry.rs
+++ b/crates/core/src/telemetry.rs
@@ -252,7 +252,9 @@ fn build_tracer_provider(endpoint: &str, resource: Resource) -> Result<SdkTracer
     let processor = BatchSpanProcessor::builder(exporter)
         .with_batch_config(
             opentelemetry_sdk::trace::BatchConfigBuilder::default()
-                .with_scheduled_delay(Duration::from_millis(100))
+                .with_max_queue_size(32768)
+                .with_max_export_batch_size(1024)
+                .with_scheduled_delay(Duration::from_millis(500))
                 .build(),
         )
         .build();

--- a/crates/core/src/view/home/shelf.rs
+++ b/crates/core/src/view/home/shelf.rs
@@ -107,10 +107,7 @@ impl Shelf {
                     let path = info.file.path.clone();
                     let full_path = context.library.home.join(&info.file.path);
                     let database = context.library.db.clone();
-                    let fp = full_path
-                        .metadata()
-                        .ok()
-                        .and_then(|md| md.fingerprint(context.library.fat32_epoch).ok());
+                    let fp = full_path.fingerprint().ok();
 
                     if let Some(fp) = fp {
                         thread::spawn(move || {

--- a/devenv.lock
+++ b/devenv.lock
@@ -112,9 +112,6 @@
         "devenv": "devenv",
         "git-hooks": "git-hooks",
         "nixpkgs": "nixpkgs",
-        "pre-commit-hooks": [
-          "git-hooks"
-        ],
         "rust-overlay": "rust-overlay"
       }
     },

--- a/devenv.nix
+++ b/devenv.nix
@@ -377,6 +377,8 @@ in
             server:
               http_listen_port: 3200
               grpc_listen_port: 9096
+              grpc_server_max_recv_msg_size: 104857600
+              grpc_server_max_send_msg_size: 104857600
 
             distributor:
               receivers:
@@ -411,6 +413,16 @@ in
                   path: ${config.devenv.state}/tempo/traces
                 wal:
                   path: ${config.devenv.state}/tempo/wal
+
+            overrides:
+              defaults:
+                global:
+                  max_bytes_per_trace: 104857600
+
+            querier:
+              frontend_worker:
+                grpc_client_config:
+                  max_send_msg_size: 104857600
 
             query_frontend:
               search:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1131,6 +1131,7 @@
       "integrity": "sha512-csJvb+6kEiQaqo1woTdSAuOWdN0WTLIydkKrBnS+V5gZz0oqBrp4kQ35519QgK6TpBThiG3V1vNSHlIkv4AglQ==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@chevrotain/cst-dts-gen": "12.0.0",
         "@chevrotain/gast": "12.0.0",
@@ -1363,6 +1364,7 @@
       "version": "3.33.1",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10"
       }
@@ -1737,6 +1739,7 @@
       "version": "3.0.0",
       "dev": true,
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -1919,7 +1922,8 @@
       "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1581282.tgz",
       "integrity": "sha512-nv7iKtNZQshSW2hKzYNr46nM/Cfh5SEvE2oV0/SEGgc9XupIY5ggf84Cz8eJIkBce7S3bmTAauFD6aysMpnqsQ==",
       "dev": true,
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "node_modules/didyoumean": {
       "version": "1.2.2",
@@ -2502,6 +2506,7 @@
       "version": "1.21.7",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -2760,6 +2765,7 @@
       "version": "11.12.3",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@braintree/sanitize-url": "^7.1.1",
         "@iconify/utils": "^3.0.1",
@@ -3542,6 +3548,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3642,6 +3649,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -3857,6 +3865,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@puppeteer/browsers": "2.13.0",
         "chromium-bidi": "14.0.0",
@@ -3936,6 +3945,7 @@
       "version": "19.2.4",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3944,6 +3954,7 @@
       "version": "19.2.4",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -4380,6 +4391,7 @@
       "version": "3.4.19",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
         "arg": "^5.0.2",


### PR DESCRIPTION
This pull request introduces a new content-based fingerprint system for files using BLAKE3 hashing, replacing the previous approach that relied on file metadata. It also adds a benchmarking suite to measure fingerprinting performance and updates related dependencies and tests accordingly. Additionally, several new SQL queries are introduced to support operations involving the new fingerprint format.

**Fingerprinting system overhaul:**

* Replaced the old metadata-based fingerprint implementation with a new `Fingerprint` trait for `Path`, which computes a stable 32-byte BLAKE3 hash of file contents (`crates/core/src/helpers.rs`). This ensures fingerprints are consistent and independent of file system metadata.
* Updated the `Fp` struct to store a 32-byte array, with hex string serialization/deserialization and error handling. Added a `from_u64` constructor for tests.
* Updated all tests and code using the old `Fp` format to use the new 32-byte version and the `from_u64` test helper. [[1]](diffhunk://#diff-33955eebcd2d35035da0d5b8f42c9b63747665dd63a4933615ee9db1d2f3df7aL245-R245) [[2]](diffhunk://#diff-33955eebcd2d35035da0d5b8f42c9b63747665dd63a4933615ee9db1d2f3df7aL260-R260) [[3]](diffhunk://#diff-f6eb50e8069440c4bc8144ed2b9bd52ae25d385ef14e6db3695e2592c253e2d9L1316-R1315) [[4]](diffhunk://#diff-f6eb50e8069440c4bc8144ed2b9bd52ae25d385ef14e6db3695e2592c253e2d9L1370-R1369) [[5]](diffhunk://#diff-f6eb50e8069440c4bc8144ed2b9bd52ae25d385ef14e6db3695e2592c253e2d9L1416-R1415) [[6]](diffhunk://#diff-f6eb50e8069440c4bc8144ed2b9bd52ae25d385ef14e6db3695e2592c253e2d9L1466-R1465) [[7]](diffhunk://#diff-f6eb50e8069440c4bc8144ed2b9bd52ae25d385ef14e6db3695e2592c253e2d9L1488-R1487) [[8]](diffhunk://#diff-f6eb50e8069440c4bc8144ed2b9bd52ae25d385ef14e6db3695e2592c253e2d9L1502-R1501) [[9]](diffhunk://#diff-f6eb50e8069440c4bc8144ed2b9bd52ae25d385ef14e6db3695e2592c253e2d9L1552-R1551) [[10]](diffhunk://#diff-f6eb50e8069440c4bc8144ed2b9bd52ae25d385ef14e6db3695e2592c253e2d9L1587-R1586) [[11]](diffhunk://#diff-f6eb50e8069440c4bc8144ed2b9bd52ae25d385ef14e6db3695e2592c253e2d9L1661-R1660)

**Benchmarking and dependencies:**

* Added a new Criterion-based benchmark (`fingerprint_bench.rs`) to measure the performance of fingerprinting files of various sizes, including up to 1GB. [[1]](diffhunk://#diff-3c189d2f66d63029d54ac3fb35b2f0e8410b501d82f1182d436f56cf9542705dR1-R65) [[2]](diffhunk://#diff-bac59d6e5ada615de3d27a8e8f87d272613a80b5d3e4a7e2c2e4a08e63dcf0a1R104-R107)
* Added `blake3` and `rayon` as dependencies to support the new fingerprinting and potential parallelization. [[1]](diffhunk://#diff-bac59d6e5ada615de3d27a8e8f87d272613a80b5d3e4a7e2c2e4a08e63dcf0a1R15) [[2]](diffhunk://#diff-bac59d6e5ada615de3d27a8e8f87d272613a80b5d3e4a7e2c2e4a08e63dcf0a1R48)

**Database and SQL support:**

* Added new `.sqlx` query files for updating fingerprints and selecting relevant book/library data, supporting the new fingerprint system in the database layer. [[1]](diffhunk://#diff-d7c4bbe6add629f250fff22227e84cdb9ca5779ea8daa04c69d07e72883eb07aR1-R12) [[2]](diffhunk://#diff-a709247c8a384ee50090c5f08e13899d39a7f537342497b54cd9dc40e021f5d6R1-R23) [[3]](diffhunk://#diff-c6740930f5f454037c1d6515d855dd4c9de737327091215c54f27682fca22623R1-R12) [[4]](diffhunk://#diff-2bc7ebb6a47bae74d415168cdd657b2553b0636df57dc3c1d78f5759c6c8468dR1-R23) [[5]](diffhunk://#diff-c3b270b2800cb48dd3c22b3ae61597c63e9d71845e749c03fd8d497a7f7925edR1-R18) [[6]](diffhunk://#diff-d41f6d15a003417c0534dc5329f8154b79920c52781c9d61ff0a4dc28606d0e6R1-R12) [[7]](diffhunk://#diff-88027aed3395e5452bcbe08d2bcb454aa8a52c9278ef2136f2127b5a426d923dR1-R12) [[8]](diffhunk://#diff-c6a375369599eb3e2e8c345a9502bdc4de5a11b5e47027df62b7fea45d87cdd4R1-R12) [[9]](diffhunk://#diff-2916785c432f1e8cfb60819c9b1edc3bc5f01b5c5d32571d8561112fc14d3a84R1-R12) [[10]](diffhunk://#diff-5db647c8cc66c8bcc2e48cdd1267446eb324df90c258126d014789d468dffe4cR1-R12)

These changes ensure that file fingerprints are robust, unique, and consistent, and provide the necessary infrastructure and testing to support this throughout the codebase.

---

benchmark looks worse, but the timings are still acceptable, and is worth the deterministic result. 

```
     Running benches/fingerprint_bench.rs (target/release/deps/fingerprint_bench-aa2eb2240ec53c3f)
fingerprint/size/1KB    time:   [13.333 µs 13.519 µs 13.729 µs]
                        change: [+930.34% +1003.6% +1069.8%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 3 outliers among 50 measurements (6.00%)
  3 (6.00%) high mild
fingerprint/size/10KB   time:   [18.969 µs 19.192 µs 19.471 µs]
                        change: [+1702.8% +1737.1% +1770.7%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 3 outliers among 50 measurements (6.00%)
  1 (2.00%) high mild
  2 (4.00%) high severe
fingerprint/size/100KB  time:   [62.356 µs 62.607 µs 62.865 µs]
                        change: [+4305.4% +4764.1% +5176.0%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 4 outliers among 50 measurements (8.00%)
  3 (6.00%) high mild
  1 (2.00%) high severe
fingerprint/size/200KB  time:   [108.79 µs 108.96 µs 109.17 µs]
                        change: [+7261.6% +7657.6% +8050.0%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 2 outliers among 50 measurements (4.00%)
  1 (2.00%) high mild
  1 (2.00%) high severe
fingerprint/size/500KB  time:   [247.30 µs 248.03 µs 248.84 µs]
                        change: [+16893% +17913% +18859%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 3 outliers among 50 measurements (6.00%)
  3 (6.00%) high mild
fingerprint/size/700KB  time:   [340.01 µs 341.21 µs 342.67 µs]
                        change: [+20323% +22738% +25166%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 3 outliers among 50 measurements (6.00%)
  3 (6.00%) high severe
fingerprint/size/1MB    time:   [488.21 µs 489.26 µs 490.28 µs]
                        change: [+32205% +34101% +35819%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 2 outliers among 50 measurements (4.00%)
  1 (2.00%) high mild
  1 (2.00%) high severe
fingerprint/size/200MB  time:   [99.566 ms 101.33 ms 103.84 ms]
                        change: [+6805580% +7246863% +7682088%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 6 outliers among 50 measurements (12.00%)
  3 (6.00%) high mild
  3 (6.00%) high severe
Benchmarking fingerprint/size/500MB: Warming up for 3.0000 s
Warning: Unable to complete 50 samples in 10.0s. You may wish to increase target time to 12.8s, or reduce sample count to 30.
fingerprint/size/500MB  time:   [246.77 ms 249.10 ms 252.74 ms]
                        change: [+14224687% +16159277% +17998458%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 5 outliers among 50 measurements (10.00%)
  5 (10.00%) high severe
Benchmarking fingerprint/size/700MB: Warming up for 3.0000 s
Warning: Unable to complete 50 samples in 10.0s. You may wish to increase target time to 17.7s, or reduce sample count to 20.
fingerprint/size/700MB  time:   [344.31 ms 346.70 ms 350.58 ms]
                        change: [+27259755% +28551880% +29771598%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 4 outliers among 50 measurements (8.00%)
  1 (2.00%) high mild
  3 (6.00%) high severe
Benchmarking fingerprint/size/1GB: Warming up for 3.0000 s
Warning: Unable to complete 50 samples in 10.0s. You may wish to increase target time to 26.0s, or reduce sample count to 10.
fingerprint/size/1GB    time:   [503.03 ms 506.17 ms 511.09 ms]
                        change: [+40049679% +41460686% +42876145%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 6 outliers among 50 measurements (12.00%)
  4 (8.00%) high mild
  2 (4.00%) high severe
  ```