### PR TITLE
ci: skip Cloudflare preview deploy on forks

### DIFF
--- a/.github/workflows/cadmus-docs.yml
+++ b/.github/workflows/cadmus-docs.yml
@@ -123,7 +123,7 @@ jobs:
   deploy-cloudflare-preview:
     runs-on: ubuntu-latest
     needs: build
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork
     environment:
       name: cloudflare-pages-preview
       url: ${{ steps.deploy.outputs.pages-deployment-alias-url }}


### PR DESCRIPTION
Prevent deploy-cloudflare-preview job from running on pull requests from forked repositories, as they lack access to the required secrets.

- Add !github.event.pull_request.head.repo.fork condition to job if statement

Change-Id: f3fbdf9e80d5a847c9efb822204c9c7e
Change-Id-Short: kwkomkqlrzmu