### PR TITLE
ci: share single cargo cache across matrix jobs

### DIFF
--- a/.github/actions/build-kobo/action.yml
+++ b/.github/actions/build-kobo/action.yml
@@ -19,6 +19,10 @@ inputs:
     description: "Build the test variant (installs to .adds/cadmus-tst)"
     required: false
     default: "false"
+  skip-docs:
+    description: "Skip building documentation (caller must provide docs/book/epub/)"
+    required: false
+    default: "false"
 
 runs:
   using: composite
@@ -86,10 +90,8 @@ runs:
       shell: bash
       run: echo "$HOME/linaro-toolchain/bin" >> "$GITHUB_PATH"
 
-    - name: Install mdBook tools
-      uses: ./.github/actions/install-doc-tools
-
     - name: Build documentation
+      if: inputs.skip-docs != 'true'
       shell: bash
       run: cargo xtask docs --mdbook-only
 

--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -21,6 +21,8 @@ concurrency:
 
 jobs:
   format:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -28,28 +30,25 @@ jobs:
         id: rust-toolchain
         with:
           components: rustfmt
-      - name: Cache cargo registry
-        uses: actions/cache@v5
+      - &restore-shared-cache
+        name: Restore shared cargo cache
+        uses: actions/cache/restore@v5
         with:
           path: |
             ~/.cargo/bin/
             ~/.cargo/registry/index/
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
-          key: ${{ runner.os }}-cargo-registry-${{ steps.rust-toolchain.outputs.cachekey }}-${{ hashFiles('**/Cargo.lock') }}
+            target/
+          key: ${{ runner.os }}-cargo-shared-${{ steps.rust-toolchain.outputs.cachekey }}-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
-            ${{ runner.os }}-cargo-registry-${{ steps.rust-toolchain.outputs.cachekey }}-
-      - name: Cache cargo target
-        uses: actions/cache@v5
-        with:
-          path: target/
-          key: ${{ runner.os }}-cargo-target-${{ steps.rust-toolchain.outputs.cachekey }}-default-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-target-${{ steps.rust-toolchain.outputs.cachekey }}-default-
+            ${{ runner.os }}-cargo-shared-${{ steps.rust-toolchain.outputs.cachekey }}-
       - name: Check formatting
         run: cargo xtask fmt
 
   generate-matrix:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.matrix.outputs.matrix }}
@@ -58,52 +57,20 @@ jobs:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
         id: rust-toolchain
-      - name: Cache cargo registry
-        uses: actions/cache@v5
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-          key: ${{ runner.os }}-cargo-registry-${{ steps.rust-toolchain.outputs.cachekey }}-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-registry-${{ steps.rust-toolchain.outputs.cachekey }}-
-      - name: Cache cargo target
-        uses: actions/cache@v5
-        with:
-          path: target/
-          key: ${{ runner.os }}-cargo-target-${{ steps.rust-toolchain.outputs.cachekey }}-default-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-target-${{ steps.rust-toolchain.outputs.cachekey }}-default-
+      - *restore-shared-cache
       - name: Generate feature matrix
         id: matrix
         run: cargo xtask ci matrix
 
   build-docs-epub:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
         id: rust-toolchain
-      - name: Cache cargo registry
-        uses: actions/cache@v5
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-          key: ${{ runner.os }}-cargo-registry-${{ steps.rust-toolchain.outputs.cachekey }}-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-registry-${{ steps.rust-toolchain.outputs.cachekey }}-
-      - name: Cache cargo target
-        uses: actions/cache@v5
-        with:
-          path: target/
-          key: ${{ runner.os }}-cargo-target-${{ steps.rust-toolchain.outputs.cachekey }}-default-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-target-${{ steps.rust-toolchain.outputs.cachekey }}-default-
+      - *restore-shared-cache
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
@@ -128,9 +95,62 @@ jobs:
           path: docs/book/epub/Cadmus Documentation.epub
           retention-days: 1
 
+  cache-warmup:
+    needs: build-docs-epub
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@stable
+        id: rust-toolchain
+      - name: Set build metadata
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            echo "PR_NUMBER=${{ github.event.pull_request.number }}" >> "$GITHUB_ENV"
+            echo "PR_HEAD_SHA=${{ github.event.pull_request.head.sha }}" >> "$GITHUB_ENV"
+          fi
+          echo "GIT_VERSION=$(git describe --tags --dirty --always)" >> "$GITHUB_ENV"
+      - name: Install apt packages
+        uses: awalsh128/cache-apt-pkgs-action@latest
+        with:
+          packages: git wget curl pkg-config gcc g++ make cmake meson ninja-build autoconf automake libtool gperf python3 zlib1g-dev libbz2-dev libpng-dev libjpeg-dev libopenjp2-7-dev libjbig2dec0-dev libgumbo-dev libfreetype6-dev libharfbuzz-dev libdjvulibre-dev libsdl2-dev
+          version: 1.0
+      - name: Cache thirdparty libraries
+        uses: ./.github/actions/cache-thirdparty
+        with:
+          kind: native
+      - name: Cache shared cargo artifacts
+        id: cache
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-shared-${{ steps.rust-toolchain.outputs.cachekey }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-shared-${{ steps.rust-toolchain.outputs.cachekey }}-
+      - name: Setup native dependencies
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: cargo xtask setup-native
+      - name: Download documentation EPUB
+        if: steps.cache.outputs.cache-hit != 'true'
+        uses: actions/download-artifact@v8
+        with:
+          name: docs-epub
+          path: docs/book/epub
+      - name: Warmup build
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: cargo check --workspace --all-features --all-targets
+
   clippy:
     if: github.event_name == 'pull_request'
-    needs: [generate-matrix, build-docs-epub]
+    needs: [generate-matrix, build-docs-epub, cache-warmup]
+    permissions:
+      contents: read
 
     strategy:
       fail-fast: false
@@ -154,24 +174,7 @@ jobs:
             echo "PR_HEAD_SHA=${{ github.event.pull_request.head.sha }}" >> "$GITHUB_ENV"
           fi
           echo "GIT_VERSION=$(git describe --tags --dirty --always)" >> "$GITHUB_ENV"
-      - name: Cache cargo registry
-        uses: actions/cache@v5
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-          key: ${{ runner.os }}-cargo-registry-${{ steps.rust-toolchain.outputs.cachekey }}-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-registry-${{ steps.rust-toolchain.outputs.cachekey }}-
-      - name: Cache cargo target
-        uses: actions/cache@v5
-        with:
-          path: target/
-          key: ${{ runner.os }}-cargo-target-${{ steps.rust-toolchain.outputs.cachekey }}-${{ matrix.label || 'default' }}-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-target-${{ steps.rust-toolchain.outputs.cachekey }}-${{ matrix.label || 'default' }}-
+      - *restore-shared-cache
       - name: Download documentation EPUB
         uses: actions/download-artifact@v8
         with:
@@ -211,25 +214,7 @@ jobs:
         with:
           components: clippy
       - *set-build-metadata
-      - name: Cache cargo registry
-        uses: actions/cache@v5
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-          key: ${{ runner.os }}-cargo-registry-${{ steps.rust-toolchain.outputs.cachekey }}-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-registry-${{ steps.rust-toolchain.outputs.cachekey }}-
-      - name: Cache cargo target
-        uses: actions/cache@v5
-        with:
-          path: target/
-          key: ${{ runner.os }}-cargo-target-${{ steps.rust-toolchain.outputs.cachekey }}-default-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-target-${{ steps.rust-toolchain.outputs.cachekey }}-default-
-
+      - *restore-shared-cache
       - name: Download all clippy JSON artifacts
         uses: actions/download-artifact@v8
         with:
@@ -246,7 +231,9 @@ jobs:
           REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   test:
-    needs: [generate-matrix, build-docs-epub]
+    needs: [generate-matrix, build-docs-epub, cache-warmup]
+    permissions:
+      contents: read
     env:
       TEST_ROOT_DIR: ${{ github.workspace }}
 
@@ -291,24 +278,7 @@ jobs:
         if: runner.os == 'macOS'
         run: brew install sdl2 freetype harfbuzz openjpeg jpeg-turbo libpng jbig2dec gumbo-parser djvulibre pkg-config
 
-      - name: Cache cargo registry
-        uses: actions/cache@v5
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-          key: ${{ runner.os }}-cargo-registry-${{ steps.rust-toolchain.outputs.cachekey }}-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-registry-${{ steps.rust-toolchain.outputs.cachekey }}-
-      - name: Cache cargo target
-        uses: actions/cache@v5
-        with:
-          path: target/
-          key: ${{ runner.os }}-cargo-target-${{ steps.rust-toolchain.outputs.cachekey }}-${{ matrix.label || 'default' }}-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-target-${{ steps.rust-toolchain.outputs.cachekey }}-${{ matrix.label || 'default' }}-
+      - *restore-shared-cache
       - name: Cache thirdparty libraries
         uses: ./.github/actions/cache-thirdparty
         with:
@@ -337,6 +307,7 @@ jobs:
         run: cargo xtask test --features "${{ matrix.label }}"
 
   build-kobo:
+    needs: [cache-warmup, build-docs-epub]
     runs-on: ubuntu-latest
 
     permissions: &build-permissions
@@ -356,11 +327,19 @@ jobs:
         with:
           targets: arm-unknown-linux-gnueabihf
 
+      - *restore-shared-cache
+      - name: Download documentation EPUB
+        uses: actions/download-artifact@v8
+        with:
+          name: docs-epub
+          path: docs/book/epub
+
       - name: Build Kobo artifacts
         uses: ./.github/actions/build-kobo
         with:
           gh-token: ${{ secrets.GITHUB_TOKEN }}
           gh-oauth-client-id: ${{ secrets.GH_OAUTH_CLIENT_ID }}
+          skip-docs: "true"
 
       - &get-commit
         name: Get commit hash
@@ -398,6 +377,7 @@ jobs:
           retention-days: 7
 
   build-kobo-test:
+    needs: [cache-warmup, build-docs-epub]
     runs-on: ubuntu-latest
 
     permissions: *build-permissions
@@ -414,12 +394,20 @@ jobs:
         with:
           targets: arm-unknown-linux-gnueabihf
 
+      - *restore-shared-cache
+      - name: Download documentation EPUB
+        uses: actions/download-artifact@v8
+        with:
+          name: docs-epub
+          path: docs/book/epub
+
       - name: Build Kobo test artifacts
         uses: ./.github/actions/build-kobo
         with:
           gh-token: ${{ secrets.GITHUB_TOKEN }}
           gh-oauth-client-id: ${{ secrets.GH_OAUTH_CLIENT_ID }}
           test: "true"
+          skip-docs: "true"
 
       - *get-commit
       - *determine-suffix


### PR DESCRIPTION
Replace per-feature caches with one shared cache to stay under the 10 GB GitHub Actions cache limit.

- Add cache-warmup job that builds --all-features once and saves
- Replace registry+target cache pairs with shared restore anchor
- Matrix jobs (clippy, test) depend on cache-warmup and restore only

Change-Id: 96c68b9d6384d8bae3b795a8f3c88a2d
Change-Id-Short: qtntroqmtwrv