### PR TITLE
feat(Library): async thumbnail extraction

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -20,7 +20,7 @@ reviews:
   auto_assign_reviewers: true
   path_filters:
     - "!docs/po/messages.pot"
-    - "!.sqlx/"
+    - "!.sqlx/**"
   auto_review:
     auto_pause_after_reviewed_commits: 3
     labels:

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -20,6 +20,7 @@ reviews:
   auto_assign_reviewers: true
   path_filters:
     - "!docs/po/messages.pot"
+    - "!.sqlx/"
   auto_review:
     auto_pause_after_reviewed_commits: 3
     labels:

--- a/.sqlx/query-f57b916e338839ca6233d33a41127cc39c64d2d0fd1beebfbf30fe1e7202805f.json
+++ b/.sqlx/query-f57b916e338839ca6233d33a41127cc39c64d2d0fd1beebfbf30fe1e7202805f.json
@@ -1,0 +1,26 @@
+{
+  "db_name": "SQLite",
+  "query": "\n                SELECT lb.book_fingerprint AS \"fingerprint!: Fp\",\n                       lb.file_path        AS \"file_path!: String\"\n                FROM library_books lb\n                LEFT JOIN thumbnails t ON lb.book_fingerprint = t.fingerprint\n                WHERE lb.library_id = ? AND t.fingerprint IS NULL\n                ",
+  "describe": {
+    "columns": [
+      {
+        "name": "fingerprint!: Fp",
+        "ordinal": 0,
+        "type_info": "Text"
+      },
+      {
+        "name": "file_path!: String",
+        "ordinal": 1,
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Right": 1
+    },
+    "nullable": [
+      false,
+      false
+    ]
+  },
+  "hash": "f57b916e338839ca6233d33a41127cc39c64d2d0fd1beebfbf30fe1e7202805f"
+}

--- a/crates/cadmus/src/app.rs
+++ b/crates/cadmus/src/app.rs
@@ -731,8 +731,7 @@ pub fn run() -> Result<(), Error> {
 
     let mut history: Vec<HistoryItem> = Vec::new();
     let mut rq = RenderQueue::new();
-    let mut view: Box<dyn View> =
-        Box::new(Home::new(context.fb.rect(), &tx, &mut rq, &mut context)?);
+    let mut view: Box<dyn View> = Box::new(Home::new(context.fb.rect(), &mut rq, &mut context)?);
 
     let mut updating = Vec::new();
 

--- a/crates/core/src/library/db/mod.rs
+++ b/crates/core/src/library/db/mod.rs
@@ -2568,6 +2568,32 @@ impl Db {
         })
     }
 
+    /// Returns `(fingerprint, path)` pairs for every book that does not have a thumbnail cached.
+    #[cfg_attr(
+        feature = "tracing",
+        tracing::instrument(skip(self), fields(library_id))
+    )]
+    pub fn books_without_thumbnails(&self, library_id: i64) -> Result<Vec<(Fp, PathBuf)>, Error> {
+        RUNTIME.block_on(async {
+            let rows = sqlx::query!(
+                r#"
+                SELECT lb.book_fingerprint AS "fingerprint!: Fp",
+                       lb.file_path        AS "file_path!: String"
+                FROM library_books lb
+                LEFT JOIN thumbnails t ON lb.book_fingerprint = t.fingerprint
+                WHERE lb.library_id = ? AND t.fingerprint IS NULL
+                "#,
+                library_id,
+            )
+            .fetch_all(&self.pool)
+            .await?;
+
+            rows.into_iter()
+                .map(|row| Ok((row.fingerprint, PathBuf::from(row.file_path))))
+                .collect()
+        })
+    }
+
     /// Updates both the relative and absolute path of a book in a single transaction.
     /// No-op if the book is not found in the library.
     #[cfg_attr(feature = "tracing", tracing::instrument(skip(self), fields(library_id, fp = %fp)))]
@@ -3596,6 +3622,50 @@ mod tests {
 
         let thumbnail = libdb.get_thumbnail(fp).expect("failed to get thumbnail");
         assert!(thumbnail.is_none());
+    }
+
+    #[test]
+    fn test_books_without_thumbnails() {
+        let (_db, libdb) = create_test_db();
+        let library_id = register_test_library(
+            &libdb,
+            "/tmp/test_library_thumbnails_missing",
+            "Missing Thumbs Library",
+        );
+        let fp1 = Fp::from_str("0000000000000008").unwrap();
+        let fp2 = Fp::from_str("0000000000000009").unwrap();
+
+        libdb
+            .insert_book(
+                library_id,
+                fp1,
+                &make_info("thumbs/book1.epub", "Thumb Book 1", "Thumb Author 1"),
+            )
+            .expect("failed to insert book 1");
+
+        libdb
+            .insert_book(
+                library_id,
+                fp2,
+                &make_info("thumbs/book2.epub", "Thumb Book 2", "Thumb Author 2"),
+            )
+            .expect("failed to insert book 2");
+
+        let missing = libdb.books_without_thumbnails(library_id).unwrap();
+        assert_eq!(missing.len(), 2);
+        assert!(missing.contains(&(fp1, PathBuf::from("thumbs/book1.epub"))));
+        assert!(missing.contains(&(fp2, PathBuf::from("thumbs/book2.epub"))));
+
+        libdb.save_thumbnail(fp1, &[1, 2, 3]).unwrap();
+
+        let missing = libdb.books_without_thumbnails(library_id).unwrap();
+        assert_eq!(missing.len(), 1);
+        assert_eq!(missing[0], (fp2, PathBuf::from("thumbs/book2.epub")));
+
+        libdb.save_thumbnail(fp2, &[4, 5, 6]).unwrap();
+
+        let missing = libdb.books_without_thumbnails(library_id).unwrap();
+        assert!(missing.is_empty());
     }
 
     #[test]

--- a/crates/core/src/task/import.rs
+++ b/crates/core/src/task/import.rs
@@ -80,12 +80,11 @@ impl BackgroundTask for ImportTask {
                 }
             }
         }
+    }
 
-        if !shutdown.should_stop() {
-            hub.send(Event::ImportFinished {
-                library_index: self.library_index,
-            })
-            .ok();
-        }
+    fn finished_event(&self) -> Option<Event> {
+        Some(Event::ImportFinished {
+            library_index: self.library_index,
+        })
     }
 }

--- a/crates/core/src/task/mod.rs
+++ b/crates/core/src/task/mod.rs
@@ -44,7 +44,7 @@ pub mod thumbnail;
 #[cfg(any(feature = "kobo", doc))]
 mod wifi_status_monitor;
 
-use std::collections::HashMap;
+use std::collections::{HashMap, VecDeque};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::mpsc::{self, Receiver, Sender};
 use std::thread::{self, JoinHandle};
@@ -228,9 +228,10 @@ struct RunningTask {
 /// methods to stop individual tasks or all tasks at once.
 pub struct TaskManager {
     tasks: HashMap<TaskId, RunningTask>,
-    /// A pending import rerun queued while an import was already running.
-    /// `Some(library_index)` means re-run for that index after current finishes.
-    pending_import_rerun: Option<Option<usize>>,
+    /// Library indices awaiting import while one is already running.
+    pending_import_indices: VecDeque<Option<usize>>,
+    /// Library indices awaiting thumbnail extraction while a run is in progress.
+    pending_thumbnail_indices: VecDeque<Option<usize>>,
 }
 
 impl TaskManager {
@@ -238,7 +239,8 @@ impl TaskManager {
     pub fn new() -> Self {
         Self {
             tasks: HashMap::new(),
-            pending_import_rerun: None,
+            pending_import_indices: VecDeque::new(),
+            pending_thumbnail_indices: VecDeque::new(),
         }
     }
 
@@ -358,19 +360,18 @@ impl TaskManager {
             }
             Event::ImportFinished { library_index } => {
                 self.schedule_thumbnail_extraction(*library_index, hub, database, settings);
-                if let Some(pending) = self.pending_import_rerun.take() {
-                    self.schedule_import(pending, hub, database, settings);
-                }
             }
             Event::ReindexDictionaries => {
                 self.schedule_dictionary_index(hub, database);
             }
             _ => {}
         }
+        self.drain_pending_imports(hub, database, settings);
+        self.drain_pending_thumbnails(hub, database, settings);
         false
     }
 
-    /// Schedules an import task, coalescing if one is already running.
+    /// Schedules an import task, queuing the index if one is already running.
     #[cfg_attr(feature = "tracing", tracing::instrument(skip_all))]
     fn schedule_import(
         &mut self,
@@ -380,7 +381,8 @@ impl TaskManager {
         settings: &Settings,
     ) {
         if self.is_running(&TaskId::Import) {
-            self.pending_import_rerun = Some(library_index);
+            tracing::info!(library_index = ?library_index, "import already running, queueing");
+            self.pending_import_indices.push_back(library_index);
             return;
         }
 
@@ -393,6 +395,22 @@ impl TaskManager {
         if let Err(e) = self.start(task, hub.clone()) {
             tracing::warn!(error = %e, "failed to start import task");
         }
+    }
+
+    /// Starts the next pending import when the current one finishes.
+    #[cfg_attr(feature = "tracing", tracing::instrument(skip_all))]
+    fn drain_pending_imports(
+        &mut self,
+        hub: &Sender<Event>,
+        database: &Database,
+        settings: &Settings,
+    ) {
+        if self.is_running(&TaskId::Import) || self.pending_import_indices.is_empty() {
+            return;
+        }
+
+        let next = self.pending_import_indices.pop_front().unwrap();
+        self.schedule_import(next, hub, database, settings);
     }
 
     /// Schedules a dictionary index scan, stopping any running instance first.
@@ -412,7 +430,7 @@ impl TaskManager {
         }
     }
 
-    /// Schedules a thumbnail extraction task, stopping any running instance first.
+    /// Schedules a thumbnail extraction task, queuing the index if one is already running.
     #[cfg_attr(feature = "tracing", tracing::instrument(skip_all))]
     pub fn schedule_thumbnail_extraction(
         &mut self,
@@ -422,10 +440,9 @@ impl TaskManager {
         settings: &Settings,
     ) {
         if self.is_running(&TaskId::ThumbnailExtraction) {
-            tracing::info!("stopping running thumbnail extraction task for restart");
-            if let Err(e) = self.stop(&TaskId::ThumbnailExtraction) {
-                tracing::warn!(error = %e, "failed to stop thumbnail extraction task for restart");
-            }
+            tracing::info!(library_index = ?library_index, "thumbnail extraction already running, queueing");
+            self.pending_thumbnail_indices.push_back(library_index);
+            return;
         }
 
         let task = Box::new(thumbnail::ThumbnailExtractionTask::new(
@@ -437,6 +454,24 @@ impl TaskManager {
         if let Err(e) = self.start(task, hub.clone()) {
             tracing::warn!(error = %e, "failed to start thumbnail extraction task");
         }
+    }
+
+    /// Starts the next pending thumbnail extraction when the current one finishes.
+    #[cfg_attr(feature = "tracing", tracing::instrument(skip_all))]
+    fn drain_pending_thumbnails(
+        &mut self,
+        hub: &Sender<Event>,
+        database: &Database,
+        settings: &Settings,
+    ) {
+        if self.is_running(&TaskId::ThumbnailExtraction)
+            || self.pending_thumbnail_indices.is_empty()
+        {
+            return;
+        }
+
+        let next = self.pending_thumbnail_indices.pop_front().unwrap();
+        self.schedule_thumbnail_extraction(next, hub, database, settings);
     }
 
     /// Returns `true` if a task with the given ID is running.
@@ -636,9 +671,56 @@ mod tests {
         let settings = Settings::default();
 
         manager.schedule_thumbnail_extraction(None, &hub, &database, &settings);
-        assert!(manager.is_running(&TaskId::ThumbnailExtraction));
+
+        // Task exits quickly on an unseeded database, so wait for
+        // completion rather than asserting the transient running state.
+        wait_until_not_running(&mut manager, &TaskId::ThumbnailExtraction);
+        assert!(!manager.is_running(&TaskId::ThumbnailExtraction));
+
+        let err = manager.stop(&TaskId::ThumbnailExtraction).unwrap_err();
+        assert!(matches!(
+            err,
+            TaskError::NotRunning(TaskId::ThumbnailExtraction)
+        ));
+    }
+
+    #[test]
+    fn thumbnail_extraction_queues_when_running() {
+        let mut manager = TaskManager::new();
+        let (hub, _rx) = mpsc::channel();
+
+        // Simulate a running ThumbnailExtraction task with a blocking thread.
+        let (shutdown_tx, shutdown_rx) = mpsc::channel();
+        let blocking_handle = thread::spawn(move || {
+            let _ = shutdown_rx.recv();
+        });
+        manager.tasks.insert(
+            TaskId::ThumbnailExtraction,
+            RunningTask {
+                handle: blocking_handle,
+                shutdown: shutdown_tx,
+            },
+        );
+
+        let database = Database::new(":memory:").unwrap();
+        database.migrate().unwrap();
+        let settings = Settings::default();
+
+        manager.schedule_thumbnail_extraction(Some(0), &hub, &database, &settings);
+        manager.schedule_thumbnail_extraction(Some(1), &hub, &database, &settings);
+
+        assert_eq!(manager.pending_thumbnail_indices.len(), 2);
 
         manager.stop(&TaskId::ThumbnailExtraction).unwrap();
-        assert!(!manager.is_running(&TaskId::ThumbnailExtraction));
+
+        manager.drain_pending_thumbnails(&hub, &database, &settings);
+        assert_eq!(manager.pending_thumbnail_indices.len(), 1);
+
+        wait_until_not_running(&mut manager, &TaskId::ThumbnailExtraction);
+
+        manager.drain_pending_thumbnails(&hub, &database, &settings);
+        assert!(manager.pending_thumbnail_indices.is_empty());
+
+        wait_until_not_running(&mut manager, &TaskId::ThumbnailExtraction);
     }
 }

--- a/crates/core/src/task/mod.rs
+++ b/crates/core/src/task/mod.rs
@@ -40,6 +40,7 @@ pub mod dictionary_index;
 #[cfg(any(feature = "test", doc))]
 mod hello_world;
 pub mod import;
+pub mod thumbnail;
 #[cfg(any(feature = "kobo", doc))]
 mod wifi_status_monitor;
 
@@ -74,6 +75,8 @@ pub enum TaskId {
     Placeholder,
     /// Library import task.
     Import,
+    /// Thumbnail extraction background task.
+    ThumbnailExtraction,
     /// Dictionary index background task.
     DictionaryIndex,
     /// The example task that prints periodically (test builds only).
@@ -98,6 +101,7 @@ impl std::fmt::Display for TaskId {
         match self {
             TaskId::Placeholder => write!(f, "placeholder"),
             TaskId::Import => write!(f, "import"),
+            TaskId::ThumbnailExtraction => write!(f, "thumbnail_extraction"),
             TaskId::DictionaryIndex => write!(f, "dictionary_index"),
             #[cfg(feature = "test")]
             TaskId::HelloWorld => write!(f, "hello_world"),
@@ -352,7 +356,8 @@ impl TaskManager {
             Event::ImportLibrary { library_index } => {
                 self.schedule_import(*library_index, hub, database, settings);
             }
-            Event::ImportFinished { .. } => {
+            Event::ImportFinished { library_index } => {
+                self.schedule_thumbnail_extraction(*library_index, hub, database, settings);
                 if let Some(pending) = self.pending_import_rerun.take() {
                     self.schedule_import(pending, hub, database, settings);
                 }
@@ -404,6 +409,33 @@ impl TaskManager {
 
         if let Err(e) = self.start(task, hub.clone()) {
             tracing::warn!(error = %e, "failed to start dictionary_index task");
+        }
+    }
+
+    /// Schedules a thumbnail extraction task, stopping any running instance first.
+    #[cfg_attr(feature = "tracing", tracing::instrument(skip_all))]
+    pub fn schedule_thumbnail_extraction(
+        &mut self,
+        library_index: Option<usize>,
+        hub: &Sender<Event>,
+        database: &Database,
+        settings: &Settings,
+    ) {
+        if self.is_running(&TaskId::ThumbnailExtraction) {
+            tracing::info!("stopping running thumbnail extraction task for restart");
+            if let Err(e) = self.stop(&TaskId::ThumbnailExtraction) {
+                tracing::warn!(error = %e, "failed to stop thumbnail extraction task for restart");
+            }
+        }
+
+        let task = Box::new(thumbnail::ThumbnailExtractionTask::new(
+            database.clone(),
+            settings.clone(),
+            library_index,
+        ));
+
+        if let Err(e) = self.start(task, hub.clone()) {
+            tracing::warn!(error = %e, "failed to start thumbnail extraction task");
         }
     }
 
@@ -593,5 +625,20 @@ mod tests {
         manager.stop_all();
 
         assert!(!manager.is_running(&TaskId::TestTask));
+    }
+
+    #[test]
+    fn test_thumbnail_extraction_task_lifecycle() {
+        let mut manager = TaskManager::new();
+        let (hub, _rx) = mpsc::channel();
+        let database = Database::new(":memory:").unwrap();
+        database.migrate().unwrap();
+        let settings = Settings::default();
+
+        manager.schedule_thumbnail_extraction(None, &hub, &database, &settings);
+        assert!(manager.is_running(&TaskId::ThumbnailExtraction));
+
+        manager.stop(&TaskId::ThumbnailExtraction).unwrap();
+        assert!(!manager.is_running(&TaskId::ThumbnailExtraction));
     }
 }

--- a/crates/core/src/task/mod.rs
+++ b/crates/core/src/task/mod.rs
@@ -215,6 +215,15 @@ pub trait BackgroundTask: Send {
     ///
     /// Override this to perform cleanup. The default implementation does nothing.
     fn stop(&mut self) {}
+
+    /// Returns a "finished" event to send after the task thread exits.
+    ///
+    /// Called after [`stop`](Self::stop) in the thread closure. If the
+    /// returned `Event` is `Some`, it is sent on the hub once the thread
+    /// has truly finished running. The default returns `None`.
+    fn finished_event(&self) -> Option<Event> {
+        None
+    }
 }
 
 struct RunningTask {
@@ -273,6 +282,11 @@ impl TaskManager {
             tracing::info!("task started");
             task.run(&hub, &shutdown_signal);
             task.stop();
+            if !shutdown_signal.should_stop() {
+                if let Some(evt) = task.finished_event() {
+                    hub.send(evt).ok();
+                }
+            }
             tracing::info!("task stopped");
         });
 

--- a/crates/core/src/task/mod.rs
+++ b/crates/core/src/task/mod.rs
@@ -218,9 +218,8 @@ pub trait BackgroundTask: Send {
 
     /// Returns a "finished" event to send after the task thread exits.
     ///
-    /// Called after [`stop`](Self::stop) in the thread closure. If the
-    /// returned `Event` is `Some`, it is sent on the hub once the thread
-    /// has truly finished running. The default returns `None`.
+    /// The [`TaskManager`] sends this event after
+    /// observing the task's thread as finished. The default returns `None`.
     fn finished_event(&self) -> Option<Event> {
         None
     }
@@ -229,6 +228,8 @@ pub trait BackgroundTask: Send {
 struct RunningTask {
     handle: JoinHandle<()>,
     shutdown: Sender<()>,
+    /// Event to emit when the task is observed as naturally finished.
+    finished_event: Option<Event>,
 }
 
 /// Manages the lifecycle of background tasks.
@@ -241,6 +242,8 @@ pub struct TaskManager {
     pending_import_indices: VecDeque<Option<usize>>,
     /// Library indices awaiting thumbnail extraction while a run is in progress.
     pending_thumbnail_indices: VecDeque<Option<usize>>,
+    /// Events from naturally finished tasks, waiting to be sent.
+    buffered_events: Vec<Event>,
 }
 
 impl TaskManager {
@@ -250,6 +253,7 @@ impl TaskManager {
             tasks: HashMap::new(),
             pending_import_indices: VecDeque::new(),
             pending_thumbnail_indices: VecDeque::new(),
+            buffered_events: Vec::new(),
         }
     }
 
@@ -277,16 +281,13 @@ impl TaskManager {
         let (shutdown_tx, shutdown_rx) = mpsc::channel();
         let shutdown_signal = ShutdownSignal::new(shutdown_rx);
 
+        let finished_event = task.finished_event();
+
         let handle = thread::spawn(move || {
             let mut task = task;
             tracing::info!("task started");
             task.run(&hub, &shutdown_signal);
             task.stop();
-            if !shutdown_signal.should_stop() {
-                if let Some(evt) = task.finished_event() {
-                    hub.send(evt).ok();
-                }
-            }
             tracing::info!("task stopped");
         });
 
@@ -295,6 +296,7 @@ impl TaskManager {
             RunningTask {
                 handle,
                 shutdown: shutdown_tx,
+                finished_event,
             },
         );
 
@@ -348,9 +350,28 @@ impl TaskManager {
         }
     }
 
-    /// Removes entries for tasks whose threads have finished.
+    /// Removes entries for tasks whose threads have finished, buffering
+    /// their completion events to be sent later.
     fn cleanup_finished(&mut self) {
-        self.tasks.retain(|_, task| !task.handle.is_finished());
+        let mut events = Vec::new();
+        self.tasks.retain(|_, task| {
+            if task.handle.is_finished() {
+                if let Some(evt) = task.finished_event.take() {
+                    events.push(evt);
+                }
+                false
+            } else {
+                true
+            }
+        });
+        self.buffered_events.extend(events);
+    }
+
+    /// Sends any buffered completion events from naturally finished tasks.
+    fn flush_buffered_events(&mut self, hub: &Sender<Event>) {
+        for evt in self.buffered_events.drain(..) {
+            hub.send(evt).ok();
+        }
     }
 
     /// Observes an event without consuming it.
@@ -368,6 +389,9 @@ impl TaskManager {
         database: &Database,
         settings: &Settings,
     ) -> bool {
+        self.cleanup_finished();
+        self.flush_buffered_events(hub);
+
         match evt {
             Event::ImportLibrary { library_index } => {
                 self.schedule_import(*library_index, hub, database, settings);
@@ -402,6 +426,8 @@ impl TaskManager {
             return;
         }
 
+        self.flush_buffered_events(hub);
+
         let task = Box::new(import::ImportTask::new(
             database.clone(),
             settings.clone(),
@@ -425,7 +451,9 @@ impl TaskManager {
             return;
         }
 
-        let next = self.pending_import_indices.pop_front().unwrap();
+        let Some(next) = self.pending_import_indices.pop_front() else {
+            return;
+        };
         self.schedule_import(next, hub, database, settings);
     }
 
@@ -438,6 +466,8 @@ impl TaskManager {
                 tracing::warn!(error = %e, "failed to stop dictionary_index task for restart");
             }
         }
+
+        self.flush_buffered_events(hub);
 
         let task = Box::new(dictionary_index::DictionaryIndexTask::new(database.clone()));
 
@@ -460,6 +490,8 @@ impl TaskManager {
             self.pending_thumbnail_indices.push_back(library_index);
             return;
         }
+
+        self.flush_buffered_events(hub);
 
         let task = Box::new(thumbnail::ThumbnailExtractionTask::new(
             database.clone(),
@@ -486,7 +518,9 @@ impl TaskManager {
             return;
         }
 
-        let next = self.pending_thumbnail_indices.pop_front().unwrap();
+        let Some(next) = self.pending_thumbnail_indices.pop_front() else {
+            return;
+        };
         self.schedule_thumbnail_extraction(next, hub, database, settings);
     }
 
@@ -715,6 +749,7 @@ mod tests {
             RunningTask {
                 handle: blocking_handle,
                 shutdown: shutdown_tx,
+                finished_event: None,
             },
         );
 

--- a/crates/core/src/task/mod.rs
+++ b/crates/core/src/task/mod.rs
@@ -351,20 +351,26 @@ impl TaskManager {
     }
 
     /// Removes entries for tasks whose threads have finished, buffering
-    /// their completion events to be sent later.
+    /// their completion events only if the thread exited successfully.
     fn cleanup_finished(&mut self) {
-        let mut events = Vec::new();
-        self.tasks.retain(|_, task| {
-            if task.handle.is_finished() {
-                if let Some(evt) = task.finished_event.take() {
-                    events.push(evt);
+        let finished: Vec<TaskId> = self
+            .tasks
+            .iter()
+            .filter(|(_, task)| task.handle.is_finished())
+            .map(|(id, _)| id.clone())
+            .collect();
+
+        for id in finished {
+            if let Some(task) = self.tasks.remove(&id) {
+                if task.handle.join().is_ok() {
+                    if let Some(evt) = task.finished_event {
+                        self.buffered_events.push(evt);
+                    }
+                } else {
+                    tracing::error!(task_id = %id, "task thread panicked");
                 }
-                false
-            } else {
-                true
             }
-        });
-        self.buffered_events.extend(events);
+        }
     }
 
     /// Sends any buffered completion events from naturally finished tasks.

--- a/crates/core/src/task/mod.rs
+++ b/crates/core/src/task/mod.rs
@@ -359,15 +359,17 @@ impl TaskManager {
                 self.schedule_import(*library_index, hub, database, settings);
             }
             Event::ImportFinished { library_index } => {
+                self.drain_pending_imports(hub, database, settings);
                 self.schedule_thumbnail_extraction(*library_index, hub, database, settings);
+            }
+            Event::ThumbnailExtractionFinished { .. } => {
+                self.drain_pending_thumbnails(hub, database, settings);
             }
             Event::ReindexDictionaries => {
                 self.schedule_dictionary_index(hub, database);
             }
             _ => {}
         }
-        self.drain_pending_imports(hub, database, settings);
-        self.drain_pending_thumbnails(hub, database, settings);
         false
     }
 

--- a/crates/core/src/task/thumbnail.rs
+++ b/crates/core/src/task/thumbnail.rs
@@ -127,5 +127,12 @@ impl BackgroundTask for ThumbnailExtractionTask {
                 }
             }
         }
+
+        if !shutdown.should_stop() {
+            hub.send(Event::ThumbnailExtractionFinished {
+                library_index: self.library_index,
+            })
+            .ok();
+        }
     }
 }

--- a/crates/core/src/task/thumbnail.rs
+++ b/crates/core/src/task/thumbnail.rs
@@ -1,0 +1,131 @@
+//! Background task that extracts book cover thumbnails.
+
+use std::sync::mpsc::Sender;
+
+use crate::db::Database;
+use crate::device::CURRENT_DEVICE;
+use crate::document::open;
+use crate::library::Library;
+use crate::settings::Settings;
+use crate::task::{BackgroundTask, ShutdownSignal, TaskId};
+use crate::unit::scale_by_dpi;
+use crate::view::Event;
+use crate::view::BIG_BAR_HEIGHT;
+
+/// Runs thumbnail extraction for missing book previews in a library (or all libraries when `library_index` is `None`).
+pub struct ThumbnailExtractionTask {
+    database: Database,
+    settings: Settings,
+    /// Which library to process. `None` means all configured libraries.
+    library_index: Option<usize>,
+}
+
+impl ThumbnailExtractionTask {
+    pub fn new(database: Database, settings: Settings, library_index: Option<usize>) -> Self {
+        Self {
+            database,
+            settings,
+            library_index,
+        }
+    }
+
+    #[cfg_attr(feature = "tracing", tracing::instrument(skip(hub, shutdown, self)))]
+    fn run_for_index(&self, index: usize, hub: &Sender<Event>, shutdown: &ShutdownSignal) {
+        let lib_settings = match self.settings.libraries.get(index) {
+            Some(s) => s,
+            None => {
+                tracing::warn!(
+                    library_index = index,
+                    "library index out of range, skipping"
+                );
+                return;
+            }
+        };
+
+        let library = match Library::new(&lib_settings.path, &self.database, &lib_settings.name) {
+            Ok(lib) => lib,
+            Err(e) => {
+                tracing::error!(error = %e, library_index = index, "failed to open library for thumbnail extraction");
+                return;
+            }
+        };
+
+        let books = match library.db.books_without_thumbnails(library.library_id) {
+            Ok(books) => books,
+            Err(e) => {
+                tracing::error!(error = %e, library_id = library.library_id, "failed to query books without thumbnails");
+                return;
+            }
+        };
+
+        if books.is_empty() {
+            tracing::debug!(
+                library_id = library.library_id,
+                "no missing thumbnails for library"
+            );
+            return;
+        }
+
+        tracing::info!(
+            library_id = library.library_id,
+            count = books.len(),
+            "starting thumbnail extraction for library"
+        );
+
+        let dpi = CURRENT_DEVICE.dpi;
+        let big_height = scale_by_dpi(BIG_BAR_HEIGHT, dpi) as i32;
+        let th = big_height;
+        let tw = 3 * th / 4;
+
+        for (fp, path) in books {
+            if shutdown.should_stop() {
+                tracing::info!("thumbnail extraction task shutdown requested, stopping");
+                return;
+            }
+
+            let full_path = library.home.join(&path);
+            tracing::debug!(path = %path.display(), "extracting thumbnail");
+
+            match open(&full_path)
+                .and_then(|mut doc| {
+                    doc.preview_pixmap(tw as f32, th as f32, CURRENT_DEVICE.color_samples())
+                })
+                .and_then(|pixmap| pixmap.to_png_bytes().ok())
+            {
+                Some(bytes) => {
+                    if let Err(e) = library.db.save_thumbnail(fp, &bytes) {
+                        tracing::error!(error = %e, path = %path.display(), "failed to save thumbnail to database");
+                    } else {
+                        hub.send(Event::RefreshBookPreview(path)).ok();
+                    }
+                }
+                None => {
+                    tracing::warn!(path = %path.display(), "failed to extract preview for book");
+                }
+            }
+        }
+    }
+}
+
+impl BackgroundTask for ThumbnailExtractionTask {
+    fn id(&self) -> TaskId {
+        TaskId::ThumbnailExtraction
+    }
+
+    #[cfg_attr(feature = "tracing", tracing::instrument(skip_all))]
+    fn run(&mut self, hub: &Sender<Event>, shutdown: &ShutdownSignal) {
+        match self.library_index {
+            Some(index) => {
+                self.run_for_index(index, hub, shutdown);
+            }
+            None => {
+                for index in 0..self.settings.libraries.len() {
+                    if shutdown.should_stop() {
+                        return;
+                    }
+                    self.run_for_index(index, hub, shutdown);
+                }
+            }
+        }
+    }
+}

--- a/crates/core/src/task/thumbnail.rs
+++ b/crates/core/src/task/thumbnail.rs
@@ -127,12 +127,11 @@ impl BackgroundTask for ThumbnailExtractionTask {
                 }
             }
         }
+    }
 
-        if !shutdown.should_stop() {
-            hub.send(Event::ThumbnailExtractionFinished {
-                library_index: self.library_index,
-            })
-            .ok();
-        }
+    fn finished_event(&self) -> Option<Event> {
+        Some(Event::ThumbnailExtractionFinished {
+            library_index: self.library_index,
+        })
     }
 }

--- a/crates/core/src/view/home/mod.rs
+++ b/crates/core/src/view/home/mod.rs
@@ -80,10 +80,9 @@ struct Fetcher {
 
 impl Home {
     /// Builds the Home view and loads the initial page of books for the selected library.
-    #[cfg_attr(feature = "tracing", tracing::instrument(skip(rq, hub, context)))]
+    #[cfg_attr(feature = "tracing", tracing::instrument(skip(rq, context)))]
     pub fn new(
         rect: Rectangle,
-        hub: &Hub,
         rq: &mut RenderQueue,
         context: &mut Context,
     ) -> Result<Home, Error> {
@@ -210,7 +209,7 @@ impl Home {
         let count = page_result.total_count;
         let pages_count = count.div_ceil(max_lines);
 
-        shelf.update(&page_result.books, hub, &mut RenderQueue::new(), context);
+        shelf.update(&page_result.books, &mut RenderQueue::new(), context);
 
         children.push(Box::new(shelf) as Box<dyn View>);
 
@@ -314,7 +313,7 @@ impl Home {
             ));
         }
 
-        self.update_shelf(true, hub, rq, context);
+        self.update_shelf(true, rq, context);
         self.update_bottom_bar(rq, context);
     }
 
@@ -352,22 +351,16 @@ impl Home {
         }
     }
 
-    fn go_to_page(&mut self, index: usize, hub: &Hub, rq: &mut RenderQueue, context: &mut Context) {
+    fn go_to_page(&mut self, index: usize, rq: &mut RenderQueue, context: &mut Context) {
         if index >= self.pages_count {
             return;
         }
         self.current_page = index;
-        self.update_shelf(false, hub, rq, context);
+        self.update_shelf(false, rq, context);
         self.update_bottom_bar(rq, context);
     }
 
-    fn go_to_neighbor(
-        &mut self,
-        dir: CycleDir,
-        hub: &Hub,
-        rq: &mut RenderQueue,
-        context: &mut Context,
-    ) {
+    fn go_to_neighbor(&mut self, dir: CycleDir, rq: &mut RenderQueue, context: &mut Context) {
         match dir {
             CycleDir::Next if self.current_page < self.pages_count.saturating_sub(1) => {
                 self.current_page += 1;
@@ -378,17 +371,11 @@ impl Home {
             _ => return,
         }
 
-        self.update_shelf(false, hub, rq, context);
+        self.update_shelf(false, rq, context);
         self.update_bottom_bar(rq, context);
     }
 
-    fn go_to_status_change(
-        &mut self,
-        dir: CycleDir,
-        hub: &Hub,
-        rq: &mut RenderQueue,
-        context: &mut Context,
-    ) {
+    fn go_to_status_change(&mut self, dir: CycleDir, rq: &mut RenderQueue, context: &mut Context) {
         if self.pages_count < 2 {
             return;
         }
@@ -407,7 +394,7 @@ impl Home {
         ) {
             Ok(Some(page)) => {
                 self.current_page = page;
-                self.update_shelf(false, hub, rq, context);
+                self.update_shelf(false, rq, context);
                 self.update_bottom_bar(rq, context);
             }
             Ok(None) => {}
@@ -422,7 +409,6 @@ impl Home {
         &mut self,
         update: bool,
         reset_page: bool,
-        hub: &Hub,
         rq: &mut RenderQueue,
         context: &mut Context,
     ) {
@@ -475,37 +461,32 @@ impl Home {
         }
 
         if update {
-            self.update_shelf(false, hub, rq, context);
+            self.update_shelf(false, rq, context);
             self.update_bottom_bar(rq, context);
         }
     }
 
-    fn update_first_column(&mut self, hub: &Hub, rq: &mut RenderQueue, context: &mut Context) {
+    fn update_first_column(&mut self, rq: &mut RenderQueue, context: &mut Context) {
         let selected_library = context.settings.selected_library;
         self.children[self.shelf_index]
             .as_mut()
             .downcast_mut::<Shelf>()
             .unwrap()
             .set_first_column(context.settings.libraries[selected_library].first_column);
-        self.update_shelf(false, hub, rq, context);
+        self.update_shelf(false, rq, context);
     }
 
-    fn update_second_column(&mut self, hub: &Hub, rq: &mut RenderQueue, context: &mut Context) {
+    fn update_second_column(&mut self, rq: &mut RenderQueue, context: &mut Context) {
         let selected_library = context.settings.selected_library;
         self.children[self.shelf_index]
             .as_mut()
             .downcast_mut::<Shelf>()
             .unwrap()
             .set_second_column(context.settings.libraries[selected_library].second_column);
-        self.update_shelf(false, hub, rq, context);
+        self.update_shelf(false, rq, context);
     }
 
-    fn update_thumbnail_previews(
-        &mut self,
-        hub: &Hub,
-        rq: &mut RenderQueue,
-        context: &mut Context,
-    ) {
+    fn update_thumbnail_previews(&mut self, rq: &mut RenderQueue, context: &mut Context) {
         let selected_library = context.settings.selected_library;
         self.children[self.shelf_index]
             .as_mut()
@@ -514,16 +495,10 @@ impl Home {
             .set_thumbnail_previews(
                 context.settings.libraries[selected_library].thumbnail_previews,
             );
-        self.update_shelf(false, hub, rq, context);
+        self.update_shelf(false, rq, context);
     }
 
-    fn update_shelf(
-        &mut self,
-        was_resized: bool,
-        hub: &Hub,
-        rq: &mut RenderQueue,
-        context: &mut Context,
-    ) {
+    fn update_shelf(&mut self, was_resized: bool, rq: &mut RenderQueue, context: &mut Context) {
         let dpi = CURRENT_DEVICE.dpi;
         let big_height = scale_by_dpi(BIG_BAR_HEIGHT, dpi) as i32;
         let thickness = scale_by_dpi(THICKNESS_MEDIUM, dpi) as i32;
@@ -570,7 +545,7 @@ impl Home {
             }
         }
 
-        shelf.update(&self.current_page_books, hub, rq, context);
+        shelf.update(&self.current_page_books, rq, context);
     }
 
     fn update_top_bar(&mut self, search_visible: bool, rq: &mut RenderQueue) {
@@ -834,7 +809,7 @@ impl Home {
                 ));
             }
 
-            self.update_shelf(true, hub, rq, context);
+            self.update_shelf(true, rq, context);
             self.update_bottom_bar(rq, context);
         }
     }
@@ -843,7 +818,6 @@ impl Home {
         &mut self,
         enable: Option<bool>,
         update: bool,
-        hub: &Hub,
         rq: &mut RenderQueue,
         context: &mut Context,
     ) {
@@ -920,7 +894,7 @@ impl Home {
                 ));
             }
 
-            self.update_shelf(true, hub, rq, context);
+            self.update_shelf(true, rq, context);
             self.update_bottom_bar(rq, context);
         }
     }
@@ -1039,7 +1013,7 @@ impl Home {
 
         if update {
             if !search_visible {
-                self.refresh_visibles(false, true, hub, rq, context);
+                self.refresh_visibles(false, true, rq, context);
             }
 
             self.update_top_bar(search_visible, rq);
@@ -1053,7 +1027,7 @@ impl Home {
                 let mut rect = *self.child(self.shelf_index).rect();
                 rect.max.y = self.child(self.shelf_index + 1).rect().min.y;
                 // Render the part of the shelf that isn't covered.
-                self.update_shelf(true, hub, &mut RenderQueue::new(), context);
+                self.update_shelf(true, &mut RenderQueue::new(), context);
                 rq.add(RenderData::new(
                     self.child(self.shelf_index).id(),
                     rect,
@@ -1067,7 +1041,7 @@ impl Home {
             } else {
                 for i in self.shelf_index - 1..=self.shelf_index + 1 {
                     if i == self.shelf_index {
-                        self.update_shelf(true, hub, rq, context);
+                        self.update_shelf(true, rq, context);
                         continue;
                     }
                     rq.add(RenderData::new(
@@ -1527,17 +1501,16 @@ impl Home {
         }
     }
 
-    fn add_document(&mut self, info: Info, hub: &Hub, rq: &mut RenderQueue, context: &mut Context) {
+    fn add_document(&mut self, info: Info, rq: &mut RenderQueue, context: &mut Context) {
         context.library.add_document(info);
-        self.sort(false, hub, rq, context);
-        self.refresh_visibles(true, false, hub, rq, context);
+        self.sort(false, rq, context);
+        self.refresh_visibles(true, false, rq, context);
     }
 
     fn set_status(
         &mut self,
         path: &Path,
         status: SimpleStatus,
-        hub: &Hub,
         rq: &mut RenderQueue,
         context: &mut Context,
     ) {
@@ -1545,10 +1518,10 @@ impl Home {
 
         // Is the current sort method affected by this change?
         if self.sort_method.is_status_related() {
-            self.sort(false, hub, rq, context);
+            self.sort(false, rq, context);
         }
 
-        self.refresh_visibles(true, false, hub, rq, context);
+        self.refresh_visibles(true, false, rq, context);
     }
 
     fn empty_trash(&mut self, hub: &Hub, rq: &mut RenderQueue, context: &mut Context) {
@@ -1588,19 +1561,17 @@ impl Home {
         &mut self,
         path: &Path,
         file_name: &str,
-        hub: &Hub,
         rq: &mut RenderQueue,
         context: &mut Context,
     ) -> Result<(), Error> {
         context.library.rename(path, file_name)?;
-        self.refresh_visibles(true, false, hub, rq, context);
+        self.refresh_visibles(true, false, rq, context);
         Ok(())
     }
 
     fn remove(
         &mut self,
         path: &Path,
-        hub: &Hub,
         rq: &mut RenderQueue,
         context: &mut Context,
     ) -> Result<(), Error> {
@@ -1628,7 +1599,7 @@ impl Home {
         } else {
             context.library.remove(path)?;
         }
-        self.refresh_visibles(true, false, hub, rq, context);
+        self.refresh_visibles(true, false, rq, context);
         Ok(())
     }
 
@@ -1648,7 +1619,6 @@ impl Home {
         &mut self,
         path: &Path,
         index: usize,
-        hub: &Hub,
         rq: &mut RenderQueue,
         context: &mut Context,
     ) -> Result<(), Error> {
@@ -1660,26 +1630,19 @@ impl Home {
         )?;
         context.library.move_to(path, &mut library)?;
         library.flush();
-        self.refresh_visibles(true, false, hub, rq, context);
+        self.refresh_visibles(true, false, rq, context);
         Ok(())
     }
 
-    fn set_reverse_order(
-        &mut self,
-        value: bool,
-        hub: &Hub,
-        rq: &mut RenderQueue,
-        context: &mut Context,
-    ) {
+    fn set_reverse_order(&mut self, value: bool, rq: &mut RenderQueue, context: &mut Context) {
         self.reverse_order = value;
         self.current_page = 0;
-        self.sort(true, hub, rq, context);
+        self.sort(true, rq, context);
     }
 
     fn set_sort_method(
         &mut self,
         sort_method: SortMethod,
-        hub: &Hub,
         rq: &mut RenderQueue,
         context: &mut Context,
     ) {
@@ -1697,16 +1660,16 @@ impl Home {
         }
 
         self.current_page = 0;
-        self.sort(true, hub, rq, context);
+        self.sort(true, rq, context);
     }
 
-    fn sort(&mut self, update: bool, hub: &Hub, rq: &mut RenderQueue, context: &mut Context) {
+    fn sort(&mut self, update: bool, rq: &mut RenderQueue, context: &mut Context) {
         context
             .library
             .set_sort(self.sort_method, self.reverse_order);
 
         if update {
-            self.update_shelf(false, hub, rq, context);
+            self.update_shelf(false, rq, context);
             let search_visible = rlocate::<SearchBar>(self).is_some();
             self.update_top_bar(search_visible, rq);
             self.update_bottom_bar(rq, context);
@@ -1791,9 +1754,9 @@ impl Home {
         self.select_directory(&home, hub, rq, context);
     }
 
-    fn clean_up(&mut self, hub: &Hub, rq: &mut RenderQueue, context: &mut Context) {
+    fn clean_up(&mut self, rq: &mut RenderQueue, context: &mut Context) {
         context.library.clean_up();
-        self.refresh_visibles(true, false, hub, rq, context);
+        self.refresh_visibles(true, false, rq, context);
     }
 
     fn flush(&mut self, context: &mut Context) {
@@ -1983,11 +1946,11 @@ impl Home {
         Ok(process)
     }
 
-    fn reseed(&mut self, hub: &Hub, rq: &mut RenderQueue, context: &mut Context) {
+    fn reseed(&mut self, rq: &mut RenderQueue, context: &mut Context) {
         context
             .library
             .set_sort(self.sort_method, self.reverse_order);
-        self.refresh_visibles(true, false, hub, &mut RenderQueue::new(), context);
+        self.refresh_visibles(true, false, &mut RenderQueue::new(), context);
 
         if let Some(top_bar) = self.child_mut(0).downcast_mut::<TopBar>() {
             top_bar.reseed(&mut RenderQueue::new(), context);
@@ -2017,7 +1980,7 @@ impl View for Home {
                             && self.children[self.shelf_index].rect().includes(end) =>
                     {
                         if !context.settings.home.navigation_bar {
-                            self.toggle_navigation_bar(Some(true), true, hub, rq, context);
+                            self.toggle_navigation_bar(Some(true), true, rq, context);
                         } else if !context.settings.home.address_bar {
                             self.toggle_address_bar(Some(true), true, hub, rq, context);
                         }
@@ -2029,7 +1992,7 @@ impl View for Home {
                         if context.settings.home.address_bar {
                             self.toggle_address_bar(Some(false), true, hub, rq, context);
                         } else if context.settings.home.navigation_bar {
-                            self.toggle_navigation_bar(Some(false), true, hub, rq, context);
+                            self.toggle_navigation_bar(Some(false), true, rq, context);
                         }
                     }
                     _ => (),
@@ -2044,10 +2007,10 @@ impl View for Home {
             }
             Event::Gesture(GestureEvent::Arrow { dir, .. }) => {
                 match dir {
-                    Dir::West => self.go_to_page(0, hub, rq, context),
+                    Dir::West => self.go_to_page(0, rq, context),
                     Dir::East => {
                         let pages_count = self.pages_count;
-                        self.go_to_page(pages_count.saturating_sub(1), hub, rq, context);
+                        self.go_to_page(pages_count.saturating_sub(1), rq, context);
                     }
                     Dir::North => {
                         let path = context.library.home.clone();
@@ -2060,10 +2023,10 @@ impl View for Home {
             Event::Gesture(GestureEvent::Corner { dir, .. }) => {
                 match dir {
                     DiagDir::NorthWest | DiagDir::SouthWest => {
-                        self.go_to_status_change(CycleDir::Previous, hub, rq, context)
+                        self.go_to_status_change(CycleDir::Previous, rq, context)
                     }
                     DiagDir::NorthEast | DiagDir::SouthEast => {
-                        self.go_to_status_change(CycleDir::Next, hub, rq, context)
+                        self.go_to_status_change(CycleDir::Next, rq, context)
                     }
                 };
                 true
@@ -2144,12 +2107,12 @@ impl View for Home {
             Event::Select(EntryId::Sort(sort_method)) => {
                 let selected_library = context.settings.selected_library;
                 context.settings.libraries[selected_library].sort_method = sort_method;
-                self.set_sort_method(sort_method, hub, rq, context);
+                self.set_sort_method(sort_method, rq, context);
                 true
             }
             Event::Select(EntryId::ReverseOrder) => {
                 let next_value = !self.reverse_order;
-                self.set_reverse_order(next_value, hub, rq, context);
+                self.set_reverse_order(next_value, rq, context);
                 true
             }
             Event::Select(EntryId::LoadLibrary(index)) => {
@@ -2165,7 +2128,7 @@ impl View for Home {
                 true
             }
             Event::Select(EntryId::CleanUp) => {
-                self.clean_up(hub, rq, context);
+                self.clean_up(rq, context);
                 true
             }
             Event::Select(EntryId::Flush) => {
@@ -2173,30 +2136,30 @@ impl View for Home {
                 true
             }
             Event::FetcherAddDocument(_, ref info) => {
-                self.add_document(*info.clone(), hub, rq, context);
+                self.add_document(*info.clone(), rq, context);
                 true
             }
             Event::Select(EntryId::SetStatus(ref path, status)) => {
-                self.set_status(path, status, hub, rq, context);
+                self.set_status(path, status, rq, context);
                 true
             }
             Event::Select(EntryId::FirstColumn(first_column)) => {
                 let selected_library = context.settings.selected_library;
                 context.settings.libraries[selected_library].first_column = first_column;
-                self.update_first_column(hub, rq, context);
+                self.update_first_column(rq, context);
                 true
             }
             Event::Select(EntryId::SecondColumn(second_column)) => {
                 let selected_library = context.settings.selected_library;
                 context.settings.libraries[selected_library].second_column = second_column;
-                self.update_second_column(hub, rq, context);
+                self.update_second_column(rq, context);
                 true
             }
             Event::Select(EntryId::ThumbnailPreviews) => {
                 let selected_library = context.settings.selected_library;
                 context.settings.libraries[selected_library].thumbnail_previews =
                     !context.settings.libraries[selected_library].thumbnail_previews;
-                self.update_thumbnail_previews(hub, rq, context);
+                self.update_thumbnail_previews(rq, context);
                 true
             }
             Event::Submit(ViewId::AddressBarInput, ref addr) => {
@@ -2216,7 +2179,7 @@ impl View for Home {
                             UpdateMode::Gui,
                         ));
                     }
-                    self.refresh_visibles(true, true, hub, rq, context);
+                    self.refresh_visibles(true, true, rq, context);
                 } else {
                     let notif = Notification::new(
                         None,
@@ -2232,20 +2195,20 @@ impl View for Home {
             }
             Event::Submit(ViewId::GoToPageInput, ref text) => {
                 if text == "(" {
-                    self.go_to_page(0, hub, rq, context);
+                    self.go_to_page(0, rq, context);
                 } else if text == ")" {
-                    self.go_to_page(self.pages_count.saturating_sub(1), hub, rq, context);
+                    self.go_to_page(self.pages_count.saturating_sub(1), rq, context);
                 } else if text == "_" {
                     let index = (context.rng.next_u64() % self.pages_count as u64) as usize;
-                    self.go_to_page(index, hub, rq, context);
+                    self.go_to_page(index, rq, context);
                 } else if let Ok(index) = text.parse::<usize>() {
-                    self.go_to_page(index.saturating_sub(1), hub, rq, context);
+                    self.go_to_page(index.saturating_sub(1), rq, context);
                 }
                 true
             }
             Event::Submit(ViewId::RenameDocumentInput, ref file_name) => {
                 if let Some(ref path) = self.target_document.take() {
-                    self.rename(path, file_name, hub, rq, context)
+                    self.rename(path, file_name, rq, context)
                         .map_err(|e| error!("Can't rename document: {:#}.", e))
                         .ok();
                 }
@@ -2253,7 +2216,7 @@ impl View for Home {
             }
             Event::NavigationBarResized(_) => {
                 self.adjust_shelf_top_edge();
-                self.update_shelf(true, hub, rq, context);
+                self.update_shelf(true, rq, context);
                 self.update_bottom_bar(rq, context);
                 for i in self.shelf_index - 2..=self.shelf_index - 1 {
                     rq.add(RenderData::new(
@@ -2275,7 +2238,7 @@ impl View for Home {
             }
             Event::Select(EntryId::Remove(ref path))
             | Event::FetcherRemoveDocument(_, ref path) => {
-                self.remove(path, hub, rq, context)
+                self.remove(path, rq, context)
                     .map_err(|e| error!("Can't remove document: {:#}.", e))
                     .ok();
                 true
@@ -2287,14 +2250,14 @@ impl View for Home {
                 true
             }
             Event::Select(EntryId::MoveTo(ref path, index)) => {
-                self.move_to(path, index, hub, rq, context)
+                self.move_to(path, index, rq, context)
                     .map_err(|e| error!("Can't move document: {:#}.", e))
                     .ok();
                 true
             }
             Event::Select(EntryId::ToggleShowHidden) => {
                 context.library.show_hidden = !context.library.show_hidden;
-                self.refresh_visibles(true, false, hub, rq, context);
+                self.refresh_visibles(true, false, rq, context);
                 true
             }
             Event::SelectDirectory(ref path)
@@ -2327,26 +2290,24 @@ impl View for Home {
                             UpdateMode::Gui,
                         ));
                     }
-                    self.refresh_visibles(true, true, hub, rq, context);
+                    self.refresh_visibles(true, true, rq, context);
                 }
                 true
             }
             Event::GoTo(location) => {
-                self.go_to_page(location as usize, hub, rq, context);
+                self.go_to_page(location as usize, rq, context);
                 true
             }
             Event::Chapter(dir) => {
                 let pages_count = self.pages_count;
                 match dir {
-                    CycleDir::Previous => self.go_to_page(0, hub, rq, context),
-                    CycleDir::Next => {
-                        self.go_to_page(pages_count.saturating_sub(1), hub, rq, context)
-                    }
+                    CycleDir::Previous => self.go_to_page(0, rq, context),
+                    CycleDir::Next => self.go_to_page(pages_count.saturating_sub(1), rq, context),
                 }
                 true
             }
             Event::Page(dir) => {
-                self.go_to_neighbor(dir, hub, rq, context);
+                self.go_to_neighbor(dir, rq, context);
                 true
             }
             Event::Device(DeviceEvent::Button {
@@ -2354,7 +2315,7 @@ impl View for Home {
                 status: ButtonStatus::Pressed,
                 ..
             }) => {
-                self.go_to_neighbor(CycleDir::Previous, hub, rq, context);
+                self.go_to_neighbor(CycleDir::Previous, rq, context);
                 true
             }
             Event::Device(DeviceEvent::Button {
@@ -2362,7 +2323,7 @@ impl View for Home {
                 status: ButtonStatus::Pressed,
                 ..
             }) => {
-                self.go_to_neighbor(CycleDir::Next, hub, rq, context);
+                self.go_to_neighbor(CycleDir::Next, rq, context);
                 true
             }
             Event::Device(DeviceEvent::NetUp) => {
@@ -2432,7 +2393,7 @@ impl View for Home {
                 true
             }
             Event::Reseed => {
-                self.reseed(hub, rq, context);
+                self.reseed(rq, context);
                 true
             }
             Event::ImportFinished { library_index } => {
@@ -2442,7 +2403,7 @@ impl View for Home {
                     context
                         .library
                         .set_sort(self.sort_method, self.reverse_order);
-                    self.refresh_visibles(true, false, hub, rq, context);
+                    self.refresh_visibles(true, false, rq, context);
                 }
                 false
             }
@@ -2617,7 +2578,7 @@ impl View for Home {
         let shelf_rect = rect![rect.min.x, shelf_min_y, rect.max.x, shelf_max_y];
         self.children[self.shelf_index].resize(shelf_rect, hub, rq, context);
 
-        self.update_shelf(true, hub, &mut RenderQueue::new(), context);
+        self.update_shelf(true, &mut RenderQueue::new(), context);
         self.update_bottom_bar(&mut RenderQueue::new(), context);
 
         // Floating windows.
@@ -2666,9 +2627,9 @@ mod tests {
         context.settings.home.address_bar = false;
 
         let rect = rect![0, 0, 600, 800];
-        let mut home = Home::new(rect, &hub, &mut rq, &mut context).unwrap();
+        let mut home = Home::new(rect, &mut rq, &mut context).unwrap();
 
-        home.toggle_navigation_bar(Some(true), false, &hub, &mut rq, &mut context);
+        home.toggle_navigation_bar(Some(true), false, &mut rq, &mut context);
         assert!(context.settings.home.navigation_bar);
 
         let nav_bar_index =

--- a/crates/core/src/view/home/mod.rs
+++ b/crates/core/src/view/home/mod.rs
@@ -2295,7 +2295,7 @@ impl View for Home {
                 true
             }
             Event::GoTo(location) => {
-                self.go_to_page(location as usize, rq, context);
+                self.go_to_page(location, rq, context);
                 true
             }
             Event::Chapter(dir) => {

--- a/crates/core/src/view/home/shelf.rs
+++ b/crates/core/src/view/home/shelf.rs
@@ -2,26 +2,17 @@ use super::book::Book;
 use crate::color::{SEPARATOR_NORMAL, WHITE};
 use crate::context::Context;
 use crate::device::CURRENT_DEVICE;
-use crate::document::open;
 use crate::font::Fonts;
 use crate::framebuffer::{Framebuffer, UpdateMode};
 use crate::geom::divide;
 use crate::geom::{halves, CycleDir, Dir, Rectangle};
 use crate::gesture::GestureEvent;
-use crate::helpers::Fingerprint;
 use crate::metadata::Info;
 use crate::settings::{FirstColumn, SecondColumn};
 use crate::unit::scale_by_dpi;
 use crate::view::filler::Filler;
 use crate::view::{Bus, Event, Hub, Id, RenderData, RenderQueue, View, ID_FEEDER};
 use crate::view::{BIG_BAR_HEIGHT, THICKNESS_MEDIUM};
-use lazy_static::lazy_static;
-use std::sync::Mutex;
-use std::thread;
-
-lazy_static! {
-    static ref EXCLUSIVE_ACCESS: Mutex<u8> = Mutex::new(0);
-}
 
 pub struct Shelf {
     id: Id,
@@ -67,14 +58,11 @@ impl Shelf {
         self.thumbnail_previews = thumbnail_previews;
     }
 
-    #[cfg_attr(feature = "tracing", tracing::instrument(skip(self, hub, rq, context)))]
-    pub fn update(
-        &mut self,
-        metadata: &[Info],
-        hub: &Hub,
-        rq: &mut RenderQueue,
-        context: &Context,
-    ) {
+    #[cfg_attr(
+        feature = "tracing",
+        tracing::instrument(skip(self, rq, context))
+    )]
+    pub fn update(&mut self, metadata: &[Info], rq: &mut RenderQueue, context: &Context) {
         self.children.clear();
         let dpi = CURRENT_DEVICE.dpi;
         let big_height = scale_by_dpi(BIG_BAR_HEIGHT, dpi) as i32;
@@ -83,8 +71,6 @@ impl Shelf {
         let max_lines = ((self.rect.height() as i32 + thickness) / big_height) as usize;
         let book_heights = divide(self.rect.height() as i32, max_lines as i32);
         let mut y_pos = self.rect.min.y;
-        let th = big_height;
-        let tw = 3 * th / 4;
 
         #[cfg(feature = "tracing")]
         let _span = tracing::info_span!("processing metadata").entered();
@@ -103,30 +89,7 @@ impl Shelf {
             let preview = if self.thumbnail_previews {
                 let existing = context.library.thumbnail_preview(&info.file.path);
                 if existing.is_none() {
-                    let hub2 = hub.clone();
-                    let path = info.file.path.clone();
-                    let full_path = context.library.home.join(&info.file.path);
-                    let database = context.library.db.clone();
-                    let fp = full_path.fingerprint().ok();
-
-                    if let Some(fp) = fp {
-                        thread::spawn(move || {
-                            let _guard = EXCLUSIVE_ACCESS.lock().unwrap();
-                            if let Some(bytes) = open(full_path)
-                                .and_then(|mut doc| {
-                                    doc.preview_pixmap(
-                                        tw as f32,
-                                        th as f32,
-                                        CURRENT_DEVICE.color_samples(),
-                                    )
-                                })
-                                .and_then(|pixmap| pixmap.to_png_bytes().ok())
-                            {
-                                database.save_thumbnail(fp, &bytes).ok();
-                                hub2.send(Event::RefreshBookPreview(path)).ok();
-                            }
-                        });
-                    }
+                    tracing::debug!(path = %info.file.path.display(), "no preview");
                 }
                 existing
             } else {

--- a/crates/core/src/view/home/shelf.rs
+++ b/crates/core/src/view/home/shelf.rs
@@ -58,10 +58,7 @@ impl Shelf {
         self.thumbnail_previews = thumbnail_previews;
     }
 
-    #[cfg_attr(
-        feature = "tracing",
-        tracing::instrument(skip(self, rq, context))
-    )]
+    #[cfg_attr(feature = "tracing", tracing::instrument(skip(self, rq, context)))]
     pub fn update(&mut self, metadata: &[Info], rq: &mut RenderQueue, context: &Context) {
         self.children.clear();
         let dpi = CURRENT_DEVICE.dpi;

--- a/crates/core/src/view/mod.rs
+++ b/crates/core/src/view/mod.rs
@@ -557,6 +557,15 @@ pub enum Event {
     ImportFinished {
         library_index: Option<usize>,
     },
+    /// Signals that a background thumbnail extraction has finished.
+    ///
+    /// Emitted by [`ThumbnailExtractionTask`](crate::task::thumbnail::ThumbnailExtractionTask)
+    /// when it completes (regardless of whether any thumbnails were extracted).
+    /// The [`TaskManager`](crate::task::TaskManager) intercepts this event to
+    /// drain any queued extractions that accumulated while the task was running.
+    ThumbnailExtractionFinished {
+        library_index: Option<usize>,
+    },
     /// Requests a background dictionary index scan.
     ///
     /// Emitted when the settings editor closes after dictionaries were installed

--- a/crates/emulator/src/main.rs
+++ b/crates/emulator/src/main.rs
@@ -369,8 +369,7 @@ fn run() -> Result<(), Error> {
 
     let mut history: Vec<Box<dyn View>> = Vec::new();
     let mut rq = RenderQueue::new();
-    let mut view: Box<dyn View> =
-        Box::new(Home::new(context.fb.rect(), &tx, &mut rq, &mut context)?);
+    let mut view: Box<dyn View> = Box::new(Home::new(context.fb.rect(), &mut rq, &mut context)?);
 
     let mut updating = Vec::new();
 

--- a/devenv.lock
+++ b/devenv.lock
@@ -117,9 +117,6 @@
         "devenv": "devenv",
         "git-hooks": "git-hooks",
         "nixpkgs": "nixpkgs",
-        "pre-commit-hooks": [
-          "git-hooks"
-        ],
         "rust-overlay": "rust-overlay"
       }
     },

--- a/devenv.nix
+++ b/devenv.nix
@@ -841,5 +841,13 @@ in
     };
     markdownlint.enable = true;
     prettier.enable = true;
+    cargo-test = {
+      enable = true;
+      name = "cargo test (default features)";
+      entry = "cargo test --workspace --features default";
+      files = "\\.rs$";
+      pass_filenames = false;
+      language = "system";
+    };
   };
 }


### PR DESCRIPTION
Implement a background ThumbnailExtractionTask to sequentially extract and cache book cover thumbnails after library imports finish, replacing the previous blocking ad-hoc per-book threads on page turns.

- Add books_without_thumbnails query to Db module
- Implement ThumbnailExtractionTask under task/thumbnail.rs
- Integrate scheduling of task in TaskManager on Event::ImportFinished
- Simplify Shelf::update() to render placeholders and log 'no preview'

Change-Id: c080e9aff307605a7f39d86b5fa6fb32
Change-Id-Short: nzrzlqpkkwzs
Fixes: #491 