### PR TITLE
dev: skip copying .git when building third-party libraries

### DIFF
--- a/xtask/src/tasks/util/thirdparty.rs
+++ b/xtask/src/tasks/util/thirdparty.rs
@@ -311,6 +311,11 @@ fn git_clone_tag(repo: &str, tag: &str, dest: &Path) -> Result<()> {
         std::fs::read_dir(&tmp).with_context(|| format!("failed to read {}", tmp.display()))?
     {
         let entry = entry.with_context(|| format!("failed to read entry in {}", tmp.display()))?;
+
+        if entry.file_name() == ".git" {
+            continue;
+        }
+
         let target = dest.join(entry.file_name());
         if target.exists() {
             if target.is_dir() {


### PR DESCRIPTION
This fixes a lot of the issues we have with changes getting stuck in Jujutsu. There doesn't seem to be a point in keeping the cloned repo data around.