### PR TITLE
chore: tune Renovate dependency batching

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,32 @@
 {
   "extends": ["config:recommended"],
+  "minimumReleaseAge": "7 days",
   "reviewers": ["OGKevin"],
+  "packageRules": [
+    {
+      "matchManagers": ["cargo"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "Rust non-major dependencies",
+      "groupSlug": "rust-non-major"
+    },
+    {
+      "matchManagers": ["github-actions"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "GitHub Actions non-major dependencies",
+      "groupSlug": "github-actions-non-major"
+    },
+    {
+      "matchManagers": ["npm"],
+      "matchPackageNames": [
+        "@mermaid-js/mermaid-cli",
+        "markdownlint-cli",
+        "prettier"
+      ],
+      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "JavaScript tooling non-major dependencies",
+      "groupSlug": "js-tooling-non-major"
+    }
+  ],
   "customManagers": [
     {
       "customType": "regex",


### PR DESCRIPTION
Delay dependency PRs for a week so new releases have time to settle before Cadmus starts reviewing them.

- add a 7 day minimum release age for all dependency updates
- group cargo patch and minor updates into one PR
- group GitHub Actions and selected JS tooling non-majors