### PR TITLE
Only clean untracked when redownloading mupdf

### DIFF
--- a/xtask/src/tasks/setup_native.rs
+++ b/xtask/src/tasks/setup_native.rs
@@ -85,7 +85,8 @@ pub fn ensure_mupdf_sources(root: &Path, force: bool) -> Result<()> {
 
     let mupdf_dir = root.join("thirdparty/mupdf");
     if mupdf_dir.exists() {
-        std::fs::remove_dir_all(&mupdf_dir).context("failed to remove stale thirdparty/mupdf")?;
+        thirdparty::clean_untracked(&mupdf_dir)
+            .context("failed to clean untracked files from thirdparty/mupdf")?;
     }
 
     thirdparty::download_libraries(&root.join("thirdparty"), &["mupdf"])

--- a/xtask/src/tasks/util/thirdparty.rs
+++ b/xtask/src/tasks/util/thirdparty.rs
@@ -413,7 +413,7 @@ pub fn build_libraries(thirdparty_dir: &Path, names: &[&str]) -> Result<()> {
 
 /// Removes untracked files from a directory using `git ls-files`, falling back
 /// to removing and recreating the directory when git is unavailable.
-fn clean_untracked(dir: &Path) -> Result<()> {
+pub fn clean_untracked(dir: &Path) -> Result<()> {
     let result = std::process::Command::new("git")
         .args(["ls-files", "-o", "--directory", "-z"])
         .arg(dir.file_name().unwrap_or(dir.as_os_str()))


### PR DESCRIPTION
This fixes the issue where setup-native --force removes patches and breaks subsequent attempts.