### PR TITLE
feat(Device): route data files to SD card

### DIFF
--- a/crates/cadmus/src/app.rs
+++ b/crates/cadmus/src/app.rs
@@ -64,7 +64,6 @@ use std::time::{Duration, Instant};
 use tracing::{Level, debug, error, info, warn};
 
 pub const APP_NAME: &str = "Cadmus";
-const DB_FILENAME: &str = "cadmus.sqlite";
 const FB_DEVICE: &str = "/dev/fb0";
 const RTC_DEVICE: &str = "/dev/rtc0";
 const TOUCH_INPUTS: [&str; 5] = [
@@ -569,12 +568,15 @@ pub fn run() -> Result<(), Error> {
         fb.set_rotation(startup_rotation).ok();
     }
 
-    let manager = SettingsManager::new(get_current_version());
+    let manager = SettingsManager::new(CURRENT_DEVICE.data_dir(), get_current_version());
     let settings = manager.load();
 
     cadmus_core::crypto::init_crypto_provider();
 
-    if let Err(e) = cadmus_core::logging::init_logging(&settings.logging) {
+    if let Err(e) = cadmus_core::logging::init_logging(
+        &settings.logging,
+        CURRENT_DEVICE.data_path(&settings.logging.directory),
+    ) {
         eprintln!("Warning: Failed to initialize logging: {:#}", e);
         eprintln!("Continuing without logging...");
     }
@@ -591,8 +593,7 @@ pub fn run() -> Result<(), Error> {
     i18n::init(settings.locale.as_ref());
 
     let startup_cwd = env::current_dir().ok();
-    let startup_db_exists = Path::new(DB_FILENAME).exists();
-    info!(cwd = ?startup_cwd, db_exists = startup_db_exists, "startup diagnostics");
+    info!(cwd = ?startup_cwd, "startup diagnostics");
     CURRENT_DEVICE.clean_tmp_dir();
 
     match CURRENT_DEVICE.power_manager() {
@@ -607,7 +608,7 @@ pub fn run() -> Result<(), Error> {
     }
 
     let mut fonts = Fonts::load().context("can't load fonts")?;
-    let database = Database::new(DB_FILENAME)
+    let database = Database::new(CURRENT_DEVICE.resolve_db_path())
         .map_err(|e| {
             error!(error = %e, "can't open database");
             e

--- a/crates/cadmus/src/app.rs
+++ b/crates/cadmus/src/app.rs
@@ -504,8 +504,8 @@ fn handle_usb_unshare(
         Ok(usb_manager) => match usb_manager.disable() {
             Ok(()) => {
                 info!("USB mass storage disabled successfully");
-                if let Some(cwd) = startup_cwd.as_ref() {
-                    let log_dir = cwd.join(&logging_settings.directory);
+                if startup_cwd.is_some() {
+                    let log_dir = CURRENT_DEVICE.data_path(&logging_settings.directory);
                     if let Err(e) =
                         cadmus_core::logging::redirect_log_to_dir(&log_dir, logging_settings)
                     {

--- a/crates/core/src/context.rs
+++ b/crates/core/src/context.rs
@@ -105,7 +105,7 @@ impl Context {
         .join(KEYBOARD_LAYOUTS_DIRNAME);
 
         #[cfg(not(test))]
-        let path = Path::new(KEYBOARD_LAYOUTS_DIRNAME);
+        let path = CURRENT_DEVICE.install_path(KEYBOARD_LAYOUTS_DIRNAME);
 
         for entry in WalkDir::new(path)
             .min_depth(1)
@@ -143,7 +143,7 @@ impl Context {
         .join(DICTIONARIES_DIRNAME);
 
         #[cfg(not(test))]
-        let path = Path::new(DICTIONARIES_DIRNAME);
+        let path = CURRENT_DEVICE.data_path(DICTIONARIES_DIRNAME);
 
         for entry in WalkDir::new(path)
             .min_depth(1)

--- a/crates/core/src/db/mod.rs
+++ b/crates/core/src/db/mod.rs
@@ -8,6 +8,9 @@ use sqlx::sqlite::{SqliteConnectOptions, SqlitePool, SqlitePoolOptions};
 use std::path::Path;
 use std::str::FromStr;
 
+/// The filename of the SQLite database used by Cadmus.
+pub const DB_FILENAME: &str = "cadmus.sqlite";
+
 /// Database handle providing synchronous API over async SQLx operations.
 /// Uses a bridge pattern with `RUNTIME.block_on()` to maintain synchronous interface
 /// for compatibility with existing single-threaded event loop.

--- a/crates/core/src/db/mod.rs
+++ b/crates/core/src/db/mod.rs
@@ -38,7 +38,12 @@ impl Database {
     /// * `Err(Error)` - Connection failure
     #[cfg_attr(feature = "tracing", tracing::instrument(fields(db_path = %path.as_ref().display())))]
     pub fn new<P: AsRef<Path> + std::fmt::Debug>(path: P) -> Result<Self, Error> {
-        let path_str = path.as_ref().display().to_string();
+        let path = path.as_ref();
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+
+        let path_str = path.display().to_string();
 
         tracing::info!(db_path = %path_str, "connecting to database");
 

--- a/crates/core/src/db/mod.rs
+++ b/crates/core/src/db/mod.rs
@@ -39,7 +39,9 @@ impl Database {
     #[cfg_attr(feature = "tracing", tracing::instrument(fields(db_path = %path.as_ref().display())))]
     pub fn new<P: AsRef<Path> + std::fmt::Debug>(path: P) -> Result<Self, Error> {
         let path = path.as_ref();
-        if let Some(parent) = path.parent() {
+        if let Some(parent) = path.parent()
+            && !parent.as_os_str().is_empty()
+        {
             std::fs::create_dir_all(parent)?;
         }
 

--- a/crates/core/src/device/migration.rs
+++ b/crates/core/src/device/migration.rs
@@ -1,0 +1,307 @@
+//! One-time migration of dynamic data files from the install directory to the
+//! SD card data directory.
+//!
+//! This migration runs once at startup when a device with removable storage has
+//! an SD card mounted. It moves settings, logs, and dictionaries — but **not**
+//! the SQLite database, which is already open by the time migrations run.
+//!
+//! # Idempotency
+//!
+//! A directory is skipped if the source no longer exists. A file is skipped if
+//! the destination already exists. Re-running the migration after a partial
+//! failure is safe.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+/// Directories and individual files to migrate from the install dir to the data
+/// dir. Dictionaries, settings, and logs are included; the SQLite database is
+/// excluded because it is already open when this runs.
+const MIGRATE_DIRS: &[&str] = &["Settings", "logs", "dictionaries"];
+const MIGRATE_FILES: &[&str] = &["Settings.toml"];
+
+crate::migration!(
+    /// Migrates dynamic data files from the install directory to the SD card
+    /// data directory on devices with removable storage.
+    ///
+    /// Settings, logs, and dictionaries are moved. The SQLite database is
+    /// excluded because it is already open when migrations run.
+    ///
+    /// This migration is a no-op when no SD card is present (`data_dir` equals
+    /// `install_dir`). It will be recorded as succeeded so it does not re-run
+    /// on subsequent boots without a card.
+    "v3_migrate_data_to_sd_card",
+    async fn migrate_data_to_sd_card(_pool: &sqlx::SqlitePool) {
+        let install_dir = crate::device::CURRENT_DEVICE.install_dir();
+        let data_dir = crate::device::CURRENT_DEVICE.data_dir();
+
+        migrate_data_to_sd(install_dir, data_dir);
+
+        Ok(())
+    }
+);
+
+fn migrate_data_to_sd(install_dir: PathBuf, data_dir: PathBuf) {
+    if install_dir == data_dir {
+        return;
+    }
+
+    tracing::info!(
+        from = %install_dir.display(),
+        to = %data_dir.display(),
+        "migrating dynamic data files to sd card"
+    );
+
+    if let Err(e) = fs::create_dir_all(&data_dir) {
+        tracing::warn!(
+            path = %data_dir.display(),
+            error = %e,
+            "failed to create data dir on sd card; skipping migration"
+        );
+        return;
+    }
+
+    for dirname in MIGRATE_DIRS {
+        migrate_dir(&install_dir.join(dirname), &data_dir.join(dirname));
+    }
+
+    for filename in MIGRATE_FILES {
+        migrate_file(&install_dir.join(filename), &data_dir.join(filename));
+    }
+}
+
+fn migrate_dir(src: &Path, dst: &Path) {
+    if !src.exists() {
+        return;
+    }
+
+    if let Err(e) = fs::create_dir_all(dst) {
+        tracing::warn!(
+            path = %dst.display(),
+            error = %e,
+            "failed to create destination dir; skipping directory migration"
+        );
+        return;
+    }
+
+    copy_dir_recursive(src, dst, src);
+
+    if let Err(e) = fs::remove_dir_all(src) {
+        tracing::warn!(
+            path = %src.display(),
+            error = %e,
+            "failed to remove source directory after migration"
+        );
+    }
+}
+
+fn copy_dir_recursive(src_root: &Path, dst_root: &Path, current: &Path) {
+    let entries = match fs::read_dir(current) {
+        Ok(e) => e,
+        Err(e) => {
+            tracing::warn!(
+                path = %current.display(),
+                error = %e,
+                "failed to read directory during migration"
+            );
+            return;
+        }
+    };
+
+    for entry in entries {
+        let entry = match entry {
+            Ok(e) => e,
+            Err(e) => {
+                tracing::warn!(error = %e, "failed to read directory entry during migration");
+                continue;
+            }
+        };
+
+        let file_type = match entry.file_type() {
+            Ok(ft) => ft,
+            Err(e) => {
+                tracing::warn!(error = %e, "failed to get file type during migration");
+                continue;
+            }
+        };
+
+        let rel = match entry.path().strip_prefix(src_root) {
+            Ok(r) => r.to_path_buf(),
+            Err(e) => {
+                tracing::warn!(error = %e, "failed to strip prefix during migration");
+                continue;
+            }
+        };
+
+        let dst_path = dst_root.join(&rel);
+
+        if file_type.is_dir() {
+            if let Err(e) = fs::create_dir_all(&dst_path) {
+                tracing::warn!(
+                    path = %dst_path.display(),
+                    error = %e,
+                    "failed to create subdirectory during migration"
+                );
+                continue;
+            }
+
+            copy_dir_recursive(src_root, dst_root, &entry.path());
+            continue;
+        }
+
+        if dst_path.exists() {
+            continue;
+        }
+
+        migrate_file(&entry.path(), &dst_path);
+    }
+}
+
+fn migrate_file(src: &Path, dst: &Path) {
+    if !src.exists() || dst.exists() {
+        return;
+    }
+
+    if let Err(e) = fs::copy(src, dst) {
+        tracing::warn!(
+            src = %src.display(),
+            dst = %dst.display(),
+            error = %e,
+            "failed to copy file during migration"
+        );
+        return;
+    }
+
+    if let Err(e) = fs::remove_file(src) {
+        tracing::warn!(
+            path = %src.display(),
+            error = %e,
+            "failed to remove source file after migration"
+        );
+    }
+
+    tracing::debug!(path = %src.display(), "migrated file to sd card");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    fn run(install: &TempDir, data: &TempDir) {
+        migrate_data_to_sd(install.path().to_path_buf(), data.path().to_path_buf());
+    }
+
+    #[test]
+    fn test_no_op_when_dirs_equal() {
+        let dir = TempDir::new().unwrap();
+        let settings = dir.path().join("Settings.toml");
+        fs::write(&settings, "key = true").unwrap();
+
+        migrate_data_to_sd(dir.path().to_path_buf(), dir.path().to_path_buf());
+
+        assert!(
+            settings.exists(),
+            "file must be untouched when dirs are equal"
+        );
+    }
+
+    #[test]
+    fn test_migrates_top_level_file() {
+        let install = TempDir::new().unwrap();
+        let data = TempDir::new().unwrap();
+
+        fs::write(install.path().join("Settings.toml"), "key = true").unwrap();
+
+        run(&install, &data);
+
+        assert!(
+            data.path().join("Settings.toml").exists(),
+            "Settings.toml must exist in data dir"
+        );
+        assert!(
+            !install.path().join("Settings.toml").exists(),
+            "Settings.toml must be removed from install dir"
+        );
+    }
+
+    #[test]
+    fn test_migrates_directory_recursively() {
+        let install = TempDir::new().unwrap();
+        let data = TempDir::new().unwrap();
+
+        let src_dir = install.path().join("Settings");
+        fs::create_dir(&src_dir).unwrap();
+        fs::write(src_dir.join("config.toml"), "x = 1").unwrap();
+
+        let nested = src_dir.join("profiles");
+        fs::create_dir(&nested).unwrap();
+        fs::write(nested.join("default.toml"), "y = 2").unwrap();
+
+        run(&install, &data);
+
+        assert!(data.path().join("Settings/config.toml").exists());
+        assert!(data.path().join("Settings/profiles/default.toml").exists());
+        assert!(
+            !install.path().join("Settings").exists(),
+            "source dir must be removed"
+        );
+    }
+
+    #[test]
+    fn test_idempotent_file() {
+        let install = TempDir::new().unwrap();
+        let data = TempDir::new().unwrap();
+
+        fs::write(install.path().join("Settings.toml"), "key = true").unwrap();
+
+        run(&install, &data);
+
+        fs::write(install.path().join("Settings.toml"), "key = false").unwrap();
+
+        run(&install, &data);
+
+        let content = fs::read_to_string(data.path().join("Settings.toml")).unwrap();
+        assert_eq!(
+            content, "key = true",
+            "second run must not overwrite already-migrated file"
+        );
+    }
+
+    #[test]
+    fn test_idempotent_dir() {
+        let install = TempDir::new().unwrap();
+        let data = TempDir::new().unwrap();
+
+        let src_dir = install.path().join("Settings");
+        fs::create_dir(&src_dir).unwrap();
+        fs::write(src_dir.join("a.toml"), "original").unwrap();
+
+        run(&install, &data);
+
+        fs::create_dir(install.path().join("Settings")).unwrap();
+        fs::write(install.path().join("Settings/a.toml"), "overwrite").unwrap();
+
+        run(&install, &data);
+
+        let content = fs::read_to_string(data.path().join("Settings/a.toml")).unwrap();
+        assert_eq!(
+            content, "original",
+            "second run must not overwrite already-migrated file"
+        );
+    }
+
+    #[test]
+    fn test_missing_source_dir_is_skipped() {
+        let install = TempDir::new().unwrap();
+        let data = TempDir::new().unwrap();
+
+        run(&install, &data);
+
+        assert!(
+            data.path().read_dir().unwrap().next().is_none(),
+            "data dir must remain empty"
+        );
+    }
+}

--- a/crates/core/src/device/migration.rs
+++ b/crates/core/src/device/migration.rs
@@ -30,20 +30,19 @@ crate::migration!(
     /// This migration is a no-op when no SD card is present (`data_dir` equals
     /// `install_dir`). It will be recorded as succeeded so it does not re-run
     /// on subsequent boots without a card.
-    "v3_migrate_data_to_sd_card",
+    "v1_migrate_data_to_sd_card",
     async fn migrate_data_to_sd_card(_pool: &sqlx::SqlitePool) {
         let install_dir = crate::device::CURRENT_DEVICE.install_dir();
         let data_dir = crate::device::CURRENT_DEVICE.data_dir();
 
-        migrate_data_to_sd(install_dir, data_dir);
+        migrate_data_to_sd(install_dir, data_dir)
 
-        Ok(())
     }
 );
 
-fn migrate_data_to_sd(install_dir: PathBuf, data_dir: PathBuf) {
+fn migrate_data_to_sd(install_dir: PathBuf, data_dir: PathBuf) -> anyhow::Result<()> {
     if install_dir == data_dir {
-        return;
+        return Ok(());
     }
 
     tracing::info!(
@@ -58,21 +57,26 @@ fn migrate_data_to_sd(install_dir: PathBuf, data_dir: PathBuf) {
             error = %e,
             "failed to create data dir on sd card; skipping migration"
         );
-        return;
+        anyhow::bail!("failed to create data dir {}", data_dir.display());
     }
 
+    let mut all_ok = true;
+
     for dirname in MIGRATE_DIRS {
-        migrate_dir(&install_dir.join(dirname), &data_dir.join(dirname));
+        all_ok &= migrate_dir(&install_dir.join(dirname), &data_dir.join(dirname));
     }
 
     for filename in MIGRATE_FILES {
-        migrate_file(&install_dir.join(filename), &data_dir.join(filename));
+        all_ok &= migrate_file(&install_dir.join(filename), &data_dir.join(filename));
     }
+
+    anyhow::ensure!(all_ok, "sd-card data migration completed with copy errors");
+    Ok(())
 }
 
-fn migrate_dir(src: &Path, dst: &Path) {
+fn migrate_dir(src: &Path, dst: &Path) -> bool {
     if !src.exists() {
-        return;
+        return true;
     }
 
     if let Err(e) = fs::create_dir_all(dst) {
@@ -81,10 +85,18 @@ fn migrate_dir(src: &Path, dst: &Path) {
             error = %e,
             "failed to create destination dir; skipping directory migration"
         );
-        return;
+        return false;
     }
 
-    copy_dir_recursive(src, dst, src);
+    let fully_copied = copy_dir_recursive(src, dst, src);
+
+    if !fully_copied {
+        tracing::warn!(
+            path = %src.display(),
+            "skipping source directory removal; not all files were copied"
+        );
+        return false;
+    }
 
     if let Err(e) = fs::remove_dir_all(src) {
         tracing::warn!(
@@ -93,9 +105,11 @@ fn migrate_dir(src: &Path, dst: &Path) {
             "failed to remove source directory after migration"
         );
     }
+
+    true
 }
 
-fn copy_dir_recursive(src_root: &Path, dst_root: &Path, current: &Path) {
+fn copy_dir_recursive(src_root: &Path, dst_root: &Path, current: &Path) -> bool {
     let entries = match fs::read_dir(current) {
         Ok(e) => e,
         Err(e) => {
@@ -104,15 +118,18 @@ fn copy_dir_recursive(src_root: &Path, dst_root: &Path, current: &Path) {
                 error = %e,
                 "failed to read directory during migration"
             );
-            return;
+            return false;
         }
     };
+
+    let mut all_ok = true;
 
     for entry in entries {
         let entry = match entry {
             Ok(e) => e,
             Err(e) => {
                 tracing::warn!(error = %e, "failed to read directory entry during migration");
+                all_ok = false;
                 continue;
             }
         };
@@ -121,6 +138,7 @@ fn copy_dir_recursive(src_root: &Path, dst_root: &Path, current: &Path) {
             Ok(ft) => ft,
             Err(e) => {
                 tracing::warn!(error = %e, "failed to get file type during migration");
+                all_ok = false;
                 continue;
             }
         };
@@ -129,6 +147,7 @@ fn copy_dir_recursive(src_root: &Path, dst_root: &Path, current: &Path) {
             Ok(r) => r.to_path_buf(),
             Err(e) => {
                 tracing::warn!(error = %e, "failed to strip prefix during migration");
+                all_ok = false;
                 continue;
             }
         };
@@ -142,10 +161,13 @@ fn copy_dir_recursive(src_root: &Path, dst_root: &Path, current: &Path) {
                     error = %e,
                     "failed to create subdirectory during migration"
                 );
+                all_ok = false;
                 continue;
             }
 
-            copy_dir_recursive(src_root, dst_root, &entry.path());
+            if !copy_dir_recursive(src_root, dst_root, &entry.path()) {
+                all_ok = false;
+            }
             continue;
         }
 
@@ -153,13 +175,17 @@ fn copy_dir_recursive(src_root: &Path, dst_root: &Path, current: &Path) {
             continue;
         }
 
-        migrate_file(&entry.path(), &dst_path);
+        if !migrate_file(&entry.path(), &dst_path) {
+            all_ok = false;
+        }
     }
+
+    all_ok
 }
 
-fn migrate_file(src: &Path, dst: &Path) {
+fn migrate_file(src: &Path, dst: &Path) -> bool {
     if !src.exists() || dst.exists() {
-        return;
+        return true;
     }
 
     if let Err(e) = fs::copy(src, dst) {
@@ -169,7 +195,7 @@ fn migrate_file(src: &Path, dst: &Path) {
             error = %e,
             "failed to copy file during migration"
         );
-        return;
+        return false;
     }
 
     if let Err(e) = fs::remove_file(src) {
@@ -181,6 +207,8 @@ fn migrate_file(src: &Path, dst: &Path) {
     }
 
     tracing::debug!(path = %src.display(), "migrated file to sd card");
+
+    true
 }
 
 #[cfg(test)]
@@ -190,7 +218,8 @@ mod tests {
     use tempfile::TempDir;
 
     fn run(install: &TempDir, data: &TempDir) {
-        migrate_data_to_sd(install.path().to_path_buf(), data.path().to_path_buf());
+        migrate_data_to_sd(install.path().to_path_buf(), data.path().to_path_buf())
+            .expect("migration failed");
     }
 
     #[test]
@@ -199,7 +228,8 @@ mod tests {
         let settings = dir.path().join("Settings.toml");
         fs::write(&settings, "key = true").unwrap();
 
-        migrate_data_to_sd(dir.path().to_path_buf(), dir.path().to_path_buf());
+        migrate_data_to_sd(dir.path().to_path_buf(), dir.path().to_path_buf())
+            .expect("migration failed");
 
         assert!(
             settings.exists(),

--- a/crates/core/src/device/mod.rs
+++ b/crates/core/src/device/mod.rs
@@ -11,6 +11,7 @@ use std::path::{Path, PathBuf};
 
 mod error;
 mod metadata;
+pub mod migration;
 mod model;
 mod power;
 mod types;
@@ -203,12 +204,85 @@ impl Device {
         self.install_dir().join(relative_path)
     }
 
+    /// Returns the subdirectory name used for dynamic data on removable storage.
+    ///
+    /// Mirrors [`Device::install_subdir`] but for the SD card, using the
+    /// `.cadmus` prefix instead of `.adds/cadmus`.
+    pub fn data_subdir(&self) -> &'static str {
+        cfg_select! {
+            feature = "test" => { ".cadmus-tst" }
+            _ => { ".cadmus" }
+        }
+    }
+
+    /// Returns the directory where dynamic data files are stored.
+    ///
+    /// On device builds for models with removable storage and an SD card
+    /// currently mounted, this returns `/mnt/sd/.cadmus` (or `.cadmus-tst`
+    /// for test builds). Otherwise it falls back to [`Device::install_dir`].
+    ///
+    /// Dynamic files include the SQLite database, settings, logs, and
+    /// dictionaries. Static assets (fonts, icons, bundled resources) always
+    /// live under [`Device::install_dir`].
+    pub fn data_dir(&self) -> PathBuf {
+        cfg_select! {
+            test => { self.install_dir() }
+            feature = "emulator" => { self.install_dir() }
+            _ => {
+                if self.has_removable_storage()
+                    && Path::new(crate::settings::EXTERNAL_CARD_ROOT).is_dir()
+                {
+                    PathBuf::from(crate::settings::EXTERNAL_CARD_ROOT)
+                        .join(self.data_subdir())
+                } else {
+                    self.install_dir()
+                }
+            }
+        }
+    }
+
+    /// Returns a path inside the dynamic data directory.
+    ///
+    /// Use this for files and directories that Cadmus writes at runtime:
+    /// the SQLite database, versioned settings, log files, and downloaded
+    /// dictionaries.
+    pub fn data_path(&self, relative_path: impl AsRef<Path>) -> PathBuf {
+        self.data_dir().join(relative_path)
+    }
+
+    /// Resolves the path to the SQLite database.
+    ///
+    /// Lookup order:
+    /// 1. `data_dir/cadmus.sqlite` — preferred location (SD card when available).
+    /// 2. `install_dir/cadmus.sqlite` — legacy location; logs a warning so the
+    ///    user knows to copy the database manually to free internal storage.
+    /// 3. `data_dir/cadmus.sqlite` — new install; the file does not exist yet.
+    pub fn resolve_db_path(&self) -> PathBuf {
+        let data_path = self.data_path(crate::db::DB_FILENAME);
+        if data_path.exists() {
+            return data_path;
+        }
+
+        let install_path = self.install_path(crate::db::DB_FILENAME);
+        if install_path.exists() {
+            tracing::warn!(
+                path = %install_path.display(),
+                "sqlite db found in install dir, not data dir; \
+                 copy it to data dir"
+            );
+            return install_path;
+        }
+
+        data_path
+    }
+
     /// Returns the path to the device-managed tmp directory.
     ///
-    /// The returned path is rooted under [`Device::install_dir`], so it remains
-    /// stable even when callers change `cwd` (for example during USB sharing).
+    /// The returned path is rooted under [`Device::data_dir`], so large
+    /// temporary downloads (e.g. OTA bundles) consume SD card space rather
+    /// than internal storage when a card is present.
     pub fn tmp_dir(&self) -> PathBuf {
-        self.install_path("tmp")
+        self.data_path("tmp")
     }
 
     /// Removes stale contents left by a previous run and recreates the tmp

--- a/crates/core/src/device/mod.rs
+++ b/crates/core/src/device/mod.rs
@@ -227,7 +227,11 @@ impl Device {
     pub fn data_dir(&self) -> PathBuf {
         cfg_select! {
             test => { self.install_dir() }
-            feature = "emulator" => { self.install_dir() }
+            feature = "emulator" => {
+                std::env::current_dir()
+                    .map(|cwd| cwd.join(self.install_dir()))
+                    .unwrap_or_else(|_| self.install_dir())
+            }
             _ => {
                 if self.has_removable_storage()
                     && Path::new(crate::settings::EXTERNAL_CARD_ROOT).is_dir()

--- a/crates/core/src/document/html/engine.rs
+++ b/crates/core/src/document/html/engine.rs
@@ -15,6 +15,7 @@ use super::parse::{
 use super::parse::{parse_letter_spacing, parse_word_spacing};
 use super::style::{StyleSheet, specified_values};
 use super::xml::XmlExt;
+use crate::device::CURRENT_DEVICE;
 use crate::document::pdf::PdfOpener;
 use crate::document::{Document, Location};
 use crate::font::{FontFamily, FontOpener};
@@ -2450,7 +2451,7 @@ fn build_fonts(root_dir: Option<std::path::PathBuf>) -> Result<Fonts, Error> {
     let font_path = |name: &str| -> std::path::PathBuf {
         match &root_dir {
             Some(root) => root.join("fonts").join(name),
-            None => std::path::PathBuf::from("fonts").join(name),
+            None => CURRENT_DEVICE.install_path("fonts").join(name),
         }
     };
     let mut fonts = Fonts {

--- a/crates/core/src/document/html/layout.rs
+++ b/crates/core/src/document/html/layout.rs
@@ -1,5 +1,6 @@
 use crate::color::BLACK;
 use crate::color::Color;
+use crate::device::CURRENT_DEVICE;
 use crate::font::{Font, FontFamily, RenderPlan};
 use crate::geom::{Edge, Point, Rectangle};
 pub use crate::metadata::TextAlign;
@@ -8,7 +9,7 @@ use kl_hyphenate::{Language, Load, Standard};
 use lazy_static::lazy_static;
 use std::fmt::Debug;
 use std::fs;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 
 pub const DEFAULT_HYPH_LANG: &str = "en";
 
@@ -554,7 +555,7 @@ pub static ref HYPHENATION_PATTERNS: FxHashMap<Language, Standard> = {
         if map.contains_key(lang) {
             continue;
         }
-        let base = Path::new("hyphenation-patterns")
+        let base = CURRENT_DEVICE.install_path("hyphenation-patterns")
                         .join(lang.code());
         let path = base.with_extension("standard.bincode");
         if let Ok(mut patterns) = Standard::from_path(*lang, path) {

--- a/crates/core/src/font/mod.rs
+++ b/crates/core/src/font/mod.rs
@@ -685,7 +685,7 @@ impl Fonts {
         let search_path = if let Some(root_dir) = root_dir {
             root_dir.join("fonts")
         } else {
-            PathBuf::from("fonts")
+            CURRENT_DEVICE.install_path("fonts")
         };
 
         let opener = FontOpener::new()?;

--- a/crates/core/src/library/migrations.rs
+++ b/crates/core/src/library/migrations.rs
@@ -13,6 +13,7 @@
 use crate::db::types::OptionalUuid7;
 use crate::db::types::UnixTimestamp;
 use crate::db::types::Uuid7;
+use crate::device::CURRENT_DEVICE;
 use crate::document::SimpleTocEntry;
 use crate::helpers::{Fingerprint, Fp};
 #[cfg(not(feature = "test"))]
@@ -48,7 +49,7 @@ crate::migration!(
     /// The migration is idempotent (all inserts use `ON CONFLICT … DO NOTHING`).
     "v1_import_legacy_filesystem_data",
     async fn import_legacy_filesystem_data(pool: &SqlitePool) {
-        let settings = SettingsManager::new(get_current_version()).load();
+        let settings = SettingsManager::new(CURRENT_DEVICE.data_dir(), get_current_version()).load();
 
         if settings.libraries.is_empty() {
             info!("no libraries in settings, skipping legacy data import");

--- a/crates/core/src/logging.rs
+++ b/crates/core/src/logging.rs
@@ -82,7 +82,7 @@ use crate::settings::LoggingSettings;
 #[cfg(feature = "tracing")]
 use crate::telemetry;
 use crate::version::get_current_version;
-use anyhow::{Context, Error};
+use anyhow::{Context, Error, ensure};
 use arc_swap::ArcSwap;
 use std::fs;
 use std::fs::DirEntry;
@@ -304,6 +304,12 @@ pub fn init_logging(settings: &LoggingSettings, log_dir: std::path::PathBuf) -> 
         return Ok(());
     }
 
+    ensure!(
+        log_dir.is_absolute(),
+        "log_dir must be absolute, got {}",
+        log_dir.display()
+    );
+
     fs::create_dir_all(&log_dir)
         .with_context(|| format!("can't create log directory {}", &log_dir.display()))?;
 
@@ -424,6 +430,12 @@ pub fn shutdown_logging() {
 /// logging system to use it. The old appender is dropped, which flushes any buffered data to disk
 /// after the new appender is in place to avoid log loss.
 pub fn redirect_log_to_dir(dir: &Path, settings: &LoggingSettings) -> Result<(), Error> {
+    ensure!(
+        dir.is_absolute(),
+        "log_dir must be absolute, got {}",
+        dir.display()
+    );
+
     let (Some(writer_swap), Some(guard_mutex)) = (WRITER_INNER.get(), LOG_GUARD.get()) else {
         return Ok(());
     };

--- a/crates/core/src/logging.rs
+++ b/crates/core/src/logging.rs
@@ -49,7 +49,8 @@
 //!
 //! # Example Usage
 //!
-//! ```rust
+//! ```no_run
+//! use cadmus_core::device::CURRENT_DEVICE;
 //! use cadmus_core::settings::LoggingSettings;
 //! use cadmus_core::logging::{init_logging, shutdown_logging, get_run_id};
 //!
@@ -65,7 +66,8 @@
 //! };
 //!
 //! // Initialize at application startup
-//! init_logging(&settings)?;
+//! let log_dir = CURRENT_DEVICE.data_path(&settings.directory);
+//! init_logging(&settings, log_dir)?;
 //! eprintln!("Started with run ID: {}", get_run_id());
 //!
 //! // Use tracing macros throughout the application
@@ -254,7 +256,13 @@ fn is_run_log_entry(entry: &DirEntry) -> bool {
 ///
 /// # Arguments
 ///
-/// * `settings` - Logging configuration including level, directory, and retention
+/// * `settings` - Logging configuration including level, directory name, and
+///   retention settings.
+/// * `log_dir` - Absolute path to the directory where log files are written.
+///   The caller is responsible for computing this from
+///   [`Device::data_path`](crate::device::Device::data_path) so that logs land
+///   on the SD card when one is present. Pass
+///   `CURRENT_DEVICE.data_path(&settings.directory)` at call sites.
 ///
 /// # Returns
 ///
@@ -263,17 +271,16 @@ fn is_run_log_entry(entry: &DirEntry) -> bool {
 /// # Errors
 ///
 /// Returns an error if:
-/// - The current working directory cannot be determined
 /// - The log directory cannot be created
 /// - Log file cleanup fails
 /// - The rolling file appender cannot be initialized
-/// - The log filter configuration is invalid
 /// - The tracing subscriber cannot be initialized
 /// - OpenTelemetry initialization fails (when `otel` feature is enabled)
 ///
 /// # Example
 ///
-/// ```
+/// ```no_run
+/// use cadmus_core::device::CURRENT_DEVICE;
 /// use cadmus_core::settings::LoggingSettings;
 /// use cadmus_core::logging::init_logging;
 ///
@@ -288,17 +295,15 @@ fn is_run_log_entry(entry: &DirEntry) -> bool {
 ///     enable_dbus_log: false,
 /// };
 ///
-/// init_logging(&settings)?;
+/// let log_dir = CURRENT_DEVICE.data_path(&settings.directory);
+/// init_logging(&settings, log_dir)?;
 /// # Ok::<(), anyhow::Error>(())
 /// ```
-pub fn init_logging(settings: &LoggingSettings) -> Result<(), Error> {
+pub fn init_logging(settings: &LoggingSettings, log_dir: std::path::PathBuf) -> Result<(), Error> {
     if !settings.enabled {
         return Ok(());
     }
 
-    let current_working_dir =
-        std::env::current_dir().context("can't get current working directory")?;
-    let log_dir = current_working_dir.join(&settings.directory);
     fs::create_dir_all(&log_dir)
         .with_context(|| format!("can't create log directory {}", &log_dir.display()))?;
 
@@ -375,12 +380,14 @@ pub fn init_logging(settings: &LoggingSettings) -> Result<(), Error> {
 /// # Example
 ///
 /// ```no_run
+/// use cadmus_core::device::CURRENT_DEVICE;
 /// use cadmus_core::logging::{init_logging, shutdown_logging};
 /// use cadmus_core::settings::LoggingSettings;
 ///
 /// // At application start
 /// let settings = LoggingSettings::default();
-/// init_logging(&settings)?;
+/// let log_dir = CURRENT_DEVICE.data_path(&settings.directory);
+/// init_logging(&settings, log_dir)?;
 ///
 /// // ... application runs ...
 ///
@@ -524,7 +531,8 @@ mod tests {
                     enable_kern_log: false,
                     enable_dbus_log: false,
                 };
-                init_logging(&settings).expect("failed to initialize logging for tests");
+                init_logging(&settings, dir.path().to_path_buf())
+                    .expect("failed to initialize logging for tests");
                 dir
             })
             .path()

--- a/crates/core/src/settings/versioned.rs
+++ b/crates/core/src/settings/versioned.rs
@@ -71,11 +71,16 @@ pub struct SettingsManager {
 }
 
 impl SettingsManager {
-    /// Creates a new settings manager.
+    /// Creates a new settings manager rooted at `root_dir`.
     ///
     /// # Arguments
     ///
-    /// * `current_version` - The current application version (from `get_current_version()`)
+    /// * `root_dir` - The directory that contains the `Settings/` subdirectory
+    ///   and the legacy `Settings.toml` file. Pass
+    ///   [`Device::data_dir()`](crate::device::Device::data_dir) so that
+    ///   versioned settings are stored on the SD card when one is present.
+    /// * `current_version` - The current application version (from
+    ///   `get_current_version()`)
     ///
     /// The build UUID is automatically obtained from the compile-time `BUILD_UUID`
     /// environment variable set by the core crate's build script.
@@ -83,13 +88,13 @@ impl SettingsManager {
     /// # Example
     ///
     /// ```no_run
+    /// use cadmus_core::device::CURRENT_DEVICE;
     /// use cadmus_core::settings::versioned::SettingsManager;
     /// use cadmus_core::version::get_current_version;
     ///
-    /// let manager = SettingsManager::new(get_current_version());
+    /// let manager = SettingsManager::new(CURRENT_DEVICE.data_dir(), get_current_version());
     /// ```
-    pub fn new(current_version: GitVersion) -> Self {
-        let root_dir = PathBuf::from(".");
+    pub fn new(root_dir: PathBuf, current_version: GitVersion) -> Self {
         let settings_dir = root_dir.join(SETTINGS_DIR);
         let manifest_path = settings_dir.join(MANIFEST_FILE);
 

--- a/crates/core/src/task/dictionary_index.rs
+++ b/crates/core/src/task/dictionary_index.rs
@@ -13,6 +13,7 @@ use walkdir::WalkDir;
 use crate::context::DICTIONARIES_DIRNAME;
 use crate::db::Database;
 use crate::db::runtime::RUNTIME;
+use crate::device::CURRENT_DEVICE;
 use crate::dictionary::{Entry, Metadata, normalize};
 use crate::fl;
 use crate::helpers::{Fingerprint, IsHidden};
@@ -677,7 +678,7 @@ impl BackgroundTask for DictionaryIndexTask {
             }
         };
 
-        let path = std::path::Path::new(DICTIONARIES_DIRNAME);
+        let path = CURRENT_DEVICE.data_path(DICTIONARIES_DIRNAME);
 
         let mut on_disk_fingerprints: Vec<String> = Vec::new();
 

--- a/crates/core/src/view/home/mod.rs
+++ b/crates/core/src/view/home/mod.rs
@@ -1802,10 +1802,11 @@ impl Home {
     fn insert_fetcher(&mut self, hook: &Hook, hub: &Hub, context: &Context) {
         let library_path = &context.library.home;
         let save_path = context.library.home.join(&hook.path);
+        let program = CURRENT_DEVICE.install_path(&hook.program);
         match self.spawn_child(
             library_path,
             &save_path,
-            &hook.program,
+            &program,
             context.settings.wifi,
             context.online,
             hub,

--- a/crates/core/src/view/icon.rs
+++ b/crates/core/src/view/icon.rs
@@ -11,7 +11,6 @@ use crate::input::{DeviceEvent, FingerStatus};
 use crate::unit::scale_by_dpi_raw;
 use fxhash::FxHashMap;
 use lazy_static::lazy_static;
-use std::path::Path;
 
 const ICON_SCALE: f32 = 1.0 / 32.0;
 
@@ -20,12 +19,12 @@ lazy_static! {
         let mut m = FxHashMap::default();
         let scale = scale_by_dpi_raw(ICON_SCALE, CURRENT_DEVICE.dpi);
         #[cfg(test)]
-        let dir = Path::new(
+        let dir = std::path::Path::new(
             &std::env::var("TEST_ROOT_DIR").expect("TEST_ROOT_DIR must be set for tests."),
         )
         .join("icons");
         #[cfg(not(test))]
-        let dir = Path::new("icons").to_path_buf();
+        let dir = CURRENT_DEVICE.install_path("icons");
         for name in [
             "home",
             "search",

--- a/crates/core/src/view/intermission/mod.rs
+++ b/crates/core/src/view/intermission/mod.rs
@@ -132,8 +132,9 @@ impl View for Intermission {
 
                 font.render(fb, scheme[1], &plan, pt!(dx, dy));
 
-                match open("icons/dodecahedron.svg") {
-                    None => warn!("failed to open icons/dodecahedron.svg"),
+                let logo_path = CURRENT_DEVICE.install_path("icons/dodecahedron.svg");
+                match open(&logo_path) {
+                    None => warn!(path = %logo_path.display(), "failed to open logo icon"),
                     Some(mut doc) => match doc.dims(0) {
                         None => warn!("failed to read dimensions from dodecahedron.svg"),
                         Some((width, height)) => {

--- a/crates/core/src/view/reader/mod.rs
+++ b/crates/core/src/view/reader/mod.rs
@@ -4399,8 +4399,9 @@ impl View for Reader {
                         } else if link.text.starts_with("https:") || link.text.starts_with("http:")
                         {
                             if let Some(path) = context.settings.external_urls_queue.as_ref() {
+                                let path = CURRENT_DEVICE.install_path(path);
                                 if let Ok(mut file) =
-                                    OpenOptions::new().create(true).append(true).open(path)
+                                    OpenOptions::new().create(true).append(true).open(&path)
                                 {
                                     if let Err(e) = writeln!(file, "{}", link.text) {
                                         error!("Couldn't write to {}: {:#}.", path.display(), e);

--- a/crates/core/src/view/settings_editor/category_editor.rs
+++ b/crates/core/src/view/settings_editor/category_editor.rs
@@ -121,7 +121,7 @@ impl CategoryEditor {
         let dict_service = if category == Category::Dictionaries {
             match MonolingualDictionaryService::new(
                 &context.database,
-                std::path::Path::new(DICTIONARIES_DIRNAME),
+                CURRENT_DEVICE.data_path(DICTIONARIES_DIRNAME).as_path(),
             ) {
                 Ok(service) => Some(service),
                 Err(e) => {

--- a/crates/core/src/view/settings_editor/category_editor.rs
+++ b/crates/core/src/view/settings_editor/category_editor.rs
@@ -22,7 +22,7 @@ use super::category::Category;
 use super::library_editor::LibraryEditor;
 use super::refresh_rate_by_kind_editor::RefreshRateByKindEditor;
 use super::setting_row::SettingRow;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use std::thread;
 
 /// A view for editing category-specific settings.
@@ -715,7 +715,8 @@ impl CategoryEditor {
         rq: &mut RenderQueue,
         context: &mut Context,
     ) -> bool {
-        let lang_dir = Path::new(DICTIONARIES_DIRNAME)
+        let lang_dir = CURRENT_DEVICE
+            .data_path(DICTIONARIES_DIRNAME)
             .join("reader-dict")
             .join(lang);
 

--- a/crates/core/src/view/settings_editor/kinds/general.rs
+++ b/crates/core/src/view/settings_editor/kinds/general.rs
@@ -3,13 +3,13 @@
 use super::{
     InputSettingKind, SettingData, SettingIdentity, SettingKind, ToggleSettings, WidgetKind,
 };
+use crate::device::CURRENT_DEVICE;
 use crate::fl;
 use crate::i18n::I18nDisplay;
 use crate::settings::Settings;
 use crate::view::{Bus, EntryId, EntryKind, Event, ToggleEvent, ViewId};
 use anyhow::Error;
 use std::fs;
-use std::path::Path;
 
 /// Language and locale selection setting
 pub struct Locale;
@@ -434,11 +434,11 @@ impl InputSettingKind for SettingsRetention {
 
 /// Scans the keyboard-layouts directory for available keyboard layouts
 fn get_available_layouts() -> Result<Vec<String>, Error> {
-    let layouts_dir = Path::new("keyboard-layouts");
+    let layouts_dir = CURRENT_DEVICE.install_path("keyboard-layouts");
     let mut layouts = Vec::new();
 
     if layouts_dir.exists() {
-        for entry in fs::read_dir(layouts_dir)? {
+        for entry in fs::read_dir(&layouts_dir)? {
             let entry = entry?;
             let path = entry.path();
 

--- a/crates/emulator/src/main.rs
+++ b/crates/emulator/src/main.rs
@@ -71,7 +71,6 @@ use std::time::Duration;
 use tracing::{info, warn};
 
 pub const APP_NAME: &str = "Cadmus";
-const DB_FILENAME: &str = "cadmus.sqlite";
 const DEFAULT_ROTATION: i8 = 1;
 
 const CLOCK_REFRESH_INTERVAL: Duration = Duration::from_secs(60);
@@ -306,13 +305,16 @@ fn run() -> Result<(), Error> {
     let mut fb = window.into_canvas().software().build().unwrap();
     fb.set_blend_mode(BlendMode::Blend);
 
-    let manager = SettingsManager::new(get_current_version());
+    let manager = SettingsManager::new(CURRENT_DEVICE.data_dir(), get_current_version());
     let settings = manager.load();
 
     cadmus_core::crypto::init_crypto_provider();
 
-    cadmus_core::logging::init_logging(&settings.logging)
-        .context("Failed to initialize logging")?;
+    cadmus_core::logging::init_logging(
+        &settings.logging,
+        CURRENT_DEVICE.data_path(&settings.logging.directory),
+    )
+    .context("Failed to initialize logging")?;
 
     cadmus_core::document::log_mupdf_features();
 
@@ -325,7 +327,8 @@ fn run() -> Result<(), Error> {
     i18n::init(settings.locale.as_ref());
 
     let mut fonts = Fonts::load().context("can't load fonts")?;
-    let database = Database::new(DB_FILENAME).context("can't open database")?;
+    let database =
+        Database::new(CURRENT_DEVICE.resolve_db_path()).context("can't open database")?;
 
     let mut fb = Box::new(FBCanvas(fb));
 

--- a/crates/importer/src/main.rs
+++ b/crates/importer/src/main.rs
@@ -1,6 +1,7 @@
 use cadmus_core::anyhow::{Context, Error, format_err};
 use cadmus_core::chrono::NaiveDateTime;
 use cadmus_core::db::Database;
+use cadmus_core::device::CURRENT_DEVICE;
 use cadmus_core::helpers::datetime_format;
 // use cadmus_core::library::importer;
 use cadmus_core::library::Library;
@@ -12,8 +13,6 @@ use getopts::Options;
 use std::env;
 use std::path::Path;
 // use std::sync::mpsc;
-
-const DB_FILENAME: &str = "cadmus.sqlite";
 
 fn main() -> Result<(), Error> {
     let args: Vec<String> = env::args().skip(1).collect();
@@ -120,7 +119,7 @@ fn main() -> Result<(), Error> {
         .as_ref()
         .and_then(|v| NaiveDateTime::parse_from_str(v, datetime_format::FORMAT).ok());
 
-    let database = Database::new(DB_FILENAME)?;
+    let database = Database::new(CURRENT_DEVICE.resolve_db_path())?;
     let library_name = library_path
         .file_name()
         .and_then(|n| n.to_str())

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -24,8 +24,14 @@ Audience: end users with no technical background, using Cadmus.
 > [!TIP]
 > A helpful suggestion or best practice.
 
+> [!IMPORTANT]
+> Key information that shouldn't be missed.
+
 > [!WARNING]
 > Critical information that highlights a potential risk.
+
+> [!CAUTION]
+> Information about potential issues that require caution.
 ```
 
 Source: <https://rust-lang.github.io/mdBook/format/markdown.html?highlight=note#admonitions>

--- a/docs/src/installation/migration.md
+++ b/docs/src/installation/migration.md
@@ -15,7 +15,14 @@ The `[[libraries]]` section is the most important part, it tells Cadmus where yo
 first launch. On first launch, Cadmus will move this file into its `Settings/` folder automatically.
 
 > [!NOTE]
-> If you insert an SD card after initial setup, Cadmus automatically migrates settings, logs, dictionaries, and the database to `/mnt/sd/.cadmus/` (or `/mnt/sd/.cadmus-tst/` for test builds) to free up internal storage.
+> If your SD card is already inserted when you upgrade, Cadmus automatically
+> moves your settings, logs, and dictionaries to `/mnt/sd/.cadmus/`
+> (or `/mnt/sd/.cadmus-tst/` for test builds) on the next boot.
+
+> [!NOTE]
+> If you insert an SD card **after** Cadmus has already run, the automatic
+> migration will not run. You will need to copy your data manually — see
+> [Moving data to an SD card](#moving-data-to-an-sd-card) below.
 
 ```toml
 [[libraries]]
@@ -61,12 +68,39 @@ settings), you can start it fresh:
 
 1. Delete the Cadmus SQLite database:
 
-   | Build  | Database path (with SD card)          | Database path (without SD card)               |
-   | ------ | ------------------------------------- | --------------------------------------------- |
-   | Stable | `/mnt/sd/.cadmus/cadmus.sqlite`       | `/mnt/onboard/.adds/cadmus/cadmus.sqlite`     |
-   | Test   | `/mnt/sd/.cadmus-tst/cadmus.sqlite`   | `/mnt/onboard/.adds/cadmus-tst/cadmus.sqlite` |
+   | Build  | Database path (with SD card)        | Database path (without SD card)               |
+   | ------ | ----------------------------------- | --------------------------------------------- |
+   | Stable | `/mnt/sd/.cadmus/cadmus.sqlite`     | `/mnt/onboard/.adds/cadmus/cadmus.sqlite`     |
+   | Test   | `/mnt/sd/.cadmus-tst/cadmus.sqlite` | `/mnt/onboard/.adds/cadmus-tst/cadmus.sqlite` |
 
 2. Restart Cadmus — the import will run again from scratch.
 
 If something still looks wrong after re-running, check the logs for details.
 See [Troubleshooting](../troubleshooting/index.md) for where to find them.
+
+## Moving data to an SD card
+
+If you insert an SD card after Cadmus has already run, you need to move your
+data manually. Cadmus will use the SD card for new data once it detects the
+card, but your existing files stay in internal storage until you move them.
+
+> [!CAUTION]
+> Do these operations while Cadmus is not running!
+>
+> In other words, do this while the Nickel/KOReader/etc is running.
+
+1. Connect your Kobo to your computer
+2. Copy the following from internal storage to the SD card:
+
+   | What to move       | From (internal)                           | To (SD card)                    |
+   | ------------------ | ----------------------------------------- | ------------------------------- |
+   | Settings directory | `/mnt/onboard/.adds/cadmus/Settings/`     | `/mnt/sd/.cadmus/Settings/`     |
+   | Settings file      | `/mnt/onboard/.adds/cadmus/Settings.toml` | `/mnt/sd/.cadmus/Settings.toml` |
+   | Logs               | `/mnt/onboard/.adds/cadmus/logs/`         | `/mnt/sd/.cadmus/logs/`         |
+   | Dictionaries       | `/mnt/onboard/.adds/cadmus/dictionaries/` | `/mnt/sd/.cadmus/dictionaries/` |
+   | Database           | `/mnt/onboard/.adds/cadmus/cadmus.sqlite` | `/mnt/sd/.cadmus/cadmus.sqlite` |
+
+   > [!NOTE]
+   > Use the test paths (`cadmus-tst` / `.cadmus-tst`) if you are on a test build.
+
+3. Restart Cadmus. It will pick up the files from the SD card automatically.

--- a/docs/src/installation/migration.md
+++ b/docs/src/installation/migration.md
@@ -14,6 +14,9 @@ Copy the file as-is into the Cadmus folder so it is named `Settings.toml` (for e
 The `[[libraries]]` section is the most important part, it tells Cadmus where your books live and drives the reading-progress import on
 first launch. On first launch, Cadmus will move this file into its `Settings/` folder automatically.
 
+> [!NOTE]
+> If you insert an SD card after initial setup, Cadmus automatically migrates settings, logs, dictionaries, and the database to `/mnt/sd/.cadmus/` (or `/mnt/sd/.cadmus-tst/` for test builds) to free up internal storage.
+
 ```toml
 [[libraries]]
 name = "On Board"
@@ -58,10 +61,10 @@ settings), you can start it fresh:
 
 1. Delete the Cadmus SQLite database:
 
-   | Build  | Database path                                 |
-   | ------ | --------------------------------------------- |
-   | Stable | `/mnt/onboard/.adds/cadmus/cadmus.sqlite`     |
-   | Test   | `/mnt/onboard/.adds/cadmus-tst/cadmus.sqlite` |
+   | Build  | Database path (with SD card)          | Database path (without SD card)               |
+   | ------ | ------------------------------------- | --------------------------------------------- |
+   | Stable | `/mnt/sd/.cadmus/cadmus.sqlite`       | `/mnt/onboard/.adds/cadmus/cadmus.sqlite`     |
+   | Test   | `/mnt/sd/.cadmus-tst/cadmus.sqlite`   | `/mnt/onboard/.adds/cadmus-tst/cadmus.sqlite` |
 
 2. Restart Cadmus — the import will run again from scratch.
 

--- a/docs/src/installation/ota.md
+++ b/docs/src/installation/ota.md
@@ -90,7 +90,9 @@ first time, follow the [installation guide](./index.md) or the
 If Cadmus shows an error like _"Insufficient disk space: need 100MB, have XMB"_
 while downloading an update:
 
-- Free up space on your Kobo by deleting books or other files you do not need
-- Cadmus downloads update files into its own `tmp` folder inside the Cadmus
-  folder
-- This error means internal storage is too full for the update file
+- Cadmus downloads update files into a `tmp` folder:
+  - **With SD card**: `/mnt/sd/.cadmus/tmp` (uses SD card space)
+  - **Without SD card**: `/mnt/onboard/.adds/cadmus/tmp` (uses internal storage)
+- If you see this error and have an SD card inserted, the card may be full
+- If you do not have an SD card, free up space on internal storage by deleting
+  books or other files you do not need

--- a/docs/src/ui/settings/dictionaries.md
+++ b/docs/src/ui/settings/dictionaries.md
@@ -99,10 +99,15 @@ whenever the dictionary files change.
 
 ## Where Dictionaries are Stored
 
-Cadmus stores dictionaries in different locations depending on whether your device has an SD card:
+Cadmus stores dictionaries in different locations depending on whether your
+device has an SD card and whether you are using a test build:
 
-- **On devices with an SD card**: `/mnt/sd/.cadmus/dictionaries/reader-dict/<lang>/`
-- **On devices without an SD card**: `/mnt/onboard/.adds/cadmus/dictionaries/reader-dict/<lang>/`
+- **On devices with an SD card**:
+  - Production: `/mnt/sd/.cadmus/dictionaries/reader-dict/<lang>/`
+  - Test build: `/mnt/sd/.cadmus-tst/dictionaries/reader-dict/<lang>/`
+- **On devices without an SD card**:
+  - Production: `/mnt/onboard/.adds/cadmus/dictionaries/reader-dict/<lang>/`
+  - Test build: `/mnt/onboard/.adds/cadmus-tst/dictionaries/reader-dict/<lang>/`
 
 Each language gets its own subfolder containing a `.dict.dz` (or `.dict`) and a `.index` file.
 

--- a/docs/src/ui/settings/dictionaries.md
+++ b/docs/src/ui/settings/dictionaries.md
@@ -99,7 +99,7 @@ whenever the dictionary files change.
 
 ## Where Dictionaries are Stored
 
-Dictionary storage location depends on whether your device has an SD card:
+Cadmus stores dictionaries in different locations depending on whether your device has an SD card:
 
 - **On devices with an SD card**: `/mnt/sd/.cadmus/dictionaries/reader-dict/<lang>/`
 - **On devices without an SD card**: `/mnt/onboard/.adds/cadmus/dictionaries/reader-dict/<lang>/`
@@ -107,4 +107,7 @@ Dictionary storage location depends on whether your device has an SD card:
 Each language gets its own subfolder containing a `.dict.dz` (or `.dict`) and a `.index` file.
 
 > [!NOTE]
-> When you insert an SD card, Cadmus automatically migrates existing dictionaries from internal storage to the SD card. You don't need to move your dictionary files manually.
+> If your SD card is already inserted when you upgrade Cadmus, your dictionaries
+> are moved to the SD card automatically on the next boot. If you insert an SD
+> card after Cadmus has already run, move the `dictionaries/` folder manually —
+> see [Moving data to an SD card](../../installation/migration.md#moving-data-to-an-sd-card).

--- a/docs/src/ui/settings/dictionaries.md
+++ b/docs/src/ui/settings/dictionaries.md
@@ -99,6 +99,12 @@ whenever the dictionary files change.
 
 ## Where Dictionaries are Stored
 
-Downloaded dictionaries live in the `dictionaries/reader-dict/<lang>/`
-folder on your device. Each language gets its own subfolder containing a
-`.dict.dz` (or `.dict`) and a `.index` file.
+Dictionary storage location depends on whether your device has an SD card:
+
+- **On devices with an SD card**: `/mnt/sd/.cadmus/dictionaries/reader-dict/<lang>/`
+- **On devices without an SD card**: `/mnt/onboard/.adds/cadmus/dictionaries/reader-dict/<lang>/`
+
+Each language gets its own subfolder containing a `.dict.dz` (or `.dict`) and a `.index` file.
+
+> [!NOTE]
+> When you insert an SD card, Cadmus automatically migrates existing dictionaries from internal storage to the SD card. You don't need to move your dictionary files manually.


### PR DESCRIPTION
Add `data_dir()` / `data_path()` / `resolve_db_path()` to `Device` so that dynamic files (DB, settings, logs, dictionaries) are stored on the SD card when one is present, falling back to `install_dir` otherwise.

- Add `Device::data_dir`, `data_path`, `resolve_db_path`, `data_subdir`
- Move `tmp_dir` to `data_dir` so OTA downloads use SD card space
- Add `v3_migrate_data_to_sd_card` DB migration: move settings, logs, and dictionaries from `install_dir` to `data_dir` on SD-capable devices; SQLite database is excluded since it is already open when migrations run
- Export `DB_FILENAME` constant from `db::mod` and remove local `DB_FILENAME` constants from `app`, `emulator`, and `importer`
- Thread `log_dir` into `init_logging` instead of deriving it from the current working directory
- Thread `root_dir` into `SettingsManager::new` so versioned settings resolve relative to `data_dir`
- Update keyboard layout and dictionary path lookups in `Context` and `CategoryEditor` to use `install_path` and `data_path` respectively
- Update all call sites in `app`, `emulator`, and `importer`

Change-Id: a8311dd1f70a3c173f0e6aef922226b7
Change-Id-Short: prwyymmykszp
Closes: #464
Closes: CAD-65