### PR TITLE
feat(HTML): replace manual XmlParser with html5ever

### DIFF
--- a/.github/actions/build-kobo/action.yml
+++ b/.github/actions/build-kobo/action.yml
@@ -23,6 +23,8 @@ inputs:
 runs:
   using: composite
   steps:
+    - uses: ./.github/actions/clone-needed-cargo-submodules
+
     - name: Cache Linaro toolchain
       id: cache-linaro
       uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6

--- a/.github/actions/cargo-cache-warmup/action.yml
+++ b/.github/actions/cargo-cache-warmup/action.yml
@@ -15,6 +15,8 @@ inputs:
 runs:
   using: composite
   steps:
+    - uses: ./.github/actions/clone-needed-cargo-submodules
+
     - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
       id: rust-toolchain
       with:

--- a/.github/actions/clone-needed-cargo-submodules/action.yml
+++ b/.github/actions/clone-needed-cargo-submodules/action.yml
@@ -1,0 +1,9 @@
+name: Clone needed Cargo submodules
+description: Clone only submodules needed for Cargo manifest resolution.
+
+runs:
+  using: composite
+  steps:
+    - name: Clone html5ever submodule
+      shell: bash
+      run: git submodule update --init --depth 1 thirdparty/html5ever

--- a/.github/actions/install-doc-tools/action.yml
+++ b/.github/actions/install-doc-tools/action.yml
@@ -13,6 +13,8 @@ inputs:
 runs:
   using: composite
   steps:
+    - uses: ./.github/actions/clone-needed-cargo-submodules
+
     - name: Setup Node.js
       uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
       with:

--- a/.github/actions/install-doc-tools/action.yml
+++ b/.github/actions/install-doc-tools/action.yml
@@ -13,6 +13,8 @@ inputs:
 runs:
   using: composite
   steps:
+    - uses: ./.github/actions/clone-needed-cargo-submodules
+
     - name: Setup Node.js
       uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
       with:

--- a/.github/workflows/cadmus-docs.yml
+++ b/.github/workflows/cadmus-docs.yml
@@ -14,11 +14,22 @@ on:
       - website/**
       - crates/**/*.rs
       - .github/actions/install-doc-tools/**
+      - .github/actions/clone-needed-cargo-submodules/**
       - .github/workflows/cadmus-docs.yml
       - package.json
       - package-lock.json
   pull_request:
     types: [opened, synchronize, reopened]
+    paths:
+      - docs/**
+      - docs-portal/**
+      - website/**
+      - crates/**/*.rs
+      - .github/actions/install-doc-tools/**
+      - .github/actions/clone-needed-cargo-submodules/**
+      - .github/workflows/cadmus-docs.yml
+      - package.json
+      - package-lock.json
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -12,6 +12,22 @@ on:
   push:
     branches: [main, master, "release/*"]
   pull_request:
+    paths:
+      - "**/*.rs"
+      - crates/core/i18n/**
+      - "Cargo.*"
+      - "**/Cargo.*"
+      - ".github/workflows/cargo.yml"
+      - ".github/actions/apt/**"
+      - ".github/actions/build-kobo/**"
+      - ".github/actions/build-docs-epub/**"
+      - ".github/actions/cargo-cache/**"
+      - ".github/actions/clone-needed-cargo-submodules/**"
+      - ".github/actions/install-doc-tools/**"
+      - "build-scripts/**"
+      - ".gitmodules"
+      - "mupdf_wrapper/**"
+      - "thirdparty/**"
 
 concurrency:
   group: "cargo-${{ github.event_name }}-${{ github.event.number || github.ref }}"
@@ -43,6 +59,7 @@ jobs:
               - '.github/actions/build-kobo/**'
               - '.github/actions/build-docs-epub/**'
               - '.github/actions/cargo-cache/**'
+              - '.github/actions/clone-needed-cargo-submodules/**'
               - '.github/actions/install-doc-tools/**'
               - 'build-scripts/**'
               - '.gitmodules'
@@ -59,6 +76,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
+      - uses: ./.github/actions/clone-needed-cargo-submodules
       - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
         id: rust-toolchain
         with:
@@ -83,6 +101,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
+      - uses: ./.github/actions/clone-needed-cargo-submodules
       - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
         id: rust-toolchain
       - name: Restore shared cargo cache
@@ -124,6 +143,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
+      - uses: ./.github/actions/clone-needed-cargo-submodules
       - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
         id: rust-toolchain
         with:
@@ -243,6 +263,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
+      - uses: ./.github/actions/clone-needed-cargo-submodules
       - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
         id: rust-toolchain
         with:
@@ -288,6 +309,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
+      - uses: ./.github/actions/clone-needed-cargo-submodules
       - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
         id: rust-toolchain
         with:
@@ -334,6 +356,7 @@ jobs:
           fetch-depth: 0
           fetch-tags: true
           persist-credentials: false
+      - uses: ./.github/actions/clone-needed-cargo-submodules
       - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
         id: rust-toolchain
         with:

--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -45,6 +45,7 @@ jobs:
               - '.github/actions/cargo-cache/**'
               - '.github/actions/cargo-cache-warmup/**'
               - '.github/actions/cache-fonts/**'
+              - '.github/actions/clone-needed-cargo-submodules/**'
               - '.github/actions/install-doc-tools/**'
               - 'build-scripts/**'
               - '.gitmodules'
@@ -61,6 +62,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
+      - uses: ./.github/actions/clone-needed-cargo-submodules
       - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
         id: rust-toolchain
         with:
@@ -93,6 +95,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
+      - uses: ./.github/actions/clone-needed-cargo-submodules
       - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
         id: rust-toolchain
       - name: Restore shared cargo cache
@@ -113,6 +116,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
+      - uses: ./.github/actions/clone-needed-cargo-submodules
       - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
         id: rust-toolchain
       - name: Restore shared cargo cache
@@ -140,6 +144,9 @@ jobs:
         if: github.event_name != 'pull_request'
         with:
           persist-credentials: false
+
+      - uses: ./.github/actions/clone-needed-cargo-submodules
+        if: github.event_name != 'pull_request'
 
       - name: Set build metadata
         if: github.event_name != 'pull_request'
@@ -170,6 +177,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
+      - uses: ./.github/actions/clone-needed-cargo-submodules
       - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
         id: rust-toolchain
         with:
@@ -218,6 +226,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
+      - uses: ./.github/actions/clone-needed-cargo-submodules
       - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
         id: rust-toolchain
         with:
@@ -269,6 +278,7 @@ jobs:
           fetch-depth: 0
           fetch-tags: true
           persist-credentials: false
+      - uses: ./.github/actions/clone-needed-cargo-submodules
       - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
         id: rust-toolchain
         with:
@@ -425,6 +435,8 @@ jobs:
           fetch-tags: true
           persist-credentials: false
 
+      - uses: ./.github/actions/clone-needed-cargo-submodules
+
       - *set-build-metadata
 
       - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
@@ -495,6 +507,8 @@ jobs:
           fetch-depth: 0
           fetch-tags: true
           persist-credentials: false
+
+      - uses: ./.github/actions/clone-needed-cargo-submodules
 
       - *set-build-metadata
 

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -8,6 +8,9 @@ env:
 on:
   workflow_call:
   pull_request:
+    paths:
+      - .github/workflows/copilot-setup-steps.yml
+      - .github/actions/clone-needed-cargo-submodules/**
 
 permissions:
   contents: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,11 @@ on:
   pull_request:
     paths:
       - .github/workflows/release.yml
+      - .github/actions/build-docs-epub/**
+      - .github/actions/build-kobo/**
+      - .github/actions/cargo-cache/**
+      - .github/actions/clone-needed-cargo-submodules/**
+      - .github/actions/install-doc-tools/**
 
 permissions:
   contents: write

--- a/.gitmodules
+++ b/.gitmodules
@@ -54,3 +54,6 @@
 	path = thirdparty/mdbook-i18n-helpers
 	url = https://github.com/OGKevin/mdbook-i18n-helpers.git
 	branch = ogkevin/push/qsonrqyvotux
+[submodule "thirdparty/html5ever"]
+	path = thirdparty/html5ever
+	url = https://github.com/OGKevin/html5ever

--- a/.gitmodules
+++ b/.gitmodules
@@ -64,3 +64,6 @@
 	url = https://github.com/google/fonts
 	branch = main
 	shallow = true
+[submodule "thirdparty/html5ever"]
+	path = thirdparty/html5ever
+	url = https://github.com/OGKevin/html5ever

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -462,6 +462,7 @@ dependencies = [
  "rand_xoshiro",
  "regex",
  "reqwest",
+ "roxmltree",
  "rust-embed",
  "rustls",
  "sdl2",
@@ -1561,11 +1562,10 @@ dependencies = [
 [[package]]
 name = "html5ever"
 version = "0.39.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46a1761807faccc9a19e86944bbf40610014066306f96edcdedc2fb714bcb7b8"
 dependencies = [
  "log",
  "markup5ever",
+ "memchr",
 ]
 
 [[package]]
@@ -2244,8 +2244,6 @@ dependencies = [
 [[package]]
 name = "markup5ever"
 version = "0.39.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7122d987ec5f704ee56f6e5b41a7d93722e9aae27ae07cafa4036c4d3f9757de"
 dependencies = [
  "log",
  "tendril",
@@ -3240,6 +3238,15 @@ name = "rle-decode-fast"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3582f63211428f83597b51b2ddb88e2a91a9d52d12831f9d08f5e624e8977422"
+
+[[package]]
+name = "roxmltree"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1964b10c76125c36f8afe190065a4bf9a87bf324842c05701330bba9f1cacbb"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "rust-embed"
@@ -4845,9 +4852,9 @@ dependencies = [
 
 [[package]]
 name = "web_atoms"
-version = "0.2.3"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57a9779e9f04d2ac1ce317aee707aa2f6b773afba7b931222bff6983843b1576"
+checksum = "075474b12bcb3d2e3d4546580e9de478eeeead668a1761e2a8860c836b7ef297"
 dependencies = [
  "phf 0.13.1",
  "phf_codegen",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -457,6 +457,7 @@ dependencies = [
  "rand_xoshiro",
  "regex",
  "reqwest",
+ "roxmltree",
  "rust-embed",
  "rustc-hash",
  "rustls",
@@ -682,9 +683,9 @@ checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "combine"
-version = "4.6.8"
+version = "4.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfc320937d09e6de266b31b9afb480f197d7a861be86be7cb2ea7e5d1bfffc5e"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
 dependencies = [
  "bytes",
  "memchr",
@@ -1518,11 +1519,10 @@ dependencies = [
 [[package]]
 name = "html5ever"
 version = "0.39.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46a1761807faccc9a19e86944bbf40610014066306f96edcdedc2fb714bcb7b8"
 dependencies = [
  "log",
  "markup5ever",
+ "memchr",
 ]
 
 [[package]]
@@ -2189,8 +2189,6 @@ dependencies = [
 [[package]]
 name = "markup5ever"
 version = "0.39.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7122d987ec5f704ee56f6e5b41a7d93722e9aae27ae07cafa4036c4d3f9757de"
 dependencies = [
  "log",
  "tendril",
@@ -3195,6 +3193,15 @@ name = "rle-decode-fast"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3582f63211428f83597b51b2ddb88e2a91a9d52d12831f9d08f5e624e8977422"
+
+[[package]]
+name = "roxmltree"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1964b10c76125c36f8afe190065a4bf9a87bf324842c05701330bba9f1cacbb"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "rust-embed"
@@ -4684,9 +4691,9 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.4+wasi-0.2.12"
+version = "1.0.2+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
+checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
 dependencies = [
  "wit-bindgen",
 ]
@@ -4991,9 +4998,9 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen"
-version = "0.57.1"
+version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 
 [[package]]
 name = "writeable"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,10 @@ sdl2 = "0.38.0"
 [workspace.lints]
 rustdoc.private_intra_doc_links = "allow"
 
+[patch.crates-io]
+html5ever  = { path = "thirdparty/html5ever/html5ever" }
+markup5ever = { path = "thirdparty/html5ever/markup5ever" }
+
 [profile.release-minsized]
 inherits = "release"
 panic = "abort"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,10 @@ sdl3 = { version = "0.18.4", features = ["use-pkg-config"] }
 [workspace.lints]
 rustdoc.private_intra_doc_links = "allow"
 
+[patch.crates-io]
+html5ever  = { path = "thirdparty/html5ever/html5ever" }
+markup5ever = { path = "thirdparty/html5ever/markup5ever" }
+
 [profile.release-minsized]
 inherits = "release"
 panic = "abort"

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -41,7 +41,8 @@ secrecy = { version = "0.10", features = ["serde"] }
 walkdir = "2.5.0"
 globset = "0.4.18"
 fxhash = "0.2.1"
-html5ever = "0.39"
+html5ever = { version = "0.39", features = ["source-positions", "xhtml-self-closing"] }
+roxmltree = "0.21"
 humanize-bytes = "1.0.6"
 humantime = "2"
 rand_core = "0.10.0"

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -42,7 +42,8 @@ thiserror = "2.0.17"
 secrecy = { version = "0.10", features = ["serde"] }
 walkdir = "2.5.0"
 globset = "0.4.18"
-html5ever = "0.39"
+html5ever = { version = "0.39", features = ["source-positions", "xhtml-self-closing"] }
+roxmltree = "0.21"
 humanize-bytes = "1.0.6"
 humantime = "2"
 rand_core = "0.10.0"

--- a/crates/core/src/document/epub/mod.rs
+++ b/crates/core/src/document/epub/mod.rs
@@ -1,5 +1,5 @@
 use super::html::css::CssParser;
-use super::html::dom::{NodeRef, XmlTree};
+use super::html::dom::NodeRef;
 use super::html::engine::{Engine, Page, ResourceFetcher};
 use super::html::layout::TextAlign;
 use super::html::layout::{DrawCommand, DrawState, ImageCommand, RootData, TextCommand};
@@ -14,12 +14,15 @@ use crate::helpers::{Normalize, decode_entities};
 use crate::unit::pt_to_px;
 use anyhow::{Error, format_err};
 use fxhash::FxHashMap;
+use opf::{ManifestEntry, OpfDocument, opf_path_from_container, parse_toc};
 use percent_encoding::percent_decode_str;
 use std::collections::BTreeSet;
 use std::fs::{self, File};
 use std::io::{Cursor, Read, Seek};
 use std::path::{Path, PathBuf};
 use zip::ZipArchive;
+
+mod opf;
 
 const VIEWER_STYLESHEET: &str = "css/epub.css";
 const USER_STYLESHEET: &str = "css/epub-user.css";
@@ -38,7 +41,7 @@ impl<R: Read + Seek> ResourceFetcher for ZipArchive<R> {
 /// Generic EPUB document that works with any Read + Seek source.
 pub struct EpubDocument<R: Read + Seek> {
     archive: ZipArchive<R>,
-    info: XmlTree,
+    info: OpfDocument,
     parent: PathBuf,
     engine: Engine,
     spine: Vec<Chunk>,
@@ -61,6 +64,54 @@ struct Chunk {
 unsafe impl<R: Read + Seek> Send for EpubDocument<R> {}
 unsafe impl<R: Read + Seek> Sync for EpubDocument<R> {}
 
+/// Resolves spine `idref` values to [`Chunk`]s by probing the zip archive.
+///
+/// For each `idref` the function:
+/// 1. Looks up the matching [`ManifestEntry`] to get the file's `href`.
+/// 2. Decodes the `href` (HTML entities + percent-encoding) and resolves it
+///    relative to `opf_parent` to obtain the archive-relative path.
+/// 3. Opens the entry in the archive to read its **uncompressed byte size**.
+///    The size is stored on [`Chunk`] and used as the chapter's contribution
+///    to the global byte-offset coordinate system (reading positions, bookmarks).
+///
+/// Entries with no matching manifest item or with a non-UTF-8 path are silently
+/// skipped — those indicate a structurally malformed EPUB. Entries whose file
+/// is missing from the archive are logged at error level and skipped.
+fn build_spine<R: Read + Seek>(
+    archive: &mut ZipArchive<R>,
+    manifest: &[ManifestEntry],
+    idrefs: &[String],
+    opf_parent: &Path,
+) -> Vec<Chunk> {
+    idrefs
+        .iter()
+        .filter_map(|idref| {
+            let entry = manifest.iter().find(|e| e.id == *idref)?;
+            let href = decode_entities(&entry.href);
+            let href = percent_decode_str(&href).decode_utf8_lossy();
+            let path = opf_parent.join::<&str>(href.as_ref()).normalize();
+            let path = path.to_str()?.to_string();
+
+            let result = archive.by_name(&path).map(|zf| Chunk {
+                path: path.clone(),
+                size: zf.size() as usize,
+            });
+
+            match result {
+                Ok(chunk) => Some(chunk),
+                Err(e) => {
+                    tracing::error!(
+                        path,
+                        error = %e,
+                        "spine entry missing from archive"
+                    );
+                    None
+                }
+            }
+        })
+        .collect()
+}
+
 impl<R: Read + Seek> EpubDocument<R> {
     #[cfg_attr(feature = "tracing", tracing::instrument(skip_all))]
     fn from_archive(mut archive: ZipArchive<R>, install_dir: &Path) -> Result<Self, Error> {
@@ -68,11 +119,7 @@ impl<R: Read + Seek> EpubDocument<R> {
             let mut zf = archive.by_name("META-INF/container.xml")?;
             let mut text = String::new();
             zf.read_to_string(&mut text)?;
-            let root = XmlParser::new(&text).parse();
-            root.root()
-                .find("rootfile")
-                .and_then(|e| e.attribute("full-path"))
-                .map(String::from)
+            opf_path_from_container(&text)
         }
         .ok_or_else(|| format_err!("can't get the OPF path"))?;
 
@@ -80,57 +127,18 @@ impl<R: Read + Seek> EpubDocument<R> {
             .parent()
             .unwrap_or_else(|| Path::new(""));
 
-        let text = {
+        let opf_text = {
             let mut zf = archive.by_name(&opf_path)?;
             let mut text = String::new();
             zf.read_to_string(&mut text)?;
             text
         };
 
-        let info = XmlParser::new(&text).parse();
-        let mut spine = Vec::new();
+        let info = OpfDocument::parse(opf_text)
+            .ok_or_else(|| format_err!("failed to parse OPF document"))?;
 
-        {
-            let manifest = info
-                .root()
-                .find("manifest")
-                .ok_or_else(|| format_err!("the manifest is missing"))?;
-
-            let spn = info
-                .root()
-                .find("spine")
-                .ok_or_else(|| format_err!("the spine is missing"))?;
-
-            for child in spn.children() {
-                let vertebra_opt = child
-                    .attribute("idref")
-                    .and_then(|idref| manifest.find_by_id(idref))
-                    .and_then(|entry| entry.attribute("href"))
-                    .and_then(|href| {
-                        let href = decode_entities(href);
-                        let href = percent_decode_str(&href).decode_utf8_lossy();
-                        let href_path = parent.join::<&str>(href.as_ref());
-                        href_path.to_str().and_then(|path| {
-                            archive
-                                .by_name(path)
-                                .map_err(|e| {
-                                    tracing::error!(
-                                        "Can't retrieve '{}' from the archive: {:#}.",
-                                        path,
-                                        e
-                                    )
-                                    // We're assuming that the size of the spine is less than 4 GiB.
-                                })
-                                .map(|zf| (zf.size() as usize, path.to_string()))
-                                .ok()
-                        })
-                    });
-
-                if let Some((size, path)) = vertebra_opt {
-                    spine.push(Chunk { path, size });
-                }
-            }
-        }
+        let (idrefs, _) = info.spine_idrefs();
+        let spine = build_spine(&mut archive, &info.manifest, idrefs, parent);
 
         if spine.is_empty() {
             return Err(format_err!("the spine is empty"));
@@ -181,119 +189,6 @@ impl<R: Read + Seek> EpubDocument<R> {
 
     fn vertebra_coordinates_from_name(&self, name: &str) -> Option<(usize, usize)> {
         self.vertebra_coordinates_with(|index, _| self.spine[index].path == name)
-    }
-
-    fn walk_toc_ncx(
-        &mut self,
-        node: NodeRef,
-        toc_dir: &Path,
-        index: &mut usize,
-        cache: &mut UriCache,
-    ) -> Vec<TocEntry> {
-        let mut entries = Vec::new();
-        // TODO: Take `playOrder` into account?
-
-        for child in node.children() {
-            if child.tag_name() == Some("navPoint") {
-                let title = child
-                    .find("navLabel")
-                    .and_then(|label| label.find("text"))
-                    .map(|text| decode_entities(&text.text()).into_owned())
-                    .unwrap_or_default();
-
-                // Example URI: pr03.html#codecomma_and_what_to_do_with_it
-                let rel_uri = child
-                    .find("content")
-                    .and_then(|content| {
-                        content.attribute("src").map(|src| {
-                            percent_decode_str(&decode_entities(src))
-                                .decode_utf8_lossy()
-                                .into_owned()
-                        })
-                    })
-                    .unwrap_or_default();
-
-                let loc = toc_dir
-                    .join(&rel_uri)
-                    .normalize()
-                    .to_str()
-                    .map(|uri| Location::Uri(uri.to_string()));
-
-                let current_index = *index;
-                *index += 1;
-
-                let sub_entries = if child.children().count() > 2 {
-                    self.walk_toc_ncx(child, toc_dir, index, cache)
-                } else {
-                    Vec::new()
-                };
-
-                if let Some(location) = loc {
-                    entries.push(TocEntry {
-                        title,
-                        location,
-                        index: current_index,
-                        children: sub_entries,
-                    });
-                }
-            }
-        }
-
-        entries
-    }
-
-    fn walk_toc_nav(
-        &mut self,
-        node: NodeRef,
-        toc_dir: &Path,
-        index: &mut usize,
-        cache: &mut UriCache,
-    ) -> Vec<TocEntry> {
-        let mut entries = Vec::new();
-
-        for child in node.children() {
-            if child.tag_name() == Some("li") {
-                let link = child.children().find(|child| child.tag_name() == Some("a"));
-                let title = link
-                    .map(|link| decode_entities(&link.text()).into_owned())
-                    .unwrap_or_default();
-                let rel_uri = link
-                    .and_then(|link| {
-                        link.attribute("href").map(|href| {
-                            percent_decode_str(&decode_entities(href))
-                                .decode_utf8_lossy()
-                                .into_owned()
-                        })
-                    })
-                    .unwrap_or_default();
-
-                let loc = toc_dir
-                    .join(&rel_uri)
-                    .normalize()
-                    .to_str()
-                    .map(|uri| Location::Uri(uri.to_string()));
-
-                let current_index = *index;
-                *index += 1;
-
-                let sub_entries = if let Some(sub_list) = child.find("ol") {
-                    self.walk_toc_nav(sub_list, toc_dir, index, cache)
-                } else {
-                    Vec::new()
-                };
-
-                if let Some(location) = loc {
-                    entries.push(TocEntry {
-                        title,
-                        location,
-                        index: current_index,
-                        children: sub_entries,
-                    });
-                }
-            }
-        }
-
-        entries
     }
 
     #[inline]
@@ -488,31 +383,7 @@ impl<R: Read + Seek> EpubDocument<R> {
     }
 
     pub fn categories(&self) -> BTreeSet<String> {
-        let mut result = BTreeSet::new();
-
-        if let Some(md) = self.info.root().find("metadata") {
-            for child in md.children() {
-                if child.tag_qualified_name() == Some("dc:subject") {
-                    let text = child.text();
-                    let subject = decode_entities(&text);
-                    // Pipe separated list of BISAC categories
-                    if subject.contains(" / ") {
-                        for categ in subject.split('|') {
-                            let start_index = if let Some(index) = categ.find(" - ") {
-                                index + 3
-                            } else {
-                                0
-                            };
-                            result.insert(categ[start_index..].trim().replace(" / ", "."));
-                        }
-                    } else {
-                        result.insert(subject.into_owned());
-                    }
-                }
-            }
-        }
-
-        result
+        self.info.categories()
     }
 
     fn chapter_aux<'a>(
@@ -625,70 +496,11 @@ impl<R: Read + Seek> EpubDocument<R> {
     }
 
     pub fn series(&self) -> Option<(String, String)> {
-        self.info.root().find("metadata").and_then(|md| {
-            let mut title = None;
-            let mut index = None;
-
-            for child in md.children() {
-                if child.tag_name() == Some("meta") {
-                    if child.attribute("name") == Some("calibre:series") {
-                        title = child
-                            .attribute("content")
-                            .map(|s| decode_entities(s).into_owned());
-                    } else if child.attribute("name") == Some("calibre:series_index") {
-                        index = child
-                            .attribute("content")
-                            .map(|s| decode_entities(s).into_owned());
-                    } else if child.attribute("property") == Some("belongs-to-collection") {
-                        title = Some(decode_entities(&child.text()).into_owned());
-                    } else if child.attribute("property") == Some("group-position") {
-                        index = Some(decode_entities(&child.text()).into_owned());
-                    }
-                }
-
-                if title.is_some() && index.is_some() {
-                    break;
-                }
-            }
-
-            title.into_iter().zip(index).next()
-        })
+        self.info.series()
     }
 
-    pub fn cover_image(&self) -> Option<&str> {
-        self.info
-            .root()
-            .find("metadata")
-            .and_then(|md| {
-                md.children().find(|child| {
-                    child.tag_name() == Some("meta") && child.attribute("name") == Some("cover")
-                })
-            })
-            .and_then(|entry| entry.attribute("content"))
-            .and_then(|cover_id| {
-                self.info
-                    .root()
-                    .find("manifest")
-                    .and_then(|entry| entry.find_by_id(cover_id))
-                    .and_then(|entry| entry.attribute("href"))
-            })
-            .or_else(|| {
-                self.info
-                    .root()
-                    .find("manifest")
-                    .and_then(|mf| {
-                        mf.children().find(|child| {
-                            (child
-                                .attribute("href")
-                                .map_or(false, |hr| hr.contains("cover") || hr.contains("Cover"))
-                                || child.id().map_or(false, |id| id.contains("cover")))
-                                && child
-                                    .attribute("media-type")
-                                    .map_or(false, |mt| mt.starts_with("image/"))
-                        })
-                    })
-                    .and_then(|entry| entry.attribute("href"))
-            })
+    pub fn cover_image(&self) -> Option<String> {
+        self.info.cover_image_href()
     }
 
     pub fn description(&self) -> Option<String> {
@@ -762,41 +574,13 @@ impl<R: Read + Seek> Document for EpubDocument<R> {
     }
 
     fn toc(&mut self) -> Option<Vec<TocEntry>> {
-        let name = self
-            .info
-            .root()
-            .find("spine")
-            .and_then(|spine| spine.attribute("toc"))
-            .and_then(|toc_id| {
-                self.info
-                    .root()
-                    .find("manifest")
-                    .and_then(|manifest| manifest.find_by_id(toc_id))
-                    .and_then(|entry| entry.attribute("href"))
-            })
-            .or_else(|| {
-                self.info
-                    .root()
-                    .find("manifest")
-                    .and_then(|manifest| {
-                        manifest.children().find(|child| {
-                            child
-                                .attribute("properties")
-                                .iter()
-                                .any(|props| props.split_whitespace().any(|prop| prop == "nav"))
-                        })
-                    })
-                    .and_then(|entry| entry.attribute("href"))
-            })
-            .map(|href| {
-                self.parent
-                    .join(href)
-                    .normalize()
-                    .to_string_lossy()
-                    .into_owned()
-            })?;
-
-        let toc_dir = Path::new(&name).parent().unwrap_or_else(|| Path::new(""));
+        let name = self.info.toc_href().map(|href| {
+            self.parent
+                .join(href)
+                .normalize()
+                .to_string_lossy()
+                .into_owned()
+        })?;
 
         let mut text = String::new();
         if let Ok(mut zf) = self.archive.by_name(&name) {
@@ -805,21 +589,7 @@ impl<R: Read + Seek> Document for EpubDocument<R> {
             return None;
         }
 
-        let root = XmlParser::new(&text).parse();
-
-        if name.ends_with(".ncx") {
-            root.root()
-                .find("navMap")
-                .map(|map| self.walk_toc_ncx(map, toc_dir, &mut 0, &mut FxHashMap::default()))
-        } else {
-            root.root()
-                .descendants()
-                .find(|desc| {
-                    desc.tag_name() == Some("nav") && desc.attribute("epub:type") == Some("toc")
-                })
-                .and_then(|map| map.find("ol"))
-                .map(|map| self.walk_toc_nav(map, toc_dir, &mut 0, &mut FxHashMap::default()))
-        }
+        parse_toc(&text, &name).map(|toc| toc.into_entries())
     }
 
     fn chapter<'a>(&mut self, offset: usize, toc: &'a [TocEntry]) -> Option<(&'a TocEntry, f32)> {
@@ -1134,14 +904,7 @@ impl<R: Read + Seek> Document for EpubDocument<R> {
     }
 
     fn metadata(&self, key: &str) -> Option<String> {
-        self.info
-            .root()
-            .find("metadata")
-            .and_then(|md| {
-                md.children()
-                    .find(|child| child.tag_qualified_name() == Some(key))
-            })
-            .map(|child| decode_entities(&child.text()).into_owned())
+        self.info.metadata_value(key)
     }
 
     fn is_reflowable(&self) -> bool {
@@ -1157,7 +920,10 @@ impl<R: Read + Seek> Document for EpubDocument<R> {
 mod tests {
     use super::*;
     use crate::document::html::layout::DrawCommand;
+    use std::io::Write;
     use std::path::PathBuf;
+    use zip::write::SimpleFileOptions;
+
     fn setup_epub() -> EpubDocumentFile {
         let root_dir = PathBuf::from(
             std::env::var("TEST_ROOT_DIR").expect("TEST_ROOT_DIR must be set for epub tests"),
@@ -1302,5 +1068,117 @@ mod tests {
             assert!(has_content, "spine chapter {} has only empty pages", i);
             start_offset += doc.spine[i].size;
         }
+    }
+
+    /// Build a minimal in-memory zip with arbitrary named entries and return it
+    /// as a `ZipArchive` ready for `build_spine`.
+    fn zip_with_entries(entries: &[(&str, &[u8])]) -> ZipArchive<std::io::Cursor<Vec<u8>>> {
+        let buf = std::io::Cursor::new(Vec::new());
+        let mut zip = zip::ZipWriter::new(buf);
+        let opts = SimpleFileOptions::default();
+        for (name, data) in entries {
+            zip.start_file(*name, opts).unwrap();
+            zip.write_all(data).unwrap();
+        }
+        ZipArchive::new(zip.finish().unwrap()).unwrap()
+    }
+
+    fn manifest_entry(id: &str, href: &str) -> ManifestEntry {
+        ManifestEntry {
+            id: id.to_string(),
+            href: href.to_string(),
+            media_type: "application/xhtml+xml".to_string(),
+            properties: String::new(),
+        }
+    }
+
+    #[test]
+    fn build_spine_resolves_all_entries_in_order() {
+        let ch1 = b"chapter one content";
+        let ch2 = b"chapter two content longer";
+        let mut archive = zip_with_entries(&[("OEBPS/ch1.xhtml", ch1), ("OEBPS/ch2.xhtml", ch2)]);
+
+        let manifest = vec![
+            manifest_entry("id1", "ch1.xhtml"),
+            manifest_entry("id2", "ch2.xhtml"),
+        ];
+        let idrefs = vec!["id1".to_string(), "id2".to_string()];
+        let parent = Path::new("OEBPS");
+
+        let spine = build_spine(&mut archive, &manifest, &idrefs, parent);
+
+        assert_eq!(spine.len(), 2);
+        assert_eq!(spine[0].path, "OEBPS/ch1.xhtml");
+        assert_eq!(spine[0].size, ch1.len());
+        assert_eq!(spine[1].path, "OEBPS/ch2.xhtml");
+        assert_eq!(spine[1].size, ch2.len());
+    }
+
+    #[test]
+    fn build_spine_preserves_spine_order_not_manifest_order() {
+        let mut archive =
+            zip_with_entries(&[("OEBPS/ch1.xhtml", b"a"), ("OEBPS/ch2.xhtml", b"bb")]);
+
+        // Manifest lists ch2 before ch1, but spine references ch1 first.
+        let manifest = vec![
+            manifest_entry("id2", "ch2.xhtml"),
+            manifest_entry("id1", "ch1.xhtml"),
+        ];
+        let idrefs = vec!["id1".to_string(), "id2".to_string()];
+        let parent = Path::new("OEBPS");
+
+        let spine = build_spine(&mut archive, &manifest, &idrefs, parent);
+
+        assert_eq!(spine.len(), 2);
+        assert_eq!(spine[0].path, "OEBPS/ch1.xhtml");
+        assert_eq!(spine[1].path, "OEBPS/ch2.xhtml");
+    }
+
+    #[test]
+    fn build_spine_skips_idref_with_no_manifest_entry() {
+        let mut archive = zip_with_entries(&[("OEBPS/ch1.xhtml", b"content")]);
+
+        let manifest = vec![manifest_entry("id1", "ch1.xhtml")];
+        // "ghost" has no matching manifest entry.
+        let idrefs = vec!["id1".to_string(), "ghost".to_string()];
+        let parent = Path::new("OEBPS");
+
+        let spine = build_spine(&mut archive, &manifest, &idrefs, parent);
+
+        assert_eq!(spine.len(), 1);
+        assert_eq!(spine[0].path, "OEBPS/ch1.xhtml");
+    }
+
+    #[test]
+    fn build_spine_skips_entry_absent_from_archive() {
+        // Manifest references ch2.xhtml but it is not in the zip.
+        let mut archive = zip_with_entries(&[("OEBPS/ch1.xhtml", b"content")]);
+
+        let manifest = vec![
+            manifest_entry("id1", "ch1.xhtml"),
+            manifest_entry("id2", "ch2.xhtml"),
+        ];
+        let idrefs = vec!["id1".to_string(), "id2".to_string()];
+        let parent = Path::new("OEBPS");
+
+        let spine = build_spine(&mut archive, &manifest, &idrefs, parent);
+
+        assert_eq!(spine.len(), 1, "missing archive entry should be skipped");
+        assert_eq!(spine[0].path, "OEBPS/ch1.xhtml");
+    }
+
+    #[test]
+    fn build_spine_decodes_percent_encoded_href() {
+        // Space encoded as %20 in the manifest href.
+        let mut archive = zip_with_entries(&[("OEBPS/chapter one.xhtml", b"hello")]);
+
+        let manifest = vec![manifest_entry("id1", "chapter%20one.xhtml")];
+        let idrefs = vec!["id1".to_string()];
+        let parent = Path::new("OEBPS");
+
+        let spine = build_spine(&mut archive, &manifest, &idrefs, parent);
+
+        assert_eq!(spine.len(), 1);
+        assert_eq!(spine[0].path, "OEBPS/chapter one.xhtml");
     }
 }

--- a/crates/core/src/document/epub/mod.rs
+++ b/crates/core/src/document/epub/mod.rs
@@ -5,7 +5,7 @@ use super::html::layout::TextAlign;
 use super::html::layout::{DrawCommand, DrawState, ImageCommand, RootData, TextCommand};
 use super::html::layout::{LoopContext, StyleData};
 use super::html::style::StyleSheet;
-use super::html::xml::XmlParser;
+use super::html::xml::parse_html5;
 use super::pdf::PdfOpener;
 use crate::document::{BoundedText, Document, Location, TextLocation, TocEntry, chapter_from_uri};
 use crate::framebuffer::Pixmap;
@@ -233,7 +233,7 @@ impl<R: Read + Seek> EpubDocument<R> {
                 let mut zf = self.archive.by_name(name).ok()?;
                 zf.read_to_string(&mut text).ok()?;
             }
-            let root = XmlParser::new(&text).parse();
+            let root = parse_html5(&text);
             self.cache_uris(root.root(), name, start_offset, cache);
             cache.get(uri).cloned()
         } else {
@@ -273,7 +273,7 @@ impl<R: Read + Seek> EpubDocument<R> {
             }
         }
 
-        let mut root = XmlParser::new(&text).parse();
+        let mut root = parse_html5(&text);
         root.wrap_lost_inlines();
 
         let mut stylesheet = StyleSheet::new();
@@ -919,11 +919,287 @@ impl<R: Read + Seek> Document for EpubDocument<R> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::document::html::dom::XmlTree;
     use crate::document::html::layout::DrawCommand;
+    use crate::document::html::xml::XmlParser;
+    use opf::OpfDocument;
     use std::io::Write;
     use std::path::PathBuf;
     use zip::write::SimpleFileOptions;
 
+    /// Minimal EPUB chapter that resembles a real spine file: XML declaration,
+    /// DOCTYPE, explicit html/head/body, paragraphs with `id` attributes
+    /// (needed for `cache_uris` and `DrawCommand::Marker`), and a text span.
+    const CHAPTER_HTML: &str = concat!(
+        "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n",
+        "<!DOCTYPE html PUBLIC \"-//W3C//DTD XHTML 1.1//EN\" \"\">\n",
+        "<html xmlns=\"http://www.w3.org/1999/xhtml\">",
+        "<head><title>Test</title></head>",
+        "<body>",
+        "<p id=\"s1\">First paragraph.</p>",
+        "<p id=\"s2\">Second <em>emphasis</em> paragraph.</p>",
+        "<p id=\"s3\">Third paragraph with <span>inline</span> content.</p>",
+        "</body></html>",
+    );
+
+    /// Variant of `CHAPTER_HTML` containing only block-level structure with no
+    /// inline text nodes.  Used by the display-list Marker test because the
+    /// engine's inline-text layout path requires loaded fonts, whereas the
+    /// block path that emits `DrawCommand::Marker` does not.
+    const CHAPTER_HTML_BLOCK_ONLY: &str = concat!(
+        "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n",
+        "<!DOCTYPE html PUBLIC \"-//W3C//DTD XHTML 1.1//EN\" \"\">\n",
+        "<html xmlns=\"http://www.w3.org/1999/xhtml\">",
+        "<head></head>",
+        "<body>",
+        "<div id=\"s1\"><div id=\"s1a\"><div id=\"s1b\"></div></div></div>",
+        "<div id=\"s2\"><div id=\"s2a\"></div></div>",
+        "<div id=\"s3\"></div>",
+        "</body></html>",
+    );
+
+    /// Collect `(tag_name, id_attr_value, byte_offset)` for every element that
+    /// has an `id` attribute, in document order.  Used to compare bookmark /
+    /// annotation anchor points between parsers.
+    fn collect_id_offsets(tree: &XmlTree) -> Vec<(String, String, usize)> {
+        tree.root()
+            .descendants()
+            .filter_map(|n| {
+                let tag = n.tag_name()?;
+                let id = n.attribute("id")?;
+                Some((tag.to_string(), id.to_string(), n.offset()))
+            })
+            .collect()
+    }
+
+    /// Collect all `DrawCommand::Marker` offsets from a flat display list, in
+    /// order.  Marker offsets are exactly what gets stored as reading positions
+    /// and bookmark targets.
+    fn collect_marker_offsets(pages: &[Page]) -> Vec<usize> {
+        pages
+            .iter()
+            .flatten()
+            .filter_map(|cmd| match cmd {
+                DrawCommand::Marker(offset) => Some(*offset),
+                _ => None,
+            })
+            .collect()
+    }
+
+    /// Build an in-memory EPUB zip containing a single spine chapter and
+    /// return it as a `Vec<u8>` suitable for `EpubDocument::from_archive`.
+    fn build_minimal_epub(chapter_html: &str) -> Vec<u8> {
+        let buf = Vec::new();
+        let cursor = std::io::Cursor::new(buf);
+        let mut zip = zip::ZipWriter::new(cursor);
+        let opts = SimpleFileOptions::default();
+
+        zip.start_file("META-INF/container.xml", opts).unwrap();
+        zip.write_all(
+            br#"<?xml version="1.0"?>
+<container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container">
+  <rootfiles>
+    <rootfile full-path="OEBPS/content.opf" media-type="application/oebps-package+xml"/>
+  </rootfiles>
+</container>"#,
+        )
+        .unwrap();
+
+        let chapter_bytes = chapter_html.as_bytes();
+        zip.start_file("OEBPS/chapter.xhtml", opts).unwrap();
+        zip.write_all(chapter_bytes).unwrap();
+
+        let opf = r#"<?xml version="1.0"?>
+<package xmlns="http://www.idpf.org/2007/opf" version="2.0">
+  <metadata/>
+  <manifest>
+    <item id="ch1" href="chapter.xhtml" media-type="application/xhtml+xml"/>
+  </manifest>
+  <spine>
+    <itemref idref="ch1"/>
+  </spine>
+</package>"#;
+        zip.start_file("OEBPS/content.opf", opts).unwrap();
+        zip.write_all(opf.as_bytes()).unwrap();
+
+        zip.finish().unwrap().into_inner()
+    }
+
+    /// Verify that `parse_html5` and `XmlParser` assign identical byte offsets
+    /// to every element that carries an `id` attribute in a realistic EPUB
+    /// chapter.  These offsets are what gets stored as reading positions,
+    /// bookmark targets, and annotation anchors.
+    #[test]
+    fn epub_spine_chapter_id_offsets_match_between_parsers() {
+        let xml_offsets = {
+            let mut tree = XmlParser::new(CHAPTER_HTML).parse();
+            tree.wrap_lost_inlines();
+            collect_id_offsets(&tree)
+        };
+
+        let h5_offsets = {
+            let mut tree = parse_html5(CHAPTER_HTML);
+            tree.wrap_lost_inlines();
+            collect_id_offsets(&tree)
+        };
+
+        assert_eq!(
+            xml_offsets, h5_offsets,
+            "id-attribute node offsets differ between XmlParser and parse_html5\n\
+             XmlParser: {xml_offsets:?}\n\
+             html5ever: {h5_offsets:?}"
+        );
+    }
+
+    /// Verify that `cache_uris` (the `#anchor-id` → byte-offset map used for
+    /// in-book link resolution) produces identical mappings from both parsers.
+    #[test]
+    fn epub_spine_chapter_cache_uris_match_between_parsers() {
+        let root_dir = PathBuf::from(
+            std::env::var("TEST_ROOT_DIR").expect("TEST_ROOT_DIR must be set for epub tests"),
+        );
+        let name = "OEBPS/chapter.xhtml";
+        let start_offset: usize = 0;
+
+        let xml_cache = {
+            let mut cache = UriCache::default();
+            let tree = XmlParser::new(CHAPTER_HTML).parse();
+            let mut dummy_doc: EpubDocument<std::io::Cursor<Vec<u8>>> = EpubDocument {
+                archive: ZipArchive::new(std::io::Cursor::new(build_minimal_epub(CHAPTER_HTML)))
+                    .unwrap(),
+                info: OpfDocument::empty(),
+                parent: PathBuf::default(),
+                engine: Engine::new(&root_dir),
+                spine: vec![Chunk {
+                    path: name.to_string(),
+                    size: CHAPTER_HTML.len(),
+                }],
+                cache: FxHashMap::default(),
+                ignore_document_css: false,
+            };
+            dummy_doc.cache_uris(tree.root(), name, start_offset, &mut cache);
+            cache
+        };
+
+        let h5_cache = {
+            let mut cache = UriCache::default();
+            let tree = parse_html5(CHAPTER_HTML);
+            let mut dummy_doc: EpubDocument<std::io::Cursor<Vec<u8>>> = EpubDocument {
+                archive: ZipArchive::new(std::io::Cursor::new(build_minimal_epub(CHAPTER_HTML)))
+                    .unwrap(),
+                info: OpfDocument::empty(),
+                parent: PathBuf::default(),
+                engine: Engine::new(&root_dir),
+                spine: vec![Chunk {
+                    path: name.to_string(),
+                    size: CHAPTER_HTML.len(),
+                }],
+                cache: FxHashMap::default(),
+                ignore_document_css: false,
+            };
+            dummy_doc.cache_uris(tree.root(), name, start_offset, &mut cache);
+            cache
+        };
+
+        assert_eq!(
+            xml_cache, h5_cache,
+            "cache_uris maps differ between XmlParser and parse_html5\n\
+             XmlParser: {xml_cache:?}\n\
+             html5ever: {h5_cache:?}"
+        );
+    }
+
+    /// Verify that `build_display_list` emits `DrawCommand::Marker` commands
+    /// with identical offsets whether the spine chapter was parsed by
+    /// `XmlParser` or `parse_html5`.  Marker offsets are stored as reading
+    /// positions and bookmark byte offsets, so they must be parser-independent.
+    ///
+    /// Uses a block-only chapter variant (no inline text nodes) so the engine
+    /// does not require loaded fonts — the Marker path is font-free.
+    #[test]
+    fn epub_spine_chapter_marker_offsets_match_between_parsers() {
+        let start_offset: usize = 512;
+
+        let xml_markers = {
+            let mut tree = XmlParser::new(CHAPTER_HTML_BLOCK_ONLY).parse();
+            tree.wrap_lost_inlines();
+            marker_offsets_from_tree(tree, start_offset)
+        };
+
+        let h5_markers = {
+            let mut tree = parse_html5(CHAPTER_HTML_BLOCK_ONLY);
+            tree.wrap_lost_inlines();
+            marker_offsets_from_tree(tree, start_offset)
+        };
+
+        assert!(
+            !xml_markers.is_empty(),
+            "no Marker commands produced — check id attributes"
+        );
+        assert_eq!(
+            xml_markers, h5_markers,
+            "Marker offsets differ between XmlParser and parse_html5\n\
+             XmlParser: {xml_markers:?}\n\
+             html5ever: {h5_markers:?}"
+        );
+    }
+
+    /// Drive `Engine::build_display_list` directly for a pre-parsed tree and
+    /// collect all `DrawCommand::Marker` offsets.  Uses a no-op resource
+    /// fetcher since the test chapter has no external assets.
+    fn marker_offsets_from_tree(tree: XmlTree, start_offset: usize) -> Vec<usize> {
+        let root_dir = PathBuf::from(
+            std::env::var("TEST_ROOT_DIR").expect("TEST_ROOT_DIR must be set for epub tests"),
+        );
+        struct NoopFetcher;
+        impl ResourceFetcher for NoopFetcher {
+            fn fetch(&mut self, _name: &str) -> Result<Vec<u8>, Error> {
+                Ok(Vec::new())
+            }
+        }
+
+        let mut engine = Engine::new(root_dir);
+        engine.layout(600, 800, 12.0, 265);
+
+        let rect = engine.rect();
+        let mut draw_state = DrawState {
+            position: rect.min,
+            ..Default::default()
+        };
+        let root_data = RootData {
+            start_offset,
+            spine_dir: PathBuf::default(),
+            rect,
+        };
+        let stylesheet = StyleSheet::new();
+        let style = StyleData {
+            font_size: engine.font_size,
+            line_height: crate::unit::pt_to_px(engine.line_height * engine.font_size, engine.dpi)
+                .round() as i32,
+            text_align: engine.text_align,
+            start_x: rect.min.x,
+            end_x: rect.max.x,
+            width: rect.max.x - rect.min.x,
+            ..Default::default()
+        };
+        let loop_context = LoopContext::default();
+        let mut pages: Vec<Page> = vec![Vec::new()];
+
+        if let Some(body) = tree.root().find("body") {
+            engine.build_display_list(
+                body,
+                &style,
+                &loop_context,
+                &stylesheet,
+                &root_data,
+                &mut NoopFetcher,
+                &mut draw_state,
+                &mut pages,
+            );
+        }
+
+        collect_marker_offsets(&pages)
+    }
     fn setup_epub() -> EpubDocumentFile {
         let root_dir = PathBuf::from(
             std::env::var("TEST_ROOT_DIR").expect("TEST_ROOT_DIR must be set for epub tests"),

--- a/crates/core/src/document/epub/mod.rs
+++ b/crates/core/src/document/epub/mod.rs
@@ -1,5 +1,5 @@
 use super::html::css::CssParser;
-use super::html::dom::{NodeRef, XmlTree};
+use super::html::dom::NodeRef;
 use super::html::engine::{Engine, Page, ResourceFetcher};
 use super::html::layout::TextAlign;
 use super::html::layout::{DrawCommand, DrawState, ImageCommand, RootData, TextCommand};
@@ -13,6 +13,7 @@ use crate::geom::{Boundary, CycleDir};
 use crate::helpers::{Normalize, decode_entities};
 use crate::unit::pt_to_px;
 use anyhow::{Error, format_err};
+use opf::{ManifestEntry, OpfDocument, opf_path_from_container, parse_toc};
 use percent_encoding::percent_decode_str;
 use rustc_hash::FxHashMap;
 use std::collections::BTreeSet;
@@ -20,6 +21,8 @@ use std::fs::{self, File};
 use std::io::{Cursor, Read, Seek};
 use std::path::{Path, PathBuf};
 use zip::ZipArchive;
+
+mod opf;
 
 const VIEWER_STYLESHEET: &str = "css/epub.css";
 const USER_STYLESHEET: &str = "css/epub-user.css";
@@ -38,7 +41,7 @@ impl<R: Read + Seek> ResourceFetcher for ZipArchive<R> {
 /// Generic EPUB document that works with any Read + Seek source.
 pub struct EpubDocument<R: Read + Seek> {
     archive: ZipArchive<R>,
-    info: XmlTree,
+    info: OpfDocument,
     parent: PathBuf,
     engine: Engine,
     spine: Vec<Chunk>,
@@ -61,6 +64,54 @@ struct Chunk {
 unsafe impl<R: Read + Seek> Send for EpubDocument<R> {}
 unsafe impl<R: Read + Seek> Sync for EpubDocument<R> {}
 
+/// Resolves spine `idref` values to [`Chunk`]s by probing the zip archive.
+///
+/// For each `idref` the function:
+/// 1. Looks up the matching [`ManifestEntry`] to get the file's `href`.
+/// 2. Decodes the `href` (HTML entities + percent-encoding) and resolves it
+///    relative to `opf_parent` to obtain the archive-relative path.
+/// 3. Opens the entry in the archive to read its **uncompressed byte size**.
+///    The size is stored on [`Chunk`] and used as the chapter's contribution
+///    to the global byte-offset coordinate system (reading positions, bookmarks).
+///
+/// Entries with no matching manifest item or with a non-UTF-8 path are silently
+/// skipped — those indicate a structurally malformed EPUB. Entries whose file
+/// is missing from the archive are logged at error level and skipped.
+fn build_spine<R: Read + Seek>(
+    archive: &mut ZipArchive<R>,
+    manifest: &[ManifestEntry],
+    idrefs: &[String],
+    opf_parent: &Path,
+) -> Vec<Chunk> {
+    idrefs
+        .iter()
+        .filter_map(|idref| {
+            let entry = manifest.iter().find(|e| e.id == *idref)?;
+            let href = decode_entities(&entry.href);
+            let href = percent_decode_str(&href).decode_utf8_lossy();
+            let path = opf_parent.join::<&str>(href.as_ref()).normalize();
+            let path = path.to_str()?.to_string();
+
+            let result = archive.by_name(&path).map(|zf| Chunk {
+                path: path.clone(),
+                size: zf.size() as usize,
+            });
+
+            match result {
+                Ok(chunk) => Some(chunk),
+                Err(e) => {
+                    tracing::error!(
+                        path,
+                        error = %e,
+                        "spine entry missing from archive"
+                    );
+                    None
+                }
+            }
+        })
+        .collect()
+}
+
 impl<R: Read + Seek> EpubDocument<R> {
     #[cfg_attr(feature = "tracing", tracing::instrument(skip_all))]
     fn from_archive(mut archive: ZipArchive<R>, install_dir: &Path) -> Result<Self, Error> {
@@ -68,11 +119,7 @@ impl<R: Read + Seek> EpubDocument<R> {
             let mut zf = archive.by_name("META-INF/container.xml")?;
             let mut text = String::new();
             zf.read_to_string(&mut text)?;
-            let root = XmlParser::new(&text).parse();
-            root.root()
-                .find("rootfile")
-                .and_then(|e| e.attribute("full-path"))
-                .map(String::from)
+            opf_path_from_container(&text)
         }
         .ok_or_else(|| format_err!("can't get the OPF path"))?;
 
@@ -80,57 +127,18 @@ impl<R: Read + Seek> EpubDocument<R> {
             .parent()
             .unwrap_or_else(|| Path::new(""));
 
-        let text = {
+        let opf_text = {
             let mut zf = archive.by_name(&opf_path)?;
             let mut text = String::new();
             zf.read_to_string(&mut text)?;
             text
         };
 
-        let info = XmlParser::new(&text).parse();
-        let mut spine = Vec::new();
+        let info = OpfDocument::parse(opf_text)
+            .ok_or_else(|| format_err!("failed to parse OPF document"))?;
 
-        {
-            let manifest = info
-                .root()
-                .find("manifest")
-                .ok_or_else(|| format_err!("the manifest is missing"))?;
-
-            let spn = info
-                .root()
-                .find("spine")
-                .ok_or_else(|| format_err!("the spine is missing"))?;
-
-            for child in spn.children() {
-                let vertebra_opt = child
-                    .attribute("idref")
-                    .and_then(|idref| manifest.find_by_id(idref))
-                    .and_then(|entry| entry.attribute("href"))
-                    .and_then(|href| {
-                        let href = decode_entities(href);
-                        let href = percent_decode_str(&href).decode_utf8_lossy();
-                        let href_path = parent.join::<&str>(href.as_ref());
-                        href_path.to_str().and_then(|path| {
-                            archive
-                                .by_name(path)
-                                .map_err(|e| {
-                                    tracing::error!(
-                                        "Can't retrieve '{}' from the archive: {:#}.",
-                                        path,
-                                        e
-                                    )
-                                    // We're assuming that the size of the spine is less than 4 GiB.
-                                })
-                                .map(|zf| (zf.size() as usize, path.to_string()))
-                                .ok()
-                        })
-                    });
-
-                if let Some((size, path)) = vertebra_opt {
-                    spine.push(Chunk { path, size });
-                }
-            }
-        }
+        let (idrefs, _) = info.spine_idrefs();
+        let spine = build_spine(&mut archive, &info.manifest, idrefs, parent);
 
         if spine.is_empty() {
             return Err(format_err!("the spine is empty"));
@@ -181,119 +189,6 @@ impl<R: Read + Seek> EpubDocument<R> {
 
     fn vertebra_coordinates_from_name(&self, name: &str) -> Option<(usize, usize)> {
         self.vertebra_coordinates_with(|index, _| self.spine[index].path == name)
-    }
-
-    fn walk_toc_ncx(
-        &mut self,
-        node: NodeRef,
-        toc_dir: &Path,
-        index: &mut usize,
-        cache: &mut UriCache,
-    ) -> Vec<TocEntry> {
-        let mut entries = Vec::new();
-        // TODO: Take `playOrder` into account?
-
-        for child in node.children() {
-            if child.tag_name() == Some("navPoint") {
-                let title = child
-                    .find("navLabel")
-                    .and_then(|label| label.find("text"))
-                    .map(|text| decode_entities(&text.text()).into_owned())
-                    .unwrap_or_default();
-
-                // Example URI: pr03.html#codecomma_and_what_to_do_with_it
-                let rel_uri = child
-                    .find("content")
-                    .and_then(|content| {
-                        content.attribute("src").map(|src| {
-                            percent_decode_str(&decode_entities(src))
-                                .decode_utf8_lossy()
-                                .into_owned()
-                        })
-                    })
-                    .unwrap_or_default();
-
-                let loc = toc_dir
-                    .join(&rel_uri)
-                    .normalize()
-                    .to_str()
-                    .map(|uri| Location::Uri(uri.to_string()));
-
-                let current_index = *index;
-                *index += 1;
-
-                let sub_entries = if child.children().count() > 2 {
-                    self.walk_toc_ncx(child, toc_dir, index, cache)
-                } else {
-                    Vec::new()
-                };
-
-                if let Some(location) = loc {
-                    entries.push(TocEntry {
-                        title,
-                        location,
-                        index: current_index,
-                        children: sub_entries,
-                    });
-                }
-            }
-        }
-
-        entries
-    }
-
-    fn walk_toc_nav(
-        &mut self,
-        node: NodeRef,
-        toc_dir: &Path,
-        index: &mut usize,
-        cache: &mut UriCache,
-    ) -> Vec<TocEntry> {
-        let mut entries = Vec::new();
-
-        for child in node.children() {
-            if child.tag_name() == Some("li") {
-                let link = child.children().find(|child| child.tag_name() == Some("a"));
-                let title = link
-                    .map(|link| decode_entities(&link.text()).into_owned())
-                    .unwrap_or_default();
-                let rel_uri = link
-                    .and_then(|link| {
-                        link.attribute("href").map(|href| {
-                            percent_decode_str(&decode_entities(href))
-                                .decode_utf8_lossy()
-                                .into_owned()
-                        })
-                    })
-                    .unwrap_or_default();
-
-                let loc = toc_dir
-                    .join(&rel_uri)
-                    .normalize()
-                    .to_str()
-                    .map(|uri| Location::Uri(uri.to_string()));
-
-                let current_index = *index;
-                *index += 1;
-
-                let sub_entries = if let Some(sub_list) = child.find("ol") {
-                    self.walk_toc_nav(sub_list, toc_dir, index, cache)
-                } else {
-                    Vec::new()
-                };
-
-                if let Some(location) = loc {
-                    entries.push(TocEntry {
-                        title,
-                        location,
-                        index: current_index,
-                        children: sub_entries,
-                    });
-                }
-            }
-        }
-
-        entries
     }
 
     #[inline]
@@ -488,31 +383,7 @@ impl<R: Read + Seek> EpubDocument<R> {
     }
 
     pub fn categories(&self) -> BTreeSet<String> {
-        let mut result = BTreeSet::new();
-
-        if let Some(md) = self.info.root().find("metadata") {
-            for child in md.children() {
-                if child.tag_qualified_name() == Some("dc:subject") {
-                    let text = child.text();
-                    let subject = decode_entities(&text);
-                    // Pipe separated list of BISAC categories
-                    if subject.contains(" / ") {
-                        for categ in subject.split('|') {
-                            let start_index = if let Some(index) = categ.find(" - ") {
-                                index + 3
-                            } else {
-                                0
-                            };
-                            result.insert(categ[start_index..].trim().replace(" / ", "."));
-                        }
-                    } else {
-                        result.insert(subject.into_owned());
-                    }
-                }
-            }
-        }
-
-        result
+        self.info.categories()
     }
 
     fn chapter_aux<'a>(
@@ -625,70 +496,11 @@ impl<R: Read + Seek> EpubDocument<R> {
     }
 
     pub fn series(&self) -> Option<(String, String)> {
-        self.info.root().find("metadata").and_then(|md| {
-            let mut title = None;
-            let mut index = None;
-
-            for child in md.children() {
-                if child.tag_name() == Some("meta") {
-                    if child.attribute("name") == Some("calibre:series") {
-                        title = child
-                            .attribute("content")
-                            .map(|s| decode_entities(s).into_owned());
-                    } else if child.attribute("name") == Some("calibre:series_index") {
-                        index = child
-                            .attribute("content")
-                            .map(|s| decode_entities(s).into_owned());
-                    } else if child.attribute("property") == Some("belongs-to-collection") {
-                        title = Some(decode_entities(&child.text()).into_owned());
-                    } else if child.attribute("property") == Some("group-position") {
-                        index = Some(decode_entities(&child.text()).into_owned());
-                    }
-                }
-
-                if title.is_some() && index.is_some() {
-                    break;
-                }
-            }
-
-            title.into_iter().zip(index).next()
-        })
+        self.info.series()
     }
 
-    pub fn cover_image(&self) -> Option<&str> {
-        self.info
-            .root()
-            .find("metadata")
-            .and_then(|md| {
-                md.children().find(|child| {
-                    child.tag_name() == Some("meta") && child.attribute("name") == Some("cover")
-                })
-            })
-            .and_then(|entry| entry.attribute("content"))
-            .and_then(|cover_id| {
-                self.info
-                    .root()
-                    .find("manifest")
-                    .and_then(|entry| entry.find_by_id(cover_id))
-                    .and_then(|entry| entry.attribute("href"))
-            })
-            .or_else(|| {
-                self.info
-                    .root()
-                    .find("manifest")
-                    .and_then(|mf| {
-                        mf.children().find(|child| {
-                            (child
-                                .attribute("href")
-                                .map_or(false, |hr| hr.contains("cover") || hr.contains("Cover"))
-                                || child.id().map_or(false, |id| id.contains("cover")))
-                                && child
-                                    .attribute("media-type")
-                                    .map_or(false, |mt| mt.starts_with("image/"))
-                        })
-                    })
-                    .and_then(|entry| entry.attribute("href"))
-            })
+    pub fn cover_image(&self) -> Option<String> {
+        self.info.cover_image_href()
     }
 
     pub fn description(&self) -> Option<String> {
@@ -762,41 +574,13 @@ impl<R: Read + Seek> Document for EpubDocument<R> {
     }
 
     fn toc(&mut self) -> Option<Vec<TocEntry>> {
-        let name = self
-            .info
-            .root()
-            .find("spine")
-            .and_then(|spine| spine.attribute("toc"))
-            .and_then(|toc_id| {
-                self.info
-                    .root()
-                    .find("manifest")
-                    .and_then(|manifest| manifest.find_by_id(toc_id))
-                    .and_then(|entry| entry.attribute("href"))
-            })
-            .or_else(|| {
-                self.info
-                    .root()
-                    .find("manifest")
-                    .and_then(|manifest| {
-                        manifest.children().find(|child| {
-                            child
-                                .attribute("properties")
-                                .iter()
-                                .any(|props| props.split_whitespace().any(|prop| prop == "nav"))
-                        })
-                    })
-                    .and_then(|entry| entry.attribute("href"))
-            })
-            .map(|href| {
-                self.parent
-                    .join(href)
-                    .normalize()
-                    .to_string_lossy()
-                    .into_owned()
-            })?;
-
-        let toc_dir = Path::new(&name).parent().unwrap_or_else(|| Path::new(""));
+        let name = self.info.toc_href().map(|href| {
+            self.parent
+                .join(href)
+                .normalize()
+                .to_string_lossy()
+                .into_owned()
+        })?;
 
         let mut text = String::new();
         if let Ok(mut zf) = self.archive.by_name(&name) {
@@ -805,21 +589,7 @@ impl<R: Read + Seek> Document for EpubDocument<R> {
             return None;
         }
 
-        let root = XmlParser::new(&text).parse();
-
-        if name.ends_with(".ncx") {
-            root.root()
-                .find("navMap")
-                .map(|map| self.walk_toc_ncx(map, toc_dir, &mut 0, &mut FxHashMap::default()))
-        } else {
-            root.root()
-                .descendants()
-                .find(|desc| {
-                    desc.tag_name() == Some("nav") && desc.attribute("epub:type") == Some("toc")
-                })
-                .and_then(|map| map.find("ol"))
-                .map(|map| self.walk_toc_nav(map, toc_dir, &mut 0, &mut FxHashMap::default()))
-        }
+        parse_toc(&text, &name).map(|toc| toc.into_entries())
     }
 
     fn chapter<'a>(&mut self, offset: usize, toc: &'a [TocEntry]) -> Option<(&'a TocEntry, f32)> {
@@ -1134,14 +904,7 @@ impl<R: Read + Seek> Document for EpubDocument<R> {
     }
 
     fn metadata(&self, key: &str) -> Option<String> {
-        self.info
-            .root()
-            .find("metadata")
-            .and_then(|md| {
-                md.children()
-                    .find(|child| child.tag_qualified_name() == Some(key))
-            })
-            .map(|child| decode_entities(&child.text()).into_owned())
+        self.info.metadata_value(key)
     }
 
     fn is_reflowable(&self) -> bool {
@@ -1157,7 +920,10 @@ impl<R: Read + Seek> Document for EpubDocument<R> {
 mod tests {
     use super::*;
     use crate::document::html::layout::DrawCommand;
+    use std::io::Write;
     use std::path::PathBuf;
+    use zip::write::SimpleFileOptions;
+
     fn setup_epub() -> EpubDocumentFile {
         let root_dir = PathBuf::from(
             std::env::var("TEST_ROOT_DIR").expect("TEST_ROOT_DIR must be set for epub tests"),
@@ -1302,5 +1068,117 @@ mod tests {
             assert!(has_content, "spine chapter {} has only empty pages", i);
             start_offset += doc.spine[i].size;
         }
+    }
+
+    /// Build a minimal in-memory zip with arbitrary named entries and return it
+    /// as a `ZipArchive` ready for `build_spine`.
+    fn zip_with_entries(entries: &[(&str, &[u8])]) -> ZipArchive<std::io::Cursor<Vec<u8>>> {
+        let buf = std::io::Cursor::new(Vec::new());
+        let mut zip = zip::ZipWriter::new(buf);
+        let opts = SimpleFileOptions::default();
+        for (name, data) in entries {
+            zip.start_file(*name, opts).unwrap();
+            zip.write_all(data).unwrap();
+        }
+        ZipArchive::new(zip.finish().unwrap()).unwrap()
+    }
+
+    fn manifest_entry(id: &str, href: &str) -> ManifestEntry {
+        ManifestEntry {
+            id: id.to_string(),
+            href: href.to_string(),
+            media_type: "application/xhtml+xml".to_string(),
+            properties: String::new(),
+        }
+    }
+
+    #[test]
+    fn build_spine_resolves_all_entries_in_order() {
+        let ch1 = b"chapter one content";
+        let ch2 = b"chapter two content longer";
+        let mut archive = zip_with_entries(&[("OEBPS/ch1.xhtml", ch1), ("OEBPS/ch2.xhtml", ch2)]);
+
+        let manifest = vec![
+            manifest_entry("id1", "ch1.xhtml"),
+            manifest_entry("id2", "ch2.xhtml"),
+        ];
+        let idrefs = vec!["id1".to_string(), "id2".to_string()];
+        let parent = Path::new("OEBPS");
+
+        let spine = build_spine(&mut archive, &manifest, &idrefs, parent);
+
+        assert_eq!(spine.len(), 2);
+        assert_eq!(spine[0].path, "OEBPS/ch1.xhtml");
+        assert_eq!(spine[0].size, ch1.len());
+        assert_eq!(spine[1].path, "OEBPS/ch2.xhtml");
+        assert_eq!(spine[1].size, ch2.len());
+    }
+
+    #[test]
+    fn build_spine_preserves_spine_order_not_manifest_order() {
+        let mut archive =
+            zip_with_entries(&[("OEBPS/ch1.xhtml", b"a"), ("OEBPS/ch2.xhtml", b"bb")]);
+
+        // Manifest lists ch2 before ch1, but spine references ch1 first.
+        let manifest = vec![
+            manifest_entry("id2", "ch2.xhtml"),
+            manifest_entry("id1", "ch1.xhtml"),
+        ];
+        let idrefs = vec!["id1".to_string(), "id2".to_string()];
+        let parent = Path::new("OEBPS");
+
+        let spine = build_spine(&mut archive, &manifest, &idrefs, parent);
+
+        assert_eq!(spine.len(), 2);
+        assert_eq!(spine[0].path, "OEBPS/ch1.xhtml");
+        assert_eq!(spine[1].path, "OEBPS/ch2.xhtml");
+    }
+
+    #[test]
+    fn build_spine_skips_idref_with_no_manifest_entry() {
+        let mut archive = zip_with_entries(&[("OEBPS/ch1.xhtml", b"content")]);
+
+        let manifest = vec![manifest_entry("id1", "ch1.xhtml")];
+        // "ghost" has no matching manifest entry.
+        let idrefs = vec!["id1".to_string(), "ghost".to_string()];
+        let parent = Path::new("OEBPS");
+
+        let spine = build_spine(&mut archive, &manifest, &idrefs, parent);
+
+        assert_eq!(spine.len(), 1);
+        assert_eq!(spine[0].path, "OEBPS/ch1.xhtml");
+    }
+
+    #[test]
+    fn build_spine_skips_entry_absent_from_archive() {
+        // Manifest references ch2.xhtml but it is not in the zip.
+        let mut archive = zip_with_entries(&[("OEBPS/ch1.xhtml", b"content")]);
+
+        let manifest = vec![
+            manifest_entry("id1", "ch1.xhtml"),
+            manifest_entry("id2", "ch2.xhtml"),
+        ];
+        let idrefs = vec!["id1".to_string(), "id2".to_string()];
+        let parent = Path::new("OEBPS");
+
+        let spine = build_spine(&mut archive, &manifest, &idrefs, parent);
+
+        assert_eq!(spine.len(), 1, "missing archive entry should be skipped");
+        assert_eq!(spine[0].path, "OEBPS/ch1.xhtml");
+    }
+
+    #[test]
+    fn build_spine_decodes_percent_encoded_href() {
+        // Space encoded as %20 in the manifest href.
+        let mut archive = zip_with_entries(&[("OEBPS/chapter one.xhtml", b"hello")]);
+
+        let manifest = vec![manifest_entry("id1", "chapter%20one.xhtml")];
+        let idrefs = vec!["id1".to_string()];
+        let parent = Path::new("OEBPS");
+
+        let spine = build_spine(&mut archive, &manifest, &idrefs, parent);
+
+        assert_eq!(spine.len(), 1);
+        assert_eq!(spine[0].path, "OEBPS/chapter one.xhtml");
     }
 }

--- a/crates/core/src/document/epub/opf.rs
+++ b/crates/core/src/document/epub/opf.rs
@@ -1,0 +1,761 @@
+//! Lightweight, roxmltree-backed parsers for EPUB structural XML files.
+//!
+//! Three kinds of XML are handled here — none of which are HTML and none of
+//! which require byte-offset tracking:
+//!
+//! - `META-INF/container.xml` — locates the OPF root file.
+//! - The OPF (Open Packaging Format) file — manifest, spine, metadata.
+//! - NCX or Navigation Document (NAV) — table of contents.
+//!
+//! [`OpfDocument`] parses the OPF source once at construction time and stores
+//! all data as owned fields. Queries are plain field reads — no re-parsing.
+
+use crate::document::Location;
+use crate::document::TocEntry;
+use crate::helpers::{Normalize, decode_entities};
+use percent_encoding::percent_decode_str;
+use std::collections::{BTreeSet, HashMap};
+use std::path::Path;
+
+/// XML namespace URI for Dublin Core Elements 1.1.
+///
+/// EPUB OPF files use Dublin Core to store book metadata such as `<dc:title>`,
+/// `<dc:creator>`, `<dc:language>`, etc. The `dc:` prefix in the source is a
+/// local alias that can vary between EPUBs; roxmltree resolves it to this URI,
+/// which is the stable identifier used for matching.
+const DC_NS: &str = "http://purl.org/dc/elements/1.1/";
+
+/// Extracts the OPF root-file path from a `META-INF/container.xml` string.
+///
+/// Returns `None` if the document is malformed or the `full-path` attribute
+/// is missing.
+pub fn opf_path_from_container(text: &str) -> Option<String> {
+    let doc = roxmltree::Document::parse(text).ok()?;
+    doc.descendants()
+        .find(|n| n.is_element() && n.tag_name().name() == "rootfile")
+        .and_then(|n| n.attribute("full-path"))
+        .map(String::from)
+}
+
+/// Parsed OPF document with all data pre-extracted into owned fields.
+///
+/// Constructed once via [`OpfDocument::parse`]; all accessors are `O(1)`
+/// field reads or cheap iterator passes over already-owned `Vec`s.
+pub struct OpfDocument {
+    pub manifest: Vec<ManifestEntry>,
+    /// `idref` values from `<spine><itemref>` in reading order.
+    pub spine_idrefs: Vec<String>,
+    /// The `toc` attribute of `<spine>` — the manifest id of the NCX file.
+    pub spine_toc_id: Option<String>,
+    /// Dublin Core metadata keyed by local name, e.g. `"creator"` → value.
+    dc_metadata: HashMap<String, String>,
+    pub cover_href: Option<String>,
+    pub series: Option<(String, String)>,
+    pub categories: BTreeSet<String>,
+}
+
+impl OpfDocument {
+    /// Parse an OPF source string, extracting all fields eagerly.
+    ///
+    /// Returns `None` if the XML is malformed.
+    pub fn parse(source: String) -> Option<Self> {
+        let doc = roxmltree::Document::parse(&source).ok()?;
+
+        let manifest = extract_manifest(&doc);
+        let (spine_idrefs, spine_toc_id) = extract_spine(&doc);
+        let dc_metadata = extract_dc_metadata(&doc);
+        let cover_href = extract_cover_href(&doc, &manifest);
+        let series = extract_series(&doc);
+        let categories = extract_categories(&doc);
+
+        Some(OpfDocument {
+            manifest,
+            spine_idrefs,
+            spine_toc_id,
+            dc_metadata,
+            cover_href,
+            series,
+            categories,
+        })
+    }
+
+    /// Returns the `idref` values of all `<itemref>` children of `<spine>`,
+    /// together with the `<spine toc="...">` attribute value if present.
+    pub fn spine_idrefs(&self) -> (&[String], Option<&str>) {
+        (&self.spine_idrefs, self.spine_toc_id.as_deref())
+    }
+
+    /// Returns the href of the TOC file: first tries `<spine toc="ncx-id">`,
+    /// then looks for a manifest item with `properties="nav"`.
+    pub fn toc_href(&self) -> Option<String> {
+        let via_ncx = self
+            .spine_toc_id
+            .as_deref()
+            .and_then(|ncx_id| self.manifest.iter().find(|e| e.id == ncx_id))
+            .map(|e| e.href.clone());
+
+        via_ncx.or_else(|| {
+            self.manifest
+                .iter()
+                .find(|e| e.properties.split_whitespace().any(|p| p == "nav"))
+                .map(|e| e.href.clone())
+        })
+    }
+
+    /// Returns the value of a Dublin Core metadata element by local name,
+    /// e.g. `"creator"`, `"title"`, `"language"`.
+    ///
+    /// Also accepts `"dc:local_name"` form for backward compatibility with the
+    /// callers that used to pass the full qualified key.
+    pub fn metadata_value(&self, key: &str) -> Option<String> {
+        let local = key.strip_prefix("dc:").unwrap_or(key);
+        self.dc_metadata.get(local).cloned()
+    }
+
+    /// Returns the cover image href.
+    pub fn cover_image_href(&self) -> Option<String> {
+        self.cover_href.clone()
+    }
+
+    /// Returns the Calibre / OPF3 series title and position.
+    pub fn series(&self) -> Option<(String, String)> {
+        self.series.clone()
+    }
+
+    /// Returns BISAC subject categories.
+    pub fn categories(&self) -> BTreeSet<String> {
+        self.categories.clone()
+    }
+}
+
+/// A single `<item>` entry from the OPF `<manifest>`.
+#[derive(Debug, Clone)]
+pub struct ManifestEntry {
+    pub id: String,
+    pub href: String,
+    pub media_type: String,
+    pub properties: String,
+}
+
+fn extract_manifest(doc: &roxmltree::Document<'_>) -> Vec<ManifestEntry> {
+    doc.descendants()
+        .filter(|n| n.is_element() && n.tag_name().name() == "manifest")
+        .flat_map(|manifest| {
+            manifest
+                .children()
+                .filter(|n| n.is_element() && n.tag_name().name() == "item")
+                .filter_map(|item| {
+                    let id = item.attribute("id")?;
+                    let href = item.attribute("href")?;
+                    Some(ManifestEntry {
+                        id: id.to_string(),
+                        href: href.to_string(),
+                        media_type: item.attribute("media-type").unwrap_or("").to_string(),
+                        properties: item.attribute("properties").unwrap_or("").to_string(),
+                    })
+                })
+                .collect::<Vec<_>>()
+        })
+        .collect()
+}
+
+fn extract_spine(doc: &roxmltree::Document<'_>) -> (Vec<String>, Option<String>) {
+    let spine = doc
+        .descendants()
+        .find(|n| n.is_element() && n.tag_name().name() == "spine");
+
+    let toc_id = spine
+        .as_ref()
+        .and_then(|s| s.attribute("toc"))
+        .map(String::from);
+
+    let idrefs = spine
+        .iter()
+        .flat_map(|s| s.children())
+        .filter(|n| n.is_element() && n.tag_name().name() == "itemref")
+        .filter_map(|item| item.attribute("idref").map(String::from))
+        .collect();
+
+    (idrefs, toc_id)
+}
+
+fn extract_dc_metadata(doc: &roxmltree::Document<'_>) -> HashMap<String, String> {
+    let mut map = HashMap::new();
+    let Some(md) = doc
+        .descendants()
+        .find(|n| n.is_element() && n.tag_name().name() == "metadata")
+    else {
+        return map;
+    };
+
+    for child in md.children().filter(|n| n.is_element()) {
+        if child.tag_name().namespace() == Some(DC_NS)
+            && let Some(text) = child.text()
+        {
+            map.entry(child.tag_name().name().to_string())
+                .or_insert_with(|| decode_entities(text).into_owned());
+        }
+    }
+
+    map
+}
+
+fn extract_cover_href(doc: &roxmltree::Document<'_>, manifest: &[ManifestEntry]) -> Option<String> {
+    let via_meta = doc
+        .descendants()
+        .find(|n| n.is_element() && n.tag_name().name() == "metadata")
+        .and_then(|md| {
+            md.children().find(|n| {
+                n.is_element()
+                    && n.tag_name().name() == "meta"
+                    && n.attribute("name") == Some("cover")
+            })
+        })
+        .and_then(|meta| meta.attribute("content").map(String::from))
+        .and_then(|cover_id| {
+            manifest
+                .iter()
+                .find(|e| e.id == cover_id)
+                .map(|e| e.href.clone())
+        });
+
+    via_meta.or_else(|| {
+        manifest
+            .iter()
+            .find(|e| {
+                (e.href.to_lowercase().contains("cover") || e.id.to_lowercase().contains("cover"))
+                    && e.media_type.starts_with("image/")
+            })
+            .map(|e| e.href.clone())
+    })
+}
+
+fn extract_series(doc: &roxmltree::Document<'_>) -> Option<(String, String)> {
+    let md = doc
+        .descendants()
+        .find(|n| n.is_element() && n.tag_name().name() == "metadata")?;
+
+    let mut title = None;
+    let mut index = None;
+
+    for child in md.children().filter(|n| n.is_element()) {
+        if child.tag_name().name() == "meta" {
+            match child.attribute("name") {
+                Some("calibre:series") => {
+                    title = child
+                        .attribute("content")
+                        .map(|s| decode_entities(s).into_owned());
+                }
+                Some("calibre:series_index") => {
+                    index = child
+                        .attribute("content")
+                        .map(|s| decode_entities(s).into_owned());
+                }
+                _ => {}
+            }
+            if child.attribute("property") == Some("belongs-to-collection") {
+                title = child.text().map(|t| decode_entities(t).into_owned());
+            } else if child.attribute("property") == Some("group-position") {
+                index = child.text().map(|t| decode_entities(t).into_owned());
+            }
+        }
+    }
+
+    title.zip(index)
+}
+
+fn extract_categories(doc: &roxmltree::Document<'_>) -> BTreeSet<String> {
+    let mut result = BTreeSet::new();
+
+    let Some(md) = doc
+        .descendants()
+        .find(|n| n.is_element() && n.tag_name().name() == "metadata")
+    else {
+        return result;
+    };
+
+    for child in md.children().filter(|n| n.is_element()) {
+        if child.tag_name().name() == "subject"
+            && child.tag_name().namespace() == Some(DC_NS)
+            && let Some(text) = child.text()
+        {
+            let subject = decode_entities(text);
+            if subject.contains(" / ") {
+                for categ in subject.split('|') {
+                    let start_index = categ.find(" - ").map(|i| i + 3).unwrap_or(0);
+                    result.insert(categ[start_index..].trim().replace(" / ", "."));
+                }
+            } else {
+                result.insert(subject.into_owned());
+            }
+        }
+    }
+
+    result
+}
+
+/// Parsed table-of-contents from either an NCX or Navigation Document.
+pub struct Toc {
+    entries: Vec<TocEntry>,
+}
+
+impl Toc {
+    pub fn into_entries(self) -> Vec<TocEntry> {
+        self.entries
+    }
+}
+
+/// Parses an NCX or EPUB3 Navigation Document and returns a [`Toc`].
+///
+/// `name` is the archive path of the TOC file (used to decide NCX vs NAV and
+/// to resolve relative links).
+pub fn parse_toc(text: &str, name: &str) -> Option<Toc> {
+    let doc = roxmltree::Document::parse(text).ok()?;
+    let toc_dir = Path::new(name).parent().unwrap_or_else(|| Path::new(""));
+    let mut index = 0;
+
+    let entries = if name.ends_with(".ncx") {
+        doc.descendants()
+            .find(|n| n.is_element() && n.tag_name().name() == "navMap")
+            .map(|map| walk_ncx(map, toc_dir, &mut index))
+            .unwrap_or_default()
+    } else {
+        doc.descendants()
+            .find(|n| {
+                n.is_element()
+                    && n.tag_name().name() == "nav"
+                    && n.attribute("epub:type") == Some("toc")
+            })
+            .or_else(|| {
+                doc.descendants().find(|n| {
+                    n.is_element()
+                        && n.tag_name().name() == "nav"
+                        && n.attributes()
+                            .any(|a| a.name() == "type" && a.value() == "toc")
+                })
+            })
+            .and_then(|nav| {
+                nav.children()
+                    .find(|n| n.is_element() && n.tag_name().name() == "ol")
+            })
+            .map(|ol| walk_nav(ol, toc_dir, &mut index))
+            .unwrap_or_default()
+    };
+
+    Some(Toc { entries })
+}
+
+fn walk_ncx(node: roxmltree::Node<'_, '_>, toc_dir: &Path, index: &mut usize) -> Vec<TocEntry> {
+    let mut entries = Vec::new();
+
+    for child in node.children().filter(|n| n.is_element()) {
+        if child.tag_name().name() != "navPoint" {
+            continue;
+        }
+
+        let title = child
+            .descendants()
+            .find(|n| n.is_element() && n.tag_name().name() == "text")
+            .and_then(|n| n.text())
+            .map(|t| decode_entities(t).into_owned())
+            .unwrap_or_default();
+
+        let rel_uri = child
+            .descendants()
+            .find(|n| n.is_element() && n.tag_name().name() == "content")
+            .and_then(|n| n.attribute("src"))
+            .map(|src| {
+                percent_decode_str(&decode_entities(src))
+                    .decode_utf8_lossy()
+                    .into_owned()
+            })
+            .unwrap_or_default();
+
+        let loc = toc_dir
+            .join(&rel_uri)
+            .normalize()
+            .to_str()
+            .map(|uri| Location::Uri(uri.to_string()));
+
+        let current_index = *index;
+        *index += 1;
+
+        let sub_entries = if child.children().filter(|n| n.is_element()).count() > 2 {
+            walk_ncx(child, toc_dir, index)
+        } else {
+            Vec::new()
+        };
+
+        if let Some(location) = loc {
+            entries.push(TocEntry {
+                title,
+                location,
+                index: current_index,
+                children: sub_entries,
+            });
+        }
+    }
+
+    entries
+}
+
+fn walk_nav(node: roxmltree::Node<'_, '_>, toc_dir: &Path, index: &mut usize) -> Vec<TocEntry> {
+    let mut entries = Vec::new();
+
+    for child in node.children().filter(|n| n.is_element()) {
+        if child.tag_name().name() != "li" {
+            continue;
+        }
+
+        let link = child
+            .children()
+            .find(|n| n.is_element() && n.tag_name().name() == "a");
+
+        let title = link
+            .and_then(|a| a.text())
+            .map(|t| decode_entities(t).into_owned())
+            .unwrap_or_default();
+
+        let rel_uri = link
+            .and_then(|a| a.attribute("href"))
+            .map(|href| {
+                percent_decode_str(&decode_entities(href))
+                    .decode_utf8_lossy()
+                    .into_owned()
+            })
+            .unwrap_or_default();
+
+        let loc = toc_dir
+            .join(&rel_uri)
+            .normalize()
+            .to_str()
+            .map(|uri| Location::Uri(uri.to_string()));
+
+        let current_index = *index;
+        *index += 1;
+
+        let sub_entries = child
+            .children()
+            .find(|n| n.is_element() && n.tag_name().name() == "ol")
+            .map(|ol| walk_nav(ol, toc_dir, index))
+            .unwrap_or_default();
+
+        if let Some(location) = loc {
+            entries.push(TocEntry {
+                title,
+                location,
+                index: current_index,
+                children: sub_entries,
+            });
+        }
+    }
+
+    entries
+}
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const CONTAINER_XML: &str = r#"<?xml version="1.0"?>
+<container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container">
+  <rootfiles>
+    <rootfile full-path="OEBPS/content.opf"
+              media-type="application/oebps-package+xml"/>
+  </rootfiles>
+</container>"#;
+
+    const OPF: &str = r#"<?xml version="1.0" encoding="UTF-8"?>
+<package xmlns="http://www.idpf.org/2007/opf"
+         xmlns:dc="http://purl.org/dc/elements/1.1/"
+         xmlns:opf="http://www.idpf.org/2007/opf"
+         version="2.0">
+  <metadata>
+    <dc:title>My Book</dc:title>
+    <dc:creator opf:role="aut">Alice Author</dc:creator>
+    <dc:language>en</dc:language>
+    <dc:date>2024-01-15</dc:date>
+    <dc:subject>Science / Physics</dc:subject>
+    <meta name="cover" content="cover-img"/>
+    <meta name="calibre:series" content="Great Series"/>
+    <meta name="calibre:series_index" content="3"/>
+  </metadata>
+  <manifest>
+    <item id="ch1"       href="chapter1.xhtml" media-type="application/xhtml+xml"/>
+    <item id="ch2"       href="chapter2.xhtml" media-type="application/xhtml+xml"/>
+    <item id="ncx"       href="toc.ncx"        media-type="application/x-dtbncx+xml"/>
+    <item id="cover-img" href="cover.jpg"       media-type="image/jpeg"/>
+  </manifest>
+  <spine toc="ncx">
+    <itemref idref="ch1"/>
+    <itemref idref="ch2"/>
+  </spine>
+</package>"#;
+
+    const NCX: &str = r#"<?xml version="1.0" encoding="UTF-8"?>
+<ncx xmlns="http://www.daisy.org/z3986/2005/ncx/" version="2005-1">
+  <navMap>
+    <navPoint id="np1" playOrder="1">
+      <navLabel><text>Chapter One</text></navLabel>
+      <content src="chapter1.xhtml"/>
+    </navPoint>
+    <navPoint id="np2" playOrder="2">
+      <navLabel><text>Chapter Two</text></navLabel>
+      <content src="chapter2.xhtml"/>
+      <navPoint id="np2a" playOrder="3">
+        <navLabel><text>Section 2.1</text></navLabel>
+        <content src="chapter2.xhtml#s1"/>
+      </navPoint>
+    </navPoint>
+  </navMap>
+</ncx>"#;
+
+    const NAV: &str = r#"<?xml version="1.0" encoding="UTF-8"?>
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:epub="http://www.idpf.org/2007/ops">
+  <body>
+    <nav epub:type="toc">
+      <ol>
+        <li><a href="chapter1.xhtml">Chapter One</a></li>
+        <li>
+          <a href="chapter2.xhtml">Chapter Two</a>
+          <ol>
+            <li><a href="chapter2.xhtml#s1">Section 2.1</a></li>
+          </ol>
+        </li>
+      </ol>
+    </nav>
+  </body>
+</html>"#;
+
+    #[test]
+    fn container_extracts_opf_path() {
+        assert_eq!(
+            opf_path_from_container(CONTAINER_XML),
+            Some("OEBPS/content.opf".to_string())
+        );
+    }
+
+    #[test]
+    fn container_malformed_xml_returns_none() {
+        assert_eq!(opf_path_from_container("<not valid xml>>>"), None);
+    }
+
+    #[test]
+    fn container_missing_full_path_attr_returns_none() {
+        let xml = r#"<?xml version="1.0"?>
+<container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container">
+  <rootfiles><rootfile media-type="application/oebps-package+xml"/></rootfiles>
+</container>"#;
+        assert_eq!(opf_path_from_container(xml), None);
+    }
+
+    fn doc() -> OpfDocument {
+        OpfDocument::parse(OPF.to_string()).expect("OPF fixture should parse")
+    }
+
+    #[test]
+    fn opf_parse_fails_on_malformed_xml() {
+        assert!(OpfDocument::parse("<bad".to_string()).is_none());
+    }
+
+    #[test]
+    fn opf_manifest_entries_extracted() {
+        let d = doc();
+        assert_eq!(d.manifest.len(), 4);
+
+        let ch1 = d.manifest.iter().find(|e| e.id == "ch1").unwrap();
+        assert_eq!(ch1.href, "chapter1.xhtml");
+        assert_eq!(ch1.media_type, "application/xhtml+xml");
+
+        let cover = d.manifest.iter().find(|e| e.id == "cover-img").unwrap();
+        assert_eq!(cover.href, "cover.jpg");
+        assert_eq!(cover.media_type, "image/jpeg");
+    }
+
+    #[test]
+    fn opf_spine_idrefs_in_order_with_toc_id() {
+        let d = doc();
+        let (idrefs, toc_id) = d.spine_idrefs();
+        assert_eq!(idrefs, &["ch1", "ch2"]);
+        assert_eq!(toc_id, Some("ncx"));
+    }
+
+    #[test]
+    fn opf_dc_metadata_extracted() {
+        let d = doc();
+        assert_eq!(d.metadata_value("title"), Some("My Book".to_string()));
+        assert_eq!(
+            d.metadata_value("creator"),
+            Some("Alice Author".to_string())
+        );
+        assert_eq!(d.metadata_value("language"), Some("en".to_string()));
+        assert_eq!(d.metadata_value("date"), Some("2024-01-15".to_string()));
+    }
+
+    #[test]
+    fn opf_metadata_value_accepts_dc_prefix() {
+        let d = doc();
+        assert_eq!(d.metadata_value("dc:title"), Some("My Book".to_string()));
+        assert_eq!(
+            d.metadata_value("dc:creator"),
+            Some("Alice Author".to_string())
+        );
+    }
+
+    #[test]
+    fn opf_metadata_value_missing_key_returns_none() {
+        assert_eq!(doc().metadata_value("publisher"), None);
+    }
+
+    #[test]
+    fn opf_cover_href_via_meta_name() {
+        assert_eq!(doc().cover_href, Some("cover.jpg".to_string()));
+    }
+
+    #[test]
+    fn opf_cover_href_fallback_by_id_contains_cover() {
+        let xml = r#"<?xml version="1.0"?>
+<package xmlns="http://www.idpf.org/2007/opf" version="2.0">
+  <metadata/>
+  <manifest>
+    <item id="cover-image" href="img/cover.jpg" media-type="image/jpeg"/>
+    <item id="ch1" href="chapter1.xhtml" media-type="application/xhtml+xml"/>
+  </manifest>
+  <spine><itemref idref="ch1"/></spine>
+</package>"#;
+        let d = OpfDocument::parse(xml.to_string()).unwrap();
+        assert_eq!(d.cover_href, Some("img/cover.jpg".to_string()));
+    }
+
+    #[test]
+    fn opf_cover_href_none_when_no_cover() {
+        let xml = r#"<?xml version="1.0"?>
+<package xmlns="http://www.idpf.org/2007/opf" version="2.0">
+  <metadata/>
+  <manifest>
+    <item id="ch1" href="chapter1.xhtml" media-type="application/xhtml+xml"/>
+  </manifest>
+  <spine><itemref idref="ch1"/></spine>
+</package>"#;
+        let d = OpfDocument::parse(xml.to_string()).unwrap();
+        assert_eq!(d.cover_href, None);
+    }
+
+    #[test]
+    fn opf_series_calibre_meta() {
+        assert_eq!(
+            doc().series,
+            Some(("Great Series".to_string(), "3".to_string()))
+        );
+    }
+
+    #[test]
+    fn opf_series_none_when_absent() {
+        let xml = r#"<?xml version="1.0"?>
+<package xmlns="http://www.idpf.org/2007/opf" version="2.0">
+  <metadata/>
+  <manifest/>
+  <spine/>
+</package>"#;
+        assert_eq!(OpfDocument::parse(xml.to_string()).unwrap().series, None);
+    }
+
+    #[test]
+    fn opf_categories_bisac_splitting() {
+        let d = doc();
+        // "Science / Physics" contains " / " so it becomes "Science.Physics"
+        // after the BISAC replace.
+        assert!(
+            d.categories.contains("Science.Physics"),
+            "expected 'Science.Physics', got: {:?}",
+            d.categories
+        );
+    }
+
+    #[test]
+    fn toc_href_via_spine_toc_attribute() {
+        assert_eq!(doc().toc_href(), Some("toc.ncx".to_string()));
+    }
+
+    #[test]
+    fn toc_href_via_nav_properties() {
+        let xml = r#"<?xml version="1.0"?>
+<package xmlns="http://www.idpf.org/2007/opf" version="3.0">
+  <metadata/>
+  <manifest>
+    <item id="nav" href="nav.xhtml"
+          media-type="application/xhtml+xml" properties="nav"/>
+    <item id="ch1" href="chapter1.xhtml" media-type="application/xhtml+xml"/>
+  </manifest>
+  <spine><itemref idref="ch1"/></spine>
+</package>"#;
+        let d = OpfDocument::parse(xml.to_string()).unwrap();
+        assert_eq!(d.toc_href(), Some("nav.xhtml".to_string()));
+    }
+
+    #[test]
+    fn toc_href_none_when_no_toc() {
+        let xml = r#"<?xml version="1.0"?>
+<package xmlns="http://www.idpf.org/2007/opf" version="2.0">
+  <metadata/>
+  <manifest>
+    <item id="ch1" href="chapter1.xhtml" media-type="application/xhtml+xml"/>
+  </manifest>
+  <spine><itemref idref="ch1"/></spine>
+</package>"#;
+        assert_eq!(
+            OpfDocument::parse(xml.to_string()).unwrap().toc_href(),
+            None
+        );
+    }
+
+    #[test]
+    fn parse_toc_ncx_top_level_entries() {
+        let toc = parse_toc(NCX, "OEBPS/toc.ncx").unwrap();
+        let entries = toc.into_entries();
+        assert_eq!(entries.len(), 2);
+        assert_eq!(entries[0].title, "Chapter One");
+        assert_eq!(entries[1].title, "Chapter Two");
+    }
+
+    #[test]
+    fn parse_toc_ncx_resolves_paths_relative_to_toc() {
+        let toc = parse_toc(NCX, "OEBPS/toc.ncx").unwrap();
+        let entries = toc.into_entries();
+        assert!(
+            matches!(&entries[0].location, Location::Uri(u) if u == "OEBPS/chapter1.xhtml"),
+            "expected OEBPS/chapter1.xhtml, got {:?}",
+            entries[0].location
+        );
+    }
+
+    #[test]
+    fn parse_toc_ncx_nested_entries() {
+        let toc = parse_toc(NCX, "OEBPS/toc.ncx").unwrap();
+        let entries = toc.into_entries();
+        assert_eq!(entries[1].children.len(), 1);
+        assert_eq!(entries[1].children[0].title, "Section 2.1");
+    }
+
+    #[test]
+    fn parse_toc_nav_top_level_entries() {
+        let toc = parse_toc(NAV, "OEBPS/nav.xhtml").unwrap();
+        let entries = toc.into_entries();
+        assert_eq!(entries.len(), 2);
+        assert_eq!(entries[0].title, "Chapter One");
+        assert_eq!(entries[1].title, "Chapter Two");
+    }
+
+    #[test]
+    fn parse_toc_nav_nested_entries() {
+        let toc = parse_toc(NAV, "OEBPS/nav.xhtml").unwrap();
+        let entries = toc.into_entries();
+        assert_eq!(entries[1].children.len(), 1);
+        assert_eq!(entries[1].children[0].title, "Section 2.1");
+    }
+
+    #[test]
+    fn parse_toc_malformed_xml_returns_none() {
+        assert!(parse_toc("<bad", "toc.ncx").is_none());
+    }
+}

--- a/crates/core/src/document/epub/opf.rs
+++ b/crates/core/src/document/epub/opf.rs
@@ -79,6 +79,23 @@ impl OpfDocument {
         })
     }
 
+    /// Returns an empty `OpfDocument` with no manifest, spine, or metadata.
+    ///
+    /// Used in tests that construct a stub [`super::EpubDocument`] without a
+    /// real OPF file.
+    #[cfg(test)]
+    pub fn empty() -> Self {
+        OpfDocument {
+            manifest: Vec::new(),
+            spine_idrefs: Vec::new(),
+            spine_toc_id: None,
+            dc_metadata: HashMap::new(),
+            cover_href: None,
+            series: None,
+            categories: BTreeSet::new(),
+        }
+    }
+
     /// Returns the `idref` values of all `<itemref>` children of `<spine>`,
     /// together with the `<spine toc="...">` attribute value if present.
     pub fn spine_idrefs(&self) -> (&[String], Option<&str>) {

--- a/crates/core/src/document/html/dom.rs
+++ b/crates/core/src/document/html/dom.rs
@@ -337,6 +337,8 @@ impl XmlTree {
         }
     }
 
+    // TODO(OGKevin): determine if this is actually still needed
+    //                with the move to external parser.
     pub fn wrap_lost_inlines(&mut self) {
         self.promote_blockish_inlines();
 

--- a/crates/core/src/document/html/html5.rs
+++ b/crates/core/src/document/html/html5.rs
@@ -3,13 +3,6 @@
 //! This module exposes a single public type, [`Html5Document`], which wraps
 //! the shared [`HtmlBase`] rendering pipeline and uses [`parse_html5`] to
 //! build the document tree.
-//!
-//! Use [`Html5Document`] when HTML5 conformance matters more than offset
-//! precision — for example, the dictionary view, which renders content from
-//! third-party dictionaries that may contain entities, void elements, and
-//! implicitly-closed tags. Because node offsets are synthetic (not byte
-//! positions), reading positions must **not** be persisted when using this
-//! type.
 
 use super::HtmlBase;
 use super::layout::TextAlign;
@@ -28,13 +21,10 @@ const USER_STYLESHEET: &str = "css/dictionary-user.css";
 /// HTML document backed by the html5ever spec-compliant parser.
 ///
 /// Handles HTML entities, void elements (`<br>`, `<img>`), and implicitly-
-/// closed block tags correctly per the HTML5 spec. Node offsets are **synthetic**
-/// (not byte positions in the source), so this type is **not** suitable for
-/// persisting reading positions to disk. Use it for ephemeral rendering such
-/// as the dictionary view.
-///
-/// For documents where offset accuracy matters (EPUB spine chapters, standalone
-/// HTML files) use [`HtmlDocument`](super::HtmlDocument) instead.
+/// closed block tags correctly per the HTML5 spec. Node offsets are
+/// byte-accurate source positions supplied by the `source-positions` feature
+/// of `html5ever`, matching those produced by [`XmlParser`](super::xml::XmlParser)
+/// for the same input.
 pub struct Html5Document {
     /// Shared rendering state (tree, engine, page cache, stylesheets).
     pub(super) base: HtmlBase,
@@ -52,7 +42,8 @@ impl Html5Document {
     /// [`set_user_stylesheet`](Self::set_user_stylesheet) to override them.
     #[cfg_attr(feature = "tracing", tracing::instrument(skip(text), fields(len = text.len())))]
     pub fn new_from_memory(text: &str, install_dir: &Path) -> Html5Document {
-        let content = parse_html5(text);
+        let mut content = parse_html5(text);
+        content.wrap_lost_inlines();
         Html5Document {
             base: HtmlBase::new(
                 content,
@@ -70,7 +61,9 @@ impl Html5Document {
     #[cfg_attr(feature = "tracing", tracing::instrument(skip(self, text), fields(len = text.len())))]
     pub fn update(&mut self, text: &str) {
         self.base.size = text.len();
-        self.base.content = parse_html5(text);
+        let mut content = parse_html5(text);
+        content.wrap_lost_inlines();
+        self.base.content = content;
         self.base.pages.clear();
     }
 

--- a/crates/core/src/document/html/mod.rs
+++ b/crates/core/src/document/html/mod.rs
@@ -3,14 +3,13 @@
 //! This module provides two concrete document types that share a common
 //! rendering pipeline through [`HtmlBase`]:
 //!
-//! - [`HtmlDocument`] — backed by the hand-rolled [`XmlParser`]. Node offsets
-//!   are exact byte positions in the source string, which is required when
-//!   reading positions, bookmarks, and annotations are persisted to disk.
-//!   Used for standalone HTML files and EPUB spine chapters.
+//! - [`HtmlDocument`] — backed by the html5ever parser. Node offsets are
+//!   byte-accurate source positions, which is required when reading positions,
+//!   bookmarks, and annotations are persisted to disk. Used for standalone
+//!   HTML files and EPUB spine chapters.
 //!
-//! - [`Html5Document`] — backed by html5ever. Node offsets are synthetic.
-//!   Used for ephemeral rendering (e.g. the dictionary view) where HTML5
-//!   conformance matters more than offset precision.
+//! - [`Html5Document`] — also backed by html5ever. Used for ephemeral
+//!   rendering where no positions are persisted (e.g. the dictionary view).
 //!
 //! The shared [`HtmlBase`] struct holds the parsed [`XmlTree`], the layout
 //! [`Engine`], the page cache, and stylesheet paths. Both document types
@@ -33,7 +32,7 @@ use self::engine::{Engine, Page, ResourceFetcher};
 use self::layout::{DrawCommand, ImageCommand, TextAlign, TextCommand};
 use self::layout::{DrawState, LoopContext, RootData, StyleData};
 use self::style::StyleSheet;
-use self::xml::XmlParser;
+use self::xml::parse_html5;
 use crate::document::{BoundedText, Document, Location, TextLocation, TocEntry};
 use crate::framebuffer::Pixmap;
 use crate::geom::{Boundary, CycleDir, Edge};
@@ -456,11 +455,11 @@ impl ResourceFetcher for PathBuf {
     }
 }
 
-/// HTML document backed by the hand-rolled [`XmlParser`].
+/// HTML document backed by html5ever.
 ///
-/// Node offsets are exact byte positions in the source string, making this
-/// suitable for EPUB spine chapters and standalone HTML files where reading
-/// positions are persisted to disk as absolute byte offsets.
+/// Node offsets are byte-accurate source positions, making this suitable for
+/// standalone HTML files where reading positions are persisted to disk as
+/// absolute byte offsets.
 pub struct HtmlDocument {
     /// The raw source text, retained so that [`Document::save`] can write it
     /// back to disk unchanged.
@@ -473,7 +472,7 @@ unsafe impl Send for HtmlDocument {}
 unsafe impl Sync for HtmlDocument {}
 
 impl HtmlDocument {
-    /// Opens the file at `path`, parses it with [`XmlParser`], and returns a
+    /// Opens the file at `path`, parses it with html5ever, and returns a
     /// ready-to-render document.
     #[cfg_attr(feature = "tracing", tracing::instrument(skip(path), fields(path = %path.as_ref().display())))]
     pub fn new<P: AsRef<Path>>(path: P, install_dir: &Path) -> Result<HtmlDocument, Error> {
@@ -481,7 +480,7 @@ impl HtmlDocument {
         let size = file.metadata()?.len() as usize;
         let mut text = String::new();
         file.read_to_string(&mut text)?;
-        let mut content = XmlParser::new(&text).parse();
+        let mut content = parse_html5(&text);
         content.wrap_lost_inlines();
         let parent = path.as_ref().parent().unwrap_or_else(|| Path::new(""));
 
@@ -505,7 +504,7 @@ impl HtmlDocument {
     #[cfg_attr(feature = "tracing", tracing::instrument(skip(text), fields(len = text.len())))]
     pub fn new_from_memory(text: &str, install_dir: &Path) -> HtmlDocument {
         let size = text.len();
-        let mut content = XmlParser::new(text).parse();
+        let mut content = parse_html5(text);
         content.wrap_lost_inlines();
 
         HtmlDocument {
@@ -526,8 +525,9 @@ impl HtmlDocument {
     #[cfg_attr(feature = "tracing", tracing::instrument(skip(self, text), fields(len = text.len())))]
     pub fn update(&mut self, text: &str) {
         self.base.size = text.len();
-        self.base.content = XmlParser::new(text).parse();
-        self.base.content.wrap_lost_inlines();
+        let mut content = parse_html5(text);
+        content.wrap_lost_inlines();
+        self.base.content = content;
         self.text = text.to_string();
         self.base.pages.clear();
     }

--- a/crates/core/src/document/html/style.rs
+++ b/crates/core/src/document/html/style.rs
@@ -227,12 +227,12 @@ fn expand_and_insert(name: &str, value: &str, props: &mut PropertyMap) {
 #[cfg(test)]
 mod tests {
     use super::super::css::CssParser;
-    use super::super::xml::XmlParser;
+    use super::super::xml::parse_html5;
     use super::specified_values;
 
     #[test]
     fn comma_selector_matches_ol() {
-        let xml = XmlParser::new("<ol><li>item</li></ol>").parse();
+        let xml = parse_html5("<ol><li>item</li></ol>");
         let mut css = CssParser::new("ul, ol { margin-left: 1.5em }").parse();
         css.sort();
         let ol = xml.root().find("ol").unwrap();
@@ -246,8 +246,8 @@ mod tests {
 
     #[test]
     fn simple_style() {
-        let xml1 = XmlParser::new("<a class='c x y' style='c: 7'/>").parse();
-        let xml2 = XmlParser::new("<a id='e' class='x y'/>").parse();
+        let xml1 = parse_html5("<a class='c x y' style='c: 7'></a>");
+        let xml2 = parse_html5("<a id='e' class='x y'></a>");
         let mut css = CssParser::new(
             "a { b: 23 }\
                                       .c.x.y { b: 6; c: 3 }\

--- a/crates/core/src/document/html/xml.rs
+++ b/crates/core/src/document/html/xml.rs
@@ -1,24 +1,21 @@
-//! HTML and XML parsers that produce an [`XmlTree`].
+//! HTML parser and associated utilities that produce an [`XmlTree`].
 //!
-//! Two parsers are provided, each suited to a different use-case:
+//! **Production code** should always use [`parse_html5`] to parse HTML content.
+//! It handles entities, void elements, and the full HTML5 error-recovery
+//! algorithm. Node offsets are byte-accurate source positions supplied by the
+//! `source-positions` feature on the `html5ever` crate.
 //!
-//! - [`XmlParser`] — a hand-rolled recursive-descent parser. Node offsets are
-//!   exact byte positions of each token in the source string. Use this wherever
-//!   reading positions need to be persisted to disk (EPUB spine chapters,
-//!   standalone HTML files).
-//!
-//! - [`parse_html5`] — a thin wrapper around `html5ever`. Handles entities,
-//!   void elements, and the full HTML5 error-recovery algorithm. Node offsets
-//!   are **synthetic** (a monotonically increasing counter, not source
-//!   positions). Use this for ephemeral rendering where offset precision is
-//!   not required (e.g. the dictionary view).
+//! [`XmlParser`] is only compiled in **test builds** (`#[cfg(test)]`). It is
+//! retained exclusively for parity tests that compare its output against
+//! `parse_html5` to validate byte-offset equivalence. Do not use it in
+//! production code.
 
 use super::dom::{Attributes, NodeId, XmlTree, element, text, whitespace};
 use fxhash::FxHashMap;
 use html5ever::tendril::{Tendril, TendrilSink};
 use html5ever::tree_builder::{ElementFlags, NodeOrText, QuirksMode, TreeSink};
 use html5ever::{Attribute, QualName};
-use std::cell::{Ref, RefCell};
+use std::cell::{Cell, Ref, RefCell};
 
 /// Extension trait that adds XML whitespace detection to [`char`].
 pub trait XmlExt {
@@ -35,14 +32,15 @@ impl XmlExt for char {
 
 /// Hand-rolled recursive-descent parser for XML and basic HTML documents.
 ///
+/// **Only available in test builds.** Production code uses [`parse_html5`] for
+/// HTML content and `roxmltree` (via `epub::opf`) for XML metadata files.
+/// This parser is retained solely for parity tests that compare its output
+/// against `parse_html5` to validate byte-offset equivalence.
+///
 /// Produces an [`XmlTree`] where every node's `offset` field is the exact byte
 /// position of the opening `<` (elements) or first character (text nodes) in
-/// `input`. This byte-accuracy is required when reading positions are
-/// persisted across sessions.
-///
-/// The parser is intentionally lenient: unknown tags, processing instructions,
-/// and CDATA sections are skipped silently. Self-closing tags (`<br/>`,
-/// `<img/>`) are supported.
+/// `input`.
+#[cfg(test)]
 #[derive(Debug)]
 pub struct XmlParser<'a> {
     /// The full source string being parsed.
@@ -51,6 +49,7 @@ pub struct XmlParser<'a> {
     pub offset: usize,
 }
 
+#[cfg(test)]
 impl<'a> XmlParser<'a> {
     /// Creates a new parser positioned at the start of `input`.
     pub fn new(input: &str) -> XmlParser<'_> {
@@ -229,11 +228,12 @@ impl<'a> XmlParser<'a> {
 /// [`TreeSink`] implementation that bridges html5ever's push-based API into
 /// an [`XmlTree`].
 ///
-/// Node offsets are assigned from a monotonically increasing counter rather
-/// than from source byte positions, because html5ever's `TreeSink` callbacks
-/// do not receive source positions. The counter advances by 1 per element and
-/// by `text.len()` per text chunk, preserving the non-overlap invariant needed
-/// by the layout engine's page-finding binary search.
+/// Node offsets are byte-accurate source positions supplied by
+/// [`TreeSink::set_current_byte`], which html5ever calls before every tree
+/// mutation when the `source-positions` feature is enabled on the `html5ever`
+/// crate. This makes offsets stable and comparable to those produced by
+/// [`XmlParser`], enabling html5ever-parsed documents to be used wherever
+/// persisted byte offsets are required (EPUB spine, bookmarks, annotations).
 struct Html5Sink {
     /// The tree being built. `RefCell` is required because multiple `TreeSink`
     /// methods need mutable access and Rust's borrow checker cannot see that
@@ -245,32 +245,20 @@ struct Html5Sink {
     /// Maps `<template>` element `NodeId`s to their associated content root
     /// `NodeId`, as required by the HTML5 template element spec.
     template_contents: RefCell<FxHashMap<NodeId, NodeId>>,
-    /// Synthetic position counter. Incremented for every node created so that
-    /// all offsets are unique and ordered by document position.
-    offset_counter: RefCell<usize>,
+    /// Byte offset of the most recent token in the source string, forwarded
+    /// from the tokenizer via [`TreeSink::set_current_byte`].
+    current_byte: Cell<usize>,
 }
 
 impl Html5Sink {
-    /// Creates a new sink with an empty tree and a zeroed offset counter.
+    /// Creates a new sink with an empty tree and a zeroed byte offset.
     fn new() -> Self {
         Html5Sink {
             tree: RefCell::new(XmlTree::new()),
             qual_names: RefCell::new(FxHashMap::default()),
             template_contents: RefCell::new(FxHashMap::default()),
-            offset_counter: RefCell::new(0),
+            current_byte: Cell::new(0),
         }
-    }
-
-    /// Returns the current value of the offset counter without advancing it.
-    fn next_offset(&self) -> usize {
-        *self.offset_counter.borrow()
-    }
-
-    /// Advances the offset counter by `by`, clamped to a minimum of 1 to
-    /// guarantee that every node receives a strictly larger offset than the
-    /// previous one even for zero-length text runs.
-    fn advance_offset(&self, by: usize) {
-        *self.offset_counter.borrow_mut() += by.max(1);
     }
 
     /// Returns `true` when `text` contains only ASCII whitespace characters.
@@ -296,6 +284,45 @@ impl Html5Sink {
         }
         attributes
     }
+
+    /// Creates text or whitespace node data for a text callback.
+    fn text_data(text_str: &str, offset: usize) -> super::dom::NodeData {
+        if Self::is_whitespace_only(text_str) {
+            return whitespace(text_str, offset);
+        }
+
+        text(text_str, offset)
+    }
+
+    /// Appends text while preserving source offset gaps around entities.
+    fn append_text_segment(&self, parent: &NodeId, text_str: &str, offset: usize) {
+        let last_child_id = self
+            .tree
+            .borrow()
+            .get(*parent)
+            .last_child()
+            .filter(|n| n.tag_name().is_none() && !n.text().is_empty())
+            .map(|n| n.id);
+
+        if let Some(last_id) = last_child_id {
+            let expected_offset = {
+                let tree = self.tree.borrow();
+                let last = tree.get(last_id);
+                last.offset() + last.text().len()
+            };
+
+            if offset == expected_offset {
+                self.tree.borrow_mut().append_text_to(last_id, text_str);
+                return;
+            }
+        }
+
+        let node_id = self
+            .tree
+            .borrow_mut()
+            .push_node(Self::text_data(text_str, offset));
+        self.tree.borrow_mut().attach_child(*parent, node_id);
+    }
 }
 
 impl TreeSink for Html5Sink {
@@ -305,6 +332,10 @@ impl TreeSink for Html5Sink {
 
     fn finish(self) -> Self::Output {
         self.tree.into_inner()
+    }
+
+    fn set_current_byte(&self, byte_offset: u64) {
+        self.current_byte.set(byte_offset as usize);
     }
 
     /// Silently ignores all parse errors. The dictionary content from
@@ -322,8 +353,8 @@ impl TreeSink for Html5Sink {
         })
     }
 
-    /// Creates a new element node, assigns it the next synthetic offset, and
-    /// registers its qualified name for later `elem_name` lookups.
+    /// Creates a new element node, assigns it the current source byte offset,
+    /// and registers its qualified name for later `elem_name` lookups.
     ///
     /// For `<template>` elements an additional content-root node is created
     /// and stored in `template_contents`, as required by the spec.
@@ -334,19 +365,16 @@ impl TreeSink for Html5Sink {
         flags: ElementFlags,
     ) -> Self::Handle {
         let tag_name = name.local.as_ref();
-        let offset = self.next_offset();
-        self.advance_offset(1);
+        let offset = self.current_byte.get();
         let attributes = Self::build_attributes(attrs);
         let data = element(tag_name, offset, attributes);
         let id = self.tree.borrow_mut().push_node(data);
         self.qual_names.borrow_mut().insert(id, name.clone());
 
         if flags.template {
-            let template_root_offset = self.next_offset();
-            self.advance_offset(1);
             let template_root = element(
                 "template-contents",
-                template_root_offset,
+                self.current_byte.get(),
                 Attributes::default(),
             );
             let template_id = self.tree.borrow_mut().push_node(template_root);
@@ -356,26 +384,21 @@ impl TreeSink for Html5Sink {
         id
     }
 
-    /// Maps an HTML comment to an empty whitespace node so it occupies a slot
-    /// in the offset space without contributing visible content.
+    /// Maps an HTML comment to an empty whitespace node at the current source
+    /// byte offset without contributing visible content.
     fn create_comment(&self, _text: Tendril<html5ever::tendril::fmt::UTF8>) -> Self::Handle {
-        let offset = self.next_offset();
-        self.advance_offset(1);
-        let data = whitespace("", offset);
+        let data = whitespace("", self.current_byte.get());
         self.tree.borrow_mut().push_node(data)
     }
 
-    /// Maps a processing instruction to an empty whitespace node so it
-    /// occupies a slot in the offset space without contributing visible
-    /// content.
+    /// Maps a processing instruction to an empty whitespace node at the
+    /// current source byte offset without contributing visible content.
     fn create_pi(
         &self,
         _target: Tendril<html5ever::tendril::fmt::UTF8>,
         _data: Tendril<html5ever::tendril::fmt::UTF8>,
     ) -> Self::Handle {
-        let offset = self.next_offset();
-        self.advance_offset(1);
-        let data = whitespace("", offset);
+        let data = whitespace("", self.current_byte.get());
         self.tree.borrow_mut().push_node(data)
     }
 
@@ -383,7 +406,9 @@ impl TreeSink for Html5Sink {
     ///
     /// Text runs are coalesced into the preceding sibling text node when one
     /// exists, to match the behaviour of the hand-rolled parser and avoid
-    /// producing redundant nodes for adjacent text chunks.
+    /// producing redundant nodes for adjacent text chunks. When coalescing,
+    /// the first node's byte offset is preserved — it marks where the text
+    /// content started in the source.
     fn append(&self, parent: &Self::Handle, child: NodeOrText<Self::Handle>) {
         match child {
             NodeOrText::AppendNode(node) => {
@@ -391,28 +416,7 @@ impl TreeSink for Html5Sink {
             }
             NodeOrText::AppendText(t) => {
                 let text_str = t.as_ref();
-                let last_child_id = self
-                    .tree
-                    .borrow()
-                    .get(*parent)
-                    .last_child()
-                    .filter(|n| n.tag_name().is_none() && !n.text().is_empty())
-                    .map(|n| n.id);
-
-                if let Some(last_id) = last_child_id {
-                    self.advance_offset(text_str.len());
-                    self.tree.borrow_mut().append_text_to(last_id, text_str);
-                } else {
-                    let offset = self.next_offset();
-                    self.advance_offset(text_str.len());
-                    let data = if Self::is_whitespace_only(text_str) {
-                        whitespace(text_str, offset)
-                    } else {
-                        text(text_str, offset)
-                    };
-                    let node_id = self.tree.borrow_mut().push_node(data);
-                    self.tree.borrow_mut().attach_child(*parent, node_id);
-                }
+                self.append_text_segment(parent, text_str, self.current_byte.get());
             }
         }
     }
@@ -444,14 +448,10 @@ impl TreeSink for Html5Sink {
             }
             NodeOrText::AppendText(t) => {
                 let text_str = t.as_ref();
-                let offset = self.next_offset();
-                self.advance_offset(text_str.len());
-                let data = if Self::is_whitespace_only(text_str) {
-                    whitespace(text_str, offset)
-                } else {
-                    text(text_str, offset)
-                };
-                let node_id = self.tree.borrow_mut().push_node(data);
+                let node_id = self
+                    .tree
+                    .borrow_mut()
+                    .push_node(Self::text_data(text_str, self.current_byte.get()));
                 self.tree.borrow_mut().insert_before(*sibling, node_id);
             }
         }
@@ -518,19 +518,21 @@ impl TreeSink for Html5Sink {
 /// - Implicitly-closed block tags (`<p>`, `<li>`, …) are auto-closed per spec.
 /// - Unclosed tags at EOF are closed automatically.
 ///
-/// **Offset semantics:** node offsets are synthetic (a monotonically
-/// increasing counter) and are **not** byte positions in the source string.
-/// This makes the tree unsuitable for persisting reading positions to disk.
-/// Use [`XmlParser`] when byte-accurate offsets are required.
+/// **Offset semantics:** node offsets are byte-accurate source positions
+/// supplied by the `source-positions` feature of the `html5ever` crate.
+/// Offsets for nodes that exist in both parsers' output are identical to those
+/// produced by [`XmlParser`].
+///
+/// The caller is responsible for calling [`XmlTree::wrap_lost_inlines`] on the
+/// returned tree if inline wrapping is required (it is for EPUB spine chapters
+/// and standalone HTML files, but not for all use cases).
 #[cfg_attr(feature = "tracing", tracing::instrument(skip(input), fields(len = input.len())))]
 pub fn parse_html5(input: &str) -> XmlTree {
     use html5ever::{ParseOpts, parse_document};
 
     let parser = parse_document(Html5Sink::new(), ParseOpts::default());
     let input_tendril: Tendril<html5ever::tendril::fmt::UTF8> = input.into();
-    let mut tree = parser.one(input_tendril);
-    tree.wrap_lost_inlines();
-    tree
+    parser.one(input_tendril)
 }
 
 #[cfg(test)]
@@ -538,45 +540,56 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_simple_element() {
-        let text = "<a/>";
-        let xml = XmlParser::new(text).parse();
-        let n = xml.root().first_child().unwrap();
-        assert_eq!(n.offset(), 0);
-        assert_eq!(n.tag_name(), Some("a"));
+    fn simple_element_has_correct_tag_name() {
+        let tree = parse_html5("<p></p>");
+        assert!(tree.root().find("p").is_some());
+        assert_eq!(tree.root().find("p").unwrap().tag_name(), Some("p"));
     }
 
     #[test]
-    fn test_attributes() {
-        let text = r#"<a b="c" d='e"'/>"#;
-        let xml = XmlParser::new(text).parse();
-        let n = xml.root().first_child().unwrap();
-        assert_eq!(n.attribute("b"), Some("c"));
-        assert_eq!(n.attribute("d"), Some("e\""));
+    fn simple_element_has_correct_offset() {
+        let tree = parse_html5("<p></p>");
+        let p = tree.root().find("p").unwrap();
+        assert_eq!(p.offset(), 0);
     }
 
     #[test]
-    fn test_text() {
+    fn attributes_double_and_single_quoted() {
+        let text = r#"<a b="c" d='e"'></a>"#;
+        let tree = parse_html5(text);
+        let a = tree.root().find("a").unwrap();
+        assert_eq!(a.attribute("b"), Some("c"));
+        assert_eq!(a.attribute("d"), Some("e\""));
+    }
+
+    #[test]
+    fn text_node_content_and_offset() {
         let text = "<a>bcd</a>";
-        let xml = XmlParser::new(text).parse();
-        let child = xml.root().first_child().unwrap().children().next();
-        assert_eq!(child.map(|c| c.offset()), Some(3));
+        let tree = parse_html5(text);
+        let a = tree.root().find("a").unwrap();
+        let child = a.children().find(|n| !n.text().is_empty());
         assert_eq!(child.map(|c| c.text()), Some("bcd".to_string()));
+        assert_eq!(child.map(|c| c.offset()), Some(3));
     }
 
     #[test]
-    fn test_inbetween_space() {
-        let text = "<a><b>x</b> <c>y</c></a>";
-        let xml = XmlParser::new(text).parse();
-        let child = xml.root().first_child().unwrap().children().nth(1);
-        assert_eq!(child.map(|c| c.text()), Some(" ".to_string()));
+    fn whitespace_text_node_preserved_between_inline_siblings() {
+        let text = "<p><b>x</b> <i>y</i></p>";
+        let tree = parse_html5(text);
+        let p = tree.root().find("p").unwrap();
+        let space_node = p.children().find(|n| n.text() == " ");
+        assert!(
+            space_node.is_some(),
+            "whitespace text node should be preserved between inline siblings"
+        );
     }
 
     #[test]
-    fn test_central_space() {
-        let text = "<a><b> </b></a>";
-        let xml = XmlParser::new(text).parse();
-        assert_eq!(xml.root().text(), " ");
+    fn whitespace_text_inside_element_accessible_via_tree_text() {
+        let text = "<p><span> </span></p>";
+        let tree = parse_html5(text);
+        let span = tree.root().find("span").unwrap();
+        assert_eq!(span.text(), " ");
     }
 
     #[test]
@@ -586,12 +599,106 @@ mod tests {
         assert!(xml.root().find("br").is_some());
     }
 
+    /// XHTML EPUB content frequently uses self-closing syntax on RCDATA/RAWTEXT
+    /// elements (`<title/>`, `<style/>`). Without the `xhtml-self-closing`
+    /// feature, html5ever treats `<title>` as opening a RCDATA region that
+    /// swallows the rest of the document, leaving the `<body>` empty. With the
+    /// feature, the self-closing flag is honoured and the body parses normally.
+    #[test]
+    fn html5_self_closing_title_does_not_swallow_body() {
+        let text = concat!(
+            "<html><head><title/></head>",
+            "<body><p>visible</p></body></html>",
+        );
+        let tree = parse_html5(text);
+        let body = tree.root().find("body").expect("body should exist");
+        let p = body
+            .descendants()
+            .find(|n| n.tag_name() == Some("p"))
+            .expect("body paragraph should not be swallowed by <title/>");
+        assert_eq!(p.text(), "visible");
+    }
+
+    /// A self-closing `<style/>` must likewise not swallow following content.
+    #[test]
+    fn html5_self_closing_style_does_not_swallow_body() {
+        let text = concat!(
+            "<html><head><style/></head>",
+            "<body><p>visible</p></body></html>",
+        );
+        let tree = parse_html5(text);
+        let p = tree
+            .root()
+            .find("body")
+            .and_then(|b| b.descendants().find(|n| n.tag_name() == Some("p")))
+            .expect("body paragraph should not be swallowed by <style/>");
+        assert_eq!(p.text(), "visible");
+    }
+
+    /// A normally-closed `<title>…</title>` still captures its text content as
+    /// an RCDATA region, unaffected by the self-closing handling.
+    #[test]
+    fn html5_normal_title_still_parses_as_rcdata() {
+        let text = "<html><head><title>My Book</title></head><body></body></html>";
+        let tree = parse_html5(text);
+        let title = tree.root().find("title").expect("title should exist");
+        assert_eq!(title.text(), "My Book");
+    }
+
     #[test]
     fn html5_entity_decoding() {
         let text = "<p>hello&amp;world</p>";
         let xml = parse_html5(text);
         let p = xml.root().find("p").unwrap();
         assert_eq!(p.text(), "hello&world");
+    }
+
+    #[test]
+    fn html5_entity_text_offsets_preserve_source_positions() {
+        let text = "<p>a&amp;b</p>";
+        let xml = parse_html5(text);
+        let p = xml.root().find("p").unwrap();
+        let text_nodes: Vec<_> = p
+            .children()
+            .filter(|n| n.tag_name().is_none() && !n.text().is_empty())
+            .map(|n| (n.text(), n.offset()))
+            .collect();
+
+        assert_eq!(
+            text_nodes,
+            vec![("a&".to_string(), 3), ("b".to_string(), 9),]
+        );
+    }
+
+    #[test]
+    fn html5_text_after_entity_can_match_entity_name() {
+        let text = "<p>a&amp;a</p>";
+        let xml = parse_html5(text);
+        let p = xml.root().find("p").unwrap();
+        let text_nodes: Vec<_> = p
+            .children()
+            .filter(|n| n.tag_name().is_none() && !n.text().is_empty())
+            .map(|n| (n.text(), n.offset()))
+            .collect();
+
+        assert_eq!(
+            text_nodes,
+            vec![("a&".to_string(), 3), ("a".to_string(), 9),]
+        );
+    }
+
+    #[test]
+    fn html5_adjacent_text_without_source_gap_is_coalesced() {
+        let text = "<p>abc</p>";
+        let xml = parse_html5(text);
+        let p = xml.root().find("p").unwrap();
+        let text_nodes: Vec<_> = p
+            .children()
+            .filter(|n| n.tag_name().is_none() && !n.text().is_empty())
+            .map(|n| (n.text(), n.offset()))
+            .collect();
+
+        assert_eq!(text_nodes, vec![("abc".to_string(), 3)]);
     }
 
     #[test]
@@ -719,5 +826,128 @@ mod tests {
                 offset_b
             );
         }
+    }
+
+    /// Collect `(tag_name, offset)` for every element in the tree, skipping
+    /// implicit wrapper tags that html5ever inserts but XmlParser does not
+    /// (`html`, `head`, `body`, `anonymous`).
+    fn element_offsets(tree: &XmlTree) -> Vec<(String, usize)> {
+        tree.root()
+            .descendants()
+            .filter_map(|n| {
+                n.tag_name().and_then(|name| {
+                    if matches!(name, "html" | "head" | "body" | "anonymous") {
+                        None
+                    } else {
+                        Some((name.to_string(), n.offset()))
+                    }
+                })
+            })
+            .collect()
+    }
+
+    /// Collect `(parent_tag, first_text_offset, concatenated_text)` for every
+    /// element that has at least one text-node child. The offset is that of
+    /// the first text child; the text is all text children concatenated. This
+    /// lets us compare text content and positions without being sensitive to
+    /// how each parser splits text runs.
+    fn text_first_offsets(tree: &XmlTree) -> Vec<(String, usize, String)> {
+        tree.root()
+            .descendants()
+            .filter_map(|n| {
+                let tag = n.tag_name()?;
+                if matches!(tag, "html" | "head" | "body" | "anonymous") {
+                    return None;
+                }
+                let text_children: Vec<_> = n
+                    .children()
+                    .filter(|c| c.tag_name().is_none() && !c.text().is_empty())
+                    .collect();
+                if text_children.is_empty() {
+                    return None;
+                }
+                let first_offset = text_children[0].offset();
+                let full_text: String = text_children.iter().map(|c| c.text()).collect();
+                Some((tag.to_string(), first_offset, full_text))
+            })
+            .collect()
+    }
+
+    #[test]
+    fn parity_simple_element() {
+        let src = "<p>hello</p>";
+        let xml = element_offsets(&XmlParser::new(src).parse());
+        let h5 = element_offsets(&parse_html5(src));
+        assert_eq!(xml, h5, "element offsets differ for {:?}", src);
+    }
+
+    #[test]
+    fn parity_nested_elements() {
+        let src = "<div><p>text</p></div>";
+        let xml = element_offsets(&XmlParser::new(src).parse());
+        let h5 = element_offsets(&parse_html5(src));
+        assert_eq!(xml, h5, "element offsets differ for {:?}", src);
+    }
+
+    #[test]
+    fn parity_adjacent_text_and_element() {
+        let src = "<p><em>A</em> B</p>";
+        let xml = element_offsets(&XmlParser::new(src).parse());
+        let h5 = element_offsets(&parse_html5(src));
+        assert_eq!(xml, h5, "element offsets differ for {:?}", src);
+    }
+
+    #[test]
+    fn parity_text_first_offset_simple() {
+        let src = "<p>hello</p>";
+        let xml = text_first_offsets(&XmlParser::new(src).parse());
+        let h5 = text_first_offsets(&parse_html5(src));
+        assert_eq!(xml, h5, "text offsets differ for {:?}", src);
+    }
+
+    #[test]
+    fn parity_text_first_offset_nested() {
+        let src = "<p><em>A</em> B</p>";
+        let xml = text_first_offsets(&XmlParser::new(src).parse());
+        let h5 = text_first_offsets(&parse_html5(src));
+        assert_eq!(xml, h5, "text offsets differ for {:?}", src);
+    }
+
+    #[test]
+    fn parity_multibyte_utf8() {
+        // 'é' encodes as 2 bytes (0xC3 0xA9); offset of "café" must be the
+        // byte position of 'c', not the char index.
+        let src = "<p>café</p>";
+        let xml = text_first_offsets(&XmlParser::new(src).parse());
+        let h5 = text_first_offsets(&parse_html5(src));
+        assert_eq!(xml, h5, "text offsets differ for {:?}", src);
+    }
+
+    #[test]
+    fn parity_sequential_siblings() {
+        let src = "<h1>Title</h1><p>Body</p>";
+        let xml = element_offsets(&XmlParser::new(src).parse());
+        let h5 = element_offsets(&parse_html5(src));
+        assert_eq!(xml, h5, "element offsets differ for {:?}", src);
+    }
+
+    #[test]
+    fn parity_sequential_siblings_text() {
+        let src = "<h1>Title</h1><p>Body</p>";
+        let xml = text_first_offsets(&XmlParser::new(src).parse());
+        let h5 = text_first_offsets(&parse_html5(src));
+        assert_eq!(xml, h5, "text offsets differ for {:?}", src);
+    }
+
+    #[test]
+    fn parity_deep_offset_accumulation() {
+        let src = "<article><section><div><p>deep text</p></div></section></article>";
+        let xml_el = element_offsets(&XmlParser::new(src).parse());
+        let h5_el = element_offsets(&parse_html5(src));
+        assert_eq!(xml_el, h5_el, "element offsets differ for {:?}", src);
+
+        let xml_tx = text_first_offsets(&XmlParser::new(src).parse());
+        let h5_tx = text_first_offsets(&parse_html5(src));
+        assert_eq!(xml_tx, h5_tx, "text offsets differ for {:?}", src);
     }
 }

--- a/crates/core/src/document/html/xml.rs
+++ b/crates/core/src/document/html/xml.rs
@@ -1,24 +1,21 @@
-//! HTML and XML parsers that produce an [`XmlTree`].
+//! HTML parser and associated utilities that produce an [`XmlTree`].
 //!
-//! Two parsers are provided, each suited to a different use-case:
+//! **Production code** should always use [`parse_html5`] to parse HTML content.
+//! It handles entities, void elements, and the full HTML5 error-recovery
+//! algorithm. Node offsets are byte-accurate source positions supplied by the
+//! `source-positions` feature on the `html5ever` crate.
 //!
-//! - [`XmlParser`] — a hand-rolled recursive-descent parser. Node offsets are
-//!   exact byte positions of each token in the source string. Use this wherever
-//!   reading positions need to be persisted to disk (EPUB spine chapters,
-//!   standalone HTML files).
-//!
-//! - [`parse_html5`] — a thin wrapper around `html5ever`. Handles entities,
-//!   void elements, and the full HTML5 error-recovery algorithm. Node offsets
-//!   are **synthetic** (a monotonically increasing counter, not source
-//!   positions). Use this for ephemeral rendering where offset precision is
-//!   not required (e.g. the dictionary view).
+//! [`XmlParser`] is only compiled in **test builds** (`#[cfg(test)]`). It is
+//! retained exclusively for parity tests that compare its output against
+//! `parse_html5` to validate byte-offset equivalence. Do not use it in
+//! production code.
 
 use super::dom::{Attributes, NodeId, XmlTree, element, text, whitespace};
 use html5ever::tendril::{Tendril, TendrilSink};
 use html5ever::tree_builder::{ElementFlags, NodeOrText, QuirksMode, TreeSink};
 use html5ever::{Attribute, QualName};
 use rustc_hash::FxHashMap;
-use std::cell::{Ref, RefCell};
+use std::cell::{Cell, Ref, RefCell};
 
 /// Extension trait that adds XML whitespace detection to [`char`].
 pub trait XmlExt {
@@ -35,14 +32,15 @@ impl XmlExt for char {
 
 /// Hand-rolled recursive-descent parser for XML and basic HTML documents.
 ///
+/// **Only available in test builds.** Production code uses [`parse_html5`] for
+/// HTML content and `roxmltree` (via `epub::opf`) for XML metadata files.
+/// This parser is retained solely for parity tests that compare its output
+/// against `parse_html5` to validate byte-offset equivalence.
+///
 /// Produces an [`XmlTree`] where every node's `offset` field is the exact byte
 /// position of the opening `<` (elements) or first character (text nodes) in
-/// `input`. This byte-accuracy is required when reading positions are
-/// persisted across sessions.
-///
-/// The parser is intentionally lenient: unknown tags, processing instructions,
-/// and CDATA sections are skipped silently. Self-closing tags (`<br/>`,
-/// `<img/>`) are supported.
+/// `input`.
+#[cfg(test)]
 #[derive(Debug)]
 pub struct XmlParser<'a> {
     /// The full source string being parsed.
@@ -51,6 +49,7 @@ pub struct XmlParser<'a> {
     pub offset: usize,
 }
 
+#[cfg(test)]
 impl<'a> XmlParser<'a> {
     /// Creates a new parser positioned at the start of `input`.
     pub fn new(input: &str) -> XmlParser<'_> {
@@ -229,11 +228,12 @@ impl<'a> XmlParser<'a> {
 /// [`TreeSink`] implementation that bridges html5ever's push-based API into
 /// an [`XmlTree`].
 ///
-/// Node offsets are assigned from a monotonically increasing counter rather
-/// than from source byte positions, because html5ever's `TreeSink` callbacks
-/// do not receive source positions. The counter advances by 1 per element and
-/// by `text.len()` per text chunk, preserving the non-overlap invariant needed
-/// by the layout engine's page-finding binary search.
+/// Node offsets are byte-accurate source positions supplied by
+/// [`TreeSink::set_current_byte`], which html5ever calls before every tree
+/// mutation when the `source-positions` feature is enabled on the `html5ever`
+/// crate. This makes offsets stable and comparable to those produced by
+/// [`XmlParser`], enabling html5ever-parsed documents to be used wherever
+/// persisted byte offsets are required (EPUB spine, bookmarks, annotations).
 struct Html5Sink {
     /// The tree being built. `RefCell` is required because multiple `TreeSink`
     /// methods need mutable access and Rust's borrow checker cannot see that
@@ -245,32 +245,20 @@ struct Html5Sink {
     /// Maps `<template>` element `NodeId`s to their associated content root
     /// `NodeId`, as required by the HTML5 template element spec.
     template_contents: RefCell<FxHashMap<NodeId, NodeId>>,
-    /// Synthetic position counter. Incremented for every node created so that
-    /// all offsets are unique and ordered by document position.
-    offset_counter: RefCell<usize>,
+    /// Byte offset of the most recent token in the source string, forwarded
+    /// from the tokenizer via [`TreeSink::set_current_byte`].
+    current_byte: Cell<usize>,
 }
 
 impl Html5Sink {
-    /// Creates a new sink with an empty tree and a zeroed offset counter.
+    /// Creates a new sink with an empty tree and a zeroed byte offset.
     fn new() -> Self {
         Html5Sink {
             tree: RefCell::new(XmlTree::new()),
             qual_names: RefCell::new(FxHashMap::default()),
             template_contents: RefCell::new(FxHashMap::default()),
-            offset_counter: RefCell::new(0),
+            current_byte: Cell::new(0),
         }
-    }
-
-    /// Returns the current value of the offset counter without advancing it.
-    fn next_offset(&self) -> usize {
-        *self.offset_counter.borrow()
-    }
-
-    /// Advances the offset counter by `by`, clamped to a minimum of 1 to
-    /// guarantee that every node receives a strictly larger offset than the
-    /// previous one even for zero-length text runs.
-    fn advance_offset(&self, by: usize) {
-        *self.offset_counter.borrow_mut() += by.max(1);
     }
 
     /// Returns `true` when `text` contains only ASCII whitespace characters.
@@ -296,6 +284,45 @@ impl Html5Sink {
         }
         attributes
     }
+
+    /// Creates text or whitespace node data for a text callback.
+    fn text_data(text_str: &str, offset: usize) -> super::dom::NodeData {
+        if Self::is_whitespace_only(text_str) {
+            return whitespace(text_str, offset);
+        }
+
+        text(text_str, offset)
+    }
+
+    /// Appends text while preserving source offset gaps around entities.
+    fn append_text_segment(&self, parent: &NodeId, text_str: &str, offset: usize) {
+        let last_child_id = self
+            .tree
+            .borrow()
+            .get(*parent)
+            .last_child()
+            .filter(|n| n.tag_name().is_none() && !n.text().is_empty())
+            .map(|n| n.id);
+
+        if let Some(last_id) = last_child_id {
+            let expected_offset = {
+                let tree = self.tree.borrow();
+                let last = tree.get(last_id);
+                last.offset() + last.text().len()
+            };
+
+            if offset == expected_offset {
+                self.tree.borrow_mut().append_text_to(last_id, text_str);
+                return;
+            }
+        }
+
+        let node_id = self
+            .tree
+            .borrow_mut()
+            .push_node(Self::text_data(text_str, offset));
+        self.tree.borrow_mut().attach_child(*parent, node_id);
+    }
 }
 
 impl TreeSink for Html5Sink {
@@ -305,6 +332,10 @@ impl TreeSink for Html5Sink {
 
     fn finish(self) -> Self::Output {
         self.tree.into_inner()
+    }
+
+    fn set_current_byte(&self, byte_offset: u64) {
+        self.current_byte.set(byte_offset as usize);
     }
 
     /// Silently ignores all parse errors. The dictionary content from
@@ -322,8 +353,8 @@ impl TreeSink for Html5Sink {
         })
     }
 
-    /// Creates a new element node, assigns it the next synthetic offset, and
-    /// registers its qualified name for later `elem_name` lookups.
+    /// Creates a new element node, assigns it the current source byte offset,
+    /// and registers its qualified name for later `elem_name` lookups.
     ///
     /// For `<template>` elements an additional content-root node is created
     /// and stored in `template_contents`, as required by the spec.
@@ -334,19 +365,16 @@ impl TreeSink for Html5Sink {
         flags: ElementFlags,
     ) -> Self::Handle {
         let tag_name = name.local.as_ref();
-        let offset = self.next_offset();
-        self.advance_offset(1);
+        let offset = self.current_byte.get();
         let attributes = Self::build_attributes(attrs);
         let data = element(tag_name, offset, attributes);
         let id = self.tree.borrow_mut().push_node(data);
         self.qual_names.borrow_mut().insert(id, name.clone());
 
         if flags.template {
-            let template_root_offset = self.next_offset();
-            self.advance_offset(1);
             let template_root = element(
                 "template-contents",
-                template_root_offset,
+                self.current_byte.get(),
                 Attributes::default(),
             );
             let template_id = self.tree.borrow_mut().push_node(template_root);
@@ -356,26 +384,21 @@ impl TreeSink for Html5Sink {
         id
     }
 
-    /// Maps an HTML comment to an empty whitespace node so it occupies a slot
-    /// in the offset space without contributing visible content.
+    /// Maps an HTML comment to an empty whitespace node at the current source
+    /// byte offset without contributing visible content.
     fn create_comment(&self, _text: Tendril<html5ever::tendril::fmt::UTF8>) -> Self::Handle {
-        let offset = self.next_offset();
-        self.advance_offset(1);
-        let data = whitespace("", offset);
+        let data = whitespace("", self.current_byte.get());
         self.tree.borrow_mut().push_node(data)
     }
 
-    /// Maps a processing instruction to an empty whitespace node so it
-    /// occupies a slot in the offset space without contributing visible
-    /// content.
+    /// Maps a processing instruction to an empty whitespace node at the
+    /// current source byte offset without contributing visible content.
     fn create_pi(
         &self,
         _target: Tendril<html5ever::tendril::fmt::UTF8>,
         _data: Tendril<html5ever::tendril::fmt::UTF8>,
     ) -> Self::Handle {
-        let offset = self.next_offset();
-        self.advance_offset(1);
-        let data = whitespace("", offset);
+        let data = whitespace("", self.current_byte.get());
         self.tree.borrow_mut().push_node(data)
     }
 
@@ -383,7 +406,9 @@ impl TreeSink for Html5Sink {
     ///
     /// Text runs are coalesced into the preceding sibling text node when one
     /// exists, to match the behaviour of the hand-rolled parser and avoid
-    /// producing redundant nodes for adjacent text chunks.
+    /// producing redundant nodes for adjacent text chunks. When coalescing,
+    /// the first node's byte offset is preserved — it marks where the text
+    /// content started in the source.
     fn append(&self, parent: &Self::Handle, child: NodeOrText<Self::Handle>) {
         match child {
             NodeOrText::AppendNode(node) => {
@@ -391,28 +416,7 @@ impl TreeSink for Html5Sink {
             }
             NodeOrText::AppendText(t) => {
                 let text_str = t.as_ref();
-                let last_child_id = self
-                    .tree
-                    .borrow()
-                    .get(*parent)
-                    .last_child()
-                    .filter(|n| n.tag_name().is_none() && !n.text().is_empty())
-                    .map(|n| n.id);
-
-                if let Some(last_id) = last_child_id {
-                    self.advance_offset(text_str.len());
-                    self.tree.borrow_mut().append_text_to(last_id, text_str);
-                } else {
-                    let offset = self.next_offset();
-                    self.advance_offset(text_str.len());
-                    let data = if Self::is_whitespace_only(text_str) {
-                        whitespace(text_str, offset)
-                    } else {
-                        text(text_str, offset)
-                    };
-                    let node_id = self.tree.borrow_mut().push_node(data);
-                    self.tree.borrow_mut().attach_child(*parent, node_id);
-                }
+                self.append_text_segment(parent, text_str, self.current_byte.get());
             }
         }
     }
@@ -444,14 +448,10 @@ impl TreeSink for Html5Sink {
             }
             NodeOrText::AppendText(t) => {
                 let text_str = t.as_ref();
-                let offset = self.next_offset();
-                self.advance_offset(text_str.len());
-                let data = if Self::is_whitespace_only(text_str) {
-                    whitespace(text_str, offset)
-                } else {
-                    text(text_str, offset)
-                };
-                let node_id = self.tree.borrow_mut().push_node(data);
+                let node_id = self
+                    .tree
+                    .borrow_mut()
+                    .push_node(Self::text_data(text_str, self.current_byte.get()));
                 self.tree.borrow_mut().insert_before(*sibling, node_id);
             }
         }
@@ -518,19 +518,21 @@ impl TreeSink for Html5Sink {
 /// - Implicitly-closed block tags (`<p>`, `<li>`, …) are auto-closed per spec.
 /// - Unclosed tags at EOF are closed automatically.
 ///
-/// **Offset semantics:** node offsets are synthetic (a monotonically
-/// increasing counter) and are **not** byte positions in the source string.
-/// This makes the tree unsuitable for persisting reading positions to disk.
-/// Use [`XmlParser`] when byte-accurate offsets are required.
+/// **Offset semantics:** node offsets are byte-accurate source positions
+/// supplied by the `source-positions` feature of the `html5ever` crate.
+/// Offsets for nodes that exist in both parsers' output are identical to those
+/// produced by [`XmlParser`].
+///
+/// The caller is responsible for calling [`XmlTree::wrap_lost_inlines`] on the
+/// returned tree if inline wrapping is required (it is for EPUB spine chapters
+/// and standalone HTML files, but not for all use cases).
 #[cfg_attr(feature = "tracing", tracing::instrument(skip(input), fields(len = input.len())))]
 pub fn parse_html5(input: &str) -> XmlTree {
     use html5ever::{ParseOpts, parse_document};
 
     let parser = parse_document(Html5Sink::new(), ParseOpts::default());
     let input_tendril: Tendril<html5ever::tendril::fmt::UTF8> = input.into();
-    let mut tree = parser.one(input_tendril);
-    tree.wrap_lost_inlines();
-    tree
+    parser.one(input_tendril)
 }
 
 #[cfg(test)]
@@ -538,45 +540,56 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_simple_element() {
-        let text = "<a/>";
-        let xml = XmlParser::new(text).parse();
-        let n = xml.root().first_child().unwrap();
-        assert_eq!(n.offset(), 0);
-        assert_eq!(n.tag_name(), Some("a"));
+    fn simple_element_has_correct_tag_name() {
+        let tree = parse_html5("<p></p>");
+        assert!(tree.root().find("p").is_some());
+        assert_eq!(tree.root().find("p").unwrap().tag_name(), Some("p"));
     }
 
     #[test]
-    fn test_attributes() {
-        let text = r#"<a b="c" d='e"'/>"#;
-        let xml = XmlParser::new(text).parse();
-        let n = xml.root().first_child().unwrap();
-        assert_eq!(n.attribute("b"), Some("c"));
-        assert_eq!(n.attribute("d"), Some("e\""));
+    fn simple_element_has_correct_offset() {
+        let tree = parse_html5("<p></p>");
+        let p = tree.root().find("p").unwrap();
+        assert_eq!(p.offset(), 0);
     }
 
     #[test]
-    fn test_text() {
+    fn attributes_double_and_single_quoted() {
+        let text = r#"<a b="c" d='e"'></a>"#;
+        let tree = parse_html5(text);
+        let a = tree.root().find("a").unwrap();
+        assert_eq!(a.attribute("b"), Some("c"));
+        assert_eq!(a.attribute("d"), Some("e\""));
+    }
+
+    #[test]
+    fn text_node_content_and_offset() {
         let text = "<a>bcd</a>";
-        let xml = XmlParser::new(text).parse();
-        let child = xml.root().first_child().unwrap().children().next();
-        assert_eq!(child.map(|c| c.offset()), Some(3));
+        let tree = parse_html5(text);
+        let a = tree.root().find("a").unwrap();
+        let child = a.children().find(|n| !n.text().is_empty());
         assert_eq!(child.map(|c| c.text()), Some("bcd".to_string()));
+        assert_eq!(child.map(|c| c.offset()), Some(3));
     }
 
     #[test]
-    fn test_inbetween_space() {
-        let text = "<a><b>x</b> <c>y</c></a>";
-        let xml = XmlParser::new(text).parse();
-        let child = xml.root().first_child().unwrap().children().nth(1);
-        assert_eq!(child.map(|c| c.text()), Some(" ".to_string()));
+    fn whitespace_text_node_preserved_between_inline_siblings() {
+        let text = "<p><b>x</b> <i>y</i></p>";
+        let tree = parse_html5(text);
+        let p = tree.root().find("p").unwrap();
+        let space_node = p.children().find(|n| n.text() == " ");
+        assert!(
+            space_node.is_some(),
+            "whitespace text node should be preserved between inline siblings"
+        );
     }
 
     #[test]
-    fn test_central_space() {
-        let text = "<a><b> </b></a>";
-        let xml = XmlParser::new(text).parse();
-        assert_eq!(xml.root().text(), " ");
+    fn whitespace_text_inside_element_accessible_via_tree_text() {
+        let text = "<p><span> </span></p>";
+        let tree = parse_html5(text);
+        let span = tree.root().find("span").unwrap();
+        assert_eq!(span.text(), " ");
     }
 
     #[test]
@@ -586,12 +599,106 @@ mod tests {
         assert!(xml.root().find("br").is_some());
     }
 
+    /// XHTML EPUB content frequently uses self-closing syntax on RCDATA/RAWTEXT
+    /// elements (`<title/>`, `<style/>`). Without the `xhtml-self-closing`
+    /// feature, html5ever treats `<title>` as opening a RCDATA region that
+    /// swallows the rest of the document, leaving the `<body>` empty. With the
+    /// feature, the self-closing flag is honoured and the body parses normally.
+    #[test]
+    fn html5_self_closing_title_does_not_swallow_body() {
+        let text = concat!(
+            "<html><head><title/></head>",
+            "<body><p>visible</p></body></html>",
+        );
+        let tree = parse_html5(text);
+        let body = tree.root().find("body").expect("body should exist");
+        let p = body
+            .descendants()
+            .find(|n| n.tag_name() == Some("p"))
+            .expect("body paragraph should not be swallowed by <title/>");
+        assert_eq!(p.text(), "visible");
+    }
+
+    /// A self-closing `<style/>` must likewise not swallow following content.
+    #[test]
+    fn html5_self_closing_style_does_not_swallow_body() {
+        let text = concat!(
+            "<html><head><style/></head>",
+            "<body><p>visible</p></body></html>",
+        );
+        let tree = parse_html5(text);
+        let p = tree
+            .root()
+            .find("body")
+            .and_then(|b| b.descendants().find(|n| n.tag_name() == Some("p")))
+            .expect("body paragraph should not be swallowed by <style/>");
+        assert_eq!(p.text(), "visible");
+    }
+
+    /// A normally-closed `<title>…</title>` still captures its text content as
+    /// an RCDATA region, unaffected by the self-closing handling.
+    #[test]
+    fn html5_normal_title_still_parses_as_rcdata() {
+        let text = "<html><head><title>My Book</title></head><body></body></html>";
+        let tree = parse_html5(text);
+        let title = tree.root().find("title").expect("title should exist");
+        assert_eq!(title.text(), "My Book");
+    }
+
     #[test]
     fn html5_entity_decoding() {
         let text = "<p>hello&amp;world</p>";
         let xml = parse_html5(text);
         let p = xml.root().find("p").unwrap();
         assert_eq!(p.text(), "hello&world");
+    }
+
+    #[test]
+    fn html5_entity_text_offsets_preserve_source_positions() {
+        let text = "<p>a&amp;b</p>";
+        let xml = parse_html5(text);
+        let p = xml.root().find("p").unwrap();
+        let text_nodes: Vec<_> = p
+            .children()
+            .filter(|n| n.tag_name().is_none() && !n.text().is_empty())
+            .map(|n| (n.text(), n.offset()))
+            .collect();
+
+        assert_eq!(
+            text_nodes,
+            vec![("a&".to_string(), 3), ("b".to_string(), 9),]
+        );
+    }
+
+    #[test]
+    fn html5_text_after_entity_can_match_entity_name() {
+        let text = "<p>a&amp;a</p>";
+        let xml = parse_html5(text);
+        let p = xml.root().find("p").unwrap();
+        let text_nodes: Vec<_> = p
+            .children()
+            .filter(|n| n.tag_name().is_none() && !n.text().is_empty())
+            .map(|n| (n.text(), n.offset()))
+            .collect();
+
+        assert_eq!(
+            text_nodes,
+            vec![("a&".to_string(), 3), ("a".to_string(), 9),]
+        );
+    }
+
+    #[test]
+    fn html5_adjacent_text_without_source_gap_is_coalesced() {
+        let text = "<p>abc</p>";
+        let xml = parse_html5(text);
+        let p = xml.root().find("p").unwrap();
+        let text_nodes: Vec<_> = p
+            .children()
+            .filter(|n| n.tag_name().is_none() && !n.text().is_empty())
+            .map(|n| (n.text(), n.offset()))
+            .collect();
+
+        assert_eq!(text_nodes, vec![("abc".to_string(), 3)]);
     }
 
     #[test]
@@ -719,5 +826,128 @@ mod tests {
                 offset_b
             );
         }
+    }
+
+    /// Collect `(tag_name, offset)` for every element in the tree, skipping
+    /// implicit wrapper tags that html5ever inserts but XmlParser does not
+    /// (`html`, `head`, `body`, `anonymous`).
+    fn element_offsets(tree: &XmlTree) -> Vec<(String, usize)> {
+        tree.root()
+            .descendants()
+            .filter_map(|n| {
+                n.tag_name().and_then(|name| {
+                    if matches!(name, "html" | "head" | "body" | "anonymous") {
+                        None
+                    } else {
+                        Some((name.to_string(), n.offset()))
+                    }
+                })
+            })
+            .collect()
+    }
+
+    /// Collect `(parent_tag, first_text_offset, concatenated_text)` for every
+    /// element that has at least one text-node child. The offset is that of
+    /// the first text child; the text is all text children concatenated. This
+    /// lets us compare text content and positions without being sensitive to
+    /// how each parser splits text runs.
+    fn text_first_offsets(tree: &XmlTree) -> Vec<(String, usize, String)> {
+        tree.root()
+            .descendants()
+            .filter_map(|n| {
+                let tag = n.tag_name()?;
+                if matches!(tag, "html" | "head" | "body" | "anonymous") {
+                    return None;
+                }
+                let text_children: Vec<_> = n
+                    .children()
+                    .filter(|c| c.tag_name().is_none() && !c.text().is_empty())
+                    .collect();
+                if text_children.is_empty() {
+                    return None;
+                }
+                let first_offset = text_children[0].offset();
+                let full_text: String = text_children.iter().map(|c| c.text()).collect();
+                Some((tag.to_string(), first_offset, full_text))
+            })
+            .collect()
+    }
+
+    #[test]
+    fn parity_simple_element() {
+        let src = "<p>hello</p>";
+        let xml = element_offsets(&XmlParser::new(src).parse());
+        let h5 = element_offsets(&parse_html5(src));
+        assert_eq!(xml, h5, "element offsets differ for {:?}", src);
+    }
+
+    #[test]
+    fn parity_nested_elements() {
+        let src = "<div><p>text</p></div>";
+        let xml = element_offsets(&XmlParser::new(src).parse());
+        let h5 = element_offsets(&parse_html5(src));
+        assert_eq!(xml, h5, "element offsets differ for {:?}", src);
+    }
+
+    #[test]
+    fn parity_adjacent_text_and_element() {
+        let src = "<p><em>A</em> B</p>";
+        let xml = element_offsets(&XmlParser::new(src).parse());
+        let h5 = element_offsets(&parse_html5(src));
+        assert_eq!(xml, h5, "element offsets differ for {:?}", src);
+    }
+
+    #[test]
+    fn parity_text_first_offset_simple() {
+        let src = "<p>hello</p>";
+        let xml = text_first_offsets(&XmlParser::new(src).parse());
+        let h5 = text_first_offsets(&parse_html5(src));
+        assert_eq!(xml, h5, "text offsets differ for {:?}", src);
+    }
+
+    #[test]
+    fn parity_text_first_offset_nested() {
+        let src = "<p><em>A</em> B</p>";
+        let xml = text_first_offsets(&XmlParser::new(src).parse());
+        let h5 = text_first_offsets(&parse_html5(src));
+        assert_eq!(xml, h5, "text offsets differ for {:?}", src);
+    }
+
+    #[test]
+    fn parity_multibyte_utf8() {
+        // 'é' encodes as 2 bytes (0xC3 0xA9); offset of "café" must be the
+        // byte position of 'c', not the char index.
+        let src = "<p>café</p>";
+        let xml = text_first_offsets(&XmlParser::new(src).parse());
+        let h5 = text_first_offsets(&parse_html5(src));
+        assert_eq!(xml, h5, "text offsets differ for {:?}", src);
+    }
+
+    #[test]
+    fn parity_sequential_siblings() {
+        let src = "<h1>Title</h1><p>Body</p>";
+        let xml = element_offsets(&XmlParser::new(src).parse());
+        let h5 = element_offsets(&parse_html5(src));
+        assert_eq!(xml, h5, "element offsets differ for {:?}", src);
+    }
+
+    #[test]
+    fn parity_sequential_siblings_text() {
+        let src = "<h1>Title</h1><p>Body</p>";
+        let xml = text_first_offsets(&XmlParser::new(src).parse());
+        let h5 = text_first_offsets(&parse_html5(src));
+        assert_eq!(xml, h5, "text offsets differ for {:?}", src);
+    }
+
+    #[test]
+    fn parity_deep_offset_accumulation() {
+        let src = "<article><section><div><p>deep text</p></div></section></article>";
+        let xml_el = element_offsets(&XmlParser::new(src).parse());
+        let h5_el = element_offsets(&parse_html5(src));
+        assert_eq!(xml_el, h5_el, "element offsets differ for {:?}", src);
+
+        let xml_tx = text_first_offsets(&XmlParser::new(src).parse());
+        let h5_tx = text_first_offsets(&parse_html5(src));
+        assert_eq!(xml_tx, h5_tx, "text offsets differ for {:?}", src);
     }
 }


### PR DESCRIPTION
## What

- Parse EPUB HTML with html5ever using real source byte offsets instead of the hand-rolled `XmlParser`
- Parse OPF metadata with roxmltree
- Keep `XmlParser` only for offset-parity tests

## Why

- The in-tree parser mishandles entities, void elements, and HTML5 error recovery, so reading positions and layout can drift from the source
- html5ever already covers that; the remaining gap was stable source positions for bookmarks and the EPUB spine

## How

- Stacked on [#588](https://github.com/OGKevin/cadmus/pull/588) (`ogkevin/push/xzxzsxmxvtxu`)
- Enable html5ever `source-positions` (and `xhtml-self-closing`) via a patched checkout
- Drive `XmlTree` from html5ever `TreeSink` callbacks using `set_current_byte`
- Replace OPF XML walking with a dedicated roxmltree document

## Issues

- [#384](https://github.com/OGKevin/cadmus/issues/384)
- CAD-43

Closes #384
Closes: CAD-43