### PR TITLE
fix(Import): stop renaming legacy library data files

### DIFF
--- a/crates/core/src/library/migrations.rs
+++ b/crates/core/src/library/migrations.rs
@@ -633,7 +633,6 @@ async fn import_library(
 
     #[cfg(not(feature = "test"))]
     {
-        mark_library_imported(library_path).await;
         delete_thumbnail_previews(library_path).await;
     }
 
@@ -811,30 +810,6 @@ async fn ensure_stub_book(
     .await?;
 
     Ok(())
-}
-
-/// Renames `.metadata.json` and `.reading-states/` to their `.imported` suffixed
-/// equivalents so that subsequent runs of the migration skip this library.
-#[cfg(not(feature = "test"))]
-#[cfg_attr(feature = "tracing", tracing::instrument(fields(path = ?library_path)))]
-async fn mark_library_imported(library_path: &Path) {
-    let metadata_src = library_path.join(METADATA_FILENAME);
-    let metadata_dst = library_path.join(format!("{}.imported", METADATA_FILENAME));
-
-    if metadata_src.exists() {
-        if let Err(e) = fs::rename(&metadata_src, &metadata_dst).await {
-            warn!(path = ?metadata_src, error = %e, "failed to rename .metadata.json after import");
-        }
-    }
-
-    let states_src = library_path.join(READING_STATES_DIRNAME);
-    let states_dst = library_path.join(format!("{}.imported", READING_STATES_DIRNAME));
-
-    if states_src.exists() {
-        if let Err(e) = fs::rename(&states_src, &states_dst).await {
-            warn!(path = ?states_src, error = %e, "failed to rename .reading-states after import");
-        }
-    }
 }
 
 /// Removes `.thumbnail-previews/` from the library directory.

--- a/docs/po/messages.pot
+++ b/docs/po/messages.pot
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Cadmus Documentation\n"
-"POT-Creation-Date: 2026-05-25T13:06:34+02:00\n"
+"POT-Creation-Date: 2026-05-29T07:38:13+02:00\n"
 "PO-Revision-Date: \n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -66,7 +66,7 @@ msgid "Importing"
 msgstr ""
 
 #: src/SUMMARY.md:17 src/installation/ota.md:86 src/troubleshooting/index.md:1
-#: src/contributing/devenv-setup.md:231
+#: src/contributing/devenv-setup.md:225
 msgid "Troubleshooting"
 msgstr ""
 
@@ -514,7 +514,7 @@ msgid "Delete the Cadmus folder from `.adds`:"
 msgstr ""
 
 #: src/installation/uninstall.md:8 src/installation/uninstall.md:16
-#: src/installation/migration.md:8 src/installation/migration.md:65
+#: src/installation/migration.md:8 src/installation/migration.md:61
 msgid "Build"
 msgstr ""
 
@@ -523,12 +523,12 @@ msgid "Folder to delete"
 msgstr ""
 
 #: src/installation/uninstall.md:10 src/installation/uninstall.md:18
-#: src/installation/migration.md:10 src/installation/migration.md:67
+#: src/installation/migration.md:10 src/installation/migration.md:63
 msgid "Stable"
 msgstr ""
 
 #: src/installation/uninstall.md:11 src/installation/uninstall.md:19
-#: src/installation/migration.md:11 src/installation/migration.md:68
+#: src/installation/migration.md:11 src/installation/migration.md:64
 msgid "Test"
 msgstr ""
 
@@ -680,8 +680,8 @@ msgstr ""
 msgid "Source"
 msgstr ""
 
-#: src/installation/ota.md:34 src/contributing/devenv-setup.md:48
-#: src/contributing/devenv-setup.md:75
+#: src/installation/ota.md:34 src/contributing/devenv-setup.md:49
+#: src/contributing/devenv-setup.md:76
 msgid "Description"
 msgstr ""
 
@@ -738,8 +738,8 @@ msgstr ""
 #: src/installation/ota.md:54
 msgid ""
 "Before that reboot, Cadmus removes the files it previously installed so the "
-"new package can replace them cleanly. Your books, settings, dictionaries, "
-"and other personal files are left alone."
+"new package can replace them cleanly. Your custom fonts, icons, and other "
+"user-added files will be preserved."
 msgstr ""
 
 #: src/installation/ota.md:58
@@ -913,67 +913,52 @@ msgid ""
 msgstr ""
 
 #: src/installation/migration.md:42
-msgid "\\[!NOTE\\] After a successful import the original files are renamed:"
-msgstr ""
-
-#: src/installation/migration.md:45
-msgid "`.metadata.json` → `.metadata.json.imported`"
-msgstr ""
-
-#: src/installation/migration.md:46
-msgid "`.reading-states/` → `.reading-states.imported`"
-msgstr ""
-
-#: src/installation/migration.md:48
 msgid ""
-"These renamed files are just a safety backup. Once you've confirmed "
-"everything looks right you can delete them."
+"\\[!NOTE\\] The original `.metadata.json` and `.reading-states/` files are "
+"not modified or deleted during import. Once you have confirmed everything "
+"looks right in Cadmus, you can safely delete them. Keeping these files means "
+"your Plato progress remains intact. If you decide to go back to Plato, you "
+"can do so without losing your original Plato reading states. Though keep in "
+"mind that any progress you make in Cadmus will not sync back to Plato."
 msgstr ""
 
-#: src/installation/migration.md:51
+#: src/installation/migration.md:50
 msgid ""
 "\\[!NOTE\\] Cadmus also removes the `.thumbnail-previews/` folder and "
 "regenerates thumbnails itself."
 msgstr ""
 
-#: src/installation/migration.md:55
+#: src/installation/migration.md:54
 msgid "Re-running the import"
 msgstr ""
 
-#: src/installation/migration.md:57
+#: src/installation/migration.md:56
 msgid ""
 "If the import went wrong (for example, the library path was incorrect in "
 "settings), you can start it fresh:"
 msgstr ""
 
-#: src/installation/migration.md:60
-msgid ""
-"Rename `.metadata.json.imported` back to `.metadata.json` and "
-"`.reading-states.imported` back to `.reading-states/` in each library "
-"directory."
-msgstr ""
-
-#: src/installation/migration.md:63
+#: src/installation/migration.md:59
 msgid "Delete the Cadmus SQLite database:"
 msgstr ""
 
-#: src/installation/migration.md:65
+#: src/installation/migration.md:61
 msgid "Database path"
 msgstr ""
 
-#: src/installation/migration.md:67
+#: src/installation/migration.md:63
 msgid "`/mnt/onboard/.adds/cadmus/cadmus.sqlite`"
 msgstr ""
 
-#: src/installation/migration.md:68
+#: src/installation/migration.md:64
 msgid "`/mnt/onboard/.adds/cadmus-tst/cadmus.sqlite`"
 msgstr ""
 
-#: src/installation/migration.md:70
+#: src/installation/migration.md:66
 msgid "Restart Cadmus — the import will run again from scratch."
 msgstr ""
 
-#: src/installation/migration.md:72
+#: src/installation/migration.md:68
 msgid ""
 "If something still looks wrong after re-running, check the logs for details. "
 "See [Troubleshooting](../troubleshooting/index.md) for where to find them."
@@ -1753,7 +1738,7 @@ msgstr ""
 msgid "Statuses"
 msgstr ""
 
-#: src/ui/settings/dictionaries.md:23 src/contributing/devenv-setup.md:192
+#: src/ui/settings/dictionaries.md:23
 msgid "Status"
 msgstr ""
 
@@ -2214,218 +2199,216 @@ msgstr ""
 
 #: src/contributing/devenv-setup.md:33
 msgid ""
-"`cadmus-core` generates some compile-time metadata from the bundled asset "
-"directories. For Kobo builds, make sure `bin/`, `resources/`, and "
-"`hyphenation-patterns/` are present before `cargo xtask build-kobo` so the "
-"generated asset list is complete."
+"\\[!NOTE\\] `cadmus-core` generates some compile-time metadata from the "
+"bundled asset directories. For Kobo builds, make sure `bin/`, `resources/`, "
+"and `hyphenation-patterns/` are present before `cargo xtask build-kobo` so "
+"the generated asset list is complete."
 msgstr ""
 
-#: src/contributing/devenv-setup.md:38
+#: src/contributing/devenv-setup.md:39
 msgid "Run the emulator:"
 msgstr ""
 
-#: src/contributing/devenv-setup.md:44
+#: src/contributing/devenv-setup.md:45
 msgid "Available Commands"
 msgstr ""
 
-#: src/contributing/devenv-setup.md:46
+#: src/contributing/devenv-setup.md:47
 msgid "Once inside the devenv shell, these commands are available:"
 msgstr ""
 
-#: src/contributing/devenv-setup.md:48
+#: src/contributing/devenv-setup.md:49
 msgid "Command"
 msgstr ""
 
-#: src/contributing/devenv-setup.md:50
+#: src/contributing/devenv-setup.md:51
 msgid "`cargo xtask setup-native`"
 msgstr ""
 
-#: src/contributing/devenv-setup.md:50
+#: src/contributing/devenv-setup.md:51
 msgid "Build MuPDF for native development (run once)"
 msgstr ""
 
-#: src/contributing/devenv-setup.md:51
+#: src/contributing/devenv-setup.md:52
 msgid "`cargo xtask download-assets`"
 msgstr ""
 
-#: src/contributing/devenv-setup.md:51
+#: src/contributing/devenv-setup.md:52
 msgid "Download packaged Plato runtime assets"
 msgstr ""
 
-#: src/contributing/devenv-setup.md:52
+#: src/contributing/devenv-setup.md:53
 msgid "`cargo xtask test`"
 msgstr ""
 
-#: src/contributing/devenv-setup.md:52
+#: src/contributing/devenv-setup.md:53
 msgid "Run the test suite across the feature matrix"
 msgstr ""
 
-#: src/contributing/devenv-setup.md:53
+#: src/contributing/devenv-setup.md:54
 msgid "`cargo xtask run-emulator`"
 msgstr ""
 
-#: src/contributing/devenv-setup.md:53
+#: src/contributing/devenv-setup.md:54
 msgid "Run the emulator"
 msgstr ""
 
-#: src/contributing/devenv-setup.md:54
+#: src/contributing/devenv-setup.md:55
 msgid "`cargo xtask build-kobo`"
 msgstr ""
 
-#: src/contributing/devenv-setup.md:54
-msgid "Cross-compile for Kobo device (Linux only)"
+#: src/contributing/devenv-setup.md:55
+msgid "Cross-compile for Kobo device"
 msgstr ""
 
-#: src/contributing/devenv-setup.md:55
+#: src/contributing/devenv-setup.md:56
 msgid "`cargo xtask dist`"
 msgstr ""
 
-#: src/contributing/devenv-setup.md:55
+#: src/contributing/devenv-setup.md:56
 msgid "Assemble the Kobo distribution directory"
 msgstr ""
 
-#: src/contributing/devenv-setup.md:56
+#: src/contributing/devenv-setup.md:57
 msgid "`cargo xtask bundle`"
 msgstr ""
 
-#: src/contributing/devenv-setup.md:56
+#: src/contributing/devenv-setup.md:57
 msgid "Package KoboRoot.tgz for installation"
 msgstr ""
 
-#: src/contributing/devenv-setup.md:57
+#: src/contributing/devenv-setup.md:58
 msgid "`cadmus-dev-otel`"
 msgstr ""
 
-#: src/contributing/devenv-setup.md:57
+#: src/contributing/devenv-setup.md:58
 msgid "Run emulator with tracing and profiling enabled"
 msgstr ""
 
-#: src/contributing/devenv-setup.md:58
+#: src/contributing/devenv-setup.md:59
 msgid "`devenv up`"
 msgstr ""
 
-#: src/contributing/devenv-setup.md:58
+#: src/contributing/devenv-setup.md:59
 msgid "Start observability stack (Grafana, Tempo, Loki)"
 msgstr ""
 
-#: src/contributing/devenv-setup.md:59
+#: src/contributing/devenv-setup.md:60
 msgid "`cargo xtask docs`"
 msgstr ""
 
-#: src/contributing/devenv-setup.md:59
+#: src/contributing/devenv-setup.md:60
 msgid "Build documentation portal (mdBook + Cargo docs)"
 msgstr ""
 
-#: src/contributing/devenv-setup.md:60
+#: src/contributing/devenv-setup.md:61
 msgid "`cadmus-docs-serve`"
 msgstr ""
 
-#: src/contributing/devenv-setup.md:60
+#: src/contributing/devenv-setup.md:61
 msgid "Serve documentation portal locally on port 1111"
 msgstr ""
 
-#: src/contributing/devenv-setup.md:61
+#: src/contributing/devenv-setup.md:62
 msgid "`cadmus-translate`"
 msgstr ""
 
-#: src/contributing/devenv-setup.md:61
-msgid "Generates the template .pot file for the docs"
+#: src/contributing/devenv-setup.md:62
+msgid "Generate the docs translation template (.pot)"
 msgstr ""
 
-#: src/contributing/devenv-setup.md:63
+#: src/contributing/devenv-setup.md:64
 msgid ""
 "Run `cargo xtask --help` to see all available subcommands, or `cargo xtask "
 "<cmd> --help` for options on a specific command."
 msgstr ""
 
-#: src/contributing/devenv-setup.md:66
+#: src/contributing/devenv-setup.md:67
 msgid ""
 "Or have a look at the rustdocs for `xtask` <a href=\"/api/xtask/\">here</a>."
 msgstr ""
 
-#: src/contributing/devenv-setup.md:68
+#: src/contributing/devenv-setup.md:69
 msgid "Tasks"
 msgstr ""
 
-#: src/contributing/devenv-setup.md:70
+#: src/contributing/devenv-setup.md:71
 msgid ""
 "The devenv environment uses [tasks](https://devenv.sh/tasks/) to manage "
 "build dependencies. Tasks are defined in `devenv.nix` and can be run with "
 "`devenv tasks run <task>`."
 msgstr ""
 
-#: src/contributing/devenv-setup.md:73
+#: src/contributing/devenv-setup.md:74
 msgid "Available Tasks"
 msgstr ""
 
-#: src/contributing/devenv-setup.md:75
+#: src/contributing/devenv-setup.md:76
 msgid "Task"
 msgstr ""
 
-#: src/contributing/devenv-setup.md:75
+#: src/contributing/devenv-setup.md:76
 msgid "Dependencies"
 msgstr ""
 
-#: src/contributing/devenv-setup.md:77 src/contributing/devenv-setup.md:79
+#: src/contributing/devenv-setup.md:78 src/contributing/devenv-setup.md:80
 msgid "`docs:build`"
 msgstr ""
 
-#: src/contributing/devenv-setup.md:77
+#: src/contributing/devenv-setup.md:78
 msgid "Build documentation EPUB (only rebuilds if files changed)"
 msgstr ""
 
-#: src/contributing/devenv-setup.md:77 src/contributing/devenv-setup.md:78
+#: src/contributing/devenv-setup.md:78 src/contributing/devenv-setup.md:79
 msgid "None"
 msgstr ""
 
-#: src/contributing/devenv-setup.md:78
+#: src/contributing/devenv-setup.md:79
 msgid "`deps:native`"
 msgstr ""
 
-#: src/contributing/devenv-setup.md:78
+#: src/contributing/devenv-setup.md:79
 msgid "Build MuPDF and wrapper for native development"
 msgstr ""
 
-#: src/contributing/devenv-setup.md:79
+#: src/contributing/devenv-setup.md:80
 msgid "`build:kobo`"
 msgstr ""
 
-#: src/contributing/devenv-setup.md:79
-msgid "Build for Kobo device (Linux only)"
+#: src/contributing/devenv-setup.md:80
+msgid "Build for Kobo device"
 msgstr ""
 
-#: src/contributing/devenv-setup.md:81
+#: src/contributing/devenv-setup.md:82
 msgid "All tasks delegate to `cargo xtask` under the hood."
 msgstr ""
 
-#: src/contributing/devenv-setup.md:83
+#: src/contributing/devenv-setup.md:84
 msgid "How Tasks Work"
 msgstr ""
 
-#: src/contributing/devenv-setup.md:85
+#: src/contributing/devenv-setup.md:86
 msgid ""
 "Tasks with dependencies automatically run their dependencies first. For "
 "example:"
 msgstr ""
 
-#: src/contributing/devenv-setup.md:88
+#: src/contributing/devenv-setup.md:89
 msgid "# This will first run docs:build (if needed), then build for Kobo\n"
 msgstr ""
 
-#: src/contributing/devenv-setup.md:92
+#: src/contributing/devenv-setup.md:93
 msgid ""
 "The `docs:build` task uses `execIfModified` to only rebuild when "
 "documentation files have actually changed."
 msgstr ""
 
-#: src/contributing/devenv-setup.md:94
+#: src/contributing/devenv-setup.md:95
 msgid "Kobo Build Notes"
 msgstr ""
 
-#: src/contributing/devenv-setup.md:96
-msgid ""
-"`cargo xtask download-assets` must run before `cargo xtask build-kobo` when "
-"you need compile-time asset metadata to match the packaged Kobo contents."
+#: src/contributing/devenv-setup.md:97
+msgid "`cargo xtask download-assets` must run before `cargo xtask build-kobo`."
 msgstr ""
 
 #: src/contributing/devenv-setup.md:98
@@ -2436,363 +2419,323 @@ msgstr ""
 
 #: src/contributing/devenv-setup.md:100
 msgid ""
-"User files outside the generated Cadmus-owned asset list must be preserved, "
-"so do not model OTA cleanup as a full directory wipe."
+"User files outside the generated Cadmus-owned asset list must be preserved."
 msgstr ""
 
-#: src/contributing/devenv-setup.md:103
+#: src/contributing/devenv-setup.md:102
 msgid "Documentation Portal"
 msgstr ""
 
-#: src/contributing/devenv-setup.md:105
+#: src/contributing/devenv-setup.md:104
 msgid ""
 "Cadmus provides a unified documentation portal that combines user guides, "
 "API reference, and contribution guides in one place."
 msgstr ""
 
-#: src/contributing/devenv-setup.md:108
+#: src/contributing/devenv-setup.md:107
 msgid "Building and Serving Locally"
 msgstr ""
 
-#: src/contributing/devenv-setup.md:110
+#: src/contributing/devenv-setup.md:109
 msgid "To build the documentation portal:"
 msgstr ""
 
-#: src/contributing/devenv-setup.md:116
+#: src/contributing/devenv-setup.md:115
 msgid "This runs the full build pipeline:"
 msgstr ""
 
-#: src/contributing/devenv-setup.md:118
+#: src/contributing/devenv-setup.md:117
 msgid "Builds the mdBook user guide (`docs/book/html/`)"
 msgstr ""
 
-#: src/contributing/devenv-setup.md:119
+#: src/contributing/devenv-setup.md:118
 msgid "Generates Rust API documentation (`target/doc/`)"
 msgstr ""
 
-#: src/contributing/devenv-setup.md:120
+#: src/contributing/devenv-setup.md:119
 msgid "Builds the Zola landing page and integrates all documentation"
 msgstr ""
 
-#: src/contributing/devenv-setup.md:122
+#: src/contributing/devenv-setup.md:121
 msgid "To serve the portal locally with live reload:"
 msgstr ""
 
-#: src/contributing/devenv-setup.md:128
+#: src/contributing/devenv-setup.md:127
 msgid ""
 "The portal will be available at <http://localhost:1111> with automatic "
 "rebuilds when you change documentation files or Rust code."
 msgstr ""
 
-#: src/contributing/devenv-setup.md:131
+#: src/contributing/devenv-setup.md:130
 msgid "Documentation Structure"
 msgstr ""
 
-#: src/contributing/devenv-setup.md:133
+#: src/contributing/devenv-setup.md:132
 msgid "The portal provides three integrated sections:"
 msgstr ""
 
-#: src/contributing/devenv-setup.md:135
+#: src/contributing/devenv-setup.md:134
 msgid "**Landing Page** (`/`) - Overview and feature highlights"
 msgstr ""
 
-#: src/contributing/devenv-setup.md:136
+#: src/contributing/devenv-setup.md:135
 msgid "**User Guide** (`/guide/`) - User-facing documentation from mdBook"
 msgstr ""
 
-#: src/contributing/devenv-setup.md:137
+#: src/contributing/devenv-setup.md:136
 msgid "**API Reference** (`/api/`) - Auto-generated Rust API documentation"
 msgstr ""
 
-#: src/contributing/devenv-setup.md:139
+#: src/contributing/devenv-setup.md:138
 msgid ""
 "All three sections are deployed as a single artifact to GitHub Pages at "
 "<https://ogkevin.github.io/cadmus/>."
 msgstr ""
 
-#: src/contributing/devenv-setup.md:142
+#: src/contributing/devenv-setup.md:141
 msgid "Continuous Integration"
 msgstr ""
 
-#: src/contributing/devenv-setup.md:144
+#: src/contributing/devenv-setup.md:143
 msgid ""
 "Documentation is automatically built and validated on every pull request and "
 "deployed on push to `main` or `master`. The CI pipeline checks:"
 msgstr ""
 
-#: src/contributing/devenv-setup.md:147
+#: src/contributing/devenv-setup.md:146
 msgid "mdBook documentation compiles"
 msgstr ""
 
-#: src/contributing/devenv-setup.md:148
+#: src/contributing/devenv-setup.md:147
 msgid "Rust code documentation is valid"
 msgstr ""
 
-#: src/contributing/devenv-setup.md:149
+#: src/contributing/devenv-setup.md:148
 msgid "Zola landing page builds successfully"
 msgstr ""
 
-#: src/contributing/devenv-setup.md:151
+#: src/contributing/devenv-setup.md:150
 msgid "Running Tests"
 msgstr ""
 
-#: src/contributing/devenv-setup.md:153
+#: src/contributing/devenv-setup.md:152
 msgid ""
 "Tests require the `TEST_ROOT_DIR` environment variable to be set. The "
 "easiest way to run the full test matrix is:"
 msgstr ""
 
-#: src/contributing/devenv-setup.md:160
+#: src/contributing/devenv-setup.md:159
 msgid ""
 "This sets `TEST_ROOT_DIR` automatically and runs tests across all feature "
 "combinations. To run a single feature combination:"
 msgstr ""
 
-#: src/contributing/devenv-setup.md:164
+#: src/contributing/devenv-setup.md:163
 msgid "\"emulator + test\""
 msgstr ""
 
-#: src/contributing/devenv-setup.md:167
+#: src/contributing/devenv-setup.md:166
 msgid "Or to run tests manually without xtask:"
 msgstr ""
 
-#: src/contributing/devenv-setup.md:170 src/contributing/devenv-setup.md:243
+#: src/contributing/devenv-setup.md:169 src/contributing/devenv-setup.md:237
 msgid "$(pwd)"
 msgstr ""
 
-#: src/contributing/devenv-setup.md:173
+#: src/contributing/devenv-setup.md:172
 msgid ""
 "`TEST_ROOT_DIR` is automatically configured in CI but must be set manually "
 "when running `cargo test` directly."
 msgstr ""
 
-#: src/contributing/devenv-setup.md:176
+#: src/contributing/devenv-setup.md:175
 msgid "Platform Support"
 msgstr ""
 
-#: src/contributing/devenv-setup.md:178
+#: src/contributing/devenv-setup.md:177
 msgid "Linux (Full Support)"
 msgstr ""
 
-#: src/contributing/devenv-setup.md:180
+#: src/contributing/devenv-setup.md:179
 msgid "Linux provides full development capabilities including:"
 msgstr ""
 
-#: src/contributing/devenv-setup.md:182
+#: src/contributing/devenv-setup.md:181 src/contributing/devenv-setup.md:191
 msgid "Native development (emulator, tests)"
 msgstr ""
 
-#: src/contributing/devenv-setup.md:183
+#: src/contributing/devenv-setup.md:182 src/contributing/devenv-setup.md:192
 msgid "Cross-compilation for Kobo devices using the Linaro ARM toolchain"
 msgstr ""
 
-#: src/contributing/devenv-setup.md:184
+#: src/contributing/devenv-setup.md:183 src/contributing/devenv-setup.md:193
 msgid "Git hooks (actionlint, shellcheck, shfmt, markdownlint, prettier)"
 msgstr ""
 
-#: src/contributing/devenv-setup.md:186
+#: src/contributing/devenv-setup.md:185
 msgid ""
 "The Linaro toolchain is automatically added to `PATH` and provides "
 "`arm-linux-gnueabihf-*` commands."
 msgstr ""
 
-#: src/contributing/devenv-setup.md:188
-msgid "macOS (Native Development Only)"
+#: src/contributing/devenv-setup.md:187
+msgid "macOS (Full Support)"
 msgstr ""
 
-#: src/contributing/devenv-setup.md:190
-msgid "macOS supports native development but has some limitations:"
-msgstr ""
-
-#: src/contributing/devenv-setup.md:192
-msgid "Feature"
-msgstr ""
-
-#: src/contributing/devenv-setup.md:192
-msgid "Notes"
-msgstr ""
-
-#: src/contributing/devenv-setup.md:194
-msgid "Native builds"
-msgstr ""
-
-#: src/contributing/devenv-setup.md:194
-msgid "Supported"
-msgstr ""
-
-#: src/contributing/devenv-setup.md:194
-msgid "Emulator and tests work"
+#: src/contributing/devenv-setup.md:189
+msgid "macOS supports full development capabilities including:"
 msgstr ""
 
 #: src/contributing/devenv-setup.md:195
-msgid "Cross-compilation"
-msgstr ""
-
-#: src/contributing/devenv-setup.md:195
-msgid "Not supported"
-msgstr ""
-
-#: src/contributing/devenv-setup.md:195
-msgid "Linaro toolchain is Linux-only"
-msgstr ""
-
-#: src/contributing/devenv-setup.md:197
 msgid "macOS-Specific Notes"
 msgstr ""
 
-#: src/contributing/devenv-setup.md:199
-msgid ""
-"**Cross-compilation for Kobo**: The Linaro ARM cross-compilation toolchain "
-"consists of x86_64 Linux ELF binaries that cannot run on macOS. To build for "
-"Kobo devices on macOS, use Docker with a Linux container or a Linux VM."
-msgstr ""
-
-#: src/contributing/devenv-setup.md:203
+#: src/contributing/devenv-setup.md:197
 msgid ""
 "**MuPDF build**: On macOS, the native setup script manually gathers "
 "pkg-config CFLAGS for system libraries because MuPDF's build system doesn't "
 "properly detect them on Darwin."
 msgstr ""
 
-#: src/contributing/devenv-setup.md:206
+#: src/contributing/devenv-setup.md:200
 msgid "Observability Stack"
 msgstr ""
 
-#: src/contributing/devenv-setup.md:208
+#: src/contributing/devenv-setup.md:202
 msgid "The devenv includes a full observability stack for development:"
 msgstr ""
 
-#: src/contributing/devenv-setup.md:211
+#: src/contributing/devenv-setup.md:205
 msgid "# Start all services\n"
 msgstr ""
 
-#: src/contributing/devenv-setup.md:213
+#: src/contributing/devenv-setup.md:207
 msgid "# In another terminal, run the instrumented emulator\n"
 msgstr ""
 
-#: src/contributing/devenv-setup.md:218
+#: src/contributing/devenv-setup.md:212
 msgid "Services available after `devenv up`:"
 msgstr ""
 
-#: src/contributing/devenv-setup.md:220
+#: src/contributing/devenv-setup.md:214
 msgid "Service"
 msgstr ""
 
-#: src/contributing/devenv-setup.md:220
+#: src/contributing/devenv-setup.md:214
 msgid "URL"
 msgstr ""
 
-#: src/contributing/devenv-setup.md:220
+#: src/contributing/devenv-setup.md:214
 #: src/contributing/library-database.md:148
 msgid "Purpose"
 msgstr ""
 
-#: src/contributing/devenv-setup.md:222
+#: src/contributing/devenv-setup.md:216
 msgid "Grafana"
 msgstr ""
 
-#: src/contributing/devenv-setup.md:222
+#: src/contributing/devenv-setup.md:216
 msgid "<http://localhost:3000>"
 msgstr ""
 
-#: src/contributing/devenv-setup.md:222
+#: src/contributing/devenv-setup.md:216
 msgid "Dashboards and exploration"
 msgstr ""
 
-#: src/contributing/devenv-setup.md:223
+#: src/contributing/devenv-setup.md:217
 msgid "Tempo"
 msgstr ""
 
-#: src/contributing/devenv-setup.md:223
+#: src/contributing/devenv-setup.md:217
 msgid "<http://localhost:3200>"
 msgstr ""
 
-#: src/contributing/devenv-setup.md:223
+#: src/contributing/devenv-setup.md:217
 msgid "Distributed tracing"
 msgstr ""
 
-#: src/contributing/devenv-setup.md:224
+#: src/contributing/devenv-setup.md:218
 msgid "Loki"
 msgstr ""
 
-#: src/contributing/devenv-setup.md:224
+#: src/contributing/devenv-setup.md:218
 msgid "<http://localhost:3100>"
 msgstr ""
 
-#: src/contributing/devenv-setup.md:224
+#: src/contributing/devenv-setup.md:218
 msgid "Log aggregation"
 msgstr ""
 
-#: src/contributing/devenv-setup.md:225
+#: src/contributing/devenv-setup.md:219
 msgid "Prometheus"
 msgstr ""
 
-#: src/contributing/devenv-setup.md:225
+#: src/contributing/devenv-setup.md:219
 msgid "<http://localhost:9090>"
 msgstr ""
 
-#: src/contributing/devenv-setup.md:225
+#: src/contributing/devenv-setup.md:219
 msgid "Metrics"
 msgstr ""
 
-#: src/contributing/devenv-setup.md:226
+#: src/contributing/devenv-setup.md:220
 msgid "OTLP Collector"
 msgstr ""
 
-#: src/contributing/devenv-setup.md:226
+#: src/contributing/devenv-setup.md:220
 msgid "<http://localhost:4318>"
 msgstr ""
 
-#: src/contributing/devenv-setup.md:226
+#: src/contributing/devenv-setup.md:220
 msgid "Telemetry ingestion"
 msgstr ""
 
-#: src/contributing/devenv-setup.md:227
+#: src/contributing/devenv-setup.md:221
 msgid "Pyroscope"
 msgstr ""
 
-#: src/contributing/devenv-setup.md:227
+#: src/contributing/devenv-setup.md:221
 msgid "<http://localhost:4040>"
 msgstr ""
 
-#: src/contributing/devenv-setup.md:227
+#: src/contributing/devenv-setup.md:221
 msgid "Continuous profiling"
 msgstr ""
 
-#: src/contributing/devenv-setup.md:229
+#: src/contributing/devenv-setup.md:223
 msgid "For more details on telemetry, see [Telemetry](telemetry/index.md)."
 msgstr ""
 
-#: src/contributing/devenv-setup.md:233
+#: src/contributing/devenv-setup.md:227
 msgid "Shell takes a long time to start"
 msgstr ""
 
-#: src/contributing/devenv-setup.md:235
+#: src/contributing/devenv-setup.md:229
 msgid ""
 "The first `devenv shell` invocation downloads and builds dependencies, which "
 "can take several minutes. Subsequent invocations are cached and should be "
 "fast."
 msgstr ""
 
-#: src/contributing/devenv-setup.md:238
+#: src/contributing/devenv-setup.md:232
 msgid "Tests fail with \"TEST_ROOT_DIR must be set\""
 msgstr ""
 
-#: src/contributing/devenv-setup.md:240
+#: src/contributing/devenv-setup.md:234
 msgid "Set the environment variable before running tests:"
 msgstr ""
 
-#: src/contributing/devenv-setup.md:246
+#: src/contributing/devenv-setup.md:240
 msgid "Local Configuration"
 msgstr ""
 
-#: src/contributing/devenv-setup.md:248
+#: src/contributing/devenv-setup.md:242
 msgid ""
 "Create `devenv.local.nix` to override settings without modifying the tracked "
 "configuration:"
 msgstr ""
 
-#: src/contributing/devenv-setup.md:250
+#: src/contributing/devenv-setup.md:244
 msgid ""
 "```nix\n"
 "{ pkgs, ... }:\n"
@@ -2806,7 +2749,7 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/contributing/devenv-setup.md:261
+#: src/contributing/devenv-setup.md:255
 msgid "This file is gitignored and won't affect other contributors."
 msgstr ""
 

--- a/docs/src/installation/migration.md
+++ b/docs/src/installation/migration.md
@@ -40,13 +40,12 @@ Both database mode and filesystem mode libraries are handled. Cadmus reads
 carry over regardless of which mode you used in Plato.
 
 > [!NOTE]
-> After a successful import the original files are renamed:
->
-> - `.metadata.json` → `.metadata.json.imported`
-> - `.reading-states/` → `.reading-states.imported`
->
-> These renamed files are just a safety backup. Once you've confirmed
-> everything looks right you can delete them.
+> The original `.metadata.json` and `.reading-states/` files are not modified
+> or deleted during import. Once you have confirmed everything looks right in
+> Cadmus, you can safely delete them. Keeping these files means your Plato
+> progress remains intact. If you decide to go back to Plato, you can do so
+> without losing your original Plato reading states. Though keep in
+> mind that any progress you make in Cadmus will not sync back to Plato.
 
 > [!NOTE]
 > Cadmus also removes the `.thumbnail-previews/` folder and regenerates
@@ -57,17 +56,14 @@ carry over regardless of which mode you used in Plato.
 If the import went wrong (for example, the library path was incorrect in
 settings), you can start it fresh:
 
-1. Rename `.metadata.json.imported` back to `.metadata.json` and
-   `.reading-states.imported` back to `.reading-states/` in each library
-   directory.
-2. Delete the Cadmus SQLite database:
+1. Delete the Cadmus SQLite database:
 
    | Build  | Database path                                 |
    | ------ | --------------------------------------------- |
    | Stable | `/mnt/onboard/.adds/cadmus/cadmus.sqlite`     |
    | Test   | `/mnt/onboard/.adds/cadmus-tst/cadmus.sqlite` |
 
-3. Restart Cadmus — the import will run again from scratch.
+2. Restart Cadmus — the import will run again from scratch.
 
 If something still looks wrong after re-running, check the logs for details.
 See [Troubleshooting](../troubleshooting/index.md) for where to find them.


### PR DESCRIPTION
Stop renaming .metadata.json and .reading-states/ to .imported during first-time launch migration, as migrations are tracked in SQLite.

- Delete mark_library_imported function from migrations.rs
- Stop calling mark_library_imported in import_library
- Update docs to reflect that files remain untouched

Change-Id: fed934f5ad18f08ff28184761e3cc93c
Change-Id-Short: klmqwvkupmyr
Closes: CAD-89
Closes: #502