### PR TITLE
ci: split cargo cache into registry and target

### DIFF
--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -28,7 +28,7 @@ jobs:
         id: rust-toolchain
         with:
           components: rustfmt
-      - name: Cache
+      - name: Cache cargo registry
         uses: actions/cache@v5
         with:
           path: |
@@ -36,8 +36,16 @@ jobs:
             ~/.cargo/registry/index/
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
-            target/
-          key: ${{ runner.os }}-cargo-${{ steps.rust-toolchain.outputs.cachekey }}-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-registry-${{ steps.rust-toolchain.outputs.cachekey }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-registry-${{ steps.rust-toolchain.outputs.cachekey }}-
+      - name: Cache cargo target
+        uses: actions/cache@v5
+        with:
+          path: target/
+          key: ${{ runner.os }}-cargo-target-${{ steps.rust-toolchain.outputs.cachekey }}-default-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-target-${{ steps.rust-toolchain.outputs.cachekey }}-default-
       - name: Check formatting
         run: cargo xtask fmt
 
@@ -50,7 +58,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
         id: rust-toolchain
-      - name: Cache
+      - name: Cache cargo registry
         uses: actions/cache@v5
         with:
           path: |
@@ -58,8 +66,16 @@ jobs:
             ~/.cargo/registry/index/
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
-            target/
-          key: ${{ runner.os }}-cargo-${{ steps.rust-toolchain.outputs.cachekey }}-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-registry-${{ steps.rust-toolchain.outputs.cachekey }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-registry-${{ steps.rust-toolchain.outputs.cachekey }}-
+      - name: Cache cargo target
+        uses: actions/cache@v5
+        with:
+          path: target/
+          key: ${{ runner.os }}-cargo-target-${{ steps.rust-toolchain.outputs.cachekey }}-default-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-target-${{ steps.rust-toolchain.outputs.cachekey }}-default-
       - name: Generate feature matrix
         id: matrix
         run: cargo xtask ci matrix
@@ -70,7 +86,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
         id: rust-toolchain
-      - name: Cache
+      - name: Cache cargo registry
         uses: actions/cache@v5
         with:
           path: |
@@ -78,8 +94,16 @@ jobs:
             ~/.cargo/registry/index/
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
-            target/
-          key: ${{ runner.os }}-cargo-${{ steps.rust-toolchain.outputs.cachekey }}-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-registry-${{ steps.rust-toolchain.outputs.cachekey }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-registry-${{ steps.rust-toolchain.outputs.cachekey }}-
+      - name: Cache cargo target
+        uses: actions/cache@v5
+        with:
+          path: target/
+          key: ${{ runner.os }}-cargo-target-${{ steps.rust-toolchain.outputs.cachekey }}-default-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-target-${{ steps.rust-toolchain.outputs.cachekey }}-default-
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
@@ -130,7 +154,7 @@ jobs:
             echo "PR_HEAD_SHA=${{ github.event.pull_request.head.sha }}" >> "$GITHUB_ENV"
           fi
           echo "GIT_VERSION=$(git describe --tags --dirty --always)" >> "$GITHUB_ENV"
-      - name: Cache
+      - name: Cache cargo registry
         uses: actions/cache@v5
         with:
           path: |
@@ -138,8 +162,16 @@ jobs:
             ~/.cargo/registry/index/
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
-            target/
-          key: ${{ runner.os }}-cargo-${{ steps.rust-toolchain.outputs.cachekey }}-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-registry-${{ steps.rust-toolchain.outputs.cachekey }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-registry-${{ steps.rust-toolchain.outputs.cachekey }}-
+      - name: Cache cargo target
+        uses: actions/cache@v5
+        with:
+          path: target/
+          key: ${{ runner.os }}-cargo-target-${{ steps.rust-toolchain.outputs.cachekey }}-${{ matrix.label || 'default' }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-target-${{ steps.rust-toolchain.outputs.cachekey }}-${{ matrix.label || 'default' }}-
       - name: Download documentation EPUB
         uses: actions/download-artifact@v8
         with:
@@ -179,7 +211,7 @@ jobs:
         with:
           components: clippy
       - *set-build-metadata
-      - name: Cache
+      - name: Cache cargo registry
         uses: actions/cache@v5
         with:
           path: |
@@ -187,8 +219,16 @@ jobs:
             ~/.cargo/registry/index/
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
-            target/
-          key: ${{ runner.os }}-cargo-${{ steps.rust-toolchain.outputs.cachekey }}-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-registry-${{ steps.rust-toolchain.outputs.cachekey }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-registry-${{ steps.rust-toolchain.outputs.cachekey }}-
+      - name: Cache cargo target
+        uses: actions/cache@v5
+        with:
+          path: target/
+          key: ${{ runner.os }}-cargo-target-${{ steps.rust-toolchain.outputs.cachekey }}-default-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-target-${{ steps.rust-toolchain.outputs.cachekey }}-default-
 
       - name: Download all clippy JSON artifacts
         uses: actions/download-artifact@v8
@@ -251,7 +291,7 @@ jobs:
         if: runner.os == 'macOS'
         run: brew install sdl2 freetype harfbuzz openjpeg jpeg-turbo libpng jbig2dec gumbo-parser djvulibre pkg-config
 
-      - name: Cache
+      - name: Cache cargo registry
         uses: actions/cache@v5
         with:
           path: |
@@ -259,8 +299,16 @@ jobs:
             ~/.cargo/registry/index/
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
-            target/
-          key: ${{ runner.os }}-cargo-${{ steps.rust-toolchain.outputs.cachekey }}-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-registry-${{ steps.rust-toolchain.outputs.cachekey }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-registry-${{ steps.rust-toolchain.outputs.cachekey }}-
+      - name: Cache cargo target
+        uses: actions/cache@v5
+        with:
+          path: target/
+          key: ${{ runner.os }}-cargo-target-${{ steps.rust-toolchain.outputs.cachekey }}-${{ matrix.label || 'default' }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-target-${{ steps.rust-toolchain.outputs.cachekey }}-${{ matrix.label || 'default' }}-
       - name: Cache thirdparty libraries
         uses: ./.github/actions/cache-thirdparty
         with:


### PR DESCRIPTION
Split monolithic cargo cache into two separate entries to fix cache misses when different feature flags introduce new dependencies.

- Registry cache (~/.cargo/{bin,registry,git}) shared across all jobs with restore-keys fallback for Cargo.lock changes
- Target cache keyed per feature label to prevent cross-feature cache pollution (e.g. profiling deps missing from default cache)

Change-Id: 68a90b18b92b370c79e8205af2d6ffd9
Change-Id-Short: trpqzoyroqxo