### PR TITLE
fix(Notifications): transfer on back navigation

### DIFF
--- a/crates/cadmus/src/app.rs
+++ b/crates/cadmus/src/app.rs
@@ -1525,7 +1525,13 @@ pub fn run() -> Result<(), Error> {
                 view = next_view;
             }
             Event::Back => {
-                if let Some(item) = history.pop() {
+                if let Some(mut item) = history.pop() {
+                    transfer_notifications(
+                        view.as_mut(),
+                        item.view.as_mut(),
+                        &mut rq,
+                        &mut context,
+                    );
                     view = item.view;
                     if item.monochrome != context.fb.monochrome() {
                         context.fb.set_monochrome(item.monochrome);

--- a/crates/emulator/src/main.rs
+++ b/crates/emulator/src/main.rs
@@ -683,7 +683,8 @@ fn run() -> Result<(), Error> {
                     show_ota_view(view.as_mut(), &tx, &mut rq, &mut context);
                 }
                 Event::Back => {
-                    if let Some(v) = history.pop() {
+                    if let Some(mut v) = history.pop() {
+                        transfer_notifications(view.as_mut(), v.as_mut(), &mut rq, &mut context);
                         view = v;
                         if view.is::<Home>() && context.display.rotation % 2 != 1 {
                             if let Ok(dims) = context.fb.set_rotation(DEFAULT_ROTATION) {


### PR DESCRIPTION
Pinned notifications were dropped when navigating back because transfer_notifications was only called on forward navigation.

- Call transfer_notifications in Event::Back handler in app.rs
- Call transfer_notifications in Event::Back handler in emulator/main.rs

Change-Id: a79e11349f3b322833d5493f53c8eac3
Change-Id-Short: psqlyywvqkwo
Closes: #438 
Closes: CAD-55