### PR TITLE
dev(devenv): Rust 1.94+ lib symlink build failure on MacOS

### DIFF
--- a/devenv.lock
+++ b/devenv.lock
@@ -3,10 +3,11 @@
     "devenv": {
       "locked": {
         "dir": "src/modules",
-        "lastModified": 1774105722,
+        "lastModified": 1779153540,
+        "narHash": "sha256-ekzTg0h7hb/FYF5XhTWC1J2MFGEs8yuEasVsQliJ6ek=",
         "owner": "cachix",
         "repo": "devenv",
-        "rev": "07dd08dbd637b09173cad4097896bd169d09cbb3",
+        "rev": "8eff3cd84a4c2a86a02fe706582ae348650e3e76",
         "type": "github"
       },
       "original": {
@@ -20,6 +21,7 @@
       "flake": false,
       "locked": {
         "lastModified": 1767039857,
+        "narHash": "sha256-vNpUSpF5Nuw8xvDLj2KCwwksIbjua2LZCqhV1LNRDns=",
         "owner": "NixOS",
         "repo": "flake-compat",
         "rev": "5edf11c44bc78a0d334f6334cdaf7d60d732daab",
@@ -40,10 +42,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1774104215,
+        "lastModified": 1778507602,
+        "narHash": "sha256-kTwur1wV+01SdqskVMSo6JMEpg71ps3HpbFY2GsflKs=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "f799ae951fde0627157f40aec28dec27b22076d0",
+        "rev": "61ab0e80d9c7ab14c256b5b453d8b3fb0189ba0a",
         "type": "github"
       },
       "original": {
@@ -60,10 +63,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1762808025,
+        "lastModified": 1709087332,
+        "narHash": "sha256-HG2cCnktfHsKV0s4XW83gU3F57gaTljL9KNSuG6bnQs=",
         "owner": "hercules-ci",
         "repo": "gitignore.nix",
-        "rev": "cb5e3fdca1de58ccbc3ef53de65bd372b48f567c",
+        "rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
         "type": "github"
       },
       "original": {
@@ -77,10 +81,11 @@
         "nixpkgs-src": "nixpkgs-src"
       },
       "locked": {
-        "lastModified": 1773704619,
+        "lastModified": 1778507786,
+        "narHash": "sha256-HzSQCKMsMr8r55LwM1JuzIOB+8bzk0FEv6sItKvsfoY=",
         "owner": "cachix",
         "repo": "devenv-nixpkgs",
-        "rev": "906534d75b0e2fe74a719559dfb1ad3563485f43",
+        "rev": "8f24a228a782e24576b155d1e39f0d914b380691",
         "type": "github"
       },
       "original": {
@@ -93,11 +98,11 @@
     "nixpkgs-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1769922788,
-        "narHash": "sha256-H3AfG4ObMDTkTJYkd8cz1/RbY9LatN5Mk4UF48VuSXc=",
+        "lastModified": 1778274207,
+        "narHash": "sha256-I4puXmX1iovcCHZlRmztO3vW0mAbbRvq4F8wgIMQ1MM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "207d15f1a6603226e1e223dc79ac29c7846da32e",
+        "rev": "b3da656039dc7a6240f27b2ef8cc6a3ef3bccae7",
         "type": "github"
       },
       "original": {
@@ -112,9 +117,6 @@
         "devenv": "devenv",
         "git-hooks": "git-hooks",
         "nixpkgs": "nixpkgs",
-        "pre-commit-hooks": [
-          "git-hooks"
-        ],
         "rust-overlay": "rust-overlay"
       }
     },
@@ -125,10 +127,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1774062094,
+        "lastModified": 1779160702,
+        "narHash": "sha256-frUihZLlBLdcFN95mq5QiQmxF2M16nxtmw1GH4rhZmg=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "c807e83cc2e32adc35f51138b3bdef722c0812ab",
+        "rev": "8cd592658d4448c57326aaa819e1c2f91086eb40",
         "type": "github"
       },
       "original": {

--- a/devenv.nix
+++ b/devenv.nix
@@ -9,6 +9,107 @@ let
   inherit (pkgs.stdenv) isLinux;
   inherit (pkgs.stdenv) isDarwin;
 
+  # Rust 1.94+ changed lib/ in tarballs from a directory to a symlink.
+  # devenv's rust module calls mk-aggregated.nix directly from the rust-overlay
+  # source, bypassing pkgs overlays. lndir can't merge components when $out/lib
+  # is already a symlink, so cp --remove-destination in postBuild fails with
+  # "are the same file" on macOS.
+  #
+  # Fix: wrap the produced toolchain derivation to resolve $out/lib from a
+  # symlink into a real directory before the cp step runs.
+  fixRustToolchainLibSymlink =
+    drv:
+    drv.overrideAttrs (old: {
+      buildCommand = builtins.replaceStrings
+        [ "for i in $(cat $pathsPath); do\n" ]
+        [
+          (
+            "for i in $(cat $pathsPath); do\n"
+            + "  if [ -L \"$out/lib\" ]; then\n"
+            + "    _lib_t=$(readlink -f \"$out/lib\")\n"
+            + "    rm \"$out/lib\"\n"
+            + "    mkdir \"$out/lib\"\n"
+            + "    ${pkgs.lndir}/bin/lndir -silent \"$_lib_t\" \"$out/lib\"\n"
+            + "  fi\n"
+          )
+        ]
+        old.buildCommand;
+    });
+
+  # Build the stable Rust toolchain the same way devenv does, but with the
+  # lib-symlink fix applied. We replicate devenv's channel != "nixpkgs" logic
+  # here so we can wrap the resulting derivation before devenv sees it.
+  rustToolchain =
+    let
+      rustOverlaySrc = inputs.rust-overlay;
+      rustBin = rustOverlaySrc.lib.mkRustBin { } pkgs.buildPackages;
+
+      mkAggregatedFn = import (rustOverlaySrc + "/lib/mk-aggregated.nix");
+      mkAggregatedArgs = builtins.functionArgs mkAggregatedFn;
+      mkAggregated = mkAggregatedFn (
+        {
+          inherit (pkgs)
+            lib
+            stdenv
+            symlinkJoin
+            bash
+            curl
+            ;
+          inherit (pkgs.buildPackages) rustc;
+          pkgsTargetTarget = pkgs.targetPackages;
+        }
+        // pkgs.lib.optionalAttrs (mkAggregatedArgs ? makeWrapper) { inherit (pkgs) makeWrapper; }
+        // pkgs.lib.optionalAttrs (mkAggregatedArgs ? pkgsHostHost) { inherit (pkgs) pkgsHostHost; }
+      );
+
+      toolchain = rustBin.stable.latest;
+      nativeTarget = pkgs.stdenv.hostPlatform.rust.rustcTargetSpec;
+      allTargets = pkgs.lib.unique ([ nativeTarget ] ++ [ "arm-unknown-linux-gnueabihf" ]);
+      components = [
+        "cargo"
+        "clippy"
+        "llvm-tools-preview"
+        "rustc"
+        "rustfmt"
+      ];
+
+      availableComponents = toolchain._manifest.profiles.complete or [ ];
+      allComponents = toolchain._components or { };
+
+      targetComponents = builtins.map (
+        target:
+        let
+          targetComponentSet = allComponents.${target} or { };
+          targetRustStd = targetComponentSet.rust-std or null;
+        in
+        targetRustStd
+      ) allTargets;
+
+      resolvedComponents = builtins.map (
+        c:
+        let
+          resolvedName =
+            if builtins.elem c availableComponents then
+              c
+            else if builtins.elem "${c}-preview" availableComponents then
+              "${c}-preview"
+            else
+              throw "Component '${c}' not found";
+          toolchainComponents = builtins.removeAttrs toolchain [ "rust" ];
+        in
+        toolchainComponents.${resolvedName}
+      ) components;
+
+      allSelectedComponents = resolvedComponents ++ targetComponents;
+
+      profile = mkAggregated {
+        pname = "rust-stable-${toolchain._manifest.version}";
+        inherit (toolchain._manifest) version date;
+        selectedComponents = allSelectedComponents;
+      };
+    in
+    fixRustToolchainLibSymlink profile;
+
   # cargo-diff-tools with Rust 1.70 for clap v2 compatibility
   cargo-diff-tools =
     let
@@ -247,6 +348,7 @@ in
         "rustc"
         "rustfmt"
       ];
+      toolchainPackage = pkgs.lib.mkForce rustToolchain;
     };
   };
 


### PR DESCRIPTION
Rust 1.94+ changed lib/ in distribution tarballs from a directory to a symlink. devenv's rust module imports mk-aggregated.nix directly from rust-overlay (bypassing pkgs overlays), so lndir can't merge components once $out/lib is a symlink - causing 'are the same file' errors in the postBuild cp step on macOS.

- Replicate devenv's toolchain construction in the let block
- Inject a symlink-to-dir resolution step inside the lndir loop via overrideAttrs on buildCommand, so each component's lib is merged into a real directory rather than a symlink
- Set languages.rust.toolchainPackage = mkForce with the fixed drv

Change-Id: bcfd1eab24c13765065e63f9ea73ba23
Change-Id-Short: onkmylpoxvny