### PR TITLE
docs: add uninstall instructions

### DIFF
--- a/docs/po/messages.pot
+++ b/docs/po/messages.pot
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Cadmus Documentation\n"
-"POT-Creation-Date: 2026-05-20T09:16:15Z\n"
+"POT-Creation-Date: 2026-05-25T09:26:23+02:00\n"
 "PO-Revision-Date: \n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -24,114 +24,118 @@ msgstr ""
 msgid "Installation"
 msgstr ""
 
-#: src/SUMMARY.md:6 src/installation/test-builds.md:1
+#: src/SUMMARY.md:6 src/installation/uninstall.md:1
+msgid "Uninstalling Cadmus"
+msgstr ""
+
+#: src/SUMMARY.md:7 src/installation/test-builds.md:1
 msgid "Test builds"
 msgstr ""
 
-#: src/SUMMARY.md:7 src/installation/ota.md:1
+#: src/SUMMARY.md:8 src/installation/ota.md:1
 msgid "OTA updates"
 msgstr ""
 
-#: src/SUMMARY.md:8 src/installation/migration.md:1
+#: src/SUMMARY.md:9 src/installation/migration.md:1
 msgid "Migrating from Plato"
 msgstr ""
 
-#: src/SUMMARY.md:9 src/SUMMARY.md:12 src/settings/index.md:1
+#: src/SUMMARY.md:10 src/SUMMARY.md:13 src/settings/index.md:1
 #: src/ui/settings/index.md:1
 msgid "Settings"
 msgstr ""
 
-#: src/SUMMARY.md:10 src/ui/index.md:1
+#: src/SUMMARY.md:11 src/ui/index.md:1
 msgid "User Interface"
 msgstr ""
 
-#: src/SUMMARY.md:11 src/ui/filechooser.md:1
+#: src/SUMMARY.md:12 src/ui/filechooser.md:1
 msgid "File Chooser"
 msgstr ""
 
-#: src/SUMMARY.md:13 src/ui/settings/dictionaries.md:1
+#: src/SUMMARY.md:14 src/ui/settings/dictionaries.md:1
 msgid "Dictionaries"
 msgstr ""
 
-#: src/SUMMARY.md:14 src/library/index.md:1
+#: src/SUMMARY.md:15 src/library/index.md:1
 msgid "Library"
 msgstr ""
 
-#: src/SUMMARY.md:15
+#: src/SUMMARY.md:16
 msgid "Importing"
 msgstr ""
 
-#: src/SUMMARY.md:16 src/installation/ota.md:82 src/troubleshooting/index.md:1
+#: src/SUMMARY.md:17 src/installation/ota.md:82 src/troubleshooting/index.md:1
 #: src/contributing/devenv-setup.md:210
 msgid "Troubleshooting"
 msgstr ""
 
-#: src/SUMMARY.md:20
+#: src/SUMMARY.md:21
 msgid "Contributor Guide"
 msgstr ""
 
-#: src/SUMMARY.md:22
+#: src/SUMMARY.md:23
 msgid "Development Environment"
 msgstr ""
 
-#: src/SUMMARY.md:23 src/contributing/event-system.md:1
+#: src/SUMMARY.md:24 src/contributing/event-system.md:1
 msgid "Event System"
 msgstr ""
 
-#: src/SUMMARY.md:24 src/settings/index.md:281
+#: src/SUMMARY.md:25 src/settings/index.md:281
 #: src/contributing/telemetry/index.md:1
 msgid "Telemetry"
 msgstr ""
 
-#: src/SUMMARY.md:25 src/contributing/telemetry/logging.md:1
+#: src/SUMMARY.md:26 src/contributing/telemetry/logging.md:1
 msgid "Logging"
 msgstr ""
 
-#: src/SUMMARY.md:26 src/contributing/telemetry/tracing.md:1
+#: src/SUMMARY.md:27 src/contributing/telemetry/tracing.md:1
 msgid "Tracing"
 msgstr ""
 
-#: src/SUMMARY.md:27 src/contributing/telemetry/profiling.md:1
+#: src/SUMMARY.md:28 src/contributing/telemetry/profiling.md:1
 msgid "Profiling"
 msgstr ""
 
-#: src/SUMMARY.md:28 src/index.md:9
+#: src/SUMMARY.md:29 src/index.md:9
 msgid "Documentation"
 msgstr ""
 
-#: src/SUMMARY.md:29 src/contributing/translations/index.md:1
+#: src/SUMMARY.md:30 src/contributing/translations/index.md:1
 msgid "Translations"
 msgstr ""
 
-#: src/SUMMARY.md:30
+#: src/SUMMARY.md:31
 msgid "UI Strings"
 msgstr ""
 
-#: src/SUMMARY.md:31
+#: src/SUMMARY.md:32
 msgid "Guide"
 msgstr ""
 
-#: src/SUMMARY.md:32 src/contributing/sqlite-sqlx.md:1
+#: src/SUMMARY.md:33 src/contributing/sqlite-sqlx.md:1
 msgid "SQLite & SQLx"
 msgstr ""
 
-#: src/SUMMARY.md:33 src/contributing/library-database.md:1
+#: src/SUMMARY.md:34 src/contributing/library-database.md:1
 msgid "Library Database"
 msgstr ""
 
-#: src/SUMMARY.md:34 src/contributing/runtime-migrations.md:1
+#: src/SUMMARY.md:35 src/contributing/runtime-migrations.md:1
 msgid "Runtime Migrations"
 msgstr ""
 
-#: src/SUMMARY.md:38 src/investigations/index.md:1
+#: src/SUMMARY.md:39 src/investigations/index.md:1
 msgid "Investigations"
 msgstr ""
 
-#: src/SUMMARY.md:40
+#: src/SUMMARY.md:41
 msgid "Intro"
 msgstr ""
 
-#: src/SUMMARY.md:41 src/investigations/kobo/issue-51-dhcp-investigation.md:1
+#: src/SUMMARY.md:42 src/investigations/kobo/issue-51-dhcp-investigation.md:1
 msgid "DHCP IP Address Changes on WiFi Toggle"
 msgstr ""
 
@@ -343,6 +347,7 @@ msgid "Cadmus only"
 msgstr ""
 
 #: src/installation/index.md:9 src/installation/index.md:10
+#: src/installation/uninstall.md:10
 msgid "`/mnt/onboard/.adds/cadmus`"
 msgstr ""
 
@@ -363,6 +368,7 @@ msgid "Test build only"
 msgstr ""
 
 #: src/installation/index.md:11 src/installation/index.md:12
+#: src/installation/uninstall.md:11
 msgid "`/mnt/onboard/.adds/cadmus-tst`"
 msgstr ""
 
@@ -407,76 +413,157 @@ msgstr ""
 msgid "Download the package you want from the table above."
 msgstr ""
 
-#: src/installation/index.md:25 src/installation/index.md:44
+#: src/installation/index.md:25 src/installation/index.md:50
+#: src/installation/uninstall.md:5
 msgid "Connect your Kobo to your computer via USB."
 msgstr ""
 
 #: src/installation/index.md:26
-msgid ""
-"Copy the downloaded file to `/mnt/onboard/.kobo/KoboRoot.tgz` on the device."
+msgid "Rename the downloaded file to `KoboRoot.tgz`."
 msgstr ""
 
-#: src/installation/index.md:27 src/installation/test-builds.md:12
+#: src/installation/index.md:27
+msgid ""
+"Copy that renamed file to `/mnt/onboard/.kobo/KoboRoot.tgz` on the device."
+msgstr ""
+
+#: src/installation/index.md:28 src/installation/test-builds.md:13
 msgid "Eject the device and reboot."
 msgstr ""
 
-#: src/installation/index.md:29
-msgid "Updating"
-msgstr ""
-
-#: src/installation/index.md:31
-msgid "There are two ways to update Cadmus once it's installed."
-msgstr ""
-
-#: src/installation/index.md:33
-msgid "Wirelessly (OTA)"
+#: src/installation/index.md:30
+msgid ""
+"\\[!NOTE\\] You must rename the file to `KoboRoot.tgz` before copying it to "
+"your Kobo. For example, `KoboRoot-nm.tgz` and `KoboRoot-test.tgz` will not "
+"install until you rename them."
 msgstr ""
 
 #: src/installation/index.md:35
+msgid "Updating"
+msgstr ""
+
+#: src/installation/index.md:37
+msgid "There are two ways to update Cadmus once it's installed."
+msgstr ""
+
+#: src/installation/index.md:39
+msgid "Wirelessly (OTA)"
+msgstr ""
+
+#: src/installation/index.md:41
 msgid ""
 "The easiest way — no computer needed, just WiFi. Open **Main Menu → Check "
 "for Updates** and follow the prompts. See [OTA updates](./ota.md) for "
 "details."
 msgstr ""
 
-#: src/installation/index.md:39
+#: src/installation/index.md:45
 msgid "Via USB"
 msgstr ""
 
-#: src/installation/index.md:41
+#: src/installation/index.md:47
 msgid ""
 "You can also update by copying a new package over USB, the same way you did "
 "the first-time install."
 msgstr ""
 
-#: src/installation/index.md:45
+#: src/installation/index.md:51
 msgid "When Cadmus asks \"Share storage via USB?\", tap **Share**."
 msgstr ""
 
-#: src/installation/index.md:46
+#: src/installation/index.md:52
 msgid ""
 "Download the package you want from the [latest "
 "release](https://github.com/OGKevin/cadmus/releases/latest)."
 msgstr ""
 
-#: src/installation/index.md:47
+#: src/installation/index.md:53
 msgid "Copy it to `/mnt/onboard/.kobo/KoboRoot.tgz` on your Kobo."
 msgstr ""
 
-#: src/installation/index.md:48
+#: src/installation/index.md:54
 msgid "Eject and disconnect the USB cable."
 msgstr ""
 
-#: src/installation/index.md:50
+#: src/installation/index.md:56
 msgid ""
 "\\[!NOTE\\] Always name the file `KoboRoot.tgz` on the device, regardless of "
 "which package you downloaded (e.g. `KoboRoot-nm.tgz` must be renamed)."
 msgstr ""
 
-#: src/installation/index.md:54
+#: src/installation/index.md:60
 msgid ""
 "Cadmus detects the file automatically and reboots your Kobo to install the "
 "update. You don't need to do anything else."
+msgstr ""
+
+#: src/installation/index.md:63
+msgid "Uninstalling"
+msgstr ""
+
+#: src/installation/index.md:65
+msgid "See [Uninstalling Cadmus](./uninstall.md)."
+msgstr ""
+
+#: src/installation/uninstall.md:3
+msgid "To remove Cadmus from your Kobo:"
+msgstr ""
+
+#: src/installation/uninstall.md:6
+msgid "Delete the Cadmus folder from `.adds`:"
+msgstr ""
+
+#: src/installation/uninstall.md:8 src/installation/uninstall.md:16
+#: src/installation/migration.md:8 src/installation/migration.md:65
+msgid "Build"
+msgstr ""
+
+#: src/installation/uninstall.md:8
+msgid "Folder to delete"
+msgstr ""
+
+#: src/installation/uninstall.md:10 src/installation/uninstall.md:18
+#: src/installation/migration.md:10 src/installation/migration.md:67
+msgid "Stable"
+msgstr ""
+
+#: src/installation/uninstall.md:11 src/installation/uninstall.md:19
+#: src/installation/migration.md:11 src/installation/migration.md:68
+msgid "Test"
+msgstr ""
+
+#: src/installation/uninstall.md:13
+msgid ""
+"If you installed a package that included NickelMenu, delete the Cadmus menu "
+"entry too:"
+msgstr ""
+
+#: src/installation/uninstall.md:16
+msgid "NickelMenu entry to delete"
+msgstr ""
+
+#: src/installation/uninstall.md:18
+msgid "`/mnt/onboard/.adds/nm/cadmus`"
+msgstr ""
+
+#: src/installation/uninstall.md:19
+msgid "`/mnt/onboard/.adds/nm/cadmus-tst`"
+msgstr ""
+
+#: src/installation/uninstall.md:21
+msgid "Eject the device and disconnect the USB cable."
+msgstr ""
+
+#: src/installation/uninstall.md:23
+msgid ""
+"\\[!NOTE\\] If you no longer want NickelMenu at all, you can remove it "
+"separately after deleting the Cadmus entry above."
+msgstr ""
+
+#: src/installation/uninstall.md:27
+msgid ""
+"\\[!TIP\\] If you copied an update file into `/mnt/onboard/.kobo/`, you can "
+"also delete that leftover `KoboRoot*.tgz` file."
 msgstr ""
 
 #: src/installation/test-builds.md:3
@@ -504,14 +591,25 @@ msgid "Extract it and pick the [package](./index.md) that matches your setup."
 msgstr ""
 
 #: src/installation/test-builds.md:10
-msgid "Copy the selected KoboRoot file to: `/mnt/onboard/.kobo/KoboRoot.tgz`"
+msgid "Rename the selected file to `KoboRoot.tgz`."
 msgstr ""
 
-#: src/installation/test-builds.md:14
+#: src/installation/test-builds.md:11
+msgid "Copy that renamed file to: `/mnt/onboard/.kobo/KoboRoot.tgz`"
+msgstr ""
+
+#: src/installation/test-builds.md:15
+msgid ""
+"\\[!NOTE\\] Test packages such as `KoboRoot-test.tgz` and "
+"`KoboRoot-nm-test.tgz` must be renamed to `KoboRoot.tgz` before you copy "
+"them to your Kobo."
+msgstr ""
+
+#: src/installation/test-builds.md:19
 msgid "Updating an existing test build"
 msgstr ""
 
-#: src/installation/test-builds.md:16
+#: src/installation/test-builds.md:21
 msgid ""
 "Use the OTA feature to download updates from a PR number directly on your "
 "device. This lets you test changes without connecting to a computer."
@@ -729,10 +827,6 @@ msgstr ""
 msgid "Copy your settings"
 msgstr ""
 
-#: src/installation/migration.md:8 src/installation/migration.md:65
-msgid "Build"
-msgstr ""
-
 #: src/installation/migration.md:8
 msgid "Plato settings"
 msgstr ""
@@ -741,20 +835,12 @@ msgstr ""
 msgid "Cadmus settings"
 msgstr ""
 
-#: src/installation/migration.md:10 src/installation/migration.md:67
-msgid "Stable"
-msgstr ""
-
 #: src/installation/migration.md:10 src/installation/migration.md:11
 msgid "`/mnt/onboard/.adds/plato/Settings.toml`"
 msgstr ""
 
 #: src/installation/migration.md:10
 msgid "`/mnt/onboard/.adds/cadmus/Settings.toml`"
-msgstr ""
-
-#: src/installation/migration.md:11 src/installation/migration.md:68
-msgid "Test"
 msgstr ""
 
 #: src/installation/migration.md:11
@@ -1731,61 +1817,125 @@ msgstr ""
 #: src/ui/settings/dictionaries.md:39
 msgid ""
 "A progress notification appears at the top of the screen while the file "
-"downloads. When it disappears, the dictionary is ready to use."
+"downloads. Once the download finishes, Cadmus begins "
+"[indexing](#how-indexing-works) the dictionary automatically."
 msgstr ""
 
-#: src/ui/settings/dictionaries.md:42
+#: src/ui/settings/dictionaries.md:43
 msgid "Updating a Dictionary"
 msgstr ""
 
-#: src/ui/settings/dictionaries.md:44
+#: src/ui/settings/dictionaries.md:45
 msgid "When a newer version is available the status shows **Update Available**."
 msgstr ""
 
-#: src/ui/settings/dictionaries.md:46 src/ui/settings/dictionaries.md:56
-#: src/ui/settings/dictionaries.md:61
+#: src/ui/settings/dictionaries.md:47 src/ui/settings/dictionaries.md:57
+#: src/ui/settings/dictionaries.md:62
 msgid "Tap the language row."
 msgstr ""
 
-#: src/ui/settings/dictionaries.md:47
+#: src/ui/settings/dictionaries.md:48
 msgid "Select **Update** from the menu."
 msgstr ""
 
-#: src/ui/settings/dictionaries.md:49
+#: src/ui/settings/dictionaries.md:50
 msgid "The updated dictionary replaces the old one automatically."
 msgstr ""
 
-#: src/ui/settings/dictionaries.md:51
+#: src/ui/settings/dictionaries.md:52
 msgid "Re-downloading a Dictionary"
 msgstr ""
 
-#: src/ui/settings/dictionaries.md:53
+#: src/ui/settings/dictionaries.md:54
 msgid ""
 "If a dictionary is already installed you can re-download it to get a fresh "
 "copy:"
 msgstr ""
 
-#: src/ui/settings/dictionaries.md:57
+#: src/ui/settings/dictionaries.md:58
 msgid "Select **Re-download** from the menu."
 msgstr ""
 
-#: src/ui/settings/dictionaries.md:59
+#: src/ui/settings/dictionaries.md:60
 msgid "Deleting a Dictionary"
 msgstr ""
 
-#: src/ui/settings/dictionaries.md:62
+#: src/ui/settings/dictionaries.md:63
 msgid "Select **Delete** from the menu."
 msgstr ""
 
-#: src/ui/settings/dictionaries.md:64
+#: src/ui/settings/dictionaries.md:65
 msgid "The dictionary files are removed from your device."
 msgstr ""
 
-#: src/ui/settings/dictionaries.md:66
+#: src/ui/settings/dictionaries.md:67
+msgid "How Indexing Works"
+msgstr ""
+
+#: src/ui/settings/dictionaries.md:69
+msgid ""
+"After you download, update, or re-download a dictionary, Cadmus needs to "
+"**index** it before you can look up words. Indexing reads every word in the "
+"dictionary and stores it in a database on disk so that lookups are fast "
+"without loading the entire dictionary into memory. This is especially "
+"important on devices with limited memory."
+msgstr ""
+
+#: src/ui/settings/dictionaries.md:75
+msgid ""
+"A notification with a progress bar appears at the top of the screen while "
+"indexing is in progress."
+msgstr ""
+
+#: src/ui/settings/dictionaries.md:78
+msgid ""
+"\\[!NOTE\\] You can keep reading while indexing runs in the background. "
+"Words that have already been indexed are available for lookup right away, so "
+"you may get partial results until indexing finishes."
+msgstr ""
+
+#: src/ui/settings/dictionaries.md:83
+msgid "What happens when you restart your Kobo"
+msgstr ""
+
+#: src/ui/settings/dictionaries.md:85
+msgid ""
+"If your Kobo restarts or shuts down while indexing is still running, Cadmus "
+"picks up where it left off the next time it starts. It does not start over "
+"from the beginning."
+msgstr ""
+
+#: src/ui/settings/dictionaries.md:89
+msgid "When does re-indexing happen"
+msgstr ""
+
+#: src/ui/settings/dictionaries.md:91
+msgid "Cadmus automatically re-indexes a dictionary when you:"
+msgstr ""
+
+#: src/ui/settings/dictionaries.md:93
+msgid "**Update** it to a newer version"
+msgstr ""
+
+#: src/ui/settings/dictionaries.md:94
+msgid "**Re-download** it"
+msgstr ""
+
+#: src/ui/settings/dictionaries.md:95
+msgid "**Delete** it (the old index is removed)"
+msgstr ""
+
+#: src/ui/settings/dictionaries.md:97
+msgid ""
+"You do not need to trigger indexing yourself — it happens automatically "
+"whenever the dictionary files change."
+msgstr ""
+
+#: src/ui/settings/dictionaries.md:100
 msgid "Where Dictionaries are Stored"
 msgstr ""
 
-#: src/ui/settings/dictionaries.md:68
+#: src/ui/settings/dictionaries.md:102
 msgid ""
 "Downloaded dictionaries live in the `dictionaries/reader-dict/<lang>/` "
 "folder on your device. Each language gets its own subfolder containing a "
@@ -2880,10 +3030,10 @@ msgstr ""
 msgid ""
 "The main loop (`app.rs`) receives events from the hub and handles them in "
 "two stages. First, `TaskManager` gets a chance to observe every event — this "
-"is where `ImportLibrary` and `ImportFinished` are intercepted to schedule or "
-"coalesce background import tasks. Then the event enters the large `match` "
-"statement, where some events are dispatched into the view tree and others "
-"are handled directly:"
+"is where `ImportLibrary`, `ImportFinished`, and `ReindexDictionaries` are "
+"intercepted to schedule or coalesce background tasks. Then the event enters "
+"the large `match` statement, where some events are dispatched into the view "
+"tree and others are handled directly:"
 msgstr ""
 
 #: src/contributing/event-system.md:175
@@ -2895,7 +3045,7 @@ msgid ""
 "\n"
 "        Recv[\"rx.recv() → evt\"]\n"
 "        TaskManager[\"TaskManager::handle_event()<br/>(ImportLibrary, "
-"ImportFinished)\"]\n"
+"ImportFinished, ReindexDictionaries)\"]\n"
 "\n"
 "        Gesture[\"Event::Gesture(Tap/Swipe/...)\"]\n"
 "        GestureAction[\"Dispatched into view tree via handle_event()\"]\n"
@@ -2916,9 +3066,10 @@ msgid ""
 "        Select[\"Event::Select(...)\"]\n"
 "        SelectAction[\"Some handled directly,<br/>some dispatched\"]\n"
 "\n"
-"        ImportLibrary[\"Event::ImportLibrary / ImportFinished\"]\n"
+"        ImportLibrary[\"Event::ImportLibrary / ImportFinished / "
+"ReindexDictionaries\"]\n"
 "        ImportAction[\"Handled by TaskManager<br/>(schedules/coalesces "
-"import)\"]\n"
+"tasks)\"]\n"
 "\n"
 "        Recv --> TaskManager\n"
 "        TaskManager --> Gesture\n"

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -3,6 +3,7 @@
 # User Guide
 
 - [Installation](installation/index.md)
+  - [Uninstalling Cadmus](installation/uninstall.md)
   - [Test builds](installation/test-builds.md)
   - [OTA updates](installation/ota.md)
   - [Migrating from Plato](installation/migration.md)

--- a/docs/src/installation/index.md
+++ b/docs/src/installation/index.md
@@ -23,8 +23,14 @@ Cadmus comes in different packages. Pick the one that matches your needs.
 1. Go to the [latest release](https://github.com/OGKevin/cadmus/releases/latest).
 2. Download the package you want from the table above.
 3. Connect your Kobo to your computer via USB.
-4. Copy the downloaded file to `/mnt/onboard/.kobo/KoboRoot.tgz` on the device.
-5. Eject the device and reboot.
+4. Rename the downloaded file to `KoboRoot.tgz`.
+5. Copy that renamed file to `/mnt/onboard/.kobo/KoboRoot.tgz` on the device.
+6. Eject the device and reboot.
+
+> [!NOTE]
+> You must rename the file to `KoboRoot.tgz` before copying it to your Kobo.
+> For example, `KoboRoot-nm.tgz` and `KoboRoot-test.tgz` will not install until
+> you rename them.
 
 ## Updating
 
@@ -53,3 +59,7 @@ first-time install.
 
 Cadmus detects the file automatically and reboots your Kobo to install the
 update. You don't need to do anything else.
+
+## Uninstalling
+
+See [Uninstalling Cadmus](./uninstall.md).

--- a/docs/src/installation/test-builds.md
+++ b/docs/src/installation/test-builds.md
@@ -7,9 +7,14 @@
 3. Download the `cadmus-kobo-test-<suffix>` file.
    ![Download from GitHub Actions](./screenshots/artifacts.png)
 4. Extract it and pick the [package](./index.md) that matches your setup.
-5. Copy the selected KoboRoot file to:
+5. Rename the selected file to `KoboRoot.tgz`.
+6. Copy that renamed file to:
    `/mnt/onboard/.kobo/KoboRoot.tgz`
-6. Eject the device and reboot.
+7. Eject the device and reboot.
+
+> [!NOTE]
+> Test packages such as `KoboRoot-test.tgz` and `KoboRoot-nm-test.tgz` must be
+> renamed to `KoboRoot.tgz` before you copy them to your Kobo.
 
 ## Updating an existing test build
 

--- a/docs/src/installation/uninstall.md
+++ b/docs/src/installation/uninstall.md
@@ -1,0 +1,24 @@
+# Uninstalling Cadmus
+
+To remove Cadmus from your Kobo:
+
+1. Connect your Kobo to your computer via USB.
+2. Delete the Cadmus folder from `.adds`:
+
+   | Build  | Folder to delete                |
+   | ------ | ------------------------------- |
+   | Stable | `/mnt/onboard/.adds/cadmus`     |
+   | Test   | `/mnt/onboard/.adds/cadmus-tst` |
+
+3. If you installed a package that included NickelMenu, delete the Cadmus menu
+   entry too:
+
+   | Build  | NickelMenu entry to delete         |
+   | ------ | ---------------------------------- |
+   | Stable | `/mnt/onboard/.adds/nm/cadmus`     |
+   | Test   | `/mnt/onboard/.adds/nm/cadmus-tst` |
+
+4. Eject the device and disconnect the USB cable.
+
+> [!NOTE]
+> If you no longer need NickelMenu at all, you can remove it separately.


### PR DESCRIPTION
Document how to remove Cadmus from Kobo installs and clarify that first-time USB installs require renaming the package to KoboRoot.tgz.

- add uninstall guide and link it from installation docs
- add explicit rename notes to stable and test install steps
- regenerate docs translation template for updated strings

Change-Id: a4f181983f146be8b15449fa86368f88
Change-Id-Short: pvkyryqrwkyv
Closes: CAD-88

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive "Uninstalling Cadmus" guide with step-by-step removal instructions
  * Updated installation instructions with explicit file renaming requirements before copying to device
  * Clarified test build installation workflow, specifying mandatory renaming steps
  * Reorganized documentation structure for improved navigation and clarity

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OGKevin/cadmus/pull/507?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->