### PR TITLE
ci(renovate): treat 0.x→0.y cargo bumps as major

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,6 +5,10 @@
   "packageRules": [
     {
       "matchManagers": ["cargo"],
+      "versioning": "cargo"
+    },
+    {
+      "matchManagers": ["cargo"],
       "matchUpdateTypes": ["minor", "patch"],
       "groupName": "Rust non-major dependencies",
       "groupSlug": "rust-non-major"


### PR DESCRIPTION
It seems this is not set as default https://github.com/renovatebot/renovate/blob/e8d31597e3c11be52bff486cb0371f007a92a464/lib/modules/manager/cargo/index.ts#L22-L25

Change-Id: 699ef2175912a7d9719cc8ce98718a10
Change-Id-Short: tqqlkxysuqyx