### PR TITLE
fix(Settings Editor): Reset dictionary display on download failure

### DIFF
--- a/crates/core/src/view/settings_editor/category_editor.rs
+++ b/crates/core/src/view/settings_editor/category_editor.rs
@@ -531,17 +531,25 @@ impl CategoryEditor {
     /// ignored to prevent duplicate background threads racing to write the same
     /// files.
     #[inline]
-    #[cfg_attr(feature = "tracing", tracing::instrument(skip(self, hub)))]
-    fn handle_download_dictionary(&mut self, lang: &str, hub: &Hub) -> bool {
+    #[cfg_attr(feature = "tracing", tracing::instrument(skip(self, hub, rq, context)))]
+    fn handle_download_dictionary(
+        &mut self,
+        lang: &str,
+        hub: &Hub,
+        rq: &mut RenderQueue,
+        context: &mut Context,
+    ) -> bool {
         let Some(service) = self.dict_service.clone() else {
             tracing::warn!(
                 lang,
                 "No MonolingualDictionaryService available to download dictionary"
             );
+            self.update_rows_list(rq, context);
             return true;
         };
 
         if service.is_installing(lang) {
+            self.update_rows_list(rq, context);
             return true;
         }
 
@@ -549,10 +557,12 @@ impl CategoryEditor {
             Ok(Some(e)) => e,
             Ok(None) => {
                 tracing::warn!(lang, "No metadata entry found for language; cannot install");
+                self.update_rows_list(rq, context);
                 return true;
             }
             Err(e) => {
                 tracing::warn!(lang, error = %e, "Failed to look up dictionary entry");
+                self.update_rows_list(rq, context);
                 return true;
             }
         };
@@ -719,7 +729,7 @@ impl View for CategoryEditor {
 
                     return true;
                 }
-                self.handle_download_dictionary(lang, hub)
+                self.handle_download_dictionary(lang, hub, rq, context)
             }
             Event::Select(EntryId::DeleteDictionary(lang)) => {
                 self.handle_delete_dictionary(lang, hub, rq, context)
@@ -828,6 +838,7 @@ impl View for CategoryEditor {
 mod tests {
     use super::*;
     use crate::context::test_helpers::create_test_context;
+    use crate::crypto;
     use crate::geom::Point;
     use crate::gesture::GestureEvent;
     use crate::settings::Settings;
@@ -1198,5 +1209,48 @@ mod tests {
         );
         assert!(handled);
         assert_eq!(editor.current_page, 0, "Should not go below page 0");
+    }
+
+    #[test]
+    fn test_download_dictionary_invalid_language_rebuilds_rows() {
+        crypto::init_crypto_provider();
+        let mut context = create_test_context();
+        context.online = true;
+
+        let rect = rect![0, 0, 600, 800];
+        let mut rq = RenderQueue::new();
+
+        let mut editor = CategoryEditor::new(rect, Category::Dictionaries, &mut rq, &mut context);
+
+        let (hub, _receiver) = channel();
+        let mut bus = VecDeque::new();
+        let mut rq2 = RenderQueue::new();
+
+        let initial_rows_count = editor
+            .separator_index
+            .saturating_sub(editor.first_row_index);
+
+        let handled = editor.handle_event(
+            &Event::Select(EntryId::DownloadDictionary("xy".to_string())),
+            &hub,
+            &mut bus,
+            &mut rq2,
+            &mut context,
+        );
+
+        assert!(handled, "Download event should be handled");
+
+        let rows_count_after = editor
+            .separator_index
+            .saturating_sub(editor.first_row_index);
+
+        assert_eq!(
+            initial_rows_count, rows_count_after,
+            "Row count unchanged after download attempt (early return triggers rebuild)"
+        );
+        assert!(
+            !rq2.is_empty(),
+            "RenderQueue should have render requests from update_rows_list()"
+        );
     }
 }


### PR DESCRIPTION
When tapping 'Download' for a dictionary, DictionaryInfo::handle() optimistically returns 'Downloading' before any validation. If the download fails early (no service, already installing, no metadata, or offline check), no completion event was ever sent, leaving the display stuck on 'Downloading'.

Fix: Call update_rows_list() at all early-return paths in handle_download_dictionary(). This rebuilds the rows from scratch, allowing DictionaryInfo::fetch() to compute the correct state based on actual conditions (is_installing, is_installed, etc.).

Also added a test to verify row rebuilding occurs when download the service is unavailable.

- Modified handle_download_dictionary() to accept rq and context parameters
- Added update_rows_list() calls at all 4 early-return paths
- Updated call site in handle_event to pass rq and context
- Added test_download_dictionary_without_service_rebuilds_rows

Change-Id: c910975b5d3f9880928dde17983fb2b7
Change-Id-Short: nqyzqsuoumwk
Closes: CAD-64
Closes: #463 