### PR TITLE
feat(Settigns Editor): add refresh rate settings

### DIFF
--- a/.agents/skills/fetch-cadmus-logs/SKILL.md
+++ b/.agents/skills/fetch-cadmus-logs/SKILL.md
@@ -14,7 +14,26 @@ The run ID is stored as a JSON field named `resources_cadmus_run_id` — it is
 It must be filtered with `| json | resources_cadmus_run_id="<id>"` in the
 LogQL pipeline.
 
-## Loki base URL
+### Two separate observability sources
+
+Cadmus uses two distinct pipelines:
+
+| Source                              | What it contains                                                                                                 | How to query                         |
+| ----------------------------------- | ---------------------------------------------------------------------------------------------------------------- | ------------------------------------ |
+| **Loki** (`http://localhost:3100`)  | `tracing`-bridge log records (third-party crate logs like `reqwest`, `i18n_embed`)                               | LogQL via `/loki/api/v1/query_range` |
+| **Tempo** (`http://localhost:3200`) | Spans and span events from `#[tracing::instrument]` — this is where cadmus-core importer, library, db spans live | `/api/traces/<traceID>`              |
+
+**Important:** Cadmus application logic (`cadmus_core::*`) emits structured
+spans via `tracing::instrument`, not log records. These appear in **Tempo**, not
+Loki. Loki for a cadmus run will mostly contain noise from `reqwest::retry`,
+`i18n_embed`, etc. — not importer or library logic.
+
+To debug application behaviour (import scan, db inserts, errors), query Tempo.
+To find third-party log noise or connectivity errors, query Loki.
+
+## Loki
+
+### Base URL
 
 ```text
 http://localhost:3100
@@ -22,16 +41,7 @@ http://localhost:3100
 
 Override with the `LOKI_URL` environment variable if the instance is elsewhere.
 
-## Step-by-step
-
-### 1. Resolve the time range (optional but recommended)
-
-If you know approximately when the run happened, pass `start` and `end` as
-Unix nanoseconds or RFC3339 to narrow the query and avoid timeouts.
-
-Leave them out to default to the last hour.
-
-### 2. Query logs for the run ID
+### Query logs for a run ID
 
 ```bash
 LOKI_URL="${LOKI_URL:-http://localhost:3100}"
@@ -46,19 +56,21 @@ curl -sG "${LOKI_URL}/loki/api/v1/query_range" \
 
 This prints the `body` field of each JSON log line in chronological order.
 
-### 3. Widen the output if needed
+### Filter to cadmus-core log records only
 
-To see all fields (level, target, span, etc.):
+Add `| instrumentation_scope_name="log"` to isolate records that went through
+the log bridge (as opposed to span events). Even then, most records will be
+from third-party crates. To further narrow to cadmus-core targets:
 
 ```bash
 curl -sG "${LOKI_URL}/loki/api/v1/query_range" \
-  --data-urlencode 'query={service_name="cadmus"} | json | resources_cadmus_run_id="'"${RUN_ID}"'"' \
+  --data-urlencode 'query={service_name="cadmus"} | json | resources_cadmus_run_id="'"${RUN_ID}"'" | instrumentation_scope_name="log"' \
   --data-urlencode 'limit=1000' \
   --data-urlencode 'direction=forward' \
-  | jq '.data.result[].values[] | .[0], (.[1] | fromjson)'
+  | jq -r '.data.result[].values[] | .[1] | fromjson | select(.attributes["log.target"] | startswith("cadmus")) | .body'
 ```
 
-### 4. Filter by log level
+### Filter by log level
 
 Loki attaches a `level` stream label (lowercase) derived from the `severity`
 JSON field. Filter by level two ways:
@@ -69,7 +81,7 @@ JSON field. Filter by level two ways:
 {service_name="cadmus", level="error"} | json | resources_cadmus_run_id="<id>"
 ```
 
-**JSON field filter (use when you need to match severity exactly as logged):**
+**JSON field filter:**
 
 ```text
 {service_name="cadmus"} | json | resources_cadmus_run_id="<id>" | severity="ERROR"
@@ -78,16 +90,14 @@ JSON field. Filter by level two ways:
 Valid `level` stream label values: `trace`, `debug`, `info`, `warn`, `error`.
 Valid `severity` JSON field values: `TRACE`, `DEBUG`, `INFO`, `WARN`, `ERROR`.
 
-### 5. Paginate large result sets
+### Paginate large result sets
 
-Loki returns at most `limit` entries per request. Use the `end` timestamp of
-the last entry as the new `start` to fetch the next page:
+Loki returns at most `limit` entries per request. Keep limit ≤ 1000 —
+larger values may return empty results. Paginate using the last timestamp:
 
 ```bash
-# Get the timestamp of the last entry from previous response
 LAST_TS=$(echo "$RESPONSE" | jq -r '.data.result[-1].values[-1][0]')
 
-# Next page: start just after the last entry
 curl -sG "${LOKI_URL}/loki/api/v1/query_range" \
   --data-urlencode 'query={service_name="cadmus"} | json | resources_cadmus_run_id="'"${RUN_ID}"'"' \
   --data-urlencode "start=$((LAST_TS + 1))" \
@@ -95,19 +105,75 @@ curl -sG "${LOKI_URL}/loki/api/v1/query_range" \
   --data-urlencode 'direction=forward'
 ```
 
-## Common patterns
+### Common Loki patterns
 
-| Goal                | LogQL suffix                                                                       |
-| ------------------- | ---------------------------------------------------------------------------------- |
-| All logs for a run  | `\| json \| resources_cadmus_run_id="<id>"`                                        |
-| Errors only         | `{service_name="cadmus", level="error"} \| json \| resources_cadmus_run_id="<id>"` |
-| Pyroscope push logs | `\| json \| resources_cadmus_run_id="<id>" \| body=~"pyroscope\|profil"`           |
-| Count entries       | Use `/loki/api/v1/query` with `count_over_time(...)`                               |
+| Goal                     | LogQL                                                                                   |
+| ------------------------ | --------------------------------------------------------------------------------------- |
+| All logs for a run       | `{service_name="cadmus"} \| json \| resources_cadmus_run_id="<id>"`                     |
+| Errors only              | `{service_name="cadmus", level="error"} \| json \| resources_cadmus_run_id="<id>"`      |
+| cadmus-core targets only | add `\| instrumentation_scope_name="log"` then filter `.attributes["log.target"]` in jq |
+| Count entries            | Use `/loki/api/v1/query` with `count_over_time(...)`                                    |
+
+## Tempo (spans and span events)
+
+### Tempo Base URL
+
+```text
+http://localhost:3200
+```
+
+### Find a trace by run ID
+
+```bash
+curl -sG "http://localhost:3200/api/search" \
+  --data-urlencode "tags=cadmus.run_id=<run-id>" \
+  --data-urlencode "limit=5" \
+  | jq -r '.traces[] | "\(.traceID) \(.rootName)"'
+```
+
+### Fetch a full trace
+
+```bash
+TRACE_ID="<traceID>"
+curl -s "http://localhost:3200/api/traces/${TRACE_ID}" \
+  | jq -r '.batches[].scopeSpans[].spans[] | "\(.name) | \(.attributes[] | "\(.key)=\(.value.stringValue // .value.intValue)")"'
+```
+
+### Find error spans
+
+```bash
+curl -s "http://localhost:3200/api/traces/${TRACE_ID}" | jq -r '
+  .batches[].scopeSpans[].spans[]
+  | select(.status.code == "STATUS_CODE_ERROR")
+  | {name, status, events: .events}
+'
+```
+
+Span events carry the actual error message. Check `.events[].attributes` for
+fields like `error` which contain the database error string.
+
+### Filter spans by name
+
+```bash
+curl -s "http://localhost:3200/api/traces/${TRACE_ID}" | jq -r '
+  .batches[].scopeSpans[].spans[]
+  | select(.name | test("scan_entries|flush_to_db|batch_insert|run"))
+  | "\(.name) | \(.attributes[] | select(.key | test("count|library_id|home")) | "\(.key)=\(.value.stringValue // .value.intValue)")"
+'
+```
+
+### Convert nanosecond timestamps
+
+Tempo span timestamps are Unix nanoseconds:
+
+```bash
+python3 -c "import datetime; print(datetime.datetime.fromtimestamp(<ns>/1e9, tz=datetime.timezone.utc))"
+```
 
 ## Loki API reference
 
-- `GET /loki/api/v1/query_range` — range query (use for fetching log lines)
-- `GET /loki/api/v1/query` — instant query (use for metric expressions)
+- `GET /loki/api/v1/query_range` — range query (fetching log lines)
+- `GET /loki/api/v1/query` — instant query (metric expressions)
 - `GET /loki/api/v1/labels` — list available label names
 - `GET /loki/api/v1/label/{name}/values` — list values for a label
 

--- a/.github/instructions/translations.instructions.md
+++ b/.github/instructions/translations.instructions.md
@@ -1,0 +1,77 @@
+---
+description: "All user-facing strings must use Fluent translations"
+applyTo: "**/*.rs,crates/core/i18n/**/*.ftl"
+---
+
+# User-Facing String Translations
+
+All user-facing strings in Rust code must use the `fl!` macro from the
+`crate::fl` re-export. Never use hardcoded string literals for labels, button
+text, input placeholders, or any other text visible to the user.
+
+## Rules
+
+1. **No hardcoded strings** — every user-visible string must have a Fluent
+   message ID in `crates/core/i18n/en-GB/cadmus_core.ftl`.
+2. **Use `fl!` macro** — import via `use crate::fl;` and call `fl!("message-id")`.
+3. **Parameterised strings** — use Fluent variables (`{ $var }`) in the `.ftl`
+   file and pass them as keyword arguments to `fl!`. Example:
+   `fl!("settings-reader-refresh-rate-by-kind-regular-input", ext = self.0.as_str())`
+
+4. **Keep `.ftl` keys sorted** — message IDs in
+   `crates/core/i18n/en-GB/cadmus_core.ftl` must remain in alphabetical order
+   within each comment section.
+5. **Naming convention** — use kebab-case, prefixed by the feature area:
+   - `settings-<category>-<description>` for settings labels
+   - `settings-<category>-<description>-input` for input field placeholder/labels
+   - `notification-<description>` for notifications
+
+## Where this applies
+
+- `label()` implementations on `SettingKind` traits
+- Input field `label` strings passed to `Event::OpenNamedInput`
+- Menu entry text in `EntryKind::Command`, `EntryKind::RadioButton`, etc.
+- Button labels, notification text, and any other user-visible string
+
+## Adding a new string
+
+1. Add the Fluent message to `crates/core/i18n/en-GB/cadmus_core.ftl` in the
+   appropriate section, keeping IDs sorted.
+2. Use `fl!("your-message-id")` at the call site.
+3. If the message has variables, declare them in the `.ftl` file with
+   `{ $varname }` syntax and pass values via `fl!("id", varname = value)`.
+
+## Example
+
+```rust
+// crates/core/i18n/en-GB/cadmus_core.ftl
+// settings-reader-refresh-rate = Refresh Rate
+// settings-reader-refresh-rate-by-kind-regular-input = { $ext } regular refresh rate (0 = never)
+
+// Rust usage
+fn label(&self, _settings: &Settings) -> String {
+    fl!("settings-reader-refresh-rate")
+}
+
+fn fetch(&self, settings: &Settings) -> SettingData {
+    SettingData {
+        widget: WidgetKind::ActionLabel(Event::OpenNamedInput {
+            label: fl!(
+                "settings-reader-refresh-rate-by-kind-regular-input",
+                ext = self.0.as_str()
+            ),
+            // ...
+        }),
+        // ...
+    }
+}
+```
+
+## Review checklist
+
+When reviewing code that adds user-facing strings:
+
+- [ ] No `"string literal".to_string()` or `format!("literal")` for user-visible text
+- [ ] New message IDs added to `cadmus_core.ftl` in the correct sorted section
+- [ ] Parameterised messages use Fluent variable syntax in `.ftl`
+- [ ] `fl!` macro is used at every call site

--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,5 @@ docs/mermaid.min.js
 docs/src/mermaid-images/
 crates/core/.sqlx-dev.db
 cadmus.sqlite
+
+.idea

--- a/crates/core/i18n/en-GB/cadmus_core.ftl
+++ b/crates/core/i18n/en-GB/cadmus_core.ftl
@@ -62,6 +62,7 @@ settings-reader-refresh-rate-inverted = Inverted
 settings-reader-refresh-rate-inverted-input = Inverted refresh rate (0 = never)
 settings-reader-refresh-rate-regular = Regular
 settings-reader-refresh-rate-regular-input = Regular refresh rate (0 = never)
+settings-reader-refresh-rate-summary = { $regular } / { $inverted }
 
 # Settings - Intermission
 settings-intermission-suspend-screen = Suspend Screen

--- a/crates/core/i18n/en-GB/cadmus_core.ftl
+++ b/crates/core/i18n/en-GB/cadmus_core.ftl
@@ -14,6 +14,7 @@ notification-downloading-dictionary-completed = Downloading dictionary for "{ $l
 notification-downloading-dictionary-progress = Downloading { $lang } ({ $downloaded }/{ $total })
 notification-dictionary-indexing = Indexing "{ $name }"
 notification-not-online = WiFi must be connected for this action.
+notification-refresh-rate-invalid = Refresh rate must be a number between 0 and 255.
 
 # Common
 delete = Delete
@@ -54,6 +55,13 @@ settings-general-unknown = Unknown
 
 # Settings - Reader
 settings-reader-end-of-book-action = End of Book Action
+settings-reader-refresh-rate = Refresh Rate
+settings-reader-refresh-rate-regular = Regular
+settings-reader-refresh-rate-inverted = Inverted
+settings-reader-refresh-rate-regular-input = Regular refresh rate (0 = never)
+settings-reader-refresh-rate-inverted-input = Inverted refresh rate (0 = never)
+settings-reader-refresh-rate-by-kind-regular-input = { $ext } regular refresh rate (0 = never)
+settings-reader-refresh-rate-by-kind-inverted-input = { $ext } inverted refresh rate (0 = never)
 
 # Settings - Intermission
 settings-intermission-suspend-screen = Suspend Screen

--- a/crates/core/i18n/en-GB/cadmus_core.ftl
+++ b/crates/core/i18n/en-GB/cadmus_core.ftl
@@ -56,12 +56,12 @@ settings-general-unknown = Unknown
 # Settings - Reader
 settings-reader-end-of-book-action = End of Book Action
 settings-reader-refresh-rate = Refresh Rate
-settings-reader-refresh-rate-regular = Regular
-settings-reader-refresh-rate-inverted = Inverted
-settings-reader-refresh-rate-regular-input = Regular refresh rate (0 = never)
-settings-reader-refresh-rate-inverted-input = Inverted refresh rate (0 = never)
-settings-reader-refresh-rate-by-kind-regular-input = { $ext } regular refresh rate (0 = never)
 settings-reader-refresh-rate-by-kind-inverted-input = { $ext } inverted refresh rate (0 = never)
+settings-reader-refresh-rate-by-kind-regular-input = { $ext } regular refresh rate (0 = never)
+settings-reader-refresh-rate-inverted = Inverted
+settings-reader-refresh-rate-inverted-input = Inverted refresh rate (0 = never)
+settings-reader-refresh-rate-regular = Regular
+settings-reader-refresh-rate-regular-input = Regular refresh rate (0 = never)
 
 # Settings - Intermission
 settings-intermission-suspend-screen = Suspend Screen

--- a/crates/core/src/library/importer.rs
+++ b/crates/core/src/library/importer.rs
@@ -155,7 +155,11 @@ fn scan_entries(
         }
 
         let kind = file_kind(path).unwrap_or_default();
-        if settings.allowed_kinds.contains(&kind) {
+        if settings
+            .allowed_kinds
+            .iter()
+            .any(|ext| ext.as_str() == kind)
+        {
             info!(fp = %fp, path = %relat.display(), "added new entry");
             let size = entry.metadata().map(|m| m.len()).unwrap_or(0);
             let mut info = Info {

--- a/crates/core/src/settings/mod.rs
+++ b/crates/core/src/settings/mod.rs
@@ -509,22 +509,25 @@ impl FileExtension {
             FileExtension::Oxps => "oxps",
         }
     }
+}
 
-    /// Parses a lowercase extension string, returning `None` for unknown values.
-    pub fn from_str(s: &str) -> Option<Self> {
+impl std::str::FromStr for FileExtension {
+    type Err = ();
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
-            "epub" => Some(FileExtension::Epub),
-            "pdf" => Some(FileExtension::Pdf),
-            "cbz" => Some(FileExtension::Cbz),
-            "cbr" => Some(FileExtension::Cbr),
-            "djvu" => Some(FileExtension::Djvu),
-            "fb2" => Some(FileExtension::Fb2),
-            "mobi" => Some(FileExtension::Mobi),
-            "txt" => Some(FileExtension::Txt),
-            "html" => Some(FileExtension::Html),
-            "xps" => Some(FileExtension::Xps),
-            "oxps" => Some(FileExtension::Oxps),
-            _ => None,
+            "epub" => Ok(FileExtension::Epub),
+            "pdf" => Ok(FileExtension::Pdf),
+            "cbz" => Ok(FileExtension::Cbz),
+            "cbr" => Ok(FileExtension::Cbr),
+            "djvu" => Ok(FileExtension::Djvu),
+            "fb2" => Ok(FileExtension::Fb2),
+            "mobi" => Ok(FileExtension::Mobi),
+            "txt" => Ok(FileExtension::Txt),
+            "html" => Ok(FileExtension::Html),
+            "xps" => Ok(FileExtension::Xps),
+            "oxps" => Ok(FileExtension::Oxps),
+            _ => Err(()),
         }
     }
 }
@@ -549,8 +552,13 @@ where
             let mut set = FxHashSet::default();
 
             while let Some(s) = seq.next_element::<String>()? {
-                if let Some(ext) = FileExtension::from_str(&s) {
-                    set.insert(ext);
+                match s.parse::<FileExtension>() {
+                    Ok(ext) => {
+                        set.insert(ext);
+                    }
+                    Err(()) => {
+                        tracing::warn!(extension = %s, "Unknown file extension skipped");
+                    }
                 }
             }
 
@@ -1073,7 +1081,7 @@ allowed-kinds = ["epub", "unknown-format", "another-unknown"]
     #[test]
     fn test_file_extension_round_trip_via_from_str() {
         for ext in FileExtension::all() {
-            let parsed = FileExtension::from_str(ext.as_str());
+            let parsed = ext.as_str().parse::<FileExtension>().ok();
             assert_eq!(parsed, Some(*ext), "round trip failed for {:?}", ext);
         }
     }

--- a/crates/core/src/settings/mod.rs
+++ b/crates/core/src/settings/mod.rs
@@ -304,13 +304,15 @@ impl Default for LibrarySettings {
     }
 }
 
+/// Settings controlling which files are imported into the library.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(default, rename_all = "kebab-case")]
 pub struct ImportSettings {
     pub startup_trigger: bool,
     pub sync_metadata: bool,
     pub metadata_kinds: FxHashSet<String>,
-    pub allowed_kinds: FxHashSet<String>,
+    #[serde(deserialize_with = "deserialize_allowed_kinds")]
+    pub allowed_kinds: FxHashSet<FileExtension>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -451,6 +453,118 @@ pub struct RefreshRateSettings {
     pub global: RefreshRatePair,
     #[serde(skip_serializing_if = "HashMap::is_empty")]
     pub by_kind: HashMap<String, RefreshRatePair>,
+}
+
+/// A known file extension for which per-kind refresh rates can be configured.
+///
+/// The serialized string (e.g. `"epub"`, `"cbz"`) is used as the key in
+/// [`RefreshRateSettings::by_kind`] and as values in [`ImportSettings::allowed_kinds`].
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum FileExtension {
+    Epub,
+    Pdf,
+    Cbz,
+    Cbr,
+    Djvu,
+    Fb2,
+    Mobi,
+    Txt,
+    Html,
+    Xps,
+    Oxps,
+}
+
+impl FileExtension {
+    /// Returns all known file extensions.
+    pub fn all() -> &'static [FileExtension] {
+        &[
+            FileExtension::Epub,
+            FileExtension::Pdf,
+            FileExtension::Cbz,
+            FileExtension::Cbr,
+            FileExtension::Djvu,
+            FileExtension::Fb2,
+            FileExtension::Mobi,
+            FileExtension::Txt,
+            FileExtension::Html,
+            FileExtension::Xps,
+            FileExtension::Oxps,
+        ]
+    }
+
+    /// Returns the lowercase string representation used as the TOML key.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            FileExtension::Epub => "epub",
+            FileExtension::Pdf => "pdf",
+            FileExtension::Cbz => "cbz",
+            FileExtension::Cbr => "cbr",
+            FileExtension::Djvu => "djvu",
+            FileExtension::Fb2 => "fb2",
+            FileExtension::Mobi => "mobi",
+            FileExtension::Txt => "txt",
+            FileExtension::Html => "html",
+            FileExtension::Xps => "xps",
+            FileExtension::Oxps => "oxps",
+        }
+    }
+
+    /// Parses a lowercase extension string, returning `None` for unknown values.
+    pub fn from_str(s: &str) -> Option<Self> {
+        match s {
+            "epub" => Some(FileExtension::Epub),
+            "pdf" => Some(FileExtension::Pdf),
+            "cbz" => Some(FileExtension::Cbz),
+            "cbr" => Some(FileExtension::Cbr),
+            "djvu" => Some(FileExtension::Djvu),
+            "fb2" => Some(FileExtension::Fb2),
+            "mobi" => Some(FileExtension::Mobi),
+            "txt" => Some(FileExtension::Txt),
+            "html" => Some(FileExtension::Html),
+            "xps" => Some(FileExtension::Xps),
+            "oxps" => Some(FileExtension::Oxps),
+            _ => None,
+        }
+    }
+}
+
+fn deserialize_allowed_kinds<'de, D>(deserializer: D) -> Result<FxHashSet<FileExtension>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    struct AllowedKindsVisitor;
+
+    impl<'de> serde::de::Visitor<'de> for AllowedKindsVisitor {
+        type Value = FxHashSet<FileExtension>;
+
+        fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+            formatter.write_str("a sequence of file extension strings")
+        }
+
+        fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+        where
+            A: serde::de::SeqAccess<'de>,
+        {
+            let mut set = FxHashSet::default();
+
+            while let Some(s) = seq.next_element::<String>()? {
+                if let Some(ext) = FileExtension::from_str(&s) {
+                    set.insert(ext);
+                }
+            }
+
+            Ok(set)
+        }
+    }
+
+    deserializer.deserialize_seq(AllowedKindsVisitor)
+}
+
+impl fmt::Display for FileExtension {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.as_str())
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -675,10 +789,18 @@ impl Default for ImportSettings {
                 .map(|k| k.to_string())
                 .collect(),
             allowed_kinds: [
-                "pdf", "djvu", "epub", "fb2", "txt", "xps", "oxps", "mobi", "cbz",
+                FileExtension::Pdf,
+                FileExtension::Djvu,
+                FileExtension::Epub,
+                FileExtension::Fb2,
+                FileExtension::Txt,
+                FileExtension::Xps,
+                FileExtension::Oxps,
+                FileExtension::Mobi,
+                FileExtension::Cbz,
             ]
             .iter()
-            .map(|k| k.to_string())
+            .copied()
             .collect(),
         }
     }
@@ -916,5 +1038,43 @@ share = "/path/to/custom.png"
             IntermissionDisplay::Logo
         );
         assert_eq!(intermissions[IntermKind::Share], IntermissionDisplay::Logo);
+    }
+
+    #[test]
+    fn test_allowed_kinds_deserializes_known_extensions() {
+        let toml_str = r#"
+startup-trigger = true
+sync-metadata = true
+metadata-kinds = ["epub"]
+allowed-kinds = ["epub", "pdf", "cbz"]
+"#;
+        let settings: ImportSettings = toml::from_str(toml_str).expect("Failed to deserialize");
+
+        assert!(settings.allowed_kinds.contains(&FileExtension::Epub));
+        assert!(settings.allowed_kinds.contains(&FileExtension::Pdf));
+        assert!(settings.allowed_kinds.contains(&FileExtension::Cbz));
+        assert_eq!(settings.allowed_kinds.len(), 3);
+    }
+
+    #[test]
+    fn test_allowed_kinds_silently_drops_unknown_extensions() {
+        let toml_str = r#"
+startup-trigger = true
+sync-metadata = true
+metadata-kinds = []
+allowed-kinds = ["epub", "unknown-format", "another-unknown"]
+"#;
+        let settings: ImportSettings = toml::from_str(toml_str).expect("Failed to deserialize");
+
+        assert!(settings.allowed_kinds.contains(&FileExtension::Epub));
+        assert_eq!(settings.allowed_kinds.len(), 1);
+    }
+
+    #[test]
+    fn test_file_extension_round_trip_via_from_str() {
+        for ext in FileExtension::all() {
+            let parsed = FileExtension::from_str(ext.as_str());
+            assert_eq!(parsed, Some(*ext), "round trip failed for {:?}", ext);
+        }
     }
 }

--- a/crates/core/src/task/mod.rs
+++ b/crates/core/src/task/mod.rs
@@ -337,6 +337,10 @@ impl TaskManager {
     ///
     /// Must be called for every event before passing it to the view tree.
     /// Always returns `false` — it never consumes events.
+    #[cfg_attr(
+        feature = "tracing",
+        tracing::instrument(skip(self, hub, database, settings))
+    )]
     pub fn handle_event(
         &mut self,
         evt: &Event,

--- a/crates/core/src/view/mod.rs
+++ b/crates/core/src/view/mod.rs
@@ -457,6 +457,14 @@ pub enum Event {
     UpdateLibrary(usize, Box<settings::LibrarySettings>),
     AddLibrary,
     DeleteLibrary(usize),
+    /// Open the refresh rate editor (global + per-kind overrides).
+    OpenRefreshRateEditor,
+    /// Open the per-kind refresh rate editor for the given file extension.
+    EditRefreshRateByKind(settings::FileExtension),
+    /// Commit a new or updated per-kind refresh rate pair to settings.
+    UpdateRefreshRateByKind(settings::FileExtension, Box<settings::RefreshRatePair>),
+    /// Delete the per-kind override for the given extension.
+    DeleteRefreshRateByKind(settings::FileExtension),
     ProcessLine(LineOrigin, String),
     History(CycleDir, bool),
     Toggle(ToggleEvent),
@@ -622,6 +630,12 @@ pub enum ViewId {
     IntermissionShareInput,
     OtlpEndpointInput,
     PyroscopeEndpointInput,
+    RefreshRateByKindEditor,
+    RefreshRateKindPairEditor,
+    RefreshRateRegularInput,
+    RefreshRateInvertedInput,
+    RefreshRateByKindRegularInput,
+    RefreshRateByKindInvertedInput,
     SketchMenu,
     RenameDocument,
     RenameDocumentInput,
@@ -823,6 +837,12 @@ pub enum EntryId {
     CheckForUpdates,
     FileEntry(PathBuf),
     Ota(OtaEntryId),
+    /// Open the per-kind refresh rate editor for the given file extension.
+    EditRefreshRateByKind(settings::FileExtension),
+    /// Delete the per-kind refresh rate override for the given file extension.
+    DeleteRefreshRateByKind(settings::FileExtension),
+    /// Add a new per-kind refresh rate override (opens extension picker submenu).
+    AddRefreshRateByKind,
 }
 
 impl EntryKind {

--- a/crates/core/src/view/settings_editor/category.rs
+++ b/crates/core/src/view/settings_editor/category.rs
@@ -6,7 +6,7 @@ use super::kinds::general::{
 use super::kinds::import::{ImportStartupTrigger, ImportSyncMetadata};
 use super::kinds::intermission::{IntermissionPowerOff, IntermissionShare, IntermissionSuspend};
 use super::kinds::library::LibraryInfo;
-use super::kinds::reader::FinishedActionSetting;
+use super::kinds::reader::{FinishedActionSetting, RefreshRateInfo};
 use super::kinds::telemetry::{LogLevel, LoggingEnabled};
 use super::kinds::SettingKind;
 use crate::context::Context;
@@ -71,7 +71,7 @@ impl Category {
                 Box::new(SleepCover),
                 Box::new(SettingsRetention),
             ],
-            Category::Reader => vec![Box::new(FinishedActionSetting)],
+            Category::Reader => vec![Box::new(FinishedActionSetting), Box::new(RefreshRateInfo)],
             Category::Libraries => (0..context.settings.libraries.len())
                 .map(|i| Box::new(LibraryInfo(i)) as Box<dyn SettingKind>)
                 .collect(),

--- a/crates/core/src/view/settings_editor/category_editor.rs
+++ b/crates/core/src/view/settings_editor/category_editor.rs
@@ -19,6 +19,7 @@ use crate::view::{
 use super::bottom_bar::{BottomBarVariant, SettingsEditorBottomBar};
 use super::category::Category;
 use super::library_editor::LibraryEditor;
+use super::refresh_rate_by_kind_editor::RefreshRateByKindEditor;
 use super::setting_row::SettingRow;
 use std::path::{Path, PathBuf};
 use std::thread;
@@ -504,6 +505,19 @@ impl CategoryEditor {
         true
     }
 
+    #[inline]
+    fn handle_open_refresh_rate_editor_event(
+        &mut self,
+        hub: &Hub,
+        rq: &mut RenderQueue,
+        context: &mut Context,
+    ) -> bool {
+        let editor = RefreshRateByKindEditor::new(self.rect, hub, rq, context);
+        self.children.push(Box::new(editor));
+        rq.add(RenderData::new(self.id, self.rect, UpdateMode::Gui));
+        true
+    }
+
     /// Spawns a background thread to download and install a dictionary for the
     /// given language code.
     ///
@@ -642,7 +656,8 @@ impl CategoryEditor {
             | ViewId::AutoPowerOffInput
             | ViewId::SettingsRetentionInput
             | ViewId::SettingsValueMenu
-            | ViewId::LibraryEditor => {
+            | ViewId::LibraryEditor
+            | ViewId::RefreshRateByKindEditor => {
                 if let Some(index) = locate_by_id(self, *view_id) {
                     let input_rect = *self.children[index].rect();
                     self.children.remove(index);
@@ -711,6 +726,9 @@ impl View for CategoryEditor {
             }
             Event::AddLibrary => self.handle_add_library_event(hub, rq, context),
             Event::EditLibrary(index) => self.handle_edit_library_event(*index, hub, rq, context),
+            Event::OpenRefreshRateEditor => {
+                self.handle_open_refresh_rate_editor_event(hub, rq, context)
+            }
             Event::UpdateLibrary(index, ref library) => {
                 self.handle_update_library_event(*index, library, rq, context)
             }

--- a/crates/core/src/view/settings_editor/editor_utils.rs
+++ b/crates/core/src/view/settings_editor/editor_utils.rs
@@ -1,0 +1,67 @@
+//! Shared utilities for settings sub-editors (e.g. LibraryEditor,
+//! RefreshRateByKindEditor).
+//!
+//! These helpers avoid duplicating the identical dimension calculations and
+//! chrome-building code across every sub-editor.
+
+use crate::color::BLACK;
+use crate::device::CURRENT_DEVICE;
+use crate::geom::{halves, Rectangle};
+use crate::unit::scale_by_dpi;
+use crate::view::filler::Filler;
+use crate::view::{View, SMALL_BAR_HEIGHT, THICKNESS_MEDIUM};
+
+use super::bottom_bar::{BottomBarVariant, SettingsEditorBottomBar};
+
+/// Returns `(bar_height, separator_thickness, separator_top_half, separator_bottom_half)`
+/// based on the current device DPI.
+pub fn calculate_dimensions() -> (i32, i32, i32, i32) {
+    let dpi = CURRENT_DEVICE.dpi;
+    let small_height = scale_by_dpi(SMALL_BAR_HEIGHT, dpi) as i32;
+    let separator_thickness = scale_by_dpi(THICKNESS_MEDIUM, dpi) as i32;
+    let (separator_top_half, separator_bottom_half) = halves(separator_thickness);
+    let bar_height = small_height;
+
+    (
+        bar_height,
+        separator_thickness,
+        separator_top_half,
+        separator_bottom_half,
+    )
+}
+
+/// Builds the black separator line just above the bottom bar.
+pub fn build_bottom_separator(
+    rect: Rectangle,
+    bar_height: i32,
+    separator_top_half: i32,
+    separator_bottom_half: i32,
+) -> Box<dyn View> {
+    let separator = Filler::new(
+        rect![
+            rect.min.x,
+            rect.max.y - bar_height - separator_top_half,
+            rect.max.x,
+            rect.max.y - bar_height + separator_bottom_half
+        ],
+        BLACK,
+    );
+    Box::new(separator) as Box<dyn View>
+}
+
+/// Builds a two-button bottom bar (close + validate).
+pub fn build_two_button_bottom_bar(
+    rect: Rectangle,
+    bar_height: i32,
+    separator_bottom_half: i32,
+    variant: BottomBarVariant,
+) -> Box<dyn View> {
+    let bottom_bar_rect = rect![
+        rect.min.x,
+        rect.max.y - bar_height + separator_bottom_half,
+        rect.max.x,
+        rect.max.y
+    ];
+
+    Box::new(SettingsEditorBottomBar::new(bottom_bar_rect, variant)) as Box<dyn View>
+}

--- a/crates/core/src/view/settings_editor/kinds/identity.rs
+++ b/crates/core/src/view/settings_editor/kinds/identity.rs
@@ -44,4 +44,16 @@ pub enum SettingIdentity {
     EnableDbusLog,
     /// Identity for a monolingual dictionary row, keyed by ISO 639-1 language code.
     DictionaryInfo(String),
+    /// Summary row in the Reader category showing "regular / inverted".
+    RefreshRate,
+    /// Global refresh rate (regular, non-inverted page turns).
+    RefreshRateRegular,
+    /// Global refresh rate (inverted page turns).
+    RefreshRateInverted,
+    /// Per-kind refresh rate row in the Reader category list.
+    RefreshRateByKind(String),
+    /// Regular refresh rate inside a per-kind editor.
+    RefreshRateByKindRegular(String),
+    /// Inverted refresh rate inside a per-kind editor.
+    RefreshRateByKindInverted(String),
 }

--- a/crates/core/src/view/settings_editor/kinds/reader.rs
+++ b/crates/core/src/view/settings_editor/kinds/reader.rs
@@ -5,7 +5,7 @@ use crate::fl;
 use crate::geom::Rectangle;
 use crate::i18n::I18nDisplay;
 use crate::settings::{FileExtension, FinishedAction, RefreshRatePair, Settings};
-use crate::view::{Bus, EntryId, EntryKind, Event};
+use crate::view::{Bus, EntryId, EntryKind, Event, ViewId};
 
 /// Reader finished action setting
 pub struct FinishedActionSetting;
@@ -79,6 +79,31 @@ impl SettingKind for RefreshRateInfo {
         SettingData {
             value,
             widget: WidgetKind::ActionLabel(Event::OpenRefreshRateEditor),
+        }
+    }
+
+    /// Updates the summary label when either global input is submitted.
+    ///
+    /// Settings are intentionally not written here. Each input (`RefreshRateRegularInput`,
+    /// `RefreshRateInvertedInput`) has its own [`SettingKind`] row (`RefreshRateRegularSetting`,
+    /// `RefreshRateInvertedSetting`) that owns the write.
+    fn handle(
+        &self,
+        evt: &Event,
+        settings: &mut Settings,
+        _bus: &mut Bus,
+    ) -> (Option<String>, bool) {
+        let global = &settings.reader.refresh_rate.global;
+        match evt {
+            Event::Submit(ViewId::RefreshRateRegularInput, text) => {
+                let regular = text.parse::<u8>().unwrap_or(global.regular);
+                (Some(format!("{} / {}", regular, global.inverted)), false)
+            }
+            Event::Submit(ViewId::RefreshRateInvertedInput, text) => {
+                let inverted = text.parse::<u8>().unwrap_or(global.inverted);
+                (Some(format!("{} / {}", global.regular, inverted)), false)
+            }
+            _ => (None, false),
         }
     }
 }
@@ -395,6 +420,69 @@ mod tests {
             let result = setting.handle(&event, &mut settings, &mut bus);
 
             assert!(result.0.is_none());
+        }
+    }
+
+    mod refresh_rate_info {
+        use super::*;
+
+        #[test]
+        fn handle_regular_submit_updates_display_without_writing_settings() {
+            let setting = RefreshRateInfo;
+            let mut settings = Settings::default();
+            settings.reader.refresh_rate.global.regular = 5;
+            settings.reader.refresh_rate.global.inverted = 10;
+            let mut bus: Bus = VecDeque::new();
+
+            let event = Event::Submit(ViewId::RefreshRateRegularInput, "3".to_string());
+            let (display, handled) = setting.handle(&event, &mut settings, &mut bus);
+
+            assert_eq!(display.as_deref(), Some("3 / 10"));
+            assert!(!handled);
+            assert_eq!(settings.reader.refresh_rate.global.regular, 5);
+        }
+
+        #[test]
+        fn handle_inverted_submit_updates_display_without_writing_settings() {
+            let setting = RefreshRateInfo;
+            let mut settings = Settings::default();
+            settings.reader.refresh_rate.global.regular = 5;
+            settings.reader.refresh_rate.global.inverted = 10;
+            let mut bus: Bus = VecDeque::new();
+
+            let event = Event::Submit(ViewId::RefreshRateInvertedInput, "7".to_string());
+            let (display, handled) = setting.handle(&event, &mut settings, &mut bus);
+
+            assert_eq!(display.as_deref(), Some("5 / 7"));
+            assert!(!handled);
+            assert_eq!(settings.reader.refresh_rate.global.inverted, 10);
+        }
+
+        #[test]
+        fn handle_invalid_text_falls_back_to_current_value() {
+            let setting = RefreshRateInfo;
+            let mut settings = Settings::default();
+            settings.reader.refresh_rate.global.regular = 5;
+            settings.reader.refresh_rate.global.inverted = 10;
+            let mut bus: Bus = VecDeque::new();
+
+            let event = Event::Submit(ViewId::RefreshRateRegularInput, "bad".to_string());
+            let (display, _) = setting.handle(&event, &mut settings, &mut bus);
+
+            assert_eq!(display.as_deref(), Some("5 / 10"));
+        }
+
+        #[test]
+        fn handle_unrelated_event_returns_none() {
+            let setting = RefreshRateInfo;
+            let mut settings = Settings::default();
+            let mut bus: Bus = VecDeque::new();
+
+            let (display, handled) =
+                setting.handle(&Event::Select(EntryId::About), &mut settings, &mut bus);
+
+            assert!(display.is_none());
+            assert!(!handled);
         }
     }
 }

--- a/crates/core/src/view/settings_editor/kinds/reader.rs
+++ b/crates/core/src/view/settings_editor/kinds/reader.rs
@@ -451,7 +451,17 @@ mod tests {
             let event = Event::Submit(ViewId::RefreshRateRegularInput, "3".to_string());
             let (display, handled) = setting.handle(&event, &mut settings, &mut bus);
 
-            assert_eq!(display.as_deref(), Some("3 / 10"));
+            assert_eq!(
+                display.as_deref(),
+                Some(
+                    fl!(
+                        "settings-reader-refresh-rate-summary",
+                        regular = 3u8,
+                        inverted = 10u8
+                    )
+                    .as_str()
+                )
+            );
             assert!(!handled);
             assert_eq!(settings.reader.refresh_rate.global.regular, 5);
         }
@@ -467,7 +477,17 @@ mod tests {
             let event = Event::Submit(ViewId::RefreshRateInvertedInput, "7".to_string());
             let (display, handled) = setting.handle(&event, &mut settings, &mut bus);
 
-            assert_eq!(display.as_deref(), Some("5 / 7"));
+            assert_eq!(
+                display.as_deref(),
+                Some(
+                    fl!(
+                        "settings-reader-refresh-rate-summary",
+                        regular = 5u8,
+                        inverted = 7u8
+                    )
+                    .as_str()
+                )
+            );
             assert!(!handled);
             assert_eq!(settings.reader.refresh_rate.global.inverted, 10);
         }
@@ -483,7 +503,17 @@ mod tests {
             let event = Event::Submit(ViewId::RefreshRateRegularInput, "bad".to_string());
             let (display, _) = setting.handle(&event, &mut settings, &mut bus);
 
-            assert_eq!(display.as_deref(), Some("5 / 10"));
+            assert_eq!(
+                display.as_deref(),
+                Some(
+                    fl!(
+                        "settings-reader-refresh-rate-summary",
+                        regular = 5u8,
+                        inverted = 10u8
+                    )
+                    .as_str()
+                )
+            );
         }
 
         #[test]

--- a/crates/core/src/view/settings_editor/kinds/reader.rs
+++ b/crates/core/src/view/settings_editor/kinds/reader.rs
@@ -97,11 +97,25 @@ impl SettingKind for RefreshRateInfo {
         match evt {
             Event::Submit(ViewId::RefreshRateRegularInput, text) => {
                 let regular = text.parse::<u8>().unwrap_or(global.regular);
-                (Some(format!("{} / {}", regular, global.inverted)), false)
+                (
+                    Some(fl!(
+                        "settings-reader-refresh-rate-summary",
+                        regular = regular,
+                        inverted = global.inverted
+                    )),
+                    false,
+                )
             }
             Event::Submit(ViewId::RefreshRateInvertedInput, text) => {
                 let inverted = text.parse::<u8>().unwrap_or(global.inverted);
-                (Some(format!("{} / {}", global.regular, inverted)), false)
+                (
+                    Some(fl!(
+                        "settings-reader-refresh-rate-summary",
+                        regular = global.regular,
+                        inverted = inverted
+                    )),
+                    false,
+                )
             }
             _ => (None, false),
         }

--- a/crates/core/src/view/settings_editor/kinds/reader.rs
+++ b/crates/core/src/view/settings_editor/kinds/reader.rs
@@ -2,8 +2,9 @@
 
 use super::{SettingData, SettingIdentity, SettingKind, WidgetKind};
 use crate::fl;
+use crate::geom::Rectangle;
 use crate::i18n::I18nDisplay;
-use crate::settings::{FinishedAction, Settings};
+use crate::settings::{FileExtension, FinishedAction, RefreshRatePair, Settings};
 use crate::view::{Bus, EntryId, EntryKind, Event};
 
 /// Reader finished action setting
@@ -55,6 +56,279 @@ impl SettingKind for FinishedActionSetting {
             settings.reader.finished = *action;
             return (Some(action.to_i18n_string()), true);
         }
+        (None, false)
+    }
+}
+
+/// Shows global refresh rate and opens the RefreshRateByKindEditor on tap.
+pub struct RefreshRateInfo;
+
+impl SettingKind for RefreshRateInfo {
+    fn identity(&self) -> SettingIdentity {
+        SettingIdentity::RefreshRate
+    }
+
+    fn label(&self, _settings: &Settings) -> String {
+        fl!("settings-reader-refresh-rate")
+    }
+
+    fn fetch(&self, settings: &Settings) -> SettingData {
+        let global = &settings.reader.refresh_rate.global;
+        let value = format!("{} / {}", global.regular, global.inverted);
+
+        SettingData {
+            value,
+            widget: WidgetKind::ActionLabel(Event::OpenRefreshRateEditor),
+        }
+    }
+}
+
+/// Shows the refresh rate pair for a specific file extension.
+pub struct RefreshRateByKindInfo(pub FileExtension);
+
+impl SettingKind for RefreshRateByKindInfo {
+    fn identity(&self) -> SettingIdentity {
+        SettingIdentity::RefreshRateByKind(self.0.as_str().to_string())
+    }
+
+    fn label(&self, _settings: &Settings) -> String {
+        self.0.to_string().to_uppercase()
+    }
+
+    fn fetch(&self, settings: &Settings) -> SettingData {
+        let pair = settings
+            .reader
+            .refresh_rate
+            .by_kind
+            .get(self.0.as_str())
+            .cloned()
+            .unwrap_or(RefreshRatePair {
+                regular: 0,
+                inverted: 0,
+            });
+
+        let value = format!("{} / {}", pair.regular, pair.inverted);
+
+        SettingData {
+            value,
+            widget: WidgetKind::ActionLabel(Event::Select(EntryId::EditRefreshRateByKind(self.0))),
+        }
+    }
+
+    fn hold_event(&self, rect: Rectangle) -> Option<Event> {
+        let entries = vec![EntryKind::Command(
+            fl!("delete"),
+            EntryId::DeleteRefreshRateByKind(self.0),
+        )];
+
+        Some(Event::SubMenu(rect, entries))
+    }
+}
+
+/// The "regular" field of the global refresh rate pair.
+pub struct RefreshRateRegularSetting;
+
+impl SettingKind for RefreshRateRegularSetting {
+    fn identity(&self) -> SettingIdentity {
+        SettingIdentity::RefreshRateRegular
+    }
+
+    fn label(&self, _settings: &Settings) -> String {
+        fl!("settings-reader-refresh-rate-regular")
+    }
+
+    fn fetch(&self, settings: &Settings) -> SettingData {
+        let value = settings.reader.refresh_rate.global.regular.to_string();
+
+        SettingData {
+            value,
+            widget: WidgetKind::ActionLabel(Event::OpenNamedInput {
+                view_id: crate::view::ViewId::RefreshRateRegularInput,
+                label: fl!("settings-reader-refresh-rate-regular-input"),
+                max_chars: 3,
+                initial_text: settings.reader.refresh_rate.global.regular.to_string(),
+            }),
+        }
+    }
+
+    fn handle(
+        &self,
+        evt: &Event,
+        settings: &mut Settings,
+        _bus: &mut Bus,
+    ) -> (Option<String>, bool) {
+        if let Event::Submit(crate::view::ViewId::RefreshRateRegularInput, ref text) = evt {
+            if let Ok(v) = text.parse::<u8>() {
+                settings.reader.refresh_rate.global.regular = v;
+                return (Some(v.to_string()), true);
+            }
+        }
+
+        (None, false)
+    }
+}
+
+/// The "inverted" field of the global refresh rate pair.
+pub struct RefreshRateInvertedSetting;
+
+impl SettingKind for RefreshRateInvertedSetting {
+    fn identity(&self) -> SettingIdentity {
+        SettingIdentity::RefreshRateInverted
+    }
+
+    fn label(&self, _settings: &Settings) -> String {
+        fl!("settings-reader-refresh-rate-inverted")
+    }
+
+    fn fetch(&self, settings: &Settings) -> SettingData {
+        let value = settings.reader.refresh_rate.global.inverted.to_string();
+
+        SettingData {
+            value,
+            widget: WidgetKind::ActionLabel(Event::OpenNamedInput {
+                view_id: crate::view::ViewId::RefreshRateInvertedInput,
+                label: fl!("settings-reader-refresh-rate-inverted-input"),
+                max_chars: 3,
+                initial_text: settings.reader.refresh_rate.global.inverted.to_string(),
+            }),
+        }
+    }
+
+    fn handle(
+        &self,
+        evt: &Event,
+        settings: &mut Settings,
+        _bus: &mut Bus,
+    ) -> (Option<String>, bool) {
+        if let Event::Submit(crate::view::ViewId::RefreshRateInvertedInput, ref text) = evt {
+            if let Ok(v) = text.parse::<u8>() {
+                settings.reader.refresh_rate.global.inverted = v;
+                return (Some(v.to_string()), true);
+            }
+        }
+
+        (None, false)
+    }
+}
+
+/// The "regular" field of a per-kind refresh rate pair.
+pub struct RefreshRateByKindRegular(pub FileExtension);
+
+impl SettingKind for RefreshRateByKindRegular {
+    fn identity(&self) -> SettingIdentity {
+        SettingIdentity::RefreshRateByKindRegular(self.0.as_str().to_string())
+    }
+
+    fn label(&self, _settings: &Settings) -> String {
+        fl!("settings-reader-refresh-rate-regular")
+    }
+
+    fn fetch(&self, settings: &Settings) -> SettingData {
+        let regular = settings
+            .reader
+            .refresh_rate
+            .by_kind
+            .get(self.0.as_str())
+            .map(|p| p.regular)
+            .unwrap_or(0);
+
+        SettingData {
+            value: regular.to_string(),
+            widget: WidgetKind::ActionLabel(Event::OpenNamedInput {
+                view_id: crate::view::ViewId::RefreshRateByKindRegularInput,
+                label: fl!(
+                    "settings-reader-refresh-rate-by-kind-regular-input",
+                    ext = self.0.as_str()
+                ),
+                max_chars: 3,
+                initial_text: regular.to_string(),
+            }),
+        }
+    }
+
+    fn handle(
+        &self,
+        evt: &Event,
+        settings: &mut Settings,
+        _bus: &mut Bus,
+    ) -> (Option<String>, bool) {
+        if let Event::Submit(crate::view::ViewId::RefreshRateByKindRegularInput, ref text) = evt {
+            if let Ok(v) = text.parse::<u8>() {
+                let pair = settings
+                    .reader
+                    .refresh_rate
+                    .by_kind
+                    .entry(self.0.as_str().to_string())
+                    .or_insert(RefreshRatePair {
+                        regular: 0,
+                        inverted: 0,
+                    });
+                pair.regular = v;
+                return (Some(v.to_string()), true);
+            }
+        }
+
+        (None, false)
+    }
+}
+
+/// The "inverted" field of a per-kind refresh rate pair.
+pub struct RefreshRateByKindInverted(pub FileExtension);
+
+impl SettingKind for RefreshRateByKindInverted {
+    fn identity(&self) -> SettingIdentity {
+        SettingIdentity::RefreshRateByKindInverted(self.0.as_str().to_string())
+    }
+
+    fn label(&self, _settings: &Settings) -> String {
+        fl!("settings-reader-refresh-rate-inverted")
+    }
+
+    fn fetch(&self, settings: &Settings) -> SettingData {
+        let inverted = settings
+            .reader
+            .refresh_rate
+            .by_kind
+            .get(self.0.as_str())
+            .map(|p| p.inverted)
+            .unwrap_or(0);
+
+        SettingData {
+            value: inverted.to_string(),
+            widget: WidgetKind::ActionLabel(Event::OpenNamedInput {
+                view_id: crate::view::ViewId::RefreshRateByKindInvertedInput,
+                label: fl!(
+                    "settings-reader-refresh-rate-by-kind-inverted-input",
+                    ext = self.0.as_str()
+                ),
+                max_chars: 3,
+                initial_text: inverted.to_string(),
+            }),
+        }
+    }
+
+    fn handle(
+        &self,
+        evt: &Event,
+        settings: &mut Settings,
+        _bus: &mut Bus,
+    ) -> (Option<String>, bool) {
+        if let Event::Submit(crate::view::ViewId::RefreshRateByKindInvertedInput, ref text) = evt {
+            if let Ok(v) = text.parse::<u8>() {
+                let pair = settings
+                    .reader
+                    .refresh_rate
+                    .by_kind
+                    .entry(self.0.as_str().to_string())
+                    .or_insert(RefreshRatePair {
+                        regular: 0,
+                        inverted: 0,
+                    });
+                pair.inverted = v;
+                return (Some(v.to_string()), true);
+            }
+        }
+
         (None, false)
     }
 }

--- a/crates/core/src/view/settings_editor/library_editor.rs
+++ b/crates/core/src/view/settings_editor/library_editor.rs
@@ -1,15 +1,18 @@
-use super::bottom_bar::{BottomBarVariant, SettingsEditorBottomBar};
+use super::bottom_bar::BottomBarVariant;
+use super::editor_utils::{
+    build_bottom_separator, build_two_button_bottom_bar, calculate_dimensions,
+};
 use super::kinds::library::{LibraryFinishedAction, LibraryName, LibraryPath};
 use super::kinds::SettingIdentity;
 use super::setting_row::SettingRow;
 use super::setting_value::SettingsEvent;
-use crate::color::{BLACK, WHITE};
+use crate::color::WHITE;
 use crate::context::Context;
 use crate::device::CURRENT_DEVICE;
 use crate::fl;
 use crate::font::Fonts;
 use crate::framebuffer::{Framebuffer, UpdateMode};
-use crate::geom::{halves, Rectangle};
+use crate::geom::Rectangle;
 use crate::gesture::GestureEvent;
 use crate::settings::{FinishedAction, LibrarySettings, Settings};
 use crate::unit::scale_by_dpi;
@@ -19,9 +22,9 @@ use crate::view::filler::Filler;
 use crate::view::menu::{Menu, MenuKind};
 use crate::view::named_input::NamedInput;
 use crate::view::toggleable_keyboard::ToggleableKeyboard;
+use crate::view::SMALL_BAR_HEIGHT;
 use crate::view::{Bus, Event, Hub, Id, RenderData, RenderQueue, View, ViewId, ID_FEEDER};
 use crate::view::{EntryId, NotificationEvent};
-use crate::view::{SMALL_BAR_HEIGHT, THICKNESS_MEDIUM};
 
 /// A view for editing library settings.
 ///
@@ -72,7 +75,7 @@ impl LibraryEditor {
         children.push(Box::new(Filler::new(rect, WHITE)) as Box<dyn View>);
 
         let (bar_height, separator_thickness, separator_top_half, separator_bottom_half) =
-            Self::calculate_dimensions();
+            calculate_dimensions();
 
         children.extend(Self::build_content_rows(
             rect,
@@ -83,7 +86,7 @@ impl LibraryEditor {
             &mut context.fonts,
         ));
 
-        children.push(Self::build_bottom_separator(
+        children.push(build_bottom_separator(
             rect,
             bar_height,
             separator_top_half,
@@ -112,22 +115,6 @@ impl LibraryEditor {
             focus: None,
             keyboard_index,
         }
-    }
-
-    #[inline]
-    fn calculate_dimensions() -> (i32, i32, i32, i32) {
-        let dpi = CURRENT_DEVICE.dpi;
-        let small_height = scale_by_dpi(SMALL_BAR_HEIGHT, dpi) as i32;
-        let separator_thickness = scale_by_dpi(THICKNESS_MEDIUM, dpi) as i32;
-        let (separator_top_half, separator_bottom_half) = halves(separator_thickness);
-        let bar_height = small_height;
-
-        (
-            bar_height,
-            separator_thickness,
-            separator_top_half,
-            separator_bottom_half,
-        )
     }
 
     #[inline]
@@ -229,47 +216,22 @@ impl LibraryEditor {
     }
 
     #[inline]
-    fn build_bottom_separator(
-        rect: Rectangle,
-        bar_height: i32,
-        separator_top_half: i32,
-        separator_bottom_half: i32,
-    ) -> Box<dyn View> {
-        let separator = Filler::new(
-            rect![
-                rect.min.x,
-                rect.max.y - bar_height - separator_top_half,
-                rect.max.x,
-                rect.max.y - bar_height + separator_bottom_half
-            ],
-            BLACK,
-        );
-        Box::new(separator) as Box<dyn View>
-    }
-
-    #[inline]
     fn build_bottom_bar(
         rect: Rectangle,
         bar_height: i32,
         separator_bottom_half: i32,
     ) -> Box<dyn View> {
-        let bottom_bar_rect = rect![
-            rect.min.x,
-            rect.max.y - bar_height + separator_bottom_half,
-            rect.max.x,
-            rect.max.y
-        ];
-
-        let bottom_bar = SettingsEditorBottomBar::new(
-            bottom_bar_rect,
+        build_two_button_bottom_bar(
+            rect,
+            bar_height,
+            separator_bottom_half,
             BottomBarVariant::TwoButtons {
                 left_event: Event::Close(ViewId::LibraryEditor),
                 left_icon: "close",
                 right_event: Event::Validate,
                 right_icon: "check_mark-large",
             },
-        );
-        Box::new(bottom_bar) as Box<dyn View>
+        )
     }
 
     #[inline]

--- a/crates/core/src/view/settings_editor/mod.rs
+++ b/crates/core/src/view/settings_editor/mod.rs
@@ -146,7 +146,9 @@ mod category_button;
 mod category_editor;
 mod category_navigation_bar;
 mod category_provider;
+mod editor_utils;
 mod library_editor;
+mod refresh_rate_by_kind_editor;
 mod setting_row;
 mod setting_value;
 

--- a/crates/core/src/view/settings_editor/refresh_rate_by_kind_editor.rs
+++ b/crates/core/src/view/settings_editor/refresh_rate_by_kind_editor.rs
@@ -1,0 +1,792 @@
+use super::bottom_bar::BottomBarVariant;
+use super::editor_utils::{
+    build_bottom_separator, build_two_button_bottom_bar, calculate_dimensions,
+};
+use super::kinds::reader::{
+    RefreshRateByKindInfo, RefreshRateByKindInverted, RefreshRateByKindRegular,
+    RefreshRateInvertedSetting, RefreshRateRegularSetting,
+};
+use super::kinds::SettingIdentity;
+use super::setting_row::SettingRow;
+use super::setting_value::SettingsEvent;
+use crate::color::WHITE;
+use crate::context::Context;
+use crate::device::CURRENT_DEVICE;
+use crate::fl;
+use crate::font::Fonts;
+use crate::framebuffer::{Framebuffer, UpdateMode};
+use crate::geom::Rectangle;
+use crate::settings::{FileExtension, RefreshRatePair, Settings};
+use crate::unit::scale_by_dpi;
+use crate::view::common::locate_by_id;
+use crate::view::filler::Filler;
+use crate::view::menu::{Menu, MenuKind};
+use crate::view::named_input::NamedInput;
+use crate::view::toggleable_keyboard::ToggleableKeyboard;
+use crate::view::SMALL_BAR_HEIGHT;
+use crate::view::{
+    Bus, EntryId, Event, Hub, Id, NotificationEvent, RenderData, RenderQueue, View, ViewId,
+    ID_FEEDER,
+};
+
+/// Sub-editor for the global refresh rate settings and per-file-extension overrides.
+///
+/// Shows two rows for the global `regular` and `inverted` values, followed by one
+/// row per entry currently present in `refresh_rate.by_kind`. A "+" button in the
+/// bottom bar lets the user pick an extension to add.
+///
+/// # Fields
+///
+/// * `id` - Unique identifier for this view
+/// * `rect` - Bounding rectangle
+/// * `children` - Child views (background, rows, separator, bottom bar, keyboard, overlays)
+/// * `add_button_rect` - Bounding rectangle of the "+" button, used to anchor the extension menu
+/// * `focus` - Currently focused input view, if any
+/// * `keyboard_index` - Index of the keyboard view in `children`
+pub struct RefreshRateByKindEditor {
+    id: Id,
+    rect: Rectangle,
+    children: Vec<Box<dyn View>>,
+    add_button_rect: Rectangle,
+    focus: Option<ViewId>,
+    keyboard_index: usize,
+}
+
+impl RefreshRateByKindEditor {
+    #[cfg_attr(feature = "tracing", tracing::instrument(skip(_hub, context, rq)))]
+    pub fn new(
+        rect: Rectangle,
+        _hub: &Hub,
+        rq: &mut RenderQueue,
+        context: &mut Context,
+    ) -> RefreshRateByKindEditor {
+        let id = ID_FEEDER.next();
+        let mut children = Vec::new();
+
+        children.push(Box::new(Filler::new(rect, WHITE)) as Box<dyn View>);
+
+        let (bar_height, separator_thickness, separator_top_half, separator_bottom_half) =
+            calculate_dimensions();
+
+        children.extend(Self::build_content_rows(
+            rect,
+            bar_height,
+            separator_thickness,
+            &context.settings,
+            &mut context.fonts,
+        ));
+
+        children.push(build_bottom_separator(
+            rect,
+            bar_height,
+            separator_top_half,
+            separator_bottom_half,
+        ));
+        children.push(Self::build_bottom_bar(
+            rect,
+            bar_height,
+            separator_bottom_half,
+        ));
+
+        let keyboard = ToggleableKeyboard::new(rect, false);
+        children.push(Box::new(keyboard) as Box<dyn View>);
+
+        let keyboard_index = children.len() - 1;
+
+        let add_button_rect = {
+            let bottom_bar_min_y = rect.max.y - bar_height + separator_bottom_half;
+            let mid_x = rect.min.x + (rect.max.x - rect.min.x) / 2;
+            rect![mid_x, bottom_bar_min_y, rect.max.x, rect.max.y]
+        };
+
+        rq.add(RenderData::new(id, rect, UpdateMode::Gui));
+
+        RefreshRateByKindEditor {
+            id,
+            rect,
+            children,
+            add_button_rect,
+            focus: None,
+            keyboard_index,
+        }
+    }
+
+    #[inline]
+    fn build_content_rows(
+        rect: Rectangle,
+        bar_height: i32,
+        separator_thickness: i32,
+        settings: &Settings,
+        fonts: &mut Fonts,
+    ) -> Vec<Box<dyn View>> {
+        let dpi = CURRENT_DEVICE.dpi;
+        let row_height = scale_by_dpi(SMALL_BAR_HEIGHT, dpi) as i32;
+
+        let content_end_y = rect.max.y - bar_height - separator_thickness;
+        let mut current_y = rect.min.y;
+        let mut rows: Vec<Box<dyn View>> = Vec::new();
+
+        if current_y + row_height <= content_end_y {
+            let row_rect = rect![rect.min.x, current_y, rect.max.x, current_y + row_height];
+            rows.push(Box::new(SettingRow::new(
+                Box::new(RefreshRateRegularSetting),
+                row_rect,
+                settings,
+                fonts,
+            )));
+            current_y += row_height;
+        }
+
+        if current_y + row_height <= content_end_y {
+            let row_rect = rect![rect.min.x, current_y, rect.max.x, current_y + row_height];
+            rows.push(Box::new(SettingRow::new(
+                Box::new(RefreshRateInvertedSetting),
+                row_rect,
+                settings,
+                fonts,
+            )));
+            current_y += row_height;
+        }
+
+        let mut by_kind: Vec<&str> = settings
+            .reader
+            .refresh_rate
+            .by_kind
+            .keys()
+            .map(String::as_str)
+            .collect();
+        by_kind.sort_unstable();
+
+        for ext_str in by_kind {
+            if current_y + row_height > content_end_y {
+                break;
+            }
+
+            if let Some(ext) = ext_str_to_file_extension(ext_str) {
+                let row_rect = rect![rect.min.x, current_y, rect.max.x, current_y + row_height];
+                rows.push(Box::new(SettingRow::new(
+                    Box::new(RefreshRateByKindInfo(ext)),
+                    row_rect,
+                    settings,
+                    fonts,
+                )));
+                current_y += row_height;
+            }
+        }
+
+        rows
+    }
+
+    #[inline]
+    fn build_bottom_bar(
+        rect: Rectangle,
+        bar_height: i32,
+        separator_bottom_half: i32,
+    ) -> Box<dyn View> {
+        build_two_button_bottom_bar(
+            rect,
+            bar_height,
+            separator_bottom_half,
+            BottomBarVariant::TwoButtons {
+                left_event: Event::Close(ViewId::RefreshRateByKindEditor),
+                left_icon: "close",
+                right_event: Event::Select(EntryId::AddRefreshRateByKind),
+                right_icon: "plus",
+            },
+        )
+    }
+
+    /// Fixed tail: background is at index 0; separator, bottom_bar, and keyboard
+    /// are the last FIXED_TAIL_LEN children appended after the content rows.
+    const FIXED_TAIL_LEN: usize = 3;
+
+    /// Rebuilds the content rows after settings change.
+    fn rebuild_rows(&mut self, rq: &mut RenderQueue, context: &mut Context) {
+        let (bar_height, separator_thickness, separator_top_half, separator_bottom_half) =
+            calculate_dimensions();
+
+        let new_rows = Self::build_content_rows(
+            self.rect,
+            bar_height,
+            separator_thickness,
+            &context.settings,
+            &mut context.fonts,
+        );
+
+        let rows_end = self.children.len() - Self::FIXED_TAIL_LEN;
+        self.children.drain(1..rows_end);
+
+        for (i, row) in new_rows.into_iter().enumerate() {
+            self.children.insert(1 + i, row);
+        }
+
+        self.keyboard_index = self.children.len() - 1;
+
+        let sep_index = self.children.len() - Self::FIXED_TAIL_LEN;
+        *self.children[sep_index].rect_mut() = *build_bottom_separator(
+            self.rect,
+            bar_height,
+            separator_top_half,
+            separator_bottom_half,
+        )
+        .rect();
+
+        rq.add(RenderData::new(self.id, self.rect, UpdateMode::Gui));
+    }
+
+    #[inline]
+    fn handle_focus_event(
+        &mut self,
+        focus: Option<ViewId>,
+        hub: &Hub,
+        rq: &mut RenderQueue,
+        context: &mut Context,
+    ) -> bool {
+        if self.focus != focus {
+            self.focus = focus;
+            let keyboard = self.children[self.keyboard_index]
+                .downcast_mut::<ToggleableKeyboard>()
+                .expect("keyboard_index points to non-ToggleableKeyboard view");
+            if focus.is_some() {
+                keyboard.set_visible(true, hub, rq, context);
+            } else {
+                keyboard.set_visible(false, hub, rq, context);
+            }
+        }
+        true
+    }
+
+    #[inline]
+    #[cfg_attr(feature = "tracing", tracing::instrument(skip(self, rq, context)))]
+    fn handle_add_by_kind_event(&mut self, rq: &mut RenderQueue, context: &mut Context) -> bool {
+        let already: std::collections::HashSet<String> = context
+            .settings
+            .reader
+            .refresh_rate
+            .by_kind
+            .keys()
+            .cloned()
+            .collect();
+
+        let entries: Vec<crate::view::EntryKind> = FileExtension::all()
+            .iter()
+            .filter(|ext| !already.contains(ext.as_str()))
+            .map(|ext| {
+                crate::view::EntryKind::Command(
+                    ext.to_string(),
+                    EntryId::EditRefreshRateByKind(*ext),
+                )
+            })
+            .collect();
+
+        if entries.is_empty() {
+            return true;
+        }
+
+        let menu = Menu::new(
+            self.add_button_rect,
+            ViewId::SettingsValueMenu,
+            MenuKind::Contextual,
+            entries,
+            context,
+        );
+        rq.add(RenderData::new(menu.id(), *menu.rect(), UpdateMode::Gui));
+        self.children.push(Box::new(menu));
+        true
+    }
+
+    /// Opens a sub-editor for the given file extension's regular/inverted pair.
+    #[inline]
+    #[cfg_attr(feature = "tracing", tracing::instrument(skip(self, hub, rq, context), fields(ext = ?ext)))]
+    fn handle_edit_by_kind_event(
+        &mut self,
+        ext: FileExtension,
+        hub: &Hub,
+        rq: &mut RenderQueue,
+        context: &mut Context,
+    ) -> bool {
+        context
+            .settings
+            .reader
+            .refresh_rate
+            .by_kind
+            .entry(ext.as_str().to_string())
+            .or_insert(RefreshRatePair {
+                regular: 0,
+                inverted: 0,
+            });
+
+        if let Some(index) = locate_by_id(self, ViewId::SettingsValueMenu) {
+            self.children.remove(index);
+        }
+
+        let editor = RefreshRateKindPairEditor::new(self.rect, ext, hub, rq, context);
+        self.children.push(Box::new(editor));
+        rq.add(RenderData::new(self.id, self.rect, UpdateMode::Gui));
+        true
+    }
+
+    /// Persists the updated refresh rate pair and rebuilds the row list.
+    ///
+    /// The [`RefreshRateKindPairEditor`] overlay is removed here explicitly
+    /// rather than relying on a subsequent `Event::Close`. `rebuild_rows`
+    /// computes the drain range from `children.len()`, so any overlay
+    /// appended after the keyboard would corrupt that range if left in place.
+    #[inline]
+    #[cfg_attr(feature = "tracing", tracing::instrument(skip(self, rq, context), fields(ext = ?ext)))]
+    fn handle_update_by_kind_event(
+        &mut self,
+        ext: FileExtension,
+        pair: &RefreshRatePair,
+        rq: &mut RenderQueue,
+        context: &mut Context,
+    ) -> bool {
+        if let Some(index) = locate_by_id(self, ViewId::RefreshRateKindPairEditor) {
+            self.children.remove(index);
+        }
+
+        context
+            .settings
+            .reader
+            .refresh_rate
+            .by_kind
+            .insert(ext.as_str().to_string(), pair.clone());
+        self.rebuild_rows(rq, context);
+        true
+    }
+
+    /// Removes the entry from settings and rebuilds the row list.
+    ///
+    /// Both the [`RefreshRateKindPairEditor`] and [`ViewId::SettingsValueMenu`]
+    /// overlays are removed here explicitly rather than relying on subsequent
+    /// `Event::Close` events. `rebuild_rows` computes the drain range from
+    /// `children.len()`, so any overlay appended after the keyboard would
+    /// corrupt that range if left in place.
+    #[inline]
+    #[cfg_attr(feature = "tracing", tracing::instrument(skip(self, rq, context), fields(ext = ?ext)))]
+    fn handle_delete_by_kind_event(
+        &mut self,
+        ext: FileExtension,
+        rq: &mut RenderQueue,
+        context: &mut Context,
+    ) -> bool {
+        context
+            .settings
+            .reader
+            .refresh_rate
+            .by_kind
+            .remove(ext.as_str());
+
+        if let Some(index) = locate_by_id(self, ViewId::RefreshRateKindPairEditor) {
+            self.children.remove(index);
+        }
+
+        if let Some(index) = locate_by_id(self, ViewId::SettingsValueMenu) {
+            self.children.remove(index);
+        }
+
+        self.rebuild_rows(rq, context);
+        true
+    }
+
+    #[inline]
+    #[cfg_attr(feature = "tracing", tracing::instrument(skip(self, entries, rq, context), fields(rect = ?rect)))]
+    fn handle_submenu_event(
+        &mut self,
+        rect: Rectangle,
+        entries: &[crate::view::EntryKind],
+        rq: &mut RenderQueue,
+        context: &mut Context,
+    ) -> bool {
+        let menu = Menu::new(
+            rect,
+            ViewId::SettingsValueMenu,
+            MenuKind::Contextual,
+            entries.to_vec(),
+            context,
+        );
+        rq.add(RenderData::new(menu.id(), *menu.rect(), UpdateMode::Gui));
+        self.children.push(Box::new(menu));
+        true
+    }
+
+    #[inline]
+    #[cfg_attr(feature = "tracing", tracing::instrument(skip(self, hub, rq), fields(view_id = ?view_id)))]
+    fn handle_close_event(&mut self, view_id: ViewId, hub: &Hub, rq: &mut RenderQueue) -> bool {
+        match view_id {
+            ViewId::SettingsValueMenu | ViewId::RefreshRateKindPairEditor => {
+                if let Some(index) = locate_by_id(self, view_id) {
+                    self.children.remove(index);
+                    rq.add(RenderData::new(self.id, self.rect, UpdateMode::Gui));
+                }
+                true
+            }
+            ViewId::RefreshRateRegularInput | ViewId::RefreshRateInvertedInput => {
+                if let Some(index) = locate_by_id(self, view_id) {
+                    let input_rect = *self.children[index].rect();
+                    self.children.remove(index);
+                    rq.add(RenderData::expose(input_rect, UpdateMode::Gui));
+                }
+                hub.send(Event::Focus(None)).ok();
+                true
+            }
+            _ => false,
+        }
+    }
+}
+
+impl View for RefreshRateByKindEditor {
+    #[cfg_attr(feature = "tracing", tracing::instrument(skip(self, hub, bus, rq, context), fields(event = ?evt), ret(level=tracing::Level::TRACE)))]
+    fn handle_event(
+        &mut self,
+        evt: &Event,
+        hub: &Hub,
+        bus: &mut Bus,
+        rq: &mut RenderQueue,
+        context: &mut Context,
+    ) -> bool {
+        match evt {
+            Event::Focus(v) => self.handle_focus_event(*v, hub, rq, context),
+            Event::Select(EntryId::AddRefreshRateByKind) => {
+                self.handle_add_by_kind_event(rq, context)
+            }
+            Event::Select(EntryId::EditRefreshRateByKind(ext)) => {
+                self.handle_edit_by_kind_event(*ext, hub, rq, context)
+            }
+            Event::Select(EntryId::DeleteRefreshRateByKind(ext)) => {
+                self.handle_delete_by_kind_event(*ext, rq, context)
+            }
+            Event::UpdateRefreshRateByKind(ext, pair) => {
+                self.handle_update_by_kind_event(*ext, pair, rq, context)
+            }
+            Event::SubMenu(rect, ref entries) => {
+                self.handle_submenu_event(*rect, entries, rq, context)
+            }
+            Event::Close(view_id) => self.handle_close_event(*view_id, hub, rq),
+            _ => {
+                let _ = bus;
+                false
+            }
+        }
+    }
+
+    #[cfg_attr(feature = "tracing", tracing::instrument(skip(self, _fb, _fonts), fields(rect = ?_rect)))]
+    fn render(&self, _fb: &mut dyn Framebuffer, _rect: Rectangle, _fonts: &mut Fonts) {}
+
+    fn rect(&self) -> &Rectangle {
+        &self.rect
+    }
+
+    fn rect_mut(&mut self) -> &mut Rectangle {
+        &mut self.rect
+    }
+
+    fn children(&self) -> &Vec<Box<dyn View>> {
+        &self.children
+    }
+
+    fn children_mut(&mut self) -> &mut Vec<Box<dyn View>> {
+        &mut self.children
+    }
+
+    fn id(&self) -> Id {
+        self.id
+    }
+
+    fn view_id(&self) -> Option<ViewId> {
+        Some(ViewId::RefreshRateByKindEditor)
+    }
+}
+
+/// Sub-editor for editing the regular/inverted pair for a specific file extension.
+struct RefreshRateKindPairEditor {
+    id: Id,
+    rect: Rectangle,
+    children: Vec<Box<dyn View>>,
+    ext: FileExtension,
+    pair: RefreshRatePair,
+    focus: Option<ViewId>,
+    keyboard_index: usize,
+    regular_input_valid: bool,
+    inverted_input_valid: bool,
+}
+
+impl RefreshRateKindPairEditor {
+    #[cfg_attr(feature = "tracing", tracing::instrument(skip(_hub, context, rq)))]
+    fn new(
+        rect: Rectangle,
+        ext: FileExtension,
+        _hub: &Hub,
+        rq: &mut RenderQueue,
+        context: &mut Context,
+    ) -> RefreshRateKindPairEditor {
+        let id = ID_FEEDER.next();
+        let mut children: Vec<Box<dyn View>> = Vec::new();
+
+        children.push(Box::new(Filler::new(rect, WHITE)) as Box<dyn View>);
+
+        let (bar_height, separator_thickness, separator_top_half, separator_bottom_half) =
+            calculate_dimensions();
+
+        let dpi = CURRENT_DEVICE.dpi;
+        let row_height = scale_by_dpi(SMALL_BAR_HEIGHT, dpi) as i32;
+        let content_end_y = rect.max.y - bar_height - separator_thickness;
+        let mut current_y = rect.min.y;
+
+        let pair = context
+            .settings
+            .reader
+            .refresh_rate
+            .by_kind
+            .get(ext.as_str())
+            .cloned()
+            .unwrap_or(RefreshRatePair {
+                regular: 0,
+                inverted: 0,
+            });
+
+        if current_y + row_height <= content_end_y {
+            let row_rect = rect![rect.min.x, current_y, rect.max.x, current_y + row_height];
+            children.push(Box::new(SettingRow::new(
+                Box::new(RefreshRateByKindRegular(ext)),
+                row_rect,
+                &context.settings,
+                &mut context.fonts,
+            )));
+            current_y += row_height;
+        }
+
+        if current_y + row_height <= content_end_y {
+            let row_rect = rect![rect.min.x, current_y, rect.max.x, current_y + row_height];
+            children.push(Box::new(SettingRow::new(
+                Box::new(RefreshRateByKindInverted(ext)),
+                row_rect,
+                &context.settings,
+                &mut context.fonts,
+            )));
+        }
+
+        children.push(build_bottom_separator(
+            rect,
+            bar_height,
+            separator_top_half,
+            separator_bottom_half,
+        ));
+        children.push(build_two_button_bottom_bar(
+            rect,
+            bar_height,
+            separator_bottom_half,
+            BottomBarVariant::TwoButtons {
+                left_event: Event::Close(ViewId::RefreshRateKindPairEditor),
+                left_icon: "close",
+                right_event: Event::Validate,
+                right_icon: "check_mark-large",
+            },
+        ));
+
+        let keyboard = ToggleableKeyboard::new(rect, false);
+        children.push(Box::new(keyboard) as Box<dyn View>);
+
+        let keyboard_index = children.len() - 1;
+
+        rq.add(RenderData::new(id, rect, UpdateMode::Gui));
+
+        RefreshRateKindPairEditor {
+            id,
+            rect,
+            children,
+            ext,
+            pair,
+            focus: None,
+            keyboard_index,
+            regular_input_valid: true,
+            inverted_input_valid: true,
+        }
+    }
+
+    #[inline]
+    #[cfg_attr(feature = "tracing", tracing::instrument(skip(self, hub, rq, context)))]
+    fn handle_focus_event(
+        &mut self,
+        focus: Option<ViewId>,
+        hub: &Hub,
+        rq: &mut RenderQueue,
+        context: &mut Context,
+    ) -> bool {
+        if self.focus != focus {
+            self.focus = focus;
+            let keyboard = self.children[self.keyboard_index]
+                .downcast_mut::<ToggleableKeyboard>()
+                .expect("keyboard_index points to non-ToggleableKeyboard view");
+            if focus.is_some() {
+                keyboard.set_visible(true, hub, rq, context);
+            } else {
+                keyboard.set_visible(false, hub, rq, context);
+            }
+        }
+        true
+    }
+
+    #[inline]
+    #[cfg_attr(feature = "tracing", tracing::instrument(skip(self, hub, bus)))]
+    fn handle_validate(&self, hub: &Hub, bus: &mut Bus) -> bool {
+        if !self.regular_input_valid || !self.inverted_input_valid {
+            hub.send(Event::Notification(NotificationEvent::Show(fl!(
+                "notification-refresh-rate-invalid"
+            ))))
+            .ok();
+            return true;
+        }
+        bus.push_back(Event::UpdateRefreshRateByKind(
+            self.ext,
+            Box::new(self.pair.clone()),
+        ));
+        true
+    }
+
+    #[inline]
+    #[cfg_attr(feature = "tracing", tracing::instrument(skip(self, bus)))]
+    fn handle_submit_regular(&mut self, text: &str, bus: &mut Bus) -> bool {
+        if let Ok(v) = text.parse::<u8>() {
+            self.pair.regular = v;
+            self.regular_input_valid = true;
+            bus.push_back(Event::Settings(SettingsEvent::UpdateValue {
+                kind: SettingIdentity::RefreshRateByKindRegular(self.ext.as_str().to_string()),
+                value: v.to_string(),
+            }));
+        } else {
+            self.regular_input_valid = false;
+        }
+        false
+    }
+
+    #[inline]
+    #[cfg_attr(feature = "tracing", tracing::instrument(skip(self, bus)))]
+    fn handle_submit_inverted(&mut self, text: &str, bus: &mut Bus) -> bool {
+        if let Ok(v) = text.parse::<u8>() {
+            self.pair.inverted = v;
+            self.inverted_input_valid = true;
+            bus.push_back(Event::Settings(SettingsEvent::UpdateValue {
+                kind: SettingIdentity::RefreshRateByKindInverted(self.ext.as_str().to_string()),
+                value: v.to_string(),
+            }));
+        } else {
+            self.inverted_input_valid = false;
+        }
+        false
+    }
+
+    #[inline]
+    #[cfg_attr(feature = "tracing", tracing::instrument(skip(self, hub, rq, context), fields(view_id = ?view_id)))]
+    fn handle_open_named_input(
+        &mut self,
+        view_id: ViewId,
+        label: &str,
+        max_chars: usize,
+        initial_text: &str,
+        hub: &Hub,
+        rq: &mut RenderQueue,
+        context: &mut Context,
+    ) -> bool {
+        let mut named_input =
+            NamedInput::new(label.to_string(), view_id, view_id, max_chars, context);
+        named_input.set_text(initial_text, rq, context);
+        self.children.push(Box::new(named_input));
+        hub.send(Event::Focus(Some(view_id))).ok();
+        rq.add(RenderData::new(self.id, self.rect, UpdateMode::Gui));
+        true
+    }
+
+    #[inline]
+    #[cfg_attr(feature = "tracing", tracing::instrument(skip(self, hub, rq), fields(view_id = ?view_id)))]
+    fn handle_close_event(&mut self, view_id: ViewId, hub: &Hub, rq: &mut RenderQueue) -> bool {
+        match view_id {
+            ViewId::RefreshRateByKindRegularInput | ViewId::RefreshRateByKindInvertedInput => {
+                if let Some(index) = locate_by_id(self, view_id) {
+                    let input_rect = *self.children[index].rect();
+                    self.children.remove(index);
+                    rq.add(RenderData::expose(input_rect, UpdateMode::Gui));
+                }
+                hub.send(Event::Focus(None)).ok();
+                true
+            }
+            _ => false,
+        }
+    }
+}
+
+impl View for RefreshRateKindPairEditor {
+    #[cfg_attr(feature = "tracing", tracing::instrument(skip(self, hub, bus, rq, context), fields(event = ?evt), ret(level=tracing::Level::TRACE)))]
+    fn handle_event(
+        &mut self,
+        evt: &Event,
+        hub: &Hub,
+        bus: &mut Bus,
+        rq: &mut RenderQueue,
+        context: &mut Context,
+    ) -> bool {
+        match evt {
+            Event::Focus(v) => self.handle_focus_event(*v, hub, rq, context),
+            Event::Validate => self.handle_validate(hub, bus),
+            Event::Submit(ViewId::RefreshRateByKindRegularInput, ref text) => {
+                self.handle_submit_regular(text, bus)
+            }
+            Event::Submit(ViewId::RefreshRateByKindInvertedInput, ref text) => {
+                self.handle_submit_inverted(text, bus)
+            }
+            Event::OpenNamedInput {
+                view_id,
+                ref label,
+                max_chars,
+                ref initial_text,
+            } => self.handle_open_named_input(
+                *view_id,
+                label,
+                *max_chars,
+                initial_text,
+                hub,
+                rq,
+                context,
+            ),
+            Event::Close(view_id) => self.handle_close_event(*view_id, hub, rq),
+            _ => {
+                let _ = bus;
+                false
+            }
+        }
+    }
+
+    #[cfg_attr(feature = "tracing", tracing::instrument(skip(self, _fb, _fonts), fields(rect = ?_rect)))]
+    fn render(&self, _fb: &mut dyn Framebuffer, _rect: Rectangle, _fonts: &mut Fonts) {}
+
+    fn rect(&self) -> &Rectangle {
+        &self.rect
+    }
+
+    fn rect_mut(&mut self) -> &mut Rectangle {
+        &mut self.rect
+    }
+
+    fn children(&self) -> &Vec<Box<dyn View>> {
+        &self.children
+    }
+
+    fn children_mut(&mut self) -> &mut Vec<Box<dyn View>> {
+        &mut self.children
+    }
+
+    fn id(&self) -> Id {
+        self.id
+    }
+
+    fn view_id(&self) -> Option<ViewId> {
+        Some(ViewId::RefreshRateKindPairEditor)
+    }
+}
+
+fn ext_str_to_file_extension(s: &str) -> Option<FileExtension> {
+    FileExtension::all()
+        .iter()
+        .find(|e| e.as_str() == s)
+        .copied()
+}

--- a/crates/core/src/view/settings_editor/refresh_rate_by_kind_editor.rs
+++ b/crates/core/src/view/settings_editor/refresh_rate_by_kind_editor.rs
@@ -88,7 +88,7 @@ impl RefreshRateByKindEditor {
             separator_bottom_half,
         ));
 
-        let keyboard = ToggleableKeyboard::new(rect, false);
+        let keyboard = ToggleableKeyboard::new(rect, true);
         children.push(Box::new(keyboard) as Box<dyn View>);
 
         let keyboard_index = children.len() - 1;
@@ -305,17 +305,6 @@ impl RefreshRateByKindEditor {
         rq: &mut RenderQueue,
         context: &mut Context,
     ) -> bool {
-        context
-            .settings
-            .reader
-            .refresh_rate
-            .by_kind
-            .entry(ext.as_str().to_string())
-            .or_insert(RefreshRatePair {
-                regular: 0,
-                inverted: 0,
-            });
-
         if let Some(index) = locate_by_id(self, ViewId::SettingsValueMenu) {
             self.children.remove(index);
         }
@@ -411,6 +400,27 @@ impl RefreshRateByKindEditor {
     }
 
     #[inline]
+    #[cfg_attr(feature = "tracing", tracing::instrument(skip(self, hub, rq, context), fields(view_id = ?view_id)))]
+    fn handle_open_named_input(
+        &mut self,
+        view_id: ViewId,
+        label: &str,
+        max_chars: usize,
+        initial_text: &str,
+        hub: &Hub,
+        rq: &mut RenderQueue,
+        context: &mut Context,
+    ) -> bool {
+        let mut named_input =
+            NamedInput::new(label.to_string(), view_id, view_id, max_chars, context);
+        named_input.set_text(initial_text, rq, context);
+        self.children.push(Box::new(named_input));
+        hub.send(Event::Focus(Some(view_id))).ok();
+        rq.add(RenderData::new(self.id, self.rect, UpdateMode::Gui));
+        true
+    }
+
+    #[inline]
     #[cfg_attr(feature = "tracing", tracing::instrument(skip(self, hub, rq), fields(view_id = ?view_id)))]
     fn handle_close_event(&mut self, view_id: ViewId, hub: &Hub, rq: &mut RenderQueue) -> bool {
         match view_id {
@@ -462,6 +472,20 @@ impl View for RefreshRateByKindEditor {
             Event::SubMenu(rect, ref entries) => {
                 self.handle_submenu_event(*rect, entries, rq, context)
             }
+            Event::OpenNamedInput {
+                view_id,
+                ref label,
+                max_chars,
+                ref initial_text,
+            } => self.handle_open_named_input(
+                *view_id,
+                label,
+                *max_chars,
+                initial_text,
+                hub,
+                rq,
+                context,
+            ),
             Event::Close(view_id) => self.handle_close_event(*view_id, hub, rq),
             _ => {
                 let _ = bus;

--- a/crates/core/src/view/settings_editor/refresh_rate_by_kind_editor.rs
+++ b/crates/core/src/view/settings_editor/refresh_rate_by_kind_editor.rs
@@ -400,6 +400,7 @@ impl RefreshRateByKindEditor {
     }
 
     #[inline]
+    #[allow(clippy::too_many_arguments)]
     #[cfg_attr(feature = "tracing", tracing::instrument(skip(self, hub, rq, context), fields(view_id = ?view_id)))]
     fn handle_open_named_input(
         &mut self,
@@ -701,6 +702,7 @@ impl RefreshRateKindPairEditor {
     }
 
     #[inline]
+    #[allow(clippy::too_many_arguments)]
     #[cfg_attr(feature = "tracing", tracing::instrument(skip(self, hub, rq, context), fields(view_id = ?view_id)))]
     fn handle_open_named_input(
         &mut self,

--- a/crates/core/src/view/settings_editor/refresh_rate_by_kind_editor.rs
+++ b/crates/core/src/view/settings_editor/refresh_rate_by_kind_editor.rs
@@ -609,7 +609,7 @@ impl RefreshRateKindPairEditor {
             },
         ));
 
-        let keyboard = ToggleableKeyboard::new(rect, false);
+        let keyboard = ToggleableKeyboard::new(rect, true);
         children.push(Box::new(keyboard) as Box<dyn View>);
 
         let keyboard_index = children.len() - 1;

--- a/crates/emulator/src/main.rs
+++ b/crates/emulator/src/main.rs
@@ -398,6 +398,13 @@ fn run() -> Result<(), Error> {
     'outer: loop {
         let mut event_pump = sdl_context.event_pump().unwrap();
         while let Some(sdl_evt) = event_pump.poll_event() {
+            #[cfg(feature = "tracing")]
+            let span = tracing::trace_span!("main-event-loop", event = ?sdl_evt);
+            #[cfg(feature = "tracing")]
+            let _enter = span.enter();
+            #[cfg(feature = "tracing")]
+            tracing::trace!(event = ?sdl_evt, "handling event");
+
             match sdl_evt {
                 SdlEvent::Quit { .. }
                 | SdlEvent::KeyDown {
@@ -543,6 +550,13 @@ fn run() -> Result<(), Error> {
         }
 
         while let Ok(evt) = rx.recv_timeout(Duration::from_millis(20)) {
+            #[cfg(feature = "tracing")]
+            let span = tracing::trace_span!("main-event-loop", event = ?evt);
+            #[cfg(feature = "tracing")]
+            let _enter = span.enter();
+            #[cfg(feature = "tracing")]
+            tracing::trace!(event = ?evt, "handling event");
+
             background_tasks.handle_event(&evt, &tx, &context.database, &context.settings);
             match evt {
                 Event::Open(info) => {

--- a/crates/emulator/src/main.rs
+++ b/crates/emulator/src/main.rs
@@ -399,7 +399,7 @@ fn run() -> Result<(), Error> {
         let mut event_pump = sdl_context.event_pump().unwrap();
         while let Some(sdl_evt) = event_pump.poll_event() {
             #[cfg(feature = "tracing")]
-            let span = tracing::trace_span!("main-event-loop", event = ?sdl_evt);
+            let span = tracing::trace_span!("sdl-event-loop", event = ?sdl_evt);
             #[cfg(feature = "tracing")]
             let _enter = span.enter();
             #[cfg(feature = "tracing")]
@@ -551,7 +551,7 @@ fn run() -> Result<(), Error> {
 
         while let Ok(evt) = rx.recv_timeout(Duration::from_millis(20)) {
             #[cfg(feature = "tracing")]
-            let span = tracing::trace_span!("main-event-loop", event = ?evt);
+            let span = tracing::trace_span!("internal-event-loop", event = ?evt);
             #[cfg(feature = "tracing")]
             let _enter = span.enter();
             #[cfg(feature = "tracing")]

--- a/crates/importer/src/main.rs
+++ b/crates/importer/src/main.rs
@@ -92,10 +92,11 @@ fn main() -> Result<(), Error> {
         ..Default::default()
     };
 
-    if let Some(allowed_kinds) = matches
-        .opt_str("k")
-        .map(|v| v.split(',').map(|k| k.to_string()).collect())
-    {
+    if let Some(allowed_kinds) = matches.opt_str("k").map(|v| {
+        v.split(',')
+            .filter_map(|k| cadmus_core::settings::FileExtension::from_str(k))
+            .collect()
+    }) {
         import_settings.allowed_kinds = allowed_kinds;
     }
 

--- a/crates/importer/src/main.rs
+++ b/crates/importer/src/main.rs
@@ -94,7 +94,15 @@ fn main() -> Result<(), Error> {
 
     if let Some(allowed_kinds) = matches.opt_str("k").map(|v| {
         v.split(',')
-            .filter_map(|k| cadmus_core::settings::FileExtension::from_str(k))
+            .filter_map(
+                |k| match k.parse::<cadmus_core::settings::FileExtension>() {
+                    Ok(ext) => Some(ext),
+                    Err(()) => {
+                        eprintln!("Warning: unknown file extension '{k}', skipping");
+                        None
+                    }
+                },
+            )
             .collect()
     }) {
         import_settings.allowed_kinds = allowed_kinds;


### PR DESCRIPTION
Closes: CAD-13

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added refresh rate settings editor to Reader configuration with support for global and per-file-extension overrides.
  * Added regular and inverted page-turn mode refresh rate controls with range validation (0–255).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OGKevin/cadmus/pull/478?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->