### PR TITLE
ci: label Renovate thirdparty deps updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -25,6 +25,10 @@
       "matchUpdateTypes": ["minor", "patch"],
       "groupName": "JavaScript tooling non-major dependencies",
       "groupSlug": "js-tooling-non-major"
+    },
+    {
+      "matchFileNames": ["xtask/src/tasks/util/thirdparty.rs"],
+      "addLabels": ["thirdparty"]
     }
   ],
   "customManagers": [


### PR DESCRIPTION
Add a package rule that applies the thirdparty label to Renovate updates sourced from xtask/src/tasks/util/thirdparty.rs.

- match thirdparty version constants by filename
- preserve existing grouping rules and labels

Change-Id: a2ce89036b8a8979e0d19ea854197662
Change-Id-Short: pxnlrqzwtorp