### PR TITLE
fix(OTA): clean bundled assets before ota install

### DIFF
--- a/.github/actions/build-kobo/action.yml
+++ b/.github/actions/build-kobo/action.yml
@@ -1,7 +1,7 @@
 name: Build Kobo
 description: >
   Full Kobo build pipeline: restore caches, install dependencies, build
-  thirdparty libraries, compile Cadmus for ARM, download static assets,
+  thirdparty libraries, download static assets, compile Cadmus for ARM,
   create the distribution, and produce release artifacts in release-artifacts/.
 
   Attestation and artifact upload are left to the caller because they require
@@ -95,6 +95,12 @@ runs:
       shell: bash
       run: cargo xtask docs --mdbook-only
 
+    - name: Download static assets
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.gh-token }}
+      run: cargo xtask download-assets
+
     - name: Build for Kobo
       shell: bash
       env:
@@ -105,12 +111,6 @@ runs:
         else
           cargo xtask build-kobo --slow
         fi
-
-    - name: Download static assets
-      shell: bash
-      env:
-        GH_TOKEN: ${{ inputs.gh-token }}
-      run: cargo xtask download-assets
 
     - name: Create distribution
       shell: bash

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -108,3 +108,15 @@ misses `#[cfg(not(feature = "..."))]` paths.
 
 5. All combinations run on `ubuntu-latest`.
 6. Only `default` and `test` features produce build artifacts.
+
+## OTA and Asset Build Order
+
+- OTA updates delete only Cadmus-owned bundled files before reboot. Do not
+  assume a whole asset directory can be removed because users may add their own
+  fonts, icons, or other files.
+- `libs/` is special: all Cadmus-shipped shared libraries may be cleaned before
+  reboot because the next `KoboRoot.tgz` repopulates that directory.
+- If code generates compile-time metadata from bundled asset directories, make
+  sure `bin/`, `resources/`, and `hyphenation-patterns/` are present before the
+  Kobo build starts. In CI, `cargo xtask download-assets` must run before
+  `cargo xtask build-kobo` for the generated asset list to stay accurate.

--- a/crates/core/build.rs
+++ b/crates/core/build.rs
@@ -1,6 +1,18 @@
 use std::env::{self, VarError};
+use std::path::{Path, PathBuf};
 use std::process::Command;
 use uuid::Uuid;
+
+const BUNDLED_ASSET_DIRS: &[&str] = &[
+    "bin",
+    "css",
+    "fonts",
+    "hyphenation-patterns",
+    "icons",
+    "keyboard-layouts",
+    "resources",
+    "scripts",
+];
 
 fn main() {
     let target = env::var("TARGET").unwrap();
@@ -54,6 +66,7 @@ fn main() {
     println!("cargo:rustc-link-lib=jbig2dec");
 
     generate_locales();
+    generate_bundled_assets();
 }
 
 fn generate_locales() {
@@ -75,6 +88,96 @@ fn generate_locales() {
     let generated = format!("pub const AVAILABLE_LOCALES: &[&str] = &[\n{entries}];\n");
     std::fs::write(std::path::Path::new(&out_dir).join("locales.rs"), generated)
         .expect("failed to write locales.rs");
+}
+
+/// Generates the bundled asset manifest.
+///
+/// This is later used during OTA to delete them so that
+/// the new update bundle can re-install bundled assets.
+///
+/// This ensures that e.g. there are no lingering scripts, fonts or libs etc
+/// when they are removed.
+fn generate_bundled_assets() {
+    let out_dir = env::var("OUT_DIR").expect("OUT_DIR not set");
+    let workspace_root = workspace_root();
+    let is_kobo = env::var("TARGET").unwrap_or_default() == "arm-unknown-linux-gnueabihf";
+    let is_release = env::var("PROFILE").unwrap_or_default() == "release";
+    let mut asset_files = Vec::new();
+
+    for dir in BUNDLED_ASSET_DIRS {
+        let asset_dir = workspace_root.join(dir);
+
+        if is_kobo
+            && is_release
+            && matches!(*dir, "bin" | "resources" | "hyphenation-patterns")
+            && !asset_dir.is_dir()
+        {
+            panic!(
+                "required asset directory missing: {}. Run `cargo xtask download-assets` before build.",
+                asset_dir.display()
+            );
+        }
+
+        println!("cargo:rerun-if-changed={}", asset_dir.display());
+        collect_asset_files(&workspace_root, &asset_dir, &mut asset_files);
+    }
+
+    asset_files.sort();
+
+    let entries: String = asset_files
+        .iter()
+        .map(|path| format!("    {path:?},\n"))
+        .collect();
+    let generated = format!("const BUNDLED_ASSET_FILES: &[&str] = &[\n{entries}];\n");
+
+    std::fs::write(Path::new(&out_dir).join("bundled_assets.rs"), generated)
+        .expect("failed to write bundled_assets.rs");
+}
+
+fn workspace_root() -> PathBuf {
+    let manifest_dir =
+        PathBuf::from(env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR not set"));
+
+    manifest_dir
+        .parent()
+        .and_then(Path::parent)
+        .expect("workspace root not found")
+        .to_path_buf()
+}
+
+fn collect_asset_files(workspace_root: &Path, dir: &Path, asset_files: &mut Vec<String>) {
+    if !dir.exists() {
+        return;
+    }
+
+    for entry in
+        std::fs::read_dir(dir).unwrap_or_else(|_| panic!("failed to read {}", dir.display()))
+    {
+        let entry = entry.unwrap_or_else(|_| panic!("failed to read entry in {}", dir.display()));
+        let path = entry.path();
+        let file_type = entry
+            .file_type()
+            .unwrap_or_else(|_| panic!("failed to read type for {}", path.display()));
+
+        if file_type.is_dir() {
+            collect_asset_files(workspace_root, &path, asset_files);
+            continue;
+        }
+
+        if !file_type.is_file() {
+            continue;
+        }
+
+        let relative_path = path.strip_prefix(workspace_root).unwrap_or_else(|_| {
+            panic!(
+                "{} is not under {}",
+                path.display(),
+                workspace_root.display()
+            )
+        });
+
+        asset_files.push(relative_path.to_string_lossy().replace('\\', "/"));
+    }
 }
 
 fn get_version_info() -> Result<(String, Option<String>), VarError> {

--- a/crates/core/src/device/mod.rs
+++ b/crates/core/src/device/mod.rs
@@ -7,7 +7,7 @@ use lazy_static::lazy_static;
 use once_cell::sync::OnceCell;
 use std::env;
 use std::fmt::Debug;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 mod error;
 mod metadata;
@@ -283,26 +283,56 @@ impl Device {
             .map(|b| b.as_ref())
     }
 
-    /// Returns the path to the device-managed tmp directory.
+    /// Returns the install subdirectory for this build.
+    ///
+    /// Kobo devices install Cadmus under `.adds/` on the user-visible storage.
+    /// Test builds use a separate sibling directory so they can coexist with
+    /// stable builds.
+    pub fn install_subdir(&self) -> &'static str {
+        #[cfg(not(feature = "test"))]
+        return ".adds/cadmus";
+
+        #[cfg(feature = "test")]
+        return ".adds/cadmus-tst";
+    }
+
+    /// Returns the absolute install directory for this device.
     ///
     /// The path is determined at compile time and does not depend on the
     /// process's current working directory, so it remains stable even when
-    /// callers change `cwd` (for example during USB sharing).
+    /// callers change `cwd`.
     ///
-    /// - Normal device builds: `/mnt/onboard/.adds/cadmus/tmp`
-    /// - Test device builds: `/mnt/onboard/.adds/cadmus-tst/tmp`
-    /// - Emulator builds: `/tmp/.adds/cadmus/tmp` (or `cadmus-tst` with `test`)
+    /// - Normal device builds: `/mnt/onboard/.adds/cadmus`
+    /// - Test device builds: `/mnt/onboard/.adds/cadmus-tst`
+    /// - Emulator builds: `/tmp/.adds/cadmus` (or `cadmus-tst` with `test`)
+    /// - Unit tests: `<temp_dir>/test-kobo-installation/.adds/cadmus-tst`
+    pub fn install_dir(&self) -> PathBuf {
+        #[cfg(test)]
+        return std::env::temp_dir()
+            .join("test-kobo-installation")
+            .join(self.install_subdir());
+
+        #[cfg(all(feature = "emulator", not(test)))]
+        return PathBuf::from("/tmp").join(self.install_subdir());
+
+        #[cfg(all(not(feature = "emulator"), not(test)))]
+        return PathBuf::from(crate::settings::INTERNAL_CARD_ROOT).join(self.install_subdir());
+    }
+
+    /// Returns a path inside the device install directory.
+    ///
+    /// Use this for files and directories that Cadmus owns under its install
+    /// root, such as `tmp/` or `.github_token`.
+    pub fn install_path(&self, relative_path: impl AsRef<Path>) -> PathBuf {
+        self.install_dir().join(relative_path)
+    }
+
+    /// Returns the path to the device-managed tmp directory.
+    ///
+    /// The returned path is rooted under [`Device::install_dir`], so it remains
+    /// stable even when callers change `cwd` (for example during USB sharing).
     pub fn tmp_dir(&self) -> PathBuf {
-        #[cfg(not(feature = "test"))]
-        const TMP_RELATIVE_PATH: &str = ".adds/cadmus/tmp";
-        #[cfg(feature = "test")]
-        const TMP_RELATIVE_PATH: &str = ".adds/cadmus-tst/tmp";
-
-        #[cfg(feature = "emulator")]
-        return PathBuf::from("/tmp").join(TMP_RELATIVE_PATH);
-
-        #[cfg(not(feature = "emulator"))]
-        return PathBuf::from(crate::settings::INTERNAL_CARD_ROOT).join(TMP_RELATIVE_PATH);
+        self.install_path("tmp")
     }
 
     /// Removes stale contents left by a previous run and recreates the tmp

--- a/crates/core/src/device/usb/mod.rs
+++ b/crates/core/src/device/usb/mod.rs
@@ -15,4 +15,4 @@ pub use manager::UsbManager;
 pub(crate) use kobo::create_usb_manager;
 
 #[cfg(not(feature = "kobo"))]
-use stub::StubUsbManager;
+pub(crate) use stub::StubUsbManager;

--- a/crates/core/src/github/device_flow.rs
+++ b/crates/core/src/github/device_flow.rs
@@ -1,21 +1,14 @@
+use crate::device::CURRENT_DEVICE;
 use secrecy::{ExposeSecret, SecretString};
 use std::fs::{self, File};
 use std::io::{Read, Write};
 use std::path::PathBuf;
 
-/// Subdirectory and filename appended to the card root for token storage.
-///
-/// Uses `.adds/cadmus/` for normal builds and `.adds/cadmus-tst/` for test
-/// builds.
-#[cfg(not(feature = "test"))]
-const TOKEN_RELATIVE_PATH: &str = ".adds/cadmus/.github_token";
-
-#[cfg(feature = "test")]
-const TOKEN_RELATIVE_PATH: &str = ".adds/cadmus-tst/.github_token";
+const TOKEN_FILENAME: &str = ".github_token";
 
 /// Persists a GitHub OAuth token to disk for reuse across app restarts.
 ///
-/// Writes to `{card_root}/.adds/cadmus/.github_token` with `0600` permissions.
+/// Writes to `<install-dir>/.github_token` with `0600` permissions.
 ///
 /// # Errors
 ///
@@ -100,14 +93,5 @@ pub fn delete_token() -> Result<(), String> {
 }
 
 fn token_path() -> PathBuf {
-    #[cfg(test)]
-    return std::env::temp_dir()
-        .join("cadmus-test")
-        .join(TOKEN_RELATIVE_PATH);
-
-    #[cfg(all(not(test), feature = "emulator"))]
-    return PathBuf::from("/tmp").join(TOKEN_RELATIVE_PATH);
-
-    #[cfg(all(not(test), not(feature = "emulator")))]
-    return PathBuf::from(crate::settings::INTERNAL_CARD_ROOT).join(TOKEN_RELATIVE_PATH);
+    CURRENT_DEVICE.install_path(TOKEN_FILENAME)
 }

--- a/crates/core/src/ota/cleanup.rs
+++ b/crates/core/src/ota/cleanup.rs
@@ -1,0 +1,101 @@
+use std::io;
+use std::path::Path;
+
+include!(concat!(env!("OUT_DIR"), "/bundled_assets.rs"));
+
+/// Deletes Cadmus-owned bundled files from an install directory before OTA reboot.
+///
+/// Files listed in the generated `BUNDLED_ASSET_FILES` manifest are removed
+/// individually so user-added files in shared asset directories remain intact.
+/// The `libs/` directory is cleaned separately because all shipped shared
+/// libraries are Cadmus-owned.
+pub fn clean_bundled_files(install_dir: &Path) -> io::Result<()> {
+    for asset in BUNDLED_ASSET_FILES {
+        remove_file_if_exists(&install_dir.join(asset))?;
+        remove_empty_parent_dirs(&install_dir.join(asset), install_dir)?;
+    }
+
+    clean_libs_dir(&install_dir.join("libs"))?;
+    remove_empty_parent_dirs(&install_dir.join("libs"), install_dir)?;
+
+    Ok(())
+}
+
+fn clean_libs_dir(libs_dir: &Path) -> io::Result<()> {
+    if let Err(e) = std::fs::remove_dir_all(libs_dir) {
+        if e.kind() != io::ErrorKind::NotFound {
+            return Err(e);
+        }
+    }
+
+    Ok(())
+}
+
+fn remove_file_if_exists(path: &Path) -> io::Result<()> {
+    match std::fs::remove_file(path) {
+        Ok(()) => Ok(()),
+        Err(e) if e.kind() == io::ErrorKind::NotFound => Ok(()),
+        Err(e) => Err(e),
+    }
+}
+
+fn remove_empty_parent_dirs(path: &Path, install_dir: &Path) -> io::Result<()> {
+    let mut current = path.parent();
+
+    while let Some(dir) = current {
+        if dir == install_dir {
+            return Ok(());
+        }
+
+        if !remove_empty_dir_if_exists(dir)? {
+            return Ok(());
+        }
+
+        current = dir.parent();
+    }
+
+    Ok(())
+}
+
+fn remove_empty_dir_if_exists(path: &Path) -> io::Result<bool> {
+    match std::fs::remove_dir(path) {
+        Ok(()) => Ok(true),
+        Err(e)
+            if e.kind() == io::ErrorKind::NotFound
+                || e.kind() == io::ErrorKind::DirectoryNotEmpty =>
+        {
+            Ok(false)
+        }
+        Err(e) => Err(e),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::device::CURRENT_DEVICE;
+
+    #[test]
+    fn cleanup_removes_bundled_files_but_keeps_user_files() {
+        let tmp = tempfile::tempdir().unwrap();
+        let install_dir = tmp.path().join(CURRENT_DEVICE.install_subdir());
+
+        std::fs::create_dir_all(install_dir.join("fonts")).unwrap();
+        std::fs::create_dir_all(install_dir.join("icons")).unwrap();
+        std::fs::create_dir_all(install_dir.join("libs")).unwrap();
+
+        std::fs::write(install_dir.join("fonts/NotoSans-Regular.ttf"), b"owned").unwrap();
+        std::fs::write(install_dir.join("fonts/custom.ttf"), b"user").unwrap();
+        std::fs::write(install_dir.join("icons/home.svg"), b"owned").unwrap();
+        std::fs::write(install_dir.join("libs/libfoo.so.1"), b"owned").unwrap();
+        std::fs::write(install_dir.join("Settings.toml"), b"user").unwrap();
+
+        clean_bundled_files(&install_dir).unwrap();
+
+        assert!(!install_dir.join("fonts/NotoSans-Regular.ttf").exists());
+        assert!(install_dir.join("fonts/custom.ttf").exists());
+        assert!(!install_dir.join("icons/home.svg").exists());
+        assert!(!install_dir.join("libs/libfoo.so.1").exists());
+        assert!(install_dir.join("Settings.toml").exists());
+    }
+}

--- a/crates/core/src/ota/mod.rs
+++ b/crates/core/src/ota/mod.rs
@@ -7,7 +7,9 @@
 //!
 //! Authentication is handled via GitHub device auth flow — see [`crate::github`].
 
+mod cleanup;
 mod client;
 
 pub use crate::github::OtaProgress;
+pub use cleanup::clean_bundled_files;
 pub use client::{ArtifactSource, OtaClient, OtaError};

--- a/crates/core/src/view/ota.rs
+++ b/crates/core/src/view/ota.rs
@@ -19,7 +19,7 @@ use crate::geom::Rectangle;
 use crate::gesture::GestureEvent;
 use crate::github::device_flow;
 use crate::github::GithubClient;
-use crate::ota::{OtaClient, OtaError, OtaProgress};
+use crate::ota::{clean_bundled_files, OtaClient, OtaError, OtaProgress};
 use crate::unit::scale_by_dpi;
 use crate::version::{get_current_version, VersionComparison};
 use crate::view::filler::Filler;
@@ -469,6 +469,7 @@ impl OtaView {
                     info!(pr_number, "Download completed, starting extraction");
                     match client.extract_and_deploy(zip_path) {
                         Ok(_) => {
+                            clean_installation_before_reboot();
                             hub2.send(Event::OtaDownloadProgress {
                                 label: "Installing and rebooting…".to_string(),
                                 percent: 100,
@@ -562,6 +563,7 @@ impl OtaView {
                     info!("Main branch download completed, starting extraction");
                     match client.extract_and_deploy(zip_path) {
                         Ok(_) => {
+                            clean_installation_before_reboot();
                             hub2.send(Event::OtaDownloadProgress {
                                 label: "Installing and rebooting…".to_string(),
                                 percent: 100,
@@ -657,6 +659,7 @@ impl OtaView {
                     info!("Stable release download completed, deploying update");
                     match client.deploy(asset_path) {
                         Ok(_) => {
+                            clean_installation_before_reboot();
                             hub2.send(Event::OtaDownloadProgress {
                                 label: "Installing and rebooting…".to_string(),
                                 percent: 100,
@@ -702,6 +705,14 @@ fn send_reboot_after_delay(hub: Hub) {
         thread::sleep(std::time::Duration::from_secs(1));
         hub.send(Event::Select(EntryId::Reboot)).ok();
     });
+}
+
+fn clean_installation_before_reboot() {
+    let install_dir = CURRENT_DEVICE.install_dir();
+
+    if let Err(e) = clean_bundled_files(&install_dir) {
+        tracing::warn!(path = ?install_dir, error = %e, "Failed to clean bundled OTA files");
+    }
 }
 
 impl OtaView {

--- a/docs/po/messages.pot
+++ b/docs/po/messages.pot
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Cadmus Documentation\n"
-"POT-Creation-Date: 2026-05-25T09:26:23+02:00\n"
+"POT-Creation-Date: 2026-05-25T13:06:34+02:00\n"
 "PO-Revision-Date: \n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -65,8 +65,8 @@ msgstr ""
 msgid "Importing"
 msgstr ""
 
-#: src/SUMMARY.md:17 src/installation/ota.md:82 src/troubleshooting/index.md:1
-#: src/contributing/devenv-setup.md:210
+#: src/SUMMARY.md:17 src/installation/ota.md:86 src/troubleshooting/index.md:1
+#: src/contributing/devenv-setup.md:231
 msgid "Troubleshooting"
 msgstr ""
 
@@ -399,7 +399,7 @@ msgid ""
 "out changes that haven't been released yet"
 msgstr ""
 
-#: src/installation/index.md:21 src/installation/ota.md:76
+#: src/installation/index.md:21 src/installation/ota.md:80
 msgid "First-time setup"
 msgstr ""
 
@@ -556,14 +556,8 @@ msgstr ""
 
 #: src/installation/uninstall.md:23
 msgid ""
-"\\[!NOTE\\] If you no longer want NickelMenu at all, you can remove it "
-"separately after deleting the Cadmus entry above."
-msgstr ""
-
-#: src/installation/uninstall.md:27
-msgid ""
-"\\[!TIP\\] If you copied an update file into `/mnt/onboard/.kobo/`, you can "
-"also delete that leftover `KoboRoot*.tgz` file."
+"\\[!NOTE\\] If you no longer need NickelMenu at all, you can remove it "
+"separately."
 msgstr ""
 
 #: src/installation/test-builds.md:3
@@ -686,8 +680,8 @@ msgstr ""
 msgid "Source"
 msgstr ""
 
-#: src/installation/ota.md:34 src/contributing/devenv-setup.md:37
-#: src/contributing/devenv-setup.md:63
+#: src/installation/ota.md:34 src/contributing/devenv-setup.md:48
+#: src/contributing/devenv-setup.md:75
 msgid "Description"
 msgstr ""
 
@@ -742,10 +736,17 @@ msgid ""
 msgstr ""
 
 #: src/installation/ota.md:54
+msgid ""
+"Before that reboot, Cadmus removes the files it previously installed so the "
+"new package can replace them cleanly. Your books, settings, dictionaries, "
+"and other personal files are left alone."
+msgstr ""
+
+#: src/installation/ota.md:58
 msgid "Testing a pull request"
 msgstr ""
 
-#: src/installation/ota.md:56
+#: src/installation/ota.md:60
 msgid ""
 "Select **PR Build** to try out a specific change before it's released. Enter "
 "the PR number when prompted. If you haven't authenticated before, Cadmus "
@@ -753,67 +754,67 @@ msgid ""
 "[Authentication](#authentication) for details."
 msgstr ""
 
-#: src/installation/ota.md:61
+#: src/installation/ota.md:65
 msgid ""
 "\\[!TIP\\] Find the PR number in the GitHub URL. For example, in "
 "`github.com/OGKevin/cadmus/pull/42` the PR number is **42**."
 msgstr ""
 
-#: src/installation/ota.md:65
+#: src/installation/ota.md:69
 msgid "Normal vs test builds"
 msgstr ""
 
-#: src/installation/ota.md:67
+#: src/installation/ota.md:71
 msgid ""
 "OTA works for both types of builds. The type you're currently using "
 "determines what gets downloaded:"
 msgstr ""
 
-#: src/installation/ota.md:70
+#: src/installation/ota.md:74
 msgid "**Normal builds** update to `KoboRoot.tgz` in `/mnt/onboard/.adds/cadmus`"
 msgstr ""
 
-#: src/installation/ota.md:71
+#: src/installation/ota.md:75
 msgid ""
 "**Test builds** update to `KoboRoot-test.tgz` in "
 "`/mnt/onboard/.adds/cadmus-tst`"
 msgstr ""
 
-#: src/installation/ota.md:73
+#: src/installation/ota.md:77
 msgid ""
 "See the [available packages](./index.md#available-packages) table for all "
 "options."
 msgstr ""
 
-#: src/installation/ota.md:78
+#: src/installation/ota.md:82
 msgid ""
 "OTA only works for updating an existing installation. To install Cadmus for "
 "the first time, follow the [installation guide](./index.md) or the [test "
 "builds guide](./test-builds.md) to copy a KoboRoot file via USB."
 msgstr ""
 
-#: src/installation/ota.md:84
+#: src/installation/ota.md:88
 msgid "\"Insufficient disk space\" error"
 msgstr ""
 
-#: src/installation/ota.md:86
+#: src/installation/ota.md:90
 msgid ""
 "If Cadmus shows an error like _\"Insufficient disk space: need 100MB, have "
 "XMB\"_ while downloading an update:"
 msgstr ""
 
-#: src/installation/ota.md:89
+#: src/installation/ota.md:93
 msgid ""
 "Free up space on your Kobo by deleting books or other files you do not need"
 msgstr ""
 
-#: src/installation/ota.md:90
+#: src/installation/ota.md:94
 msgid ""
 "Cadmus downloads update files into its own `tmp` folder inside the Cadmus "
 "folder"
 msgstr ""
 
-#: src/installation/ota.md:92
+#: src/installation/ota.md:96
 msgid "This error means internal storage is too full for the update file"
 msgstr ""
 
@@ -1752,7 +1753,7 @@ msgstr ""
 msgid "Statuses"
 msgstr ""
 
-#: src/ui/settings/dictionaries.md:23 src/contributing/devenv-setup.md:171
+#: src/ui/settings/dictionaries.md:23 src/contributing/devenv-setup.md:192
 msgid "Status"
 msgstr ""
 
@@ -2208,548 +2209,590 @@ msgid "Run the one-time setup to build native dependencies:"
 msgstr ""
 
 #: src/contributing/devenv-setup.md:27
-msgid "Run the emulator:"
+msgid "Download the packaged runtime assets used by Kobo builds:"
 msgstr ""
 
 #: src/contributing/devenv-setup.md:33
+msgid ""
+"`cadmus-core` generates some compile-time metadata from the bundled asset "
+"directories. For Kobo builds, make sure `bin/`, `resources/`, and "
+"`hyphenation-patterns/` are present before `cargo xtask build-kobo` so the "
+"generated asset list is complete."
+msgstr ""
+
+#: src/contributing/devenv-setup.md:38
+msgid "Run the emulator:"
+msgstr ""
+
+#: src/contributing/devenv-setup.md:44
 msgid "Available Commands"
 msgstr ""
 
-#: src/contributing/devenv-setup.md:35
+#: src/contributing/devenv-setup.md:46
 msgid "Once inside the devenv shell, these commands are available:"
 msgstr ""
 
-#: src/contributing/devenv-setup.md:37
+#: src/contributing/devenv-setup.md:48
 msgid "Command"
 msgstr ""
 
-#: src/contributing/devenv-setup.md:39
+#: src/contributing/devenv-setup.md:50
 msgid "`cargo xtask setup-native`"
 msgstr ""
 
-#: src/contributing/devenv-setup.md:39
+#: src/contributing/devenv-setup.md:50
 msgid "Build MuPDF for native development (run once)"
 msgstr ""
 
-#: src/contributing/devenv-setup.md:40
-msgid "`cargo xtask test`"
-msgstr ""
-
-#: src/contributing/devenv-setup.md:40
-msgid "Run the test suite across the feature matrix"
-msgstr ""
-
-#: src/contributing/devenv-setup.md:41
-msgid "`cargo xtask run-emulator`"
-msgstr ""
-
-#: src/contributing/devenv-setup.md:41
-msgid "Run the emulator"
-msgstr ""
-
-#: src/contributing/devenv-setup.md:42
-msgid "`cargo xtask build-kobo`"
-msgstr ""
-
-#: src/contributing/devenv-setup.md:42
-msgid "Cross-compile for Kobo device (Linux only)"
-msgstr ""
-
-#: src/contributing/devenv-setup.md:43
-msgid "`cargo xtask dist`"
-msgstr ""
-
-#: src/contributing/devenv-setup.md:43
-msgid "Assemble the Kobo distribution directory"
-msgstr ""
-
-#: src/contributing/devenv-setup.md:44
-msgid "`cargo xtask bundle`"
-msgstr ""
-
-#: src/contributing/devenv-setup.md:44
-msgid "Package KoboRoot.tgz for installation"
-msgstr ""
-
-#: src/contributing/devenv-setup.md:45
-msgid "`cadmus-dev-otel`"
-msgstr ""
-
-#: src/contributing/devenv-setup.md:45
-msgid "Run emulator with tracing and profiling enabled"
-msgstr ""
-
-#: src/contributing/devenv-setup.md:46
-msgid "`devenv up`"
-msgstr ""
-
-#: src/contributing/devenv-setup.md:46
-msgid "Start observability stack (Grafana, Tempo, Loki)"
-msgstr ""
-
-#: src/contributing/devenv-setup.md:47
-msgid "`cargo xtask docs`"
-msgstr ""
-
-#: src/contributing/devenv-setup.md:47
-msgid "Build documentation portal (mdBook + Cargo docs)"
-msgstr ""
-
-#: src/contributing/devenv-setup.md:48
-msgid "`cadmus-docs-serve`"
-msgstr ""
-
-#: src/contributing/devenv-setup.md:48
-msgid "Serve documentation portal locally on port 1111"
-msgstr ""
-
-#: src/contributing/devenv-setup.md:49
-msgid "`cadmus-translate`"
-msgstr ""
-
-#: src/contributing/devenv-setup.md:49
-msgid "Generates the template .pot file for the docs"
+#: src/contributing/devenv-setup.md:51
+msgid "`cargo xtask download-assets`"
 msgstr ""
 
 #: src/contributing/devenv-setup.md:51
+msgid "Download packaged Plato runtime assets"
+msgstr ""
+
+#: src/contributing/devenv-setup.md:52
+msgid "`cargo xtask test`"
+msgstr ""
+
+#: src/contributing/devenv-setup.md:52
+msgid "Run the test suite across the feature matrix"
+msgstr ""
+
+#: src/contributing/devenv-setup.md:53
+msgid "`cargo xtask run-emulator`"
+msgstr ""
+
+#: src/contributing/devenv-setup.md:53
+msgid "Run the emulator"
+msgstr ""
+
+#: src/contributing/devenv-setup.md:54
+msgid "`cargo xtask build-kobo`"
+msgstr ""
+
+#: src/contributing/devenv-setup.md:54
+msgid "Cross-compile for Kobo device (Linux only)"
+msgstr ""
+
+#: src/contributing/devenv-setup.md:55
+msgid "`cargo xtask dist`"
+msgstr ""
+
+#: src/contributing/devenv-setup.md:55
+msgid "Assemble the Kobo distribution directory"
+msgstr ""
+
+#: src/contributing/devenv-setup.md:56
+msgid "`cargo xtask bundle`"
+msgstr ""
+
+#: src/contributing/devenv-setup.md:56
+msgid "Package KoboRoot.tgz for installation"
+msgstr ""
+
+#: src/contributing/devenv-setup.md:57
+msgid "`cadmus-dev-otel`"
+msgstr ""
+
+#: src/contributing/devenv-setup.md:57
+msgid "Run emulator with tracing and profiling enabled"
+msgstr ""
+
+#: src/contributing/devenv-setup.md:58
+msgid "`devenv up`"
+msgstr ""
+
+#: src/contributing/devenv-setup.md:58
+msgid "Start observability stack (Grafana, Tempo, Loki)"
+msgstr ""
+
+#: src/contributing/devenv-setup.md:59
+msgid "`cargo xtask docs`"
+msgstr ""
+
+#: src/contributing/devenv-setup.md:59
+msgid "Build documentation portal (mdBook + Cargo docs)"
+msgstr ""
+
+#: src/contributing/devenv-setup.md:60
+msgid "`cadmus-docs-serve`"
+msgstr ""
+
+#: src/contributing/devenv-setup.md:60
+msgid "Serve documentation portal locally on port 1111"
+msgstr ""
+
+#: src/contributing/devenv-setup.md:61
+msgid "`cadmus-translate`"
+msgstr ""
+
+#: src/contributing/devenv-setup.md:61
+msgid "Generates the template .pot file for the docs"
+msgstr ""
+
+#: src/contributing/devenv-setup.md:63
 msgid ""
 "Run `cargo xtask --help` to see all available subcommands, or `cargo xtask "
 "<cmd> --help` for options on a specific command."
 msgstr ""
 
-#: src/contributing/devenv-setup.md:54
+#: src/contributing/devenv-setup.md:66
 msgid ""
 "Or have a look at the rustdocs for `xtask` <a href=\"/api/xtask/\">here</a>."
 msgstr ""
 
-#: src/contributing/devenv-setup.md:56
+#: src/contributing/devenv-setup.md:68
 msgid "Tasks"
 msgstr ""
 
-#: src/contributing/devenv-setup.md:58
+#: src/contributing/devenv-setup.md:70
 msgid ""
 "The devenv environment uses [tasks](https://devenv.sh/tasks/) to manage "
 "build dependencies. Tasks are defined in `devenv.nix` and can be run with "
 "`devenv tasks run <task>`."
 msgstr ""
 
-#: src/contributing/devenv-setup.md:61
+#: src/contributing/devenv-setup.md:73
 msgid "Available Tasks"
 msgstr ""
 
-#: src/contributing/devenv-setup.md:63
+#: src/contributing/devenv-setup.md:75
 msgid "Task"
 msgstr ""
 
-#: src/contributing/devenv-setup.md:63
+#: src/contributing/devenv-setup.md:75
 msgid "Dependencies"
 msgstr ""
 
-#: src/contributing/devenv-setup.md:65 src/contributing/devenv-setup.md:67
+#: src/contributing/devenv-setup.md:77 src/contributing/devenv-setup.md:79
 msgid "`docs:build`"
 msgstr ""
 
-#: src/contributing/devenv-setup.md:65
+#: src/contributing/devenv-setup.md:77
 msgid "Build documentation EPUB (only rebuilds if files changed)"
 msgstr ""
 
-#: src/contributing/devenv-setup.md:65 src/contributing/devenv-setup.md:66
+#: src/contributing/devenv-setup.md:77 src/contributing/devenv-setup.md:78
 msgid "None"
 msgstr ""
 
-#: src/contributing/devenv-setup.md:66
+#: src/contributing/devenv-setup.md:78
 msgid "`deps:native`"
 msgstr ""
 
-#: src/contributing/devenv-setup.md:66
+#: src/contributing/devenv-setup.md:78
 msgid "Build MuPDF and wrapper for native development"
 msgstr ""
 
-#: src/contributing/devenv-setup.md:67
+#: src/contributing/devenv-setup.md:79
 msgid "`build:kobo`"
 msgstr ""
 
-#: src/contributing/devenv-setup.md:67
+#: src/contributing/devenv-setup.md:79
 msgid "Build for Kobo device (Linux only)"
 msgstr ""
 
-#: src/contributing/devenv-setup.md:69
+#: src/contributing/devenv-setup.md:81
 msgid "All tasks delegate to `cargo xtask` under the hood."
 msgstr ""
 
-#: src/contributing/devenv-setup.md:71
+#: src/contributing/devenv-setup.md:83
 msgid "How Tasks Work"
 msgstr ""
 
-#: src/contributing/devenv-setup.md:73
+#: src/contributing/devenv-setup.md:85
 msgid ""
 "Tasks with dependencies automatically run their dependencies first. For "
 "example:"
 msgstr ""
 
-#: src/contributing/devenv-setup.md:76
+#: src/contributing/devenv-setup.md:88
 msgid "# This will first run docs:build (if needed), then build for Kobo\n"
 msgstr ""
 
-#: src/contributing/devenv-setup.md:80
+#: src/contributing/devenv-setup.md:92
 msgid ""
 "The `docs:build` task uses `execIfModified` to only rebuild when "
 "documentation files have actually changed."
 msgstr ""
 
-#: src/contributing/devenv-setup.md:82
+#: src/contributing/devenv-setup.md:94
+msgid "Kobo Build Notes"
+msgstr ""
+
+#: src/contributing/devenv-setup.md:96
+msgid ""
+"`cargo xtask download-assets` must run before `cargo xtask build-kobo` when "
+"you need compile-time asset metadata to match the packaged Kobo contents."
+msgstr ""
+
+#: src/contributing/devenv-setup.md:98
+msgid ""
+"OTA updates delete Cadmus-owned bundled files before reboot, then Kobo "
+"extracts the new `KoboRoot.tgz` over the install directory."
+msgstr ""
+
+#: src/contributing/devenv-setup.md:100
+msgid ""
+"User files outside the generated Cadmus-owned asset list must be preserved, "
+"so do not model OTA cleanup as a full directory wipe."
+msgstr ""
+
+#: src/contributing/devenv-setup.md:103
 msgid "Documentation Portal"
 msgstr ""
 
-#: src/contributing/devenv-setup.md:84
+#: src/contributing/devenv-setup.md:105
 msgid ""
 "Cadmus provides a unified documentation portal that combines user guides, "
 "API reference, and contribution guides in one place."
 msgstr ""
 
-#: src/contributing/devenv-setup.md:87
+#: src/contributing/devenv-setup.md:108
 msgid "Building and Serving Locally"
 msgstr ""
 
-#: src/contributing/devenv-setup.md:89
+#: src/contributing/devenv-setup.md:110
 msgid "To build the documentation portal:"
 msgstr ""
 
-#: src/contributing/devenv-setup.md:95
+#: src/contributing/devenv-setup.md:116
 msgid "This runs the full build pipeline:"
 msgstr ""
 
-#: src/contributing/devenv-setup.md:97
+#: src/contributing/devenv-setup.md:118
 msgid "Builds the mdBook user guide (`docs/book/html/`)"
 msgstr ""
 
-#: src/contributing/devenv-setup.md:98
+#: src/contributing/devenv-setup.md:119
 msgid "Generates Rust API documentation (`target/doc/`)"
 msgstr ""
 
-#: src/contributing/devenv-setup.md:99
+#: src/contributing/devenv-setup.md:120
 msgid "Builds the Zola landing page and integrates all documentation"
 msgstr ""
 
-#: src/contributing/devenv-setup.md:101
+#: src/contributing/devenv-setup.md:122
 msgid "To serve the portal locally with live reload:"
 msgstr ""
 
-#: src/contributing/devenv-setup.md:107
+#: src/contributing/devenv-setup.md:128
 msgid ""
 "The portal will be available at <http://localhost:1111> with automatic "
 "rebuilds when you change documentation files or Rust code."
 msgstr ""
 
-#: src/contributing/devenv-setup.md:110
+#: src/contributing/devenv-setup.md:131
 msgid "Documentation Structure"
 msgstr ""
 
-#: src/contributing/devenv-setup.md:112
+#: src/contributing/devenv-setup.md:133
 msgid "The portal provides three integrated sections:"
 msgstr ""
 
-#: src/contributing/devenv-setup.md:114
+#: src/contributing/devenv-setup.md:135
 msgid "**Landing Page** (`/`) - Overview and feature highlights"
 msgstr ""
 
-#: src/contributing/devenv-setup.md:115
+#: src/contributing/devenv-setup.md:136
 msgid "**User Guide** (`/guide/`) - User-facing documentation from mdBook"
 msgstr ""
 
-#: src/contributing/devenv-setup.md:116
+#: src/contributing/devenv-setup.md:137
 msgid "**API Reference** (`/api/`) - Auto-generated Rust API documentation"
 msgstr ""
 
-#: src/contributing/devenv-setup.md:118
+#: src/contributing/devenv-setup.md:139
 msgid ""
 "All three sections are deployed as a single artifact to GitHub Pages at "
 "<https://ogkevin.github.io/cadmus/>."
 msgstr ""
 
-#: src/contributing/devenv-setup.md:121
+#: src/contributing/devenv-setup.md:142
 msgid "Continuous Integration"
 msgstr ""
 
-#: src/contributing/devenv-setup.md:123
+#: src/contributing/devenv-setup.md:144
 msgid ""
 "Documentation is automatically built and validated on every pull request and "
 "deployed on push to `main` or `master`. The CI pipeline checks:"
 msgstr ""
 
-#: src/contributing/devenv-setup.md:126
+#: src/contributing/devenv-setup.md:147
 msgid "mdBook documentation compiles"
 msgstr ""
 
-#: src/contributing/devenv-setup.md:127
+#: src/contributing/devenv-setup.md:148
 msgid "Rust code documentation is valid"
 msgstr ""
 
-#: src/contributing/devenv-setup.md:128
+#: src/contributing/devenv-setup.md:149
 msgid "Zola landing page builds successfully"
 msgstr ""
 
-#: src/contributing/devenv-setup.md:130
+#: src/contributing/devenv-setup.md:151
 msgid "Running Tests"
 msgstr ""
 
-#: src/contributing/devenv-setup.md:132
+#: src/contributing/devenv-setup.md:153
 msgid ""
 "Tests require the `TEST_ROOT_DIR` environment variable to be set. The "
 "easiest way to run the full test matrix is:"
 msgstr ""
 
-#: src/contributing/devenv-setup.md:139
+#: src/contributing/devenv-setup.md:160
 msgid ""
 "This sets `TEST_ROOT_DIR` automatically and runs tests across all feature "
 "combinations. To run a single feature combination:"
 msgstr ""
 
-#: src/contributing/devenv-setup.md:143
+#: src/contributing/devenv-setup.md:164
 msgid "\"emulator + test\""
 msgstr ""
 
-#: src/contributing/devenv-setup.md:146
+#: src/contributing/devenv-setup.md:167
 msgid "Or to run tests manually without xtask:"
 msgstr ""
 
-#: src/contributing/devenv-setup.md:149 src/contributing/devenv-setup.md:222
+#: src/contributing/devenv-setup.md:170 src/contributing/devenv-setup.md:243
 msgid "$(pwd)"
 msgstr ""
 
-#: src/contributing/devenv-setup.md:152
+#: src/contributing/devenv-setup.md:173
 msgid ""
 "`TEST_ROOT_DIR` is automatically configured in CI but must be set manually "
 "when running `cargo test` directly."
 msgstr ""
 
-#: src/contributing/devenv-setup.md:155
+#: src/contributing/devenv-setup.md:176
 msgid "Platform Support"
 msgstr ""
 
-#: src/contributing/devenv-setup.md:157
+#: src/contributing/devenv-setup.md:178
 msgid "Linux (Full Support)"
 msgstr ""
 
-#: src/contributing/devenv-setup.md:159
+#: src/contributing/devenv-setup.md:180
 msgid "Linux provides full development capabilities including:"
 msgstr ""
 
-#: src/contributing/devenv-setup.md:161
+#: src/contributing/devenv-setup.md:182
 msgid "Native development (emulator, tests)"
 msgstr ""
 
-#: src/contributing/devenv-setup.md:162
+#: src/contributing/devenv-setup.md:183
 msgid "Cross-compilation for Kobo devices using the Linaro ARM toolchain"
 msgstr ""
 
-#: src/contributing/devenv-setup.md:163
+#: src/contributing/devenv-setup.md:184
 msgid "Git hooks (actionlint, shellcheck, shfmt, markdownlint, prettier)"
 msgstr ""
 
-#: src/contributing/devenv-setup.md:165
+#: src/contributing/devenv-setup.md:186
 msgid ""
 "The Linaro toolchain is automatically added to `PATH` and provides "
 "`arm-linux-gnueabihf-*` commands."
 msgstr ""
 
-#: src/contributing/devenv-setup.md:167
+#: src/contributing/devenv-setup.md:188
 msgid "macOS (Native Development Only)"
 msgstr ""
 
-#: src/contributing/devenv-setup.md:169
+#: src/contributing/devenv-setup.md:190
 msgid "macOS supports native development but has some limitations:"
 msgstr ""
 
-#: src/contributing/devenv-setup.md:171
+#: src/contributing/devenv-setup.md:192
 msgid "Feature"
 msgstr ""
 
-#: src/contributing/devenv-setup.md:171
+#: src/contributing/devenv-setup.md:192
 msgid "Notes"
 msgstr ""
 
-#: src/contributing/devenv-setup.md:173
+#: src/contributing/devenv-setup.md:194
 msgid "Native builds"
 msgstr ""
 
-#: src/contributing/devenv-setup.md:173
+#: src/contributing/devenv-setup.md:194
 msgid "Supported"
 msgstr ""
 
-#: src/contributing/devenv-setup.md:173
+#: src/contributing/devenv-setup.md:194
 msgid "Emulator and tests work"
 msgstr ""
 
-#: src/contributing/devenv-setup.md:174
+#: src/contributing/devenv-setup.md:195
 msgid "Cross-compilation"
 msgstr ""
 
-#: src/contributing/devenv-setup.md:174
+#: src/contributing/devenv-setup.md:195
 msgid "Not supported"
 msgstr ""
 
-#: src/contributing/devenv-setup.md:174
+#: src/contributing/devenv-setup.md:195
 msgid "Linaro toolchain is Linux-only"
 msgstr ""
 
-#: src/contributing/devenv-setup.md:176
+#: src/contributing/devenv-setup.md:197
 msgid "macOS-Specific Notes"
 msgstr ""
 
-#: src/contributing/devenv-setup.md:178
+#: src/contributing/devenv-setup.md:199
 msgid ""
 "**Cross-compilation for Kobo**: The Linaro ARM cross-compilation toolchain "
 "consists of x86_64 Linux ELF binaries that cannot run on macOS. To build for "
 "Kobo devices on macOS, use Docker with a Linux container or a Linux VM."
 msgstr ""
 
-#: src/contributing/devenv-setup.md:182
+#: src/contributing/devenv-setup.md:203
 msgid ""
 "**MuPDF build**: On macOS, the native setup script manually gathers "
 "pkg-config CFLAGS for system libraries because MuPDF's build system doesn't "
 "properly detect them on Darwin."
 msgstr ""
 
-#: src/contributing/devenv-setup.md:185
+#: src/contributing/devenv-setup.md:206
 msgid "Observability Stack"
 msgstr ""
 
-#: src/contributing/devenv-setup.md:187
+#: src/contributing/devenv-setup.md:208
 msgid "The devenv includes a full observability stack for development:"
 msgstr ""
 
-#: src/contributing/devenv-setup.md:190
+#: src/contributing/devenv-setup.md:211
 msgid "# Start all services\n"
 msgstr ""
 
-#: src/contributing/devenv-setup.md:192
+#: src/contributing/devenv-setup.md:213
 msgid "# In another terminal, run the instrumented emulator\n"
 msgstr ""
 
-#: src/contributing/devenv-setup.md:197
+#: src/contributing/devenv-setup.md:218
 msgid "Services available after `devenv up`:"
 msgstr ""
 
-#: src/contributing/devenv-setup.md:199
+#: src/contributing/devenv-setup.md:220
 msgid "Service"
 msgstr ""
 
-#: src/contributing/devenv-setup.md:199
+#: src/contributing/devenv-setup.md:220
 msgid "URL"
 msgstr ""
 
-#: src/contributing/devenv-setup.md:199
+#: src/contributing/devenv-setup.md:220
 #: src/contributing/library-database.md:148
 msgid "Purpose"
 msgstr ""
 
-#: src/contributing/devenv-setup.md:201
+#: src/contributing/devenv-setup.md:222
 msgid "Grafana"
 msgstr ""
 
-#: src/contributing/devenv-setup.md:201
+#: src/contributing/devenv-setup.md:222
 msgid "<http://localhost:3000>"
 msgstr ""
 
-#: src/contributing/devenv-setup.md:201
+#: src/contributing/devenv-setup.md:222
 msgid "Dashboards and exploration"
 msgstr ""
 
-#: src/contributing/devenv-setup.md:202
+#: src/contributing/devenv-setup.md:223
 msgid "Tempo"
 msgstr ""
 
-#: src/contributing/devenv-setup.md:202
+#: src/contributing/devenv-setup.md:223
 msgid "<http://localhost:3200>"
 msgstr ""
 
-#: src/contributing/devenv-setup.md:202
+#: src/contributing/devenv-setup.md:223
 msgid "Distributed tracing"
 msgstr ""
 
-#: src/contributing/devenv-setup.md:203
+#: src/contributing/devenv-setup.md:224
 msgid "Loki"
 msgstr ""
 
-#: src/contributing/devenv-setup.md:203
+#: src/contributing/devenv-setup.md:224
 msgid "<http://localhost:3100>"
 msgstr ""
 
-#: src/contributing/devenv-setup.md:203
+#: src/contributing/devenv-setup.md:224
 msgid "Log aggregation"
 msgstr ""
 
-#: src/contributing/devenv-setup.md:204
+#: src/contributing/devenv-setup.md:225
 msgid "Prometheus"
 msgstr ""
 
-#: src/contributing/devenv-setup.md:204
+#: src/contributing/devenv-setup.md:225
 msgid "<http://localhost:9090>"
 msgstr ""
 
-#: src/contributing/devenv-setup.md:204
+#: src/contributing/devenv-setup.md:225
 msgid "Metrics"
 msgstr ""
 
-#: src/contributing/devenv-setup.md:205
+#: src/contributing/devenv-setup.md:226
 msgid "OTLP Collector"
 msgstr ""
 
-#: src/contributing/devenv-setup.md:205
+#: src/contributing/devenv-setup.md:226
 msgid "<http://localhost:4318>"
 msgstr ""
 
-#: src/contributing/devenv-setup.md:205
+#: src/contributing/devenv-setup.md:226
 msgid "Telemetry ingestion"
 msgstr ""
 
-#: src/contributing/devenv-setup.md:206
+#: src/contributing/devenv-setup.md:227
 msgid "Pyroscope"
 msgstr ""
 
-#: src/contributing/devenv-setup.md:206
+#: src/contributing/devenv-setup.md:227
 msgid "<http://localhost:4040>"
 msgstr ""
 
-#: src/contributing/devenv-setup.md:206
+#: src/contributing/devenv-setup.md:227
 msgid "Continuous profiling"
 msgstr ""
 
-#: src/contributing/devenv-setup.md:208
+#: src/contributing/devenv-setup.md:229
 msgid "For more details on telemetry, see [Telemetry](telemetry/index.md)."
 msgstr ""
 
-#: src/contributing/devenv-setup.md:212
+#: src/contributing/devenv-setup.md:233
 msgid "Shell takes a long time to start"
 msgstr ""
 
-#: src/contributing/devenv-setup.md:214
+#: src/contributing/devenv-setup.md:235
 msgid ""
 "The first `devenv shell` invocation downloads and builds dependencies, which "
 "can take several minutes. Subsequent invocations are cached and should be "
 "fast."
 msgstr ""
 
-#: src/contributing/devenv-setup.md:217
+#: src/contributing/devenv-setup.md:238
 msgid "Tests fail with \"TEST_ROOT_DIR must be set\""
 msgstr ""
 
-#: src/contributing/devenv-setup.md:219
+#: src/contributing/devenv-setup.md:240
 msgid "Set the environment variable before running tests:"
 msgstr ""
 
-#: src/contributing/devenv-setup.md:225
+#: src/contributing/devenv-setup.md:246
 msgid "Local Configuration"
 msgstr ""
 
-#: src/contributing/devenv-setup.md:227
+#: src/contributing/devenv-setup.md:248
 msgid ""
 "Create `devenv.local.nix` to override settings without modifying the tracked "
 "configuration:"
 msgstr ""
 
-#: src/contributing/devenv-setup.md:229
+#: src/contributing/devenv-setup.md:250
 msgid ""
 "```nix\n"
 "{ pkgs, ... }:\n"
@@ -2763,7 +2806,7 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/contributing/devenv-setup.md:240
+#: src/contributing/devenv-setup.md:261
 msgid "This file is gitignored and won't affect other contributors."
 msgstr ""
 

--- a/docs/src/contributing/devenv-setup.md
+++ b/docs/src/contributing/devenv-setup.md
@@ -59,7 +59,7 @@ Once inside the devenv shell, these commands are available:
 | `devenv up`                   | Start observability stack (Grafana, Tempo, Loki) |
 | `cargo xtask docs`            | Build documentation portal (mdBook + Cargo docs) |
 | `cadmus-docs-serve`           | Serve documentation portal locally on port 1111  |
-| `cadmus-translate`            | Generates the template .pot file for the docs    |
+| `cadmus-translate`            | Generate the docs translation template (.pot)    |
 
 Run `cargo xtask --help` to see all available subcommands, or `cargo xtask <cmd> --help` for
 options on a specific command.

--- a/docs/src/contributing/devenv-setup.md
+++ b/docs/src/contributing/devenv-setup.md
@@ -24,7 +24,19 @@ This guide covers setup on both Linux and macOS.
    cargo xtask setup-native
    ```
 
-3. Run the emulator:
+3. Download the packaged runtime assets used by Kobo builds:
+
+   ```bash
+   cargo xtask download-assets
+   ```
+
+   > [!NOTE]
+   > `cadmus-core` generates some compile-time metadata from the bundled asset
+   > directories. For Kobo builds, make sure `bin/`, `resources/`, and
+   > `hyphenation-patterns/` are present before `cargo xtask build-kobo` so the
+   > generated asset list is complete.
+
+4. Run the emulator:
 
    ```bash
    cargo xtask run-emulator
@@ -34,19 +46,20 @@ This guide covers setup on both Linux and macOS.
 
 Once inside the devenv shell, these commands are available:
 
-| Command                    | Description                                      |
-| -------------------------- | ------------------------------------------------ |
-| `cargo xtask setup-native` | Build MuPDF for native development (run once)    |
-| `cargo xtask test`         | Run the test suite across the feature matrix     |
-| `cargo xtask run-emulator` | Run the emulator                                 |
-| `cargo xtask build-kobo`   | Cross-compile for Kobo device (Linux only)       |
-| `cargo xtask dist`         | Assemble the Kobo distribution directory         |
-| `cargo xtask bundle`       | Package KoboRoot.tgz for installation            |
-| `cadmus-dev-otel`          | Run emulator with tracing and profiling enabled  |
-| `devenv up`                | Start observability stack (Grafana, Tempo, Loki) |
-| `cargo xtask docs`         | Build documentation portal (mdBook + Cargo docs) |
-| `cadmus-docs-serve`        | Serve documentation portal locally on port 1111  |
-| `cadmus-translate`         | Generates the template .pot file for the docs    |
+| Command                       | Description                                      |
+| ----------------------------- | ------------------------------------------------ |
+| `cargo xtask setup-native`    | Build MuPDF for native development (run once)    |
+| `cargo xtask download-assets` | Download packaged Plato runtime assets           |
+| `cargo xtask test`            | Run the test suite across the feature matrix     |
+| `cargo xtask run-emulator`    | Run the emulator                                 |
+| `cargo xtask build-kobo`      | Cross-compile for Kobo device (Linux only)       |
+| `cargo xtask dist`            | Assemble the Kobo distribution directory         |
+| `cargo xtask bundle`          | Package KoboRoot.tgz for installation            |
+| `cadmus-dev-otel`             | Run emulator with tracing and profiling enabled  |
+| `devenv up`                   | Start observability stack (Grafana, Tempo, Loki) |
+| `cargo xtask docs`            | Build documentation portal (mdBook + Cargo docs) |
+| `cadmus-docs-serve`           | Serve documentation portal locally on port 1111  |
+| `cadmus-translate`            | Generates the template .pot file for the docs    |
 
 Run `cargo xtask --help` to see all available subcommands, or `cargo xtask <cmd> --help` for
 options on a specific command.
@@ -78,6 +91,13 @@ devenv tasks run build:kobo
 ```
 
 The `docs:build` task uses `execIfModified` to only rebuild when documentation files have actually changed.
+
+## Kobo Build Notes
+
+- `cargo xtask download-assets` must run before `cargo xtask build-kobo`.
+- OTA updates delete Cadmus-owned bundled files before reboot, then Kobo
+  extracts the new `KoboRoot.tgz` over the install directory.
+- User files outside the generated Cadmus-owned asset list must be preserved.
 
 ## Documentation Portal
 

--- a/docs/src/installation/ota.md
+++ b/docs/src/installation/ota.md
@@ -52,7 +52,8 @@ The update downloads from GitHub, installs automatically, and reboots the device
 to finish.
 
 Before that reboot, Cadmus removes the files it previously installed so the new
-package can replace them cleanly. Your custom fonts etc will be preserved.
+package can replace them cleanly. Your custom fonts, icons, and other
+user-added files will be preserved.
 
 ## Testing a pull request
 

--- a/docs/src/installation/ota.md
+++ b/docs/src/installation/ota.md
@@ -51,6 +51,9 @@ sign-in process. See [Authentication](#authentication) for details.
 The update downloads from GitHub, installs automatically, and reboots the device
 to finish.
 
+Before that reboot, Cadmus removes the files it previously installed so the new
+package can replace them cleanly. Your custom fonts etc will be preserved.
+
 ## Testing a pull request
 
 Select **PR Build** to try out a specific change before it's released. Enter the

--- a/xtask/src/tasks/download_assets.rs
+++ b/xtask/src/tasks/download_assets.rs
@@ -49,6 +49,9 @@ const ASSET_DIRS: &[&str] = &["bin", "resources", "hyphenation-patterns"];
 /// the directories are extracted into the cache, and then copied to the
 /// workspace root.
 ///
+/// These directories must exist before Kobo builds that generate compile-time
+/// bundled asset metadata, otherwise the generated list will be incomplete.
+///
 /// Workspace-level directories that already exist are left untouched.
 ///
 /// # Errors


### PR DESCRIPTION
Change-Id: 660381f19d55bca0a8c6225271e830d2
Change-Id-Short: ttzwrykyqmuu](Change-Id: 660381f19d55bca0a8c6225271e830d2
Change-Id-Short: ttzwrykyqmuu
Closes: #337 
Closes: CAD-26

---

## OTA pre-reboot cleanup of Cadmus-owned bundled files

Before rebooting after an OTA update, Cadmus now removes only the files it originally installed. This preserves user-added fonts, icons, and other personal files that live alongside Cadmus-owned assets.

### How it works

`crates/core/build.rs` gains a `generate_bundled_assets()` step that walks the bundled asset directories (`bin`, `css`, `fonts`, `hyphenation-patterns`, `icons`, `keyboard-layouts`, `resources`, `scripts`) at compile time and writes a `BUNDLED_ASSET_FILES` constant into `bundled_assets.rs`. The new `crates/core/src/ota/cleanup.rs` module reads that manifest at runtime and removes each listed file individually. The `libs/` directory is handled separately — all shipped shared libraries there are Cadmus-owned, so the whole directory is cleared. Empty parent directories are pruned after removal.

`clean_installation_before_reboot()` is called in `view/ota.rs` immediately after a successful extraction or deployment, before the reboot event is sent, for all three update paths (PR build, main branch, stable release).

### Build order requirement

Because the asset manifest is generated at compile time, `cargo xtask download-assets` **must run before** `cargo xtask build-kobo`. The CI action (`build-kobo/action.yml`) has been reordered accordingly. The `AGENTS.md` and developer setup docs document this constraint.

### Other changes

- `Device` gains `install_dir()`, `install_subdir()`, and `install_path()` helpers, and `tmp_dir()` is reimplemented on top of them. Unit tests use a stable temp-dir path (`test-kobo-installation`) instead of ad-hoc per-module paths.
- `device_flow::token_path()` is simplified to `CURRENT_DEVICE.install_path(TOKEN_FILENAME)`, removing duplicated feature-flag branches.
- The uninstall documentation note about leftover `KoboRoot*.tgz` files is removed; the OTA page now explains the pre-reboot cleanup behaviour.