### PR TITLE
chore: fix emulator install path

### DIFF
--- a/crates/core/src/device/mod.rs
+++ b/crates/core/src/device/mod.rs
@@ -163,6 +163,7 @@ impl Device {
     /// stable builds.
     pub fn install_subdir(&self) -> &'static str {
         cfg_select! {
+            feature = "emulator" => {""}
             feature = "test" => { ".adds/cadmus-tst" }
             _ => { ".adds/cadmus" }
         }
@@ -186,7 +187,7 @@ impl Device {
                     .join(self.install_subdir())
             }
             feature = "emulator" => {
-                PathBuf::from("/tmp").join(self.install_subdir())
+                PathBuf::from(".").join(self.install_subdir())
             }
             _ => {
                 PathBuf::from(crate::settings::INTERNAL_CARD_ROOT).join(self.install_subdir())


### PR DESCRIPTION
Emulator's install data path shall be the current working dir.

This got broken in the upgrade to 1.95 with the cfg select. Took me a min to figure out why the database stale when I lookg into it, but the UI showed something diff sending me down a unneeded rabbit hole :sob:.

Change-Id: fb68892f0600ad08c6f3d2ba9032dc78
Change-Id-Short: kotrrqxkztzz

Broken in #547 