### PR TITLE
ci: use shared cargo cache in copilot-setup-steps

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -26,8 +26,8 @@ jobs:
           components: rustfmt, clippy
           targets: arm-unknown-linux-gnueabihf
 
-      - name: Cache Cargo registry
-        uses: actions/cache@v5
+      - name: Restore shared cargo cache
+        uses: actions/cache/restore@v5
         with:
           path: |
             ~/.cargo/bin/
@@ -35,7 +35,9 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-          key: ${{ runner.os }}-cargo-${{ steps.rust-toolchain.outputs.cachekey }}-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-shared-${{ steps.rust-toolchain.outputs.cachekey }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-shared-${{ steps.rust-toolchain.outputs.cachekey }}-
 
       - name: Cache thirdparty libraries (Kobo cross-compile)
         uses: ./.github/actions/cache-thirdparty


### PR DESCRIPTION
Switch the Copilot setup workflow from an isolated cargo cache to the shared cache pattern used by cargo.yml.

- Rename step to "Restore shared cargo cache"
- Use actions/cache/restore@v5 instead of actions/cache@v5
- Update cache key prefix from cargo to cargo-shared
- Add restore-keys fallback for partial cache hits

Change-Id: de994b63ec63d71b3b44cb0b6bea05c6
Change-Id-Short: mlqqvotwlntw