### PR TITLE
dev(nix): enable macOS cross-compilation

### DIFF
--- a/devenv.nix
+++ b/devenv.nix
@@ -20,20 +20,21 @@ let
   fixRustToolchainLibSymlink =
     drv:
     drv.overrideAttrs (old: {
-      buildCommand = builtins.replaceStrings
-        [ "for i in $(cat $pathsPath); do\n" ]
-        [
-          (
-            "for i in $(cat $pathsPath); do\n"
-            + "  if [ -L \"$out/lib\" ]; then\n"
-            + "    _lib_t=$(readlink -f \"$out/lib\")\n"
-            + "    rm \"$out/lib\"\n"
-            + "    mkdir \"$out/lib\"\n"
-            + "    ${pkgs.lndir}/bin/lndir -silent \"$_lib_t\" \"$out/lib\"\n"
-            + "  fi\n"
-          )
-        ]
-        old.buildCommand;
+      buildCommand =
+        builtins.replaceStrings
+          [ "for i in $(cat $pathsPath); do\n" ]
+          [
+            (
+              "for i in $(cat $pathsPath); do\n"
+              + "  if [ -L \"$out/lib\" ]; then\n"
+              + "    _lib_t=$(readlink -f \"$out/lib\")\n"
+              + "    rm \"$out/lib\"\n"
+              + "    mkdir \"$out/lib\"\n"
+              + "    ${pkgs.lndir}/bin/lndir -silent \"$_lib_t\" \"$out/lib\"\n"
+              + "  fi\n"
+            )
+          ]
+          old.buildCommand;
     });
 
   # Build the stable Rust toolchain the same way devenv does, but with the
@@ -133,19 +134,26 @@ let
 
   # Linaro GCC toolchain for Kobo - same as used by Kobo Reader
   # https://github.com/kobolabs/Kobo-Reader/blob/master/toolchain/gcc-linaro-4.9.4-2017.01-x86_64_arm-linux-gnueabihf.tar.xz
-  # NOTE: This toolchain is x86_64 Linux-only (ELF binaries with autoPatchelfHook)
-  # On macOS, cross-compilation for Kobo is not supported - use Docker/Linux VM instead
+  # On macOS, we download the Darwin-compatible Linaro compiler from Google Drive.
   linaroToolchain = pkgs.stdenv.mkDerivation {
     pname = "gcc-linaro";
     version = "4.9.4-2017.01";
 
-    src = pkgs.fetchurl {
-      url = "https://releases.linaro.org/components/toolchain/binaries/4.9-2017.01/arm-linux-gnueabihf/gcc-linaro-4.9.4-2017.01-x86_64_arm-linux-gnueabihf.tar.xz";
-      sha256 = "22914118fd963f953824b58107015c6953b5bbdccbdcf25ad9fd9a2f9f11ac07";
-    };
+    src =
+      if isLinux then
+        pkgs.fetchurl {
+          url = "https://releases.linaro.org/components/toolchain/binaries/4.9-2017.01/arm-linux-gnueabihf/gcc-linaro-4.9.4-2017.01-x86_64_arm-linux-gnueabihf.tar.xz";
+          sha256 = "22914118fd963f953824b58107015c6953b5bbdccbdcf25ad9fd9a2f9f11ac07";
+        }
+      else
+        pkgs.fetchurl {
+          name = "gcc-linaro-darwin.tar.bz2";
+          url = "https://drive.usercontent.google.com/download?id=1ggMLM3VBwCYQuFTpJEC0OmyMkiDtYMju&export=download&confirm=t";
+          sha256 = "rSP4JS/KsK8dxPwvdY7Cnb5zxbKbFYnVuKe/VIOIf/Q=";
+        };
 
-    nativeBuildInputs = [ pkgs.autoPatchelfHook ];
-    buildInputs = [
+    nativeBuildInputs = pkgs.lib.optionals isLinux [ pkgs.autoPatchelfHook ];
+    buildInputs = pkgs.lib.optionals isLinux [
       pkgs.stdenv.cc.cc.lib
       pkgs.zlib
       pkgs.ncurses5
@@ -161,9 +169,11 @@ let
       cp -r * $out/
     '';
 
-    # The toolchain has pre-built binaries that need patching
-    # Ignore python dependency for gdb (we don't need gdb for building)
-    autoPatchelfIgnoreMissingDeps = [ "libpython2.7.so.1.0" ];
+    # Pre-built binaries only need patching/stripping on Linux
+    autoPatchelfIgnoreMissingDeps = pkgs.lib.optionals isLinux [ "libpython2.7.so.1.0" ];
+    dontFixup = isDarwin;
+    dontPatchELF = isDarwin;
+    dontStrip = isDarwin;
   };
 
   # Custom mdbook-epub from specific commit
@@ -304,18 +314,17 @@ in
     pkgs.wrangler
 
     pkgs.cargo-llvm-cov
+
+    # Linaro ARM cross-compilation toolchain (provides arm-linux-gnueabihf-* commands)
+    linaroToolchain
+
+    # patchelf is used to patch ELF binaries
+    pkgs.patchelf
   ]
   # Linux-only packages
   ++ pkgs.lib.optionals isLinux [
-    # patchelf is Linux-only (patches ELF binaries)
-    pkgs.patchelf
-
     # GCC - on macOS we use clang from Xcode
     pkgs.gcc
-
-    # Linaro ARM cross-compilation toolchain (provides arm-linux-gnueabihf-* commands)
-    # This is x86_64 Linux ELF binaries - cannot run on macOS
-    linaroToolchain
 
     # This seems to be borken on macos
     # https://github.com/NixOS/nixpkgs/blob/ed142ab1b3a092c4d149245d0c4126a5d7ea00b0/pkgs/by-name/po/poedit/package.nix#L88
@@ -369,8 +378,7 @@ in
     # jemalloc configure uses -O0 in debug builds, which triggers _FORTIFY_SOURCE warnings
     # treated as errors under Nix hardening. Disable hardening for jemalloc's build script.
     NIX_HARDENING_ENABLE = "";
-  }
-  // pkgs.lib.optionalAttrs isLinux {
+
     # pkg-config configuration for cross-compilation
     PKG_CONFIG_ALLOW_CROSS = "1";
 
@@ -673,16 +681,9 @@ in
       exec = "cargo xtask setup-native";
     };
 
-    # Build for Kobo with cross-compilation (Linux only)
+    # Build for Kobo with cross-compilation
     "build:kobo" = {
-      exec =
-        if isLinux then
-          "cargo xtask build-kobo --slow"
-        else
-          ''
-            echo "Error: Kobo build is only available on Linux."
-            exit 1
-          '';
+      exec = "cargo xtask build-kobo --slow";
       after = [ "docs:build" ];
     };
 
@@ -708,20 +709,11 @@ in
       cargo xtask setup-native
     '';
 
-    # Build for Kobo device (Linux only)
-    cadmus-build-kobo.exec =
-      if isLinux then
-        ''
-          cargo xtask build-kobo --slow
-          cargo xtask dist
-        ''
-      else
-        ''
-          echo "Error: cadmus-build-kobo is only available on Linux."
-          echo ""
-          echo "The Linaro ARM cross-compilation toolchain requires Linux."
-          exit 1
-        '';
+    # Build for Kobo device
+    cadmus-build-kobo.exec = ''
+      cargo xtask build-kobo --slow
+      cargo xtask dist
+    '';
 
     # Run clippy filtered to lines changed relative to master
     cadmus-clippy.exec = ''
@@ -797,20 +789,14 @@ in
     echo "  cargo xtask bundle        - Package KoboRoot.tgz"
     echo ""
   ''
-  # Linux-specific shell setup
-  + pkgs.lib.optionalString isLinux ''
+  + ''
     # Add Linaro toolchain to PATH
     export PATH="${linaroToolchain}/bin:$PATH"
 
-    echo "Cross-compilation (Linux only):"
+    echo "Cross-compilation:"
     echo "  cadmus-build-kobo         - Build for Kobo (cross-compile + dist)"
     echo "  cargo xtask build-kobo    - Cross-compile Cadmus for Kobo"
     echo "  Linaro toolchain: $(which arm-linux-gnueabihf-gcc 2>/dev/null || echo 'not found')"
-    echo ""
-  ''
-  # macOS-specific shell setup
-  + pkgs.lib.optionalString isDarwin ''
-    echo "Note: Cross-compilation for Kobo is not available on macOS."
     echo ""
   ''
   + ''

--- a/thirdparty/mupdf/build-kobo.sh
+++ b/thirdparty/mupdf/build-kobo.sh
@@ -3,6 +3,7 @@
 [ -e .gitattributes ] && rm -rf .git*
 
 BUILD_KIND=${1:-release}
+rm -rf build
 make verbose=yes generate
 make verbose=yes mujs=no tesseract=no extract=no archive=no brotli=no barcode=no commercial=no USE_SYSTEM_LIBS=yes OS=kobo build="$BUILD_KIND" libs
 

--- a/xtask/src/lib.rs
+++ b/xtask/src/lib.rs
@@ -21,7 +21,7 @@
 //! | [`clippy`](tasks::clippy) | Run `cargo clippy` across the feature matrix |
 //! | [`test`](tasks::test) | Run `cargo test` across the feature matrix |
 //! | [`bench`](tasks::bench) | Run benchmarks with the `bench` feature enabled |
-//! | [`build-kobo`](tasks::build_kobo) | Cross-compile for Kobo (ARM, Linux only) |
+//! | [`build-kobo`](tasks::build_kobo) | Cross-compile for Kobo (ARM, Linux & macOS) |
 //! | [`setup-native`](tasks::setup_native) | Build MuPDF and the C wrapper for native dev |
 //! | [`run-emulator`](tasks::run_emulator) | Run the Cadmus emulator (ensures prereqs are built) |
 //! | [`install-importer`](tasks::install_importer) | Install the Cadmus importer crate |
@@ -71,7 +71,7 @@ pub enum Command {
     Test(TestArgs),
     /// Run benchmarks with the bench feature enabled.
     Bench(BenchArgs),
-    /// Cross-compile Cadmus for Kobo devices (Linux only).
+    /// Cross-compile Cadmus for Kobo devices (Linux & macOS).
     BuildKobo(BuildKoboArgs),
     /// Build MuPDF and the C wrapper for native development.
     SetupNative(SetupNativeArgs),

--- a/xtask/src/tasks/build_kobo.rs
+++ b/xtask/src/tasks/build_kobo.rs
@@ -8,8 +8,9 @@
 //! ## Platform requirement
 //!
 //! Cross-compilation requires the Linaro ARM toolchain
-//! (`arm-linux-gnueabihf-gcc` and friends) which is only available on Linux.
-//! The task exits with a clear error on macOS.
+//! (`arm-linux-gnueabihf-gcc` and friends).
+//! The task checks for the toolchain at runtime and exits with a clear error if
+//! it is not available.
 //!
 //! ## Build modes
 //!

--- a/xtask/src/tasks/build_kobo.rs
+++ b/xtask/src/tasks/build_kobo.rs
@@ -100,11 +100,10 @@ pub struct BuildKoboArgs {
 /// - The Linaro toolchain is not on `PATH`.
 /// - Any build step fails.
 pub fn run(args: BuildKoboArgs) -> Result<()> {
-    if !cfg!(target_os = "linux") {
+    if !cfg!(any(target_os = "linux", target_os = "macos")) {
         bail!(
-            "Kobo cross-compilation is only available on Linux.\n\
-             The Linaro ARM toolchain consists of x86_64 Linux ELF binaries \
-             that cannot run on macOS. Use Docker or a Linux VM instead."
+            "Kobo cross-compilation is only available on Linux and macOS.\n\
+             On other platforms, please use Docker or a Linux VM instead."
         );
     }
 

--- a/xtask/src/tasks/build_kobo.rs
+++ b/xtask/src/tasks/build_kobo.rs
@@ -97,7 +97,7 @@ pub struct BuildKoboArgs {
 /// # Errors
 ///
 /// Returns an error if:
-/// - The platform is not Linux.
+/// - The platform is not Linux or macOS.
 /// - The Linaro toolchain is not on `PATH`.
 /// - Any build step fails.
 pub fn run(args: BuildKoboArgs) -> Result<()> {

--- a/xtask/src/tasks/setup_native.rs
+++ b/xtask/src/tasks/setup_native.rs
@@ -57,7 +57,7 @@ pub fn run(args: SetupNativeArgs) -> Result<()> {
     println!("\nNative setup complete!");
     println!("You can now run:");
     println!("  cargo test          - Run tests");
-    println!("  cargo xtask build-kobo  - Build for Kobo (Linux only)");
+    println!("  cargo xtask build-kobo  - Build for Kobo (Linux & macOS)");
 
     Ok(())
 }

--- a/xtask/src/tasks/util/thirdparty.rs
+++ b/xtask/src/tasks/util/thirdparty.rs
@@ -25,8 +25,8 @@ use super::{cmd, fs, http};
 
 /// Base names of all thirdparty shared libraries.
 ///
-/// SONAMEs are discovered at runtime via `readelf -d` because upstream
-/// libraries do not follow a consistent ABI versioning scheme.
+/// SONAMEs are discovered at runtime via `arm-linux-gnueabihf-readelf -d`
+/// because upstream libraries do not follow a consistent ABI versioning scheme.
 pub const SONAMES: &[&str] = &[
     "libz.so",
     "libbz2.so",
@@ -43,13 +43,15 @@ pub const SONAMES: &[&str] = &[
 
 /// Returns the SONAME of `lib` in `libs_dir`.
 ///
-/// When the library file exists, `readelf -d` is used to extract the SONAME
-/// from the binary. When only a versioned file exists (e.g. `libz.so.1.2.13`
-/// without `libz.so`), the versioned filename is returned directly.
+/// When the library file exists, `arm-linux-gnueabihf-readelf -d` is used to
+/// extract the SONAME from the binary. When only a versioned file exists
+/// (e.g. `libz.so.1.2.13` without `libz.so`), the versioned filename is
+/// returned directly.
 ///
 /// # Errors
 ///
-/// Returns an error if `readelf` fails or the SONAME cannot be determined.
+/// Returns an error if `arm-linux-gnueabihf-readelf` fails or the SONAME
+/// cannot be determined.
 pub fn soname(libs_dir: &Path, lib: &str) -> Result<String> {
     let so_path = libs_dir.join(lib);
     if so_path.exists() {

--- a/xtask/src/tasks/util/thirdparty.rs
+++ b/xtask/src/tasks/util/thirdparty.rs
@@ -56,7 +56,12 @@ pub fn soname(libs_dir: &Path, lib: &str) -> Result<String> {
         let so_path_str = so_path
             .to_str()
             .with_context(|| format!("shared library path is not valid UTF-8: {so_path:?}"))?;
-        let output = cmd::output("arm-linux-gnueabihf-readelf", &["-d", so_path_str], libs_dir, &[])?;
+        let output = cmd::output(
+            "arm-linux-gnueabihf-readelf",
+            &["-d", so_path_str],
+            libs_dir,
+            &[],
+        )?;
         let soname = output
             .lines()
             .find(|line| line.contains("SONAME"))

--- a/xtask/src/tasks/util/thirdparty.rs
+++ b/xtask/src/tasks/util/thirdparty.rs
@@ -56,7 +56,7 @@ pub fn soname(libs_dir: &Path, lib: &str) -> Result<String> {
         let so_path_str = so_path
             .to_str()
             .with_context(|| format!("shared library path is not valid UTF-8: {so_path:?}"))?;
-        let output = cmd::output("readelf", &["-d", so_path_str], libs_dir, &[])?;
+        let output = cmd::output("arm-linux-gnueabihf-readelf", &["-d", so_path_str], libs_dir, &[])?;
         let soname = output
             .lines()
             .find(|line| line.contains("SONAME"))
@@ -406,7 +406,17 @@ pub fn build_libraries(thirdparty_dir: &Path, names: &[&str]) -> Result<()> {
                 .with_context(|| format!("failed to apply kobo.patch for {name}"))?;
         }
 
-        cmd::run("./build-kobo.sh", &[], &lib_dir, &[])
+        let envs = [
+            ("AR", "arm-linux-gnueabihf-ar"),
+            ("AS", "arm-linux-gnueabihf-as"),
+            ("STRIP", "arm-linux-gnueabihf-strip"),
+            ("RANLIB", "arm-linux-gnueabihf-ranlib"),
+            ("LD", "arm-linux-gnueabihf-ld"),
+            ("CC_FOR_BUILD", "cc"),
+            ("CXX_FOR_BUILD", "c++"),
+            ("CC_BUILD", "cc"),
+        ];
+        cmd::run("./build-kobo.sh", &[], &lib_dir, &envs)
             .with_context(|| format!("failed to build {name}"))?;
 
         write_marker(&lib_dir, BUILT_MARKER, name, "build")?;


### PR DESCRIPTION
Add support for downloading, installing, and running the Linaro compiler and patchelf toolchains on macOS (Darwin) hosts.

Ref: https://github.com/baskerville/plato/pull/417

Change-Id: c92ac710cc19af4426704c1619dd2918
Change-Id-Short: nqxpnsyznnyq