### PR TITLE
feat(Intermission): add blank screens

### DIFF
--- a/contrib/Settings-sample.toml
+++ b/contrib/Settings-sample.toml
@@ -95,8 +95,10 @@ path = "/mnt/onboard/.kobo/kepub"
 # finished = "go-to-next"  # Optional: overrides reader.finished for this library
 
 # Defines the images displayed when entering an intermission.
-# Suspend supports "logo:", "cover:", "calendar:", and custom image paths.
-# Power-off and share support "logo:", "cover:", and custom image paths.
+# Suspend supports "logo:", "cover:", "calendar:", "blank:",
+# "blank-inverted:", and custom image paths.
+# Power-off and share support "logo:", "cover:", "blank:",
+# "blank-inverted:", and custom image paths.
 # If a relative file path is given, it will be relative to
 # the installation directory.
 # Setting suspend to "calendar:" will show the calendar when the device

--- a/crates/core/i18n/en-GB/cadmus_core.ftl
+++ b/crates/core/i18n/en-GB/cadmus_core.ftl
@@ -65,9 +65,9 @@ settings-reader-refresh-rate-regular-input = Regular refresh rate (0 = never)
 settings-reader-refresh-rate-summary = { $regular } / { $inverted }
 
 # Settings - Intermission
-settings-intermission-calendar = Calendar
 settings-intermission-blank = Blank
 settings-intermission-blank-inverted = Blank Inverted
+settings-intermission-calendar = Calendar
 settings-intermission-cover = Cover
 settings-intermission-custom = Custom
 settings-intermission-custom-image = Custom Image...

--- a/crates/core/i18n/en-GB/cadmus_core.ftl
+++ b/crates/core/i18n/en-GB/cadmus_core.ftl
@@ -65,14 +65,16 @@ settings-reader-refresh-rate-regular-input = Regular refresh rate (0 = never)
 settings-reader-refresh-rate-summary = { $regular } / { $inverted }
 
 # Settings - Intermission
-settings-intermission-suspend-screen = Suspend Screen
+settings-intermission-calendar = Calendar
+settings-intermission-blank = Blank
+settings-intermission-blank-inverted = Blank Inverted
+settings-intermission-cover = Cover
+settings-intermission-custom = Custom
+settings-intermission-custom-image = Custom Image...
+settings-intermission-logo = Logo
 settings-intermission-power-off-screen = Power Off Screen
 settings-intermission-share-screen = Share Screen
-settings-intermission-logo = Logo
-settings-intermission-cover = Cover
-settings-intermission-calendar = Calendar
-settings-intermission-custom-image = Custom Image...
-settings-intermission-custom = Custom
+settings-intermission-suspend-screen = Suspend Screen
 
 # Settings - Library
 settings-library-name = Name

--- a/crates/core/src/settings/mod.rs
+++ b/crates/core/src/settings/mod.rs
@@ -26,9 +26,12 @@ pub const EXTERNAL_CARD_ROOT: &str = "/mnt/sd";
 const LOGO_SPECIAL_PATH: &str = "logo:";
 const COVER_SPECIAL_PATH: &str = "cover:";
 const CALENDAR_SPECIAL_PATH: &str = "calendar:";
+const BLANK_SPECIAL_PATH: &str = "blank:";
+const BLANK_INVERTED_SPECIAL_PATH: &str = "blank-inverted:";
 
 /// How to display intermission screens.
-/// Logo, Cover and Calendar are special values that map to built-in displays.
+/// Logo, Cover, Calendar, Blank and BlankInverted are special values that map
+/// to built-in displays.
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub enum IntermissionDisplay {
     /// Display the built-in logo image.
@@ -37,6 +40,10 @@ pub enum IntermissionDisplay {
     Cover,
     /// Display the built-in calendar view.
     Calendar,
+    /// Display a blank white screen.
+    Blank,
+    /// Display a blank black screen.
+    BlankInverted,
     /// Display a custom image from the given path.
     Image(PathBuf),
 }
@@ -50,6 +57,10 @@ impl Serialize for IntermissionDisplay {
             IntermissionDisplay::Logo => serializer.serialize_str(LOGO_SPECIAL_PATH),
             IntermissionDisplay::Cover => serializer.serialize_str(COVER_SPECIAL_PATH),
             IntermissionDisplay::Calendar => serializer.serialize_str(CALENDAR_SPECIAL_PATH),
+            IntermissionDisplay::Blank => serializer.serialize_str(BLANK_SPECIAL_PATH),
+            IntermissionDisplay::BlankInverted => {
+                serializer.serialize_str(BLANK_INVERTED_SPECIAL_PATH)
+            }
             IntermissionDisplay::Image(path) => {
                 serializer.serialize_str(path.to_string_lossy().as_ref())
             }
@@ -67,6 +78,8 @@ impl<'de> Deserialize<'de> for IntermissionDisplay {
             LOGO_SPECIAL_PATH => IntermissionDisplay::Logo,
             COVER_SPECIAL_PATH => IntermissionDisplay::Cover,
             CALENDAR_SPECIAL_PATH => IntermissionDisplay::Calendar,
+            BLANK_SPECIAL_PATH => IntermissionDisplay::Blank,
+            BLANK_INVERTED_SPECIAL_PATH => IntermissionDisplay::BlankInverted,
             _ => IntermissionDisplay::Image(PathBuf::from(s)),
         })
     }
@@ -78,6 +91,8 @@ impl fmt::Display for IntermissionDisplay {
             IntermissionDisplay::Logo => write!(f, "Logo"),
             IntermissionDisplay::Cover => write!(f, "Cover"),
             IntermissionDisplay::Calendar => write!(f, "Calendar"),
+            IntermissionDisplay::Blank => write!(f, "Blank"),
+            IntermissionDisplay::BlankInverted => write!(f, "Blank Inverted"),
             IntermissionDisplay::Image(_) => write!(f, "Custom"),
         }
     }
@@ -930,20 +945,20 @@ mod tests {
     #[test]
     fn test_intermissions_struct_serialization() {
         let intermissions = Intermissions {
-            suspend: IntermissionDisplay::Logo,
-            power_off: IntermissionDisplay::Cover,
+            suspend: IntermissionDisplay::Blank,
+            power_off: IntermissionDisplay::BlankInverted,
             share: IntermissionDisplay::Image(PathBuf::from("/custom/share.png")),
         };
 
         let serialized = toml::to_string(&intermissions).expect("Failed to serialize");
 
         assert!(
-            serialized.contains("logo:"),
-            "Should contain logo: for suspend"
+            serialized.contains("blank:"),
+            "Should contain blank: for suspend"
         );
         assert!(
-            serialized.contains("cover:"),
-            "Should contain cover: for power-off"
+            serialized.contains("blank-inverted:"),
+            "Should contain blank-inverted: for power-off"
         );
         assert!(
             serialized.contains("/custom/share.png"),
@@ -954,20 +969,20 @@ mod tests {
     #[test]
     fn test_intermissions_struct_deserialization() {
         let toml_str = r#"
-suspend = "logo:"
-power-off = "cover:"
+suspend = "blank:"
+power-off = "blank-inverted:"
 share = "/path/to/custom.png"
 "#;
 
         let intermissions: Intermissions = toml::from_str(toml_str).expect("Failed to deserialize");
 
         assert!(
-            matches!(intermissions.suspend, IntermissionDisplay::Logo),
-            "suspend should deserialize to Logo"
+            matches!(intermissions.suspend, IntermissionDisplay::Blank),
+            "suspend should deserialize to Blank"
         );
         assert!(
-            matches!(intermissions.power_off, IntermissionDisplay::Cover),
-            "power_off should deserialize to Cover"
+            matches!(intermissions.power_off, IntermissionDisplay::BlankInverted),
+            "power_off should deserialize to BlankInverted"
         );
         assert!(
             matches!(
@@ -981,8 +996,8 @@ share = "/path/to/custom.png"
     #[test]
     fn test_intermissions_struct_round_trip() {
         let original = Intermissions {
-            suspend: IntermissionDisplay::Logo,
-            power_off: IntermissionDisplay::Cover,
+            suspend: IntermissionDisplay::Blank,
+            power_off: IntermissionDisplay::BlankInverted,
             share: IntermissionDisplay::Image(PathBuf::from("/some/custom/image.jpg")),
         };
 
@@ -1025,6 +1040,29 @@ share = "/path/to/custom.png"
             intermissions[IntermKind::Suspend],
             IntermissionDisplay::Calendar
         );
+    }
+
+    #[test]
+    fn test_intermissions_accept_blank_selection_for_all_kinds() {
+        let mut intermissions = Intermissions {
+            suspend: IntermissionDisplay::Logo,
+            power_off: IntermissionDisplay::Logo,
+            share: IntermissionDisplay::Logo,
+        };
+
+        assert!(intermissions.set_display(IntermKind::Suspend, IntermissionDisplay::Blank));
+        assert!(intermissions.set_display(IntermKind::PowerOff, IntermissionDisplay::BlankInverted));
+        assert!(intermissions.set_display(IntermKind::Share, IntermissionDisplay::Blank));
+
+        assert_eq!(
+            intermissions[IntermKind::Suspend],
+            IntermissionDisplay::Blank
+        );
+        assert_eq!(
+            intermissions[IntermKind::PowerOff],
+            IntermissionDisplay::BlankInverted
+        );
+        assert_eq!(intermissions[IntermKind::Share], IntermissionDisplay::Blank);
     }
 
     #[test]

--- a/crates/core/src/view/intermission/mod.rs
+++ b/crates/core/src/view/intermission/mod.rs
@@ -1,7 +1,7 @@
 mod calendar;
 
 use super::{Bus, Event, Hub, Id, RenderQueue, View, ID_FEEDER};
-use crate::color::{TEXT_INVERTED_HARD, TEXT_NORMAL};
+use crate::color::{Color, BLACK, TEXT_INVERTED_HARD, TEXT_NORMAL, WHITE};
 use crate::context::Context;
 use crate::device::CURRENT_DEVICE;
 use crate::document::{open, Location};
@@ -30,6 +30,7 @@ enum Message {
     Cover(PathBuf),
     /// Calendar rendering is delegated entirely to the CalendarView child.
     Calendar,
+    Fill(Color),
 }
 
 impl Intermission {
@@ -48,6 +49,8 @@ impl Intermission {
                         };
                     (msg, Vec::new())
                 }
+                IntermissionDisplay::Blank => (Message::Fill(WHITE), Vec::new()),
+                IntermissionDisplay::BlankInverted => (Message::Fill(BLACK), Vec::new()),
                 IntermissionDisplay::Image(path) => (Message::Image(path.clone()), Vec::new()),
                 IntermissionDisplay::Calendar => {
                     let minutes_until_poweroff = context
@@ -74,6 +77,8 @@ impl I18nDisplay for IntermissionDisplay {
     fn to_i18n_string(&self) -> String {
         match self {
             IntermissionDisplay::Logo => fl!("settings-intermission-logo"),
+            IntermissionDisplay::Blank => fl!("settings-intermission-blank"),
+            IntermissionDisplay::BlankInverted => fl!("settings-intermission-blank-inverted"),
             IntermissionDisplay::Cover => fl!("settings-intermission-cover"),
             IntermissionDisplay::Calendar => fl!("settings-intermission-calendar"),
             IntermissionDisplay::Image(_) => fl!("settings-intermission-custom"),
@@ -184,6 +189,9 @@ impl View for Intermission {
                         }
                     }
                 }
+            }
+            Message::Fill(color) => {
+                fb.draw_rectangle(&self.rect, color);
             }
             // CalendarView child handles its own rendering; this arm is never
             // reached because Intermission has children in the Calendar case.

--- a/crates/core/src/view/settings_editor/category_editor.rs
+++ b/crates/core/src/view/settings_editor/category_editor.rs
@@ -1095,6 +1095,35 @@ mod tests {
     }
 
     #[test]
+    fn test_set_intermission_blank_inverted() {
+        use crate::settings::{IntermKind, IntermissionDisplay};
+
+        let mut context = create_test_context();
+        let mut editor = create_test_intermissions_category_editor(&mut context);
+        let (hub, _receiver) = channel();
+        let mut bus = VecDeque::new();
+        let mut rq = RenderQueue::new();
+
+        let handled = crate::view::handle_event(
+            &mut editor,
+            &Event::Select(EntryId::SetIntermission(
+                IntermKind::Share,
+                IntermissionDisplay::BlankInverted,
+            )),
+            &hub,
+            &mut bus,
+            &mut rq,
+            &mut context,
+        );
+
+        assert!(handled);
+        assert!(matches!(
+            context.settings.intermissions[IntermKind::Share],
+            IntermissionDisplay::BlankInverted
+        ));
+    }
+
+    #[test]
     fn test_pagination_children_structure() {
         let mut context = create_test_context();
         context.settings = Settings::default();

--- a/crates/core/src/view/settings_editor/kinds/intermission.rs
+++ b/crates/core/src/view/settings_editor/kinds/intermission.rs
@@ -9,40 +9,30 @@ use crate::view::{Bus, EntryId, EntryKind, Event};
 /// Fetches the intermission display setting data for the given intermission kind
 fn fetch_intermission(kind: IntermKind, settings: &Settings) -> SettingData {
     let display = &settings.intermissions[kind];
-
-    let (value, is_logo, is_cover, is_calendar) = match display {
-        IntermissionDisplay::Logo => (display.to_i18n_string(), true, false, false),
-        IntermissionDisplay::Cover => (display.to_i18n_string(), false, true, false),
-        IntermissionDisplay::Calendar if kind.supports_calendar() => {
-            (display.to_i18n_string(), false, false, true)
-        }
-        IntermissionDisplay::Calendar => (
-            IntermissionDisplay::Logo.to_i18n_string(),
-            true,
-            false,
-            false,
-        ),
-        IntermissionDisplay::Image(path) => {
-            let i18n_display = fl!("settings-intermission-custom");
-            let display_name = path
-                .file_name()
-                .and_then(|n| n.to_str())
-                .unwrap_or(i18n_display.as_str())
-                .to_string();
-            (display_name, false, false, false)
-        }
-    };
+    let value = intermission_display_name(display);
+    let selected = selected_builtin_intermission(kind, display);
+    let is_selected = |candidate| selected.as_ref() == Some(&candidate);
 
     let mut entries = vec![
         EntryKind::RadioButton(
             IntermissionDisplay::Logo.to_i18n_string(),
             EntryId::SetIntermission(kind, IntermissionDisplay::Logo),
-            is_logo,
+            is_selected(IntermissionDisplay::Logo),
         ),
         EntryKind::RadioButton(
             IntermissionDisplay::Cover.to_i18n_string(),
             EntryId::SetIntermission(kind, IntermissionDisplay::Cover),
-            is_cover,
+            is_selected(IntermissionDisplay::Cover),
+        ),
+        EntryKind::RadioButton(
+            IntermissionDisplay::Blank.to_i18n_string(),
+            EntryId::SetIntermission(kind, IntermissionDisplay::Blank),
+            is_selected(IntermissionDisplay::Blank),
+        ),
+        EntryKind::RadioButton(
+            IntermissionDisplay::BlankInverted.to_i18n_string(),
+            EntryId::SetIntermission(kind, IntermissionDisplay::BlankInverted),
+            is_selected(IntermissionDisplay::BlankInverted),
         ),
     ];
 
@@ -50,7 +40,7 @@ fn fetch_intermission(kind: IntermKind, settings: &Settings) -> SettingData {
         entries.push(EntryKind::RadioButton(
             IntermissionDisplay::Calendar.to_i18n_string(),
             EntryId::SetIntermission(kind, IntermissionDisplay::Calendar),
-            is_calendar,
+            is_selected(IntermissionDisplay::Calendar),
         ));
     }
 
@@ -79,6 +69,19 @@ fn intermission_display_name(display: &IntermissionDisplay) -> String {
             .unwrap_or(i18n_display.as_str())
             .to_string(),
         _ => display.to_i18n_string(),
+    }
+}
+
+fn selected_builtin_intermission(
+    kind: IntermKind,
+    display: &IntermissionDisplay,
+) -> Option<IntermissionDisplay> {
+    match display {
+        IntermissionDisplay::Image(_) => None,
+        IntermissionDisplay::Calendar if !kind.supports_calendar() => {
+            Some(IntermissionDisplay::Logo)
+        }
+        _ => Some(display.clone()),
     }
 }
 
@@ -321,6 +324,42 @@ mod tests {
                 )
             }));
         }
+
+        #[test]
+        fn fetch_includes_blank_options() {
+            let setting = IntermissionSuspend;
+            let settings = Settings::default();
+            let data = setting.fetch(&settings);
+
+            let WidgetKind::SubMenu(entries) = data.widget else {
+                panic!("expected submenu widget");
+            };
+
+            assert!(entries.iter().any(|entry| {
+                matches!(
+                    entry,
+                    EntryKind::RadioButton(
+                        _,
+                        EntryId::SetIntermission(IntermKind::Suspend, IntermissionDisplay::Blank),
+                        _
+                    )
+                )
+            }));
+
+            assert!(entries.iter().any(|entry| {
+                matches!(
+                    entry,
+                    EntryKind::RadioButton(
+                        _,
+                        EntryId::SetIntermission(
+                            IntermKind::Suspend,
+                            IntermissionDisplay::BlankInverted
+                        ),
+                        _
+                    )
+                )
+            }));
+        }
     }
 
     mod intermission_power_off {
@@ -405,6 +444,25 @@ mod tests {
             assert_eq!(
                 settings.intermissions[IntermKind::PowerOff],
                 IntermissionDisplay::Logo
+            );
+        }
+
+        #[test]
+        fn handle_accepts_blank_selection() {
+            let setting = IntermissionPowerOff;
+            let mut settings = Settings::default();
+            let mut bus: Bus = VecDeque::new();
+            let event = Event::Select(EntryId::SetIntermission(
+                IntermKind::PowerOff,
+                IntermissionDisplay::Blank,
+            ));
+
+            let result = setting.handle(&event, &mut settings, &mut bus);
+
+            assert_eq!(result, (Some(fl!("settings-intermission-blank")), true));
+            assert_eq!(
+                settings.intermissions[IntermKind::PowerOff],
+                IntermissionDisplay::Blank
             );
         }
 
@@ -516,6 +574,28 @@ mod tests {
             assert_eq!(
                 settings.intermissions[IntermKind::Share],
                 IntermissionDisplay::Logo
+            );
+        }
+
+        #[test]
+        fn handle_accepts_blank_inverted_selection() {
+            let setting = IntermissionShare;
+            let mut settings = Settings::default();
+            let mut bus: Bus = VecDeque::new();
+            let event = Event::Select(EntryId::SetIntermission(
+                IntermKind::Share,
+                IntermissionDisplay::BlankInverted,
+            ));
+
+            let result = setting.handle(&event, &mut settings, &mut bus);
+
+            assert_eq!(
+                result,
+                (Some(fl!("settings-intermission-blank-inverted")), true)
+            );
+            assert_eq!(
+                settings.intermissions[IntermKind::Share],
+                IntermissionDisplay::BlankInverted
             );
         }
 


### PR DESCRIPTION
This contributes to #224. 

It only solve the blank/inverted intermission screens.
The RGB one can be added in the next release, I think it would be nicer to solve #482 first as even using the inverted intermissions screen, you can see some of the UI elements below it. 

Some minor refactoring of `fetch_intermission` as that implementation was 💩. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "Blank" and "Blank Inverted" intermission display modes (solid white/black backgrounds) to intermission options.

* **Documentation**
  * Expanded configuration comments to list additional supported intermission image specifiers and clarified support for custom image paths.
  * Reordered localization entries for intermission settings.

* **Tests**
  * Updated and added tests to cover the new blank modes and related selection behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OGKevin/cadmus/pull/483?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->