### PR TITLE
dev(xtask): auto-run setup-native and docs on emulator

### DIFF
--- a/xtask/src/tasks/run_emulator.rs
+++ b/xtask/src/tasks/run_emulator.rs
@@ -1,14 +1,17 @@
 //! `cargo xtask run-emulator` — run the Cadmus emulator.
 //!
-//! Ensures MuPDF sources and the `mupdf_wrapper` C library are built for the
-//! native platform, then launches `cargo run -p emulator`.  Any extra
-//! arguments are forwarded to the emulator.
+//! Ensures the native MuPDF build and the embedded documentation EPUB are
+//! ready, then launches `cargo run -p emulator`.  Any extra arguments are
+//! forwarded to the emulator.
+
+use std::path::Path;
 
 use anyhow::Result;
 use clap::Args;
 
-use super::setup_native;
-use super::util::{cmd, mupdf_wrapper, workspace};
+use super::docs::{self, DocsArgs};
+use super::setup_native::{self, SetupNativeArgs};
+use super::util::{cmd, workspace};
 
 /// Arguments for `cargo xtask run-emulator`.
 #[derive(Debug, Args)]
@@ -22,17 +25,33 @@ pub struct RunEmulatorArgs {
     pub extra: Vec<String>,
 }
 
+/// Returns `true` when the documentation EPUB embedded by `cadmus-core` exists.
+fn mdbook_epub_built(root: &Path) -> bool {
+    root.join("docs/book/epub/Cadmus Documentation.epub")
+        .exists()
+}
+
 /// Ensures prerequisites are built then launches the emulator.
 ///
 /// # Errors
 ///
-/// Returns an error if the MuPDF download, wrapper build, or emulator launch
-/// fails.
+/// Returns an error if the native setup, documentation build, or emulator
+/// launch fails.
 pub fn run(args: RunEmulatorArgs) -> Result<()> {
     let root = workspace::root()?;
 
-    setup_native::ensure_mupdf_sources(&root, false)?;
-    mupdf_wrapper::build_native_if_needed(&root)?;
+    if !setup_native::native_setup_done(&root) {
+        println!("Native setup not found — running setup-native…");
+        setup_native::run(SetupNativeArgs { force: false })?;
+    }
+
+    if !mdbook_epub_built(&root) {
+        println!("Documentation EPUB not found — building mdBook…");
+        docs::run(DocsArgs {
+            base_url: "http://localhost".to_string(),
+            mdbook_only: true,
+        })?;
+    }
 
     let mut cargo_args = vec!["run", "-p", "emulator"];
 

--- a/xtask/src/tasks/setup_native.rs
+++ b/xtask/src/tasks/setup_native.rs
@@ -112,6 +112,25 @@ fn read_mupdf_version(header: &Path) -> Option<String> {
     None
 }
 
+/// Returns `true` when the full native setup is complete.
+///
+/// Checks that the build marker, the compiled `libmupdf.a`, the C wrapper
+/// library `libmupdf_wrapper.a`, and both symlinks in
+/// `target/mupdf_wrapper/<platform>/` are all present.
+pub fn native_setup_done(root: &Path) -> bool {
+    let platform_dir = if cfg!(target_os = "macos") {
+        "Darwin"
+    } else {
+        "Linux"
+    };
+
+    let wrapper_dir = root.join(format!("target/mupdf_wrapper/{platform_dir}"));
+
+    native_mupdf_ready(root)
+        && wrapper_dir.join("libmupdf.a").exists()
+        && wrapper_dir.join("libmupdf_wrapper.a").exists()
+}
+
 /// Returns `true` when native MuPDF libraries are present and marked as built.
 fn native_mupdf_ready(root: &Path) -> bool {
     let marker = root.join("thirdparty/mupdf").join(NATIVE_BUILT_MARKER);


### PR DESCRIPTION
run-emulator now checks prerequisites before launching:
- Runs setup-native if native MuPDF build is missing
- Builds mdBook (--mdbook-only) if documentation EPUB is absent

- Add pub native_setup_done() to setup_native.rs
- Remove redundant ensure_mupdf_sources call from run_emulator

Change-Id: 7635ac0f3b7db0f92f3f948c85262d60
Change-Id-Short: stwupnzkwosm