### PR TITLE
docs: add i18n skip directives across doc sources

### DIFF
--- a/docs/po/messages.pot
+++ b/docs/po/messages.pot
@@ -1,14 +1,14 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Cadmus Documentation\n"
-"POT-Creation-Date: 2026-06-23T10:07:54+02:00\n"
+"POT-Creation-Date: 2026-06-26T11:11:58+02:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Language: en\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-#: src/SUMMARY.md:1 src/contributing/event-system.md:14
+#: src/SUMMARY.md:1
 msgid "Overview"
 msgstr ""
 
@@ -61,7 +61,7 @@ msgstr ""
 msgid "Keyboard"
 msgstr ""
 
-#: src/SUMMARY.md:17 src/installation/migration.md:100
+#: src/SUMMARY.md:17 src/installation/migration.md:112
 #: src/ui/settings/dictionaries.md:1
 msgid "Dictionaries"
 msgstr ""
@@ -87,7 +87,6 @@ msgid "Database Backup"
 msgstr ""
 
 #: src/SUMMARY.md:23 src/installation/ota.md:86 src/troubleshooting/index.md:1
-#: src/contributing/devenv-setup.md:221
 msgid "Troubleshooting"
 msgstr ""
 
@@ -103,68 +102,71 @@ msgstr ""
 msgid "Development Environment"
 msgstr ""
 
-#: src/SUMMARY.md:31 src/contributing/code-style.md:1
+#: src/SUMMARY.md:31
+msgid "SSH"
+msgstr ""
+
+#: src/SUMMARY.md:32
 msgid "Code Style and Linting"
 msgstr ""
 
-#: src/SUMMARY.md:32 src/contributing/event-system.md:1
+#: src/SUMMARY.md:33
 msgid "Event System"
 msgstr ""
 
-#: src/SUMMARY.md:33 src/settings/index.md:639
-#: src/contributing/telemetry/index.md:1
+#: src/SUMMARY.md:34 src/settings/index.md:723
 msgid "Telemetry"
 msgstr ""
 
-#: src/SUMMARY.md:34 src/contributing/telemetry/logging.md:1
+#: src/SUMMARY.md:35
 msgid "Logging"
 msgstr ""
 
-#: src/SUMMARY.md:35 src/contributing/telemetry/tracing.md:1
+#: src/SUMMARY.md:36
 msgid "Tracing"
 msgstr ""
 
-#: src/SUMMARY.md:36 src/contributing/telemetry/profiling.md:1
+#: src/SUMMARY.md:37
 msgid "Profiling"
 msgstr ""
 
-#: src/SUMMARY.md:37 src/index.md:9
+#: src/SUMMARY.md:38 src/index.md:9
 msgid "Documentation"
 msgstr ""
 
-#: src/SUMMARY.md:38 src/contributing/translations/index.md:1
+#: src/SUMMARY.md:39
 msgid "Translations"
 msgstr ""
 
-#: src/SUMMARY.md:39
+#: src/SUMMARY.md:40
 msgid "UI Strings"
 msgstr ""
 
-#: src/SUMMARY.md:40
+#: src/SUMMARY.md:41
 msgid "Guide"
 msgstr ""
 
-#: src/SUMMARY.md:41 src/contributing/sqlite-sqlx.md:1
+#: src/SUMMARY.md:42
 msgid "SQLite & SQLx"
 msgstr ""
 
-#: src/SUMMARY.md:42 src/contributing/library-database.md:1
+#: src/SUMMARY.md:43
 msgid "Library Database"
 msgstr ""
 
-#: src/SUMMARY.md:43 src/contributing/runtime-migrations.md:1
+#: src/SUMMARY.md:44
 msgid "Runtime Migrations"
 msgstr ""
 
-#: src/SUMMARY.md:47 src/investigations/index.md:1
+#: src/SUMMARY.md:48
 msgid "Investigations"
 msgstr ""
 
-#: src/SUMMARY.md:49
+#: src/SUMMARY.md:50
 msgid "Intro"
 msgstr ""
 
-#: src/SUMMARY.md:50 src/investigations/kobo/issue-51-dhcp-investigation.md:1
+#: src/SUMMARY.md:51
 msgid "DHCP IP Address Changes on WiFi Toggle"
 msgstr ""
 
@@ -266,182 +268,128 @@ msgstr ""
 msgid "Available packages"
 msgstr ""
 
-#: src/installation/index.md:7
-msgid "Package"
-msgstr ""
-
-#: src/installation/index.md:7
-msgid "What's included"
-msgstr ""
-
-#: src/installation/index.md:7
-msgid "Installs to"
-msgstr ""
-
-#: src/installation/index.md:9
-msgid "`KoboRoot.tgz`"
-msgstr ""
-
-#: src/installation/index.md:9
-msgid "Cadmus only"
-msgstr ""
-
-#: src/installation/index.md:9 src/installation/index.md:10
-#: src/installation/uninstall.md:10
-msgid "`/mnt/onboard/.adds/cadmus`"
-msgstr ""
-
-#: src/installation/index.md:10
-msgid "`KoboRoot-nm.tgz`"
-msgstr ""
-
-#: src/installation/index.md:10
-msgid "Cadmus + NickelMenu"
-msgstr ""
-
-#: src/installation/index.md:11
-msgid "`KoboRoot-test.tgz`"
-msgstr ""
-
-#: src/installation/index.md:11
-msgid "Test build only"
-msgstr ""
-
-#: src/installation/index.md:11 src/installation/index.md:12
-#: src/installation/uninstall.md:11
-msgid "`/mnt/onboard/.adds/cadmus-tst`"
-msgstr ""
-
-#: src/installation/index.md:12
-msgid "`KoboRoot-nm-test.tgz`"
-msgstr ""
-
-#: src/installation/index.md:12
-msgid "Test build + NickelMenu"
-msgstr ""
-
-#: src/installation/index.md:14
+#: src/installation/index.md:18
 msgid "Which one should I pick?"
 msgstr ""
 
-#: src/installation/index.md:16
+#: src/installation/index.md:20
 msgid "**Normal installs**: Use `KoboRoot.tgz` or `KoboRoot-nm.tgz`"
 msgstr ""
 
-#: src/installation/index.md:17
+#: src/installation/index.md:21
 msgid ""
 "**If you use NickelMenu**: Pick a package that includes it (`-nm` versions)"
 msgstr ""
 
-#: src/installation/index.md:18
+#: src/installation/index.md:22
 msgid ""
 "**Testing a new feature**: Use test packages (`-test` versions) for trying "
 "out changes that haven't been released yet"
 msgstr ""
 
-#: src/installation/index.md:21 src/installation/ota.md:80
+#: src/installation/index.md:25 src/installation/ota.md:80
 msgid "First-time setup"
 msgstr ""
 
-#: src/installation/index.md:23
+#: src/installation/index.md:27
 msgid ""
 "Go to the [latest "
 "release](https://github.com/OGKevin/cadmus/releases/latest)."
 msgstr ""
 
-#: src/installation/index.md:24
+#: src/installation/index.md:28
 msgid "Download the package you want from the table above."
 msgstr ""
 
-#: src/installation/index.md:25 src/installation/index.md:50
+#: src/installation/index.md:29 src/installation/index.md:54
 #: src/installation/uninstall.md:5
 msgid "Connect your Kobo to your computer via USB."
 msgstr ""
 
-#: src/installation/index.md:26
+#: src/installation/index.md:30
 msgid "Rename the downloaded file to `KoboRoot.tgz`."
 msgstr ""
 
-#: src/installation/index.md:27
+#: src/installation/index.md:31
 msgid ""
 "Copy that renamed file to `/mnt/onboard/.kobo/KoboRoot.tgz` on the device."
 msgstr ""
 
-#: src/installation/index.md:28 src/installation/test-builds.md:13
+#: src/installation/index.md:32 src/installation/test-builds.md:13
 msgid "Eject the device and reboot."
 msgstr ""
 
-#: src/installation/index.md:31
+#: src/installation/index.md:35
 msgid ""
 "You must rename the file to `KoboRoot.tgz` before copying it to your Kobo. "
 "For example, `KoboRoot-nm.tgz` and `KoboRoot-test.tgz` will not install "
 "until you rename them."
 msgstr ""
 
-#: src/installation/index.md:35
+#: src/installation/index.md:39
 msgid "Updating"
 msgstr ""
 
-#: src/installation/index.md:37
+#: src/installation/index.md:41
 msgid "There are two ways to update Cadmus once it's installed."
 msgstr ""
 
-#: src/installation/index.md:39
+#: src/installation/index.md:43
 msgid "Wirelessly (OTA)"
 msgstr ""
 
-#: src/installation/index.md:41
+#: src/installation/index.md:45
 msgid ""
 "The easiest way — no computer needed, just WiFi. Open **Main Menu → Check "
 "for Updates** and follow the prompts. See [OTA updates](./ota.md) for "
 "details."
 msgstr ""
 
-#: src/installation/index.md:45
+#: src/installation/index.md:49
 msgid "Via USB"
 msgstr ""
 
-#: src/installation/index.md:47
+#: src/installation/index.md:51
 msgid ""
 "You can also update by copying a new package over USB, the same way you did "
 "the first-time install."
 msgstr ""
 
-#: src/installation/index.md:51
+#: src/installation/index.md:55
 msgid "When Cadmus asks \"Share storage via USB?\", tap **Share**."
 msgstr ""
 
-#: src/installation/index.md:52
+#: src/installation/index.md:56
 msgid ""
 "Download the package you want from the [latest "
 "release](https://github.com/OGKevin/cadmus/releases/latest)."
 msgstr ""
 
-#: src/installation/index.md:53
+#: src/installation/index.md:57
 msgid "Copy it to `/mnt/onboard/.kobo/KoboRoot.tgz` on your Kobo."
 msgstr ""
 
-#: src/installation/index.md:54
+#: src/installation/index.md:58
 msgid "Eject and disconnect the USB cable."
 msgstr ""
 
-#: src/installation/index.md:57
+#: src/installation/index.md:61
 msgid ""
 "Always name the file `KoboRoot.tgz` on the device, regardless of which "
 "package you downloaded (e.g. `KoboRoot-nm.tgz` must be renamed)."
 msgstr ""
 
-#: src/installation/index.md:60
+#: src/installation/index.md:64
 msgid ""
 "Cadmus detects the file automatically and reboots your Kobo to install the "
 "update. You don't need to do anything else."
 msgstr ""
 
-#: src/installation/index.md:63
+#: src/installation/index.md:67
 msgid "Uninstalling"
 msgstr ""
 
-#: src/installation/index.md:65
+#: src/installation/index.md:69
 msgid "See [Uninstalling Cadmus](./uninstall.md)."
 msgstr ""
 
@@ -560,12 +508,11 @@ msgid ""
 "the update from:"
 msgstr ""
 
-#: src/installation/ota.md:34 src/installation/migration.md:43
+#: src/installation/ota.md:34 src/installation/migration.md:51
 msgid "Source"
 msgstr ""
 
-#: src/installation/ota.md:34 src/contributing/devenv-setup.md:47
-#: src/contributing/devenv-setup.md:73
+#: src/installation/ota.md:34
 msgid "Description"
 msgstr ""
 
@@ -750,42 +697,7 @@ msgstr ""
 msgid "Copy your settings"
 msgstr ""
 
-#: src/installation/migration.md:8 src/installation/migration.md:71
-#: src/installation/uninstall.md:8 src/installation/uninstall.md:16
-msgid "Build"
-msgstr ""
-
-#: src/installation/migration.md:8
-msgid "Plato settings"
-msgstr ""
-
-#: src/installation/migration.md:8
-msgid "Cadmus settings"
-msgstr ""
-
-#: src/installation/migration.md:10 src/installation/migration.md:73
-#: src/installation/uninstall.md:10 src/installation/uninstall.md:18
-msgid "Stable"
-msgstr ""
-
-#: src/installation/migration.md:10 src/installation/migration.md:11
-msgid "`/mnt/onboard/.adds/plato/Settings.toml`"
-msgstr ""
-
-#: src/installation/migration.md:10 src/installation/migration.md:98
-msgid "`/mnt/onboard/.adds/cadmus/Settings.toml`"
-msgstr ""
-
-#: src/installation/migration.md:11 src/installation/migration.md:74
-#: src/installation/uninstall.md:11 src/installation/uninstall.md:19
-msgid "Test"
-msgstr ""
-
-#: src/installation/migration.md:11
-msgid "`/mnt/onboard/.adds/cadmus-tst/Settings.toml`"
-msgstr ""
-
-#: src/installation/migration.md:13
+#: src/installation/migration.md:17
 msgid ""
 "Copy the file as-is into the Cadmus folder so it is named `Settings.toml` "
 "(for example, `/mnt/onboard/.adds/cadmus/Settings.toml` or "
@@ -795,74 +707,64 @@ msgid ""
 "move this file into its `Settings/` folder automatically."
 msgstr ""
 
-#: src/installation/migration.md:18
+#: src/installation/migration.md:22
 msgid ""
 "If your SD card is already inserted when you upgrade, Cadmus automatically "
 "moves your settings, logs, and dictionaries to `/mnt/sd/.cadmus/` (or "
 "`/mnt/sd/.cadmus-tst/` for test builds) on the next boot."
 msgstr ""
 
-#: src/installation/migration.md:23
+#: src/installation/migration.md:27
 msgid ""
 "If you insert an SD card **after** Cadmus has already run, the automatic "
 "migration will not run. You will need to copy your data manually — see "
 "[Moving data to an SD card](#moving-data-to-an-sd-card) below."
 msgstr ""
 
-#: src/installation/migration.md:27 src/settings/index.md:494
-msgid ""
-"```toml\n"
-"[[libraries]]\n"
-"name = \"On Board\"\n"
-"path = \"/mnt/onboard\"\n"
-"mode = \"database\"\n"
-"```"
-msgstr ""
-
-#: src/installation/migration.md:35
+#: src/installation/migration.md:43
 msgid ""
 "Make sure each `[[libraries]]` entry has the correct `path` and `name`. If a "
 "path doesn't match what's on disk, Cadmus skips that library's import."
 msgstr ""
 
-#: src/installation/migration.md:38
+#: src/installation/migration.md:46
 msgid "What happens on first launch"
 msgstr ""
 
-#: src/installation/migration.md:40
+#: src/installation/migration.md:48
 msgid ""
 "When Cadmus starts for the first time it automatically imports your data "
 "from each library listed in settings:"
 msgstr ""
 
-#: src/installation/migration.md:43
+#: src/installation/migration.md:51
 msgid "What's imported"
 msgstr ""
 
-#: src/installation/migration.md:45
+#: src/installation/migration.md:53
 msgid "`.metadata.json`"
 msgstr ""
 
-#: src/installation/migration.md:45
+#: src/installation/migration.md:53
 msgid "Book metadata (title, author, …) and reading progress"
 msgstr ""
 
-#: src/installation/migration.md:46
+#: src/installation/migration.md:54
 msgid "`.reading-states/<fp>.json`"
 msgstr ""
 
-#: src/installation/migration.md:46
+#: src/installation/migration.md:54
 msgid "Reading progress for books not already covered by the above"
 msgstr ""
 
-#: src/installation/migration.md:48
+#: src/installation/migration.md:56
 msgid ""
 "Both database mode and filesystem mode libraries are handled. Cadmus reads "
 "`.reading-states/` in all cases, so current page, bookmarks, and annotations "
 "carry over regardless of which mode you used in Plato."
 msgstr ""
 
-#: src/installation/migration.md:53
+#: src/installation/migration.md:61
 msgid ""
 "The original `.metadata.json` and `.reading-states/` files are not modified "
 "or deleted during import. Once you have confirmed everything looks right in "
@@ -872,149 +774,137 @@ msgid ""
 "any progress you make in Cadmus will not sync back to Plato."
 msgstr ""
 
-#: src/installation/migration.md:61
+#: src/installation/migration.md:69
 msgid ""
 "Cadmus also removes the `.thumbnail-previews/` folder and regenerates "
 "thumbnails itself."
 msgstr ""
 
-#: src/installation/migration.md:64
+#: src/installation/migration.md:72
 msgid "Re-running the import"
 msgstr ""
 
-#: src/installation/migration.md:66
+#: src/installation/migration.md:74
 msgid ""
 "If the import went wrong (for example, the library path was incorrect in "
 "settings), you can start it fresh:"
 msgstr ""
 
-#: src/installation/migration.md:69
+#: src/installation/migration.md:77
 msgid "Delete the Cadmus SQLite database:"
 msgstr ""
 
-#: src/installation/migration.md:71
-msgid "Database path (with SD card)"
-msgstr ""
-
-#: src/installation/migration.md:71
-msgid "Database path (without SD card)"
-msgstr ""
-
-#: src/installation/migration.md:73 src/installation/migration.md:101
-msgid "`/mnt/sd/.cadmus/cadmus.sqlite`"
-msgstr ""
-
-#: src/installation/migration.md:73 src/installation/migration.md:101
-msgid "`/mnt/onboard/.adds/cadmus/cadmus.sqlite`"
-msgstr ""
-
-#: src/installation/migration.md:74
-msgid "`/mnt/sd/.cadmus-tst/cadmus.sqlite`"
-msgstr ""
-
-#: src/installation/migration.md:74
-msgid "`/mnt/onboard/.adds/cadmus-tst/cadmus.sqlite`"
-msgstr ""
-
-#: src/installation/migration.md:76
+#: src/installation/migration.md:88
 msgid "Restart Cadmus — the import will run again from scratch."
 msgstr ""
 
-#: src/installation/migration.md:78
+#: src/installation/migration.md:90
 msgid ""
 "If something still looks wrong after re-running, check the logs for details. "
 "See [Troubleshooting](../troubleshooting/index.md) for where to find them."
 msgstr ""
 
-#: src/installation/migration.md:81
+#: src/installation/migration.md:93
 msgid "Moving data to an SD card"
 msgstr ""
 
-#: src/installation/migration.md:83
+#: src/installation/migration.md:95
 msgid ""
 "If you insert an SD card after Cadmus has already run, you need to move your "
 "data manually. Cadmus will use the SD card for new data once it detects the "
 "card, but your existing files stay in internal storage until you move them."
 msgstr ""
 
-#: src/installation/migration.md:88
+#: src/installation/migration.md:100
 msgid "Do these operations while Cadmus is not running!"
 msgstr ""
 
-#: src/installation/migration.md:90
+#: src/installation/migration.md:102
 msgid "In other words, do this while the Nickel/KOReader/etc is running."
 msgstr ""
 
-#: src/installation/migration.md:92
+#: src/installation/migration.md:104
 msgid "Connect your Kobo to your computer"
 msgstr ""
 
-#: src/installation/migration.md:93
+#: src/installation/migration.md:105
 msgid "Copy the following from internal storage to the SD card:"
 msgstr ""
 
-#: src/installation/migration.md:95
+#: src/installation/migration.md:107
 msgid "What to move"
 msgstr ""
 
-#: src/installation/migration.md:95
+#: src/installation/migration.md:107
 msgid "From (internal)"
 msgstr ""
 
-#: src/installation/migration.md:95
+#: src/installation/migration.md:107
 msgid "To (SD card)"
 msgstr ""
 
-#: src/installation/migration.md:97
+#: src/installation/migration.md:109
 msgid "Settings directory"
 msgstr ""
 
-#: src/installation/migration.md:97
+#: src/installation/migration.md:109
 msgid "`/mnt/onboard/.adds/cadmus/Settings/`"
 msgstr ""
 
-#: src/installation/migration.md:97
+#: src/installation/migration.md:109
 msgid "`/mnt/sd/.cadmus/Settings/`"
 msgstr ""
 
-#: src/installation/migration.md:98
+#: src/installation/migration.md:110
 msgid "Settings file"
 msgstr ""
 
-#: src/installation/migration.md:98
+#: src/installation/migration.md:110
+msgid "`/mnt/onboard/.adds/cadmus/Settings.toml`"
+msgstr ""
+
+#: src/installation/migration.md:110
 msgid "`/mnt/sd/.cadmus/Settings.toml`"
 msgstr ""
 
-#: src/installation/migration.md:99 src/troubleshooting/index.md:3
+#: src/installation/migration.md:111 src/troubleshooting/index.md:3
 msgid "Logs"
 msgstr ""
 
-#: src/installation/migration.md:99
+#: src/installation/migration.md:111
 msgid "`/mnt/onboard/.adds/cadmus/logs/`"
 msgstr ""
 
-#: src/installation/migration.md:99
+#: src/installation/migration.md:111
 msgid "`/mnt/sd/.cadmus/logs/`"
 msgstr ""
 
-#: src/installation/migration.md:100
+#: src/installation/migration.md:112
 msgid "`/mnt/onboard/.adds/cadmus/dictionaries/`"
 msgstr ""
 
-#: src/installation/migration.md:100
+#: src/installation/migration.md:112
 msgid "`/mnt/sd/.cadmus/dictionaries/`"
 msgstr ""
 
-#: src/installation/migration.md:101
+#: src/installation/migration.md:113
 msgid "Database"
 msgstr ""
 
-#: src/installation/migration.md:104
+#: src/installation/migration.md:113
+msgid "`/mnt/onboard/.adds/cadmus/cadmus.sqlite`"
+msgstr ""
+
+#: src/installation/migration.md:113
+msgid "`/mnt/sd/.cadmus/cadmus.sqlite`"
+msgstr ""
+
+#: src/installation/migration.md:116
 msgid ""
 "Use the test paths (`cadmus-tst` / `.cadmus-tst`) if you are on a test build."
 msgstr ""
 
-#: src/installation/migration.md:106
+#: src/installation/migration.md:118
 msgid "Restart Cadmus. It will pick up the files from the SD card automatically."
 msgstr ""
 
@@ -1057,37 +947,37 @@ msgstr ""
 msgid "Place the Cadmus icon somewhere on your Kobo, for example:"
 msgstr ""
 
-#: src/installation/kfmon.md:26
+#: src/installation/kfmon.md:30
 msgid ""
 "If you don't have an icon, create or copy a PNG image to use as the launcher "
 "icon."
 msgstr ""
 
-#: src/installation/kfmon.md:29
+#: src/installation/kfmon.md:33
 msgid "Create a new file on your Kobo:"
 msgstr ""
 
-#: src/installation/kfmon.md:35
+#: src/installation/kfmon.md:43
 msgid ""
 "Paste this into the file, changing the `filename` value to match your icon "
 "path:"
 msgstr ""
 
-#: src/installation/kfmon.md:57
+#: src/installation/kfmon.md:69
 msgid "Reboot your Kobo."
 msgstr ""
 
-#: src/installation/kfmon.md:60
+#: src/installation/kfmon.md:72
 msgid ""
 "The `block_spawns = 1` line is the key setting. It stops KFMon from "
 "launching another reader while Cadmus is already open."
 msgstr ""
 
-#: src/installation/kfmon.md:63
+#: src/installation/kfmon.md:75
 msgid "Pick one launcher method"
 msgstr ""
 
-#: src/installation/kfmon.md:65
+#: src/installation/kfmon.md:77
 msgid ""
 "Cadmus can be launched by either NickelMenu or KFMon, but try to avoid both "
 "at once. If you use KFMon, install a non-NickelMenu package from the "
@@ -1096,17 +986,17 @@ msgid ""
 "both can create duplicate icons and make conflicts harder to diagnose."
 msgstr ""
 
-#: src/installation/kfmon.md:71
+#: src/installation/kfmon.md:83
 msgid "Temporarily disable KFMon"
 msgstr ""
 
-#: src/installation/kfmon.md:73
+#: src/installation/kfmon.md:85
 msgid ""
 "If you need to stop KFMon from launching anything for a short time — for "
 "example, while troubleshooting — you can create a blank `BLOCK` file:"
 msgstr ""
 
-#: src/installation/kfmon.md:80
+#: src/installation/kfmon.md:96
 msgid "Remove the file when you want KFMon to work again:"
 msgstr ""
 
@@ -1118,33 +1008,17 @@ msgstr ""
 msgid "Delete the Cadmus folder from `.adds`:"
 msgstr ""
 
-#: src/installation/uninstall.md:8
-msgid "Folder to delete"
-msgstr ""
-
-#: src/installation/uninstall.md:13
+#: src/installation/uninstall.md:17
 msgid ""
 "If you installed a package that included NickelMenu, delete the Cadmus menu "
 "entry too:"
 msgstr ""
 
-#: src/installation/uninstall.md:16
-msgid "NickelMenu entry to delete"
-msgstr ""
-
-#: src/installation/uninstall.md:18
-msgid "`/mnt/onboard/.adds/nm/cadmus`"
-msgstr ""
-
-#: src/installation/uninstall.md:19
-msgid "`/mnt/onboard/.adds/nm/cadmus-tst`"
-msgstr ""
-
-#: src/installation/uninstall.md:21
+#: src/installation/uninstall.md:29
 msgid "Eject the device and disconnect the USB cable."
 msgstr ""
 
-#: src/installation/uninstall.md:24
+#: src/installation/uninstall.md:32
 msgid "If you no longer need NickelMenu at all, you can remove it separately."
 msgstr ""
 
@@ -1187,20 +1061,20 @@ msgstr ""
 msgid "`keyboard-layout`"
 msgstr ""
 
-#: src/settings/index.md:299 src/settings/index.md:311
-#: src/settings/index.md:321 src/settings/index.md:336
-#: src/settings/index.md:346 src/settings/index.md:362
-#: src/settings/index.md:374 src/settings/index.md:396
-#: src/settings/index.md:408 src/settings/index.md:420
-#: src/settings/index.md:432 src/settings/index.md:444
-#: src/settings/index.md:462 src/settings/index.md:479
-#: src/settings/index.md:490 src/settings/index.md:503
-#: src/settings/index.md:509 src/settings/index.md:515
-#: src/settings/index.md:523 src/settings/index.md:544
-#: src/settings/index.md:557 src/settings/index.md:569
-#: src/settings/index.md:577 src/settings/index.md:594
-#: src/settings/index.md:614 src/settings/index.md:663
-#: src/settings/index.md:674
+#: src/settings/index.md:299 src/settings/index.md:315
+#: src/settings/index.md:329 src/settings/index.md:348
+#: src/settings/index.md:362 src/settings/index.md:382
+#: src/settings/index.md:398 src/settings/index.md:428
+#: src/settings/index.md:444 src/settings/index.md:460
+#: src/settings/index.md:476 src/settings/index.md:492
+#: src/settings/index.md:514 src/settings/index.md:535
+#: src/settings/index.md:550 src/settings/index.md:567
+#: src/settings/index.md:573 src/settings/index.md:579
+#: src/settings/index.md:587 src/settings/index.md:612
+#: src/settings/index.md:629 src/settings/index.md:641
+#: src/settings/index.md:649 src/settings/index.md:666
+#: src/settings/index.md:694 src/settings/index.md:751
+#: src/settings/index.md:766
 msgid "✏️"
 msgstr ""
 
@@ -1212,474 +1086,393 @@ msgstr ""
 msgid "Possible values: `\"English\"`, `\"Russian\"`."
 msgstr ""
 
-#: src/settings/index.md:305
-msgid ""
-"```toml\n"
-"keyboard-layout = \"English\"\n"
-"```"
-msgstr ""
-
-#: src/settings/index.md:309
+#: src/settings/index.md:313
 msgid "`sleep-cover`"
 msgstr ""
 
-#: src/settings/index.md:313
+#: src/settings/index.md:317
 msgid "Handle the magnetic sleep cover event."
 msgstr ""
 
-#: src/settings/index.md:319
+#: src/settings/index.md:327
 msgid "`auto-share`"
 msgstr ""
 
-#: src/settings/index.md:323
+#: src/settings/index.md:331
 msgid ""
 "Automatically enter shared mode when connected to a computer, skipping the "
 "\"Share storage via USB?\" prompt."
 msgstr ""
 
-#: src/settings/index.md:327
+#: src/settings/index.md:335
 msgid ""
 "Turn this on if you update Cadmus via USB often — you won't have to confirm "
 "the sharing dialog each time you plug in."
 msgstr ""
 
-#: src/settings/index.md:334
+#: src/settings/index.md:346
 msgid "`auto-time`"
 msgstr ""
 
-#: src/settings/index.md:338
+#: src/settings/index.md:350
 msgid ""
 "Automatically synchronize the device time via NTP when WiFi connects. This "
 "will also set the correct timezone. Uses time.cloudflare.com and ipapi.co."
 msgstr ""
 
-#: src/settings/index.md:344
+#: src/settings/index.md:360
 msgid "`auto-frontlight`"
 msgstr ""
 
-#: src/settings/index.md:348
+#: src/settings/index.md:364
 msgid ""
 "Automatically adjust the frontlight warmth and brightness based on the sun's "
 "position at the device's location."
 msgstr ""
 
-#: src/settings/index.md:350
+#: src/settings/index.md:366
 msgid "During the day warmth is at its minimum."
 msgstr ""
 
-#: src/settings/index.md:351
+#: src/settings/index.md:367
 msgid "Around sunrise and sunset warmth ramps gradually between zero and full."
 msgstr ""
 
-#: src/settings/index.md:352
+#: src/settings/index.md:368
 msgid ""
 "After sunset brightness is reduced to `auto-frontlight-night-brightness` and "
 "warmth stays at its maximum until sunrise."
 msgstr ""
 
-#: src/settings/index.md:354
+#: src/settings/index.md:370
 msgid ""
 "Coordinates are auto-detected during each time sync (via ipapi.co) and "
 "stored in `auto-frontlight-last-coordinates`. Set "
 "`auto-frontlight-manual-coordinates` to override the detected location."
 msgstr ""
 
-#: src/settings/index.md:360
+#: src/settings/index.md:380
 msgid "`auto-frontlight-night-brightness`"
 msgstr ""
 
-#: src/settings/index.md:364
+#: src/settings/index.md:384
 msgid ""
 "Frontlight brightness level (0.0–100.0) applied when the sun is below the "
 "horizon."
 msgstr ""
 
-#: src/settings/index.md:366
+#: src/settings/index.md:386
 msgid "This setting is optional. When not set, a default of `1.0` is used."
 msgstr ""
 
-#: src/settings/index.md:372
+#: src/settings/index.md:396
 msgid "`auto-frontlight-manual-coordinates`"
 msgstr ""
 
-#: src/settings/index.md:376
+#: src/settings/index.md:400
 msgid ""
 "GPS coordinates `[latitude, longitude]` to use for sun-position calculations "
 "instead of the auto-detected location. Takes priority over "
 "`auto-frontlight-last-coordinates`."
 msgstr ""
 
-#: src/settings/index.md:378
+#: src/settings/index.md:402
 msgid "This setting is optional."
 msgstr ""
 
-#: src/settings/index.md:384
+#: src/settings/index.md:412
 msgid "`auto-frontlight-last-coordinates`"
 msgstr ""
 
-#: src/settings/index.md:386
+#: src/settings/index.md:414
 msgid ""
 "GPS coordinates `[latitude, longitude]` last detected during a time sync. "
 "Written automatically — do not edit this by hand; set "
 "`auto-frontlight-manual-coordinates` to override the location instead."
 msgstr ""
 
-#: src/settings/index.md:388
+#: src/settings/index.md:416
 msgid "This setting is optional and managed automatically."
 msgstr ""
 
-#: src/settings/index.md:394
+#: src/settings/index.md:426
 msgid "`auto-suspend`"
 msgstr ""
 
-#: src/settings/index.md:398
+#: src/settings/index.md:430
 msgid ""
 "Number of minutes of inactivity after which the device will automatically go "
 "to sleep."
 msgstr ""
 
-#: src/settings/index.md:400 src/settings/index.md:412
+#: src/settings/index.md:432 src/settings/index.md:448
 msgid "Zero means never."
 msgstr ""
 
-#: src/settings/index.md:406
+#: src/settings/index.md:442
 msgid "`auto-power-off`"
 msgstr ""
 
-#: src/settings/index.md:410
+#: src/settings/index.md:446
 msgid "Delay in days after which a suspended device will power off."
 msgstr ""
 
-#: src/settings/index.md:418
+#: src/settings/index.md:458
 msgid "`button-scheme`"
 msgstr ""
 
-#: src/settings/index.md:422
+#: src/settings/index.md:462
 msgid ""
 "Defines how the back and forward buttons are mapped to page forward and page "
 "backward actions."
 msgstr ""
 
-#: src/settings/index.md:424
+#: src/settings/index.md:464
 msgid "Possible values: `\"natural\"`, `\"inverted\"`."
 msgstr ""
 
-#: src/settings/index.md:426
-msgid ""
-"```toml\n"
-"button-scheme = \"natural\"\n"
-"```"
-msgstr ""
-
-#: src/settings/index.md:430
+#: src/settings/index.md:474
 msgid "`locale`"
 msgstr ""
 
-#: src/settings/index.md:434
+#: src/settings/index.md:478
 msgid ""
 "The preferred language for the user interface, using BCP 47 format (e.g., "
 "`\"en-US\"`, `\"de-DE\"`)."
 msgstr ""
 
-#: src/settings/index.md:436
+#: src/settings/index.md:480
 msgid "This setting is optional. When not set, `en-GB` is used."
 msgstr ""
 
-#: src/settings/index.md:438
-msgid ""
-"```toml\n"
-"locale = \"en-GB\"\n"
-"```"
-msgstr ""
-
-#: src/settings/index.md:442
+#: src/settings/index.md:490
 msgid "`startup-mode`"
 msgstr ""
 
-#: src/settings/index.md:446
+#: src/settings/index.md:494
 msgid "What to show when Cadmus starts."
 msgstr ""
 
-#: src/settings/index.md:448
+#: src/settings/index.md:496
 msgid "`\"home\"` — open the home screen (default)."
 msgstr ""
 
-#: src/settings/index.md:449
+#: src/settings/index.md:497
 msgid ""
 "`\"last-file\"` — re-open the last book you were reading. If there is no "
 "unfinished book in the selected library, the home screen is shown instead."
 msgstr ""
 
-#: src/settings/index.md:452
-msgid ""
-"```toml\n"
-"startup-mode = \"home\"\n"
-"```"
-msgstr ""
-
-#: src/settings/index.md:456
+#: src/settings/index.md:508
 msgid "Reader"
 msgstr ""
 
-#: src/settings/index.md:458
+#: src/settings/index.md:510
 msgid "Settings that control the reading experience."
 msgstr ""
 
-#: src/settings/index.md:460
+#: src/settings/index.md:512
 msgid "`reader.finished`"
 msgstr ""
 
-#: src/settings/index.md:464
+#: src/settings/index.md:516
 msgid "What to do when you finish reading a book."
 msgstr ""
 
-#: src/settings/index.md:466 src/settings/index.md:528
+#: src/settings/index.md:518 src/settings/index.md:592
 msgid "Possible values:"
 msgstr ""
 
-#: src/settings/index.md:468
+#: src/settings/index.md:520
 msgid "`\"notify\"` (show a notification)"
 msgstr ""
 
-#: src/settings/index.md:469
+#: src/settings/index.md:521
 msgid "`\"close\"` (close the book and go back)"
 msgstr ""
 
-#: src/settings/index.md:470
+#: src/settings/index.md:522
 msgid "`\"go-to-next\"` (open the next book in the library)."
 msgstr ""
 
-#: src/settings/index.md:472
-msgid ""
-"```toml\n"
-"[reader]\n"
-"finished = \"close\"\n"
-"```"
-msgstr ""
-
-#: src/settings/index.md:477
+#: src/settings/index.md:533
 msgid "`reader.dithered-kinds`"
 msgstr ""
 
-#: src/settings/index.md:481
+#: src/settings/index.md:537
 msgid "File extensions rendered with dithering by default."
 msgstr ""
 
-#: src/settings/index.md:483
-msgid ""
-"```toml\n"
-"[reader]\n"
-"dithered-kinds = [\"cbz\", \"png\", \"jpg\", \"jpeg\", \"webp\"]\n"
-"```"
-msgstr ""
-
-#: src/settings/index.md:488 src/contributing/library-database.md:26
+#: src/settings/index.md:548
 msgid "Libraries"
 msgstr ""
 
-#: src/settings/index.md:492
+#: src/settings/index.md:552
 msgid "Document library configuration. Each library has a name, path, and mode."
 msgstr ""
 
-#: src/settings/index.md:501
+#: src/settings/index.md:565
 msgid "`libraries.name`"
 msgstr ""
 
-#: src/settings/index.md:505
+#: src/settings/index.md:569
 msgid "Display name for the library."
 msgstr ""
 
-#: src/settings/index.md:507
+#: src/settings/index.md:571
 msgid "`libraries.path`"
 msgstr ""
 
-#: src/settings/index.md:511
+#: src/settings/index.md:575
 msgid "Directory path containing documents."
 msgstr ""
 
-#: src/settings/index.md:513
+#: src/settings/index.md:577
 msgid "`libraries.mode`"
 msgstr ""
 
-#: src/settings/index.md:517
+#: src/settings/index.md:581
 msgid "Library indexing mode."
 msgstr ""
 
-#: src/settings/index.md:519
+#: src/settings/index.md:583
 msgid "Possible values: `\"database\"`, `\"filesystem\"`."
 msgstr ""
 
-#: src/settings/index.md:521
+#: src/settings/index.md:585
 msgid "`libraries.finished`"
 msgstr ""
 
-#: src/settings/index.md:525
+#: src/settings/index.md:589
 msgid ""
 "Override the `reader.finished` setting for this specific library. When set, "
 "this takes precedence over the global reader setting."
 msgstr ""
 
-#: src/settings/index.md:530
+#: src/settings/index.md:594
 msgid "`\"notify\"`"
 msgstr ""
 
-#: src/settings/index.md:531
+#: src/settings/index.md:595
 msgid "`\"close\"`"
 msgstr ""
 
-#: src/settings/index.md:532
+#: src/settings/index.md:596
 msgid "`\"go-to-next\"`."
 msgstr ""
 
-#: src/settings/index.md:533
+#: src/settings/index.md:597
 msgid "Leave unset to inherit the global `reader.finished` setting."
 msgstr ""
 
-#: src/settings/index.md:535
-msgid ""
-"```toml\n"
-"[[libraries]]\n"
-"name = \"KePub\"\n"
-"path = \"/mnt/onboard/.kobo/kepub\"\n"
-"finished = \"go-to-next\"\n"
-"```"
-msgstr ""
-
-#: src/settings/index.md:542
+#: src/settings/index.md:610
 msgid "Intermissions"
 msgstr ""
 
-#: src/settings/index.md:546
+#: src/settings/index.md:614
 msgid "Defines the images displayed when entering an intermission state."
 msgstr ""
 
-#: src/settings/index.md:548
-msgid ""
-"```toml\n"
-"[intermissions]\n"
-"suspend = \"logo:\"\n"
-"power-off = \"logo:\"\n"
-"share = \"logo:\"\n"
-"```"
-msgstr ""
-
-#: src/settings/index.md:555
+#: src/settings/index.md:627
 msgid "`intermissions.suspend`"
 msgstr ""
 
-#: src/settings/index.md:559
+#: src/settings/index.md:631
 msgid "Image displayed when the device enters sleep mode."
 msgstr ""
 
-#: src/settings/index.md:561
+#: src/settings/index.md:633
 msgid ""
 "Setting this to `\"calendar:\"` also enables the calendar refresh: every 5 "
 "minutes, the device wakes, shows the calendar, and then goes back to sleep "
 "automatically."
 msgstr ""
 
-#: src/settings/index.md:565
+#: src/settings/index.md:637
 msgid ""
 "Possible values: `\"logo:\"` (built-in logo), `\"cover:\"` (current book "
 "cover), `\"calendar:\"` (built-in calendar), or a path to a custom image "
 "file."
 msgstr ""
 
-#: src/settings/index.md:567
+#: src/settings/index.md:639
 msgid "`intermissions.power-off`"
 msgstr ""
 
-#: src/settings/index.md:571
+#: src/settings/index.md:643
 msgid "Image displayed when the device powers off."
 msgstr ""
 
-#: src/settings/index.md:573 src/settings/index.md:581
+#: src/settings/index.md:645 src/settings/index.md:653
 msgid ""
 "Possible values: `\"logo:\"` (built-in logo), `\"cover:\"` (current book "
 "cover), or a path to a custom image file."
 msgstr ""
 
-#: src/settings/index.md:575
+#: src/settings/index.md:647
 msgid "`intermissions.share`"
 msgstr ""
 
-#: src/settings/index.md:579
+#: src/settings/index.md:651
 msgid "Image displayed when entering USB sharing mode."
 msgstr ""
 
-#: src/settings/index.md:583
+#: src/settings/index.md:655
 msgid "Import"
 msgstr ""
 
-#: src/settings/index.md:585
+#: src/settings/index.md:657
 msgid ""
 "These settings control how Cadmus imports documents from your device. They "
 "are available in the **Settings → Import** menu."
 msgstr ""
 
-#: src/settings/index.md:588
+#: src/settings/index.md:660
 msgid ""
 "Import scanning happens automatically on startup using incremental file "
 "checking — files are only re-scanned if their modification time or size has "
 "changed since the last import."
 msgstr ""
 
-#: src/settings/index.md:590
+#: src/settings/index.md:662
 msgid ""
 "To trigger a full re-scan of all files regardless of cached values, use the "
 "**Force Full Import** action button in the Import settings category."
 msgstr ""
 
-#: src/settings/index.md:592
+#: src/settings/index.md:664
 msgid "`import.sync-metadata`"
 msgstr ""
 
-#: src/settings/index.md:596
+#: src/settings/index.md:668
 msgid "Re-extract metadata (title, author, etc.) whenever a document changes."
 msgstr ""
 
-#: src/settings/index.md:603
+#: src/settings/index.md:679
 msgid "`import.metadata-kinds`"
 msgstr ""
 
-#: src/settings/index.md:605
+#: src/settings/index.md:681
 msgid "File extensions of documents whose metadata is extracted during import."
 msgstr ""
 
-#: src/settings/index.md:607
-msgid ""
-"```toml\n"
-"[import]\n"
-"metadata-kinds = [\"epub\", \"pdf\", \"djvu\"]\n"
-"```"
-msgstr ""
-
-#: src/settings/index.md:612
+#: src/settings/index.md:692
 msgid "`import.allowed-kinds`"
 msgstr ""
 
-#: src/settings/index.md:616
+#: src/settings/index.md:696
 msgid "File extensions of documents considered during the import process."
 msgstr ""
 
-#: src/settings/index.md:618
-msgid ""
-"```toml\n"
-"[import]\n"
-"allowed-kinds = [\"djvu\", \"xps\", \"fb2\", \"txt\", \"pdf\", \"oxps\", "
-"\"cbz\", \"epub\"]\n"
-"```"
-msgstr ""
-
-#: src/settings/index.md:623
+#: src/settings/index.md:707
 msgid "OTA"
 msgstr ""
 
-#: src/settings/index.md:625
+#: src/settings/index.md:709
 msgid "The OTA feature downloads builds from GitHub."
 msgstr ""
 
-#: src/settings/index.md:627
+#: src/settings/index.md:711
 msgid ""
 "Authentication for main branch and PR builds uses **GitHub device auth "
 "flow**. When you select a build that requires authentication, Cadmus will "
@@ -1688,224 +1481,188 @@ msgid ""
 "once you authorize."
 msgstr ""
 
-#: src/settings/index.md:633
+#: src/settings/index.md:717
 msgid ""
 "The token is saved to disk after the first authorization so you will not be "
 "prompted again on subsequent downloads."
 msgstr ""
 
-#: src/settings/index.md:636
+#: src/settings/index.md:720
 msgid ""
 "For step-by-step instructions with screenshots, see the [OTA "
 "updates](../installation/ota.md) guide."
 msgstr ""
 
-#: src/settings/index.md:641
+#: src/settings/index.md:725
 msgid ""
 "Cadmus writes JSON logs to disk. When the build enables the `tracing` "
 "feature, it can also export logs to an OpenTelemetry endpoint."
 msgstr ""
 
-#: src/settings/index.md:644
+#: src/settings/index.md:728
 msgid "These settings are available in the **Settings → Telemetry** menu."
 msgstr ""
 
-#: src/settings/index.md:647
+#: src/settings/index.md:731
 msgid ""
 "Changes to these settings only take effect after restarting Cadmus. The "
 "application initializes telemetry on startup."
 msgstr ""
 
-#: src/settings/index.md:650
+#: src/settings/index.md:734
 msgid "`logging`"
 msgstr ""
 
-#: src/settings/index.md:652
-msgid ""
-"```toml\n"
-"[logging]\n"
-"enabled = true\n"
-"level = \"info\"\n"
-"max-files = 3\n"
-"directory = \"logs\"\n"
-"# otlp-endpoint = \"https://otel.example.com:4318\"\n"
-"```"
-msgstr ""
-
-#: src/settings/index.md:661 src/contributing/telemetry/logging.md:50
+#: src/settings/index.md:749
 msgid "`logging.enabled`"
 msgstr ""
 
-#: src/settings/index.md:665
+#: src/settings/index.md:753
 msgid "Enable or disable structured JSON logging."
 msgstr ""
 
-#: src/settings/index.md:672 src/contributing/telemetry/logging.md:51
+#: src/settings/index.md:764
 msgid "`logging.level`"
 msgstr ""
 
-#: src/settings/index.md:676
+#: src/settings/index.md:768
 msgid "Minimum log level to record."
 msgstr ""
 
-#: src/settings/index.md:678
+#: src/settings/index.md:770
 msgid ""
 "Possible values: `\"trace\"`, `\"debug\"`, `\"info\"`, `\"warn\"`, "
 "`\"error\"`."
 msgstr ""
 
-#: src/settings/index.md:680
-msgid ""
-"```toml\n"
-"[logging]\n"
-"level = \"info\"\n"
-"```"
-msgstr ""
-
-#: src/settings/index.md:685 src/contributing/telemetry/logging.md:52
+#: src/settings/index.md:781
 msgid "`logging.max-files`"
 msgstr ""
 
-#: src/settings/index.md:687
+#: src/settings/index.md:783
 msgid ""
 "Number of log files to keep. Only the most recent N files are kept — older "
 "ones are deleted automatically when Cadmus starts."
 msgstr ""
 
-#: src/settings/index.md:690 src/settings/index.md:763
+#: src/settings/index.md:786 src/settings/index.md:879
 msgid "Default: `3`"
 msgstr ""
 
-#: src/settings/index.md:691
+#: src/settings/index.md:787
 msgid "Set to `0` to keep all log files."
 msgstr ""
 
-#: src/settings/index.md:698 src/contributing/telemetry/logging.md:54
+#: src/settings/index.md:798
 msgid "`logging.otlp-endpoint`"
 msgstr ""
 
-#: src/settings/index.md:700
+#: src/settings/index.md:800
 msgid "✏️ (only when the `tracing` feature is enabled)"
 msgstr ""
 
-#: src/settings/index.md:702
+#: src/settings/index.md:802
 msgid "Optional OTLP endpoint for exporting logs to an OpenTelemetry collector."
 msgstr ""
 
-#: src/settings/index.md:704
-msgid ""
-"```toml\n"
-"[logging]\n"
-"otlp-endpoint = \"https://otel.example.com:4318\"\n"
-"```"
-msgstr ""
-
-#: src/settings/index.md:709 src/settings/index.md:726
+#: src/settings/index.md:813 src/settings/index.md:834
 msgid "Environment override:"
 msgstr ""
 
-#: src/settings/index.md:711
+#: src/settings/index.md:815
 msgid ""
 "`OTEL_EXPORTER_OTLP_ENDPOINT` takes precedence over `logging.otlp-endpoint`."
 msgstr ""
 
-#: src/settings/index.md:713 src/contributing/telemetry/profiling.md:32
+#: src/settings/index.md:817
 msgid "`logging.pyroscope-endpoint`"
 msgstr ""
 
-#: src/settings/index.md:715
+#: src/settings/index.md:819
 msgid "✏️ (only when the `profiling` feature is enabled)"
 msgstr ""
 
-#: src/settings/index.md:717
+#: src/settings/index.md:821
 msgid ""
 "Optional Pyroscope server URL for continuous profiling. When set, Cadmus "
 "starts both a heap profiling agent (via jemalloc) and a CPU profiling agent "
 "(via pprof) that push profiles to this endpoint."
 msgstr ""
 
-#: src/settings/index.md:721
-msgid ""
-"```toml\n"
-"[logging]\n"
-"pyroscope-endpoint = \"http://localhost:4040\"\n"
-"```"
-msgstr ""
-
-#: src/settings/index.md:728
+#: src/settings/index.md:836
 msgid ""
 "`PYROSCOPE_SERVER_URL` takes precedence over `logging.pyroscope-endpoint`."
 msgstr ""
 
-#: src/settings/index.md:730
+#: src/settings/index.md:838
 msgid "`logging.enable-kern-log`"
 msgstr ""
 
-#: src/settings/index.md:732 src/settings/index.md:744
+#: src/settings/index.md:840 src/settings/index.md:856
 msgid "🧪 📱 ✏️"
 msgstr ""
 
-#: src/settings/index.md:734
+#: src/settings/index.md:842
 msgid ""
 "Captures kernel logs via `logread -F` and forwards them to structured "
 "logging with the target `cadmus_core::logging:kern`."
 msgstr ""
 
-#: src/settings/index.md:742
+#: src/settings/index.md:854
 msgid "`logging.enable-dbus-log`"
 msgstr ""
 
-#: src/settings/index.md:746
+#: src/settings/index.md:858
 msgid ""
 "Captures D-Bus signals via the built-in zbus-based DbusMonitorTask and "
 "forwards them to structured logging."
 msgstr ""
 
-#: src/settings/index.md:754
+#: src/settings/index.md:870
 msgid "Settings Retention"
 msgstr ""
 
-#: src/settings/index.md:756
+#: src/settings/index.md:872
 msgid ""
 "Cadmus stores each version's settings in a separate file in the `Settings/` "
 "directory (for example, `Settings-v1.2.3.toml`). This ensures backward and "
 "forward compatibility when you upgrade."
 msgstr ""
 
-#: src/settings/index.md:759
+#: src/settings/index.md:875
 msgid "`settings-retention`"
 msgstr ""
 
-#: src/settings/index.md:761
+#: src/settings/index.md:877
 msgid ""
 "Number of recent version settings files to keep. Only the most recent N "
 "version files are kept. When a new version is saved, older versions beyond "
 "this limit are deleted automatically."
 msgstr ""
 
-#: src/settings/index.md:764
+#: src/settings/index.md:880
 msgid "Set to `0` to keep all version files"
 msgstr ""
 
-#: src/settings/index.md:770
+#: src/settings/index.md:890
 msgid "`db-backup-retention`"
 msgstr ""
 
-#: src/settings/index.md:772
+#: src/settings/index.md:892
 msgid ""
 "Number of database backups to keep. When a new backup is created and the "
 "total would exceed this limit, the oldest backups are deleted automatically."
 msgstr ""
 
-#: src/settings/index.md:775 src/database-backup.md:72
+#: src/settings/index.md:895 src/database-backup.md:76
 msgid "Default: `2`"
 msgstr ""
 
-#: src/settings/index.md:776 src/database-backup.md:73
+#: src/settings/index.md:896 src/database-backup.md:77
 msgid "Set to `0` to disable backups entirely."
 msgstr ""
 
-#: src/settings/index.md:778
+#: src/settings/index.md:898
 msgid "See [Database Backup](../database-backup.md) for more details."
 msgstr ""
 
@@ -2067,1161 +1824,25 @@ msgid ""
 "corresponding character."
 msgstr ""
 
-#: src/ui/keyboard.md:34
-msgid "Keys"
-msgstr ""
-
-#: src/ui/keyboard.md:34
-msgid "Result"
-msgstr ""
-
-#: src/ui/keyboard.md:36
-msgid "`a '`"
-msgstr ""
-
-#: src/ui/keyboard.md:36
-msgid "á"
-msgstr ""
-
-#: src/ui/keyboard.md:36
-msgid "`A '`"
-msgstr ""
-
-#: src/ui/keyboard.md:36
-msgid "Á"
-msgstr ""
-
-#: src/ui/keyboard.md:36
-msgid "```a `` ```"
-msgstr ""
-
-#: src/ui/keyboard.md:36
-msgid "à"
-msgstr ""
-
-#: src/ui/keyboard.md:36
-msgid "```A `` ```"
-msgstr ""
-
-#: src/ui/keyboard.md:36
-msgid "À"
-msgstr ""
-
-#: src/ui/keyboard.md:37
-msgid "`e '`"
-msgstr ""
-
-#: src/ui/keyboard.md:37
-msgid "é"
-msgstr ""
-
-#: src/ui/keyboard.md:37
-msgid "`E '`"
-msgstr ""
-
-#: src/ui/keyboard.md:37
-msgid "É"
-msgstr ""
-
-#: src/ui/keyboard.md:37
-msgid "```e `` ```"
-msgstr ""
-
-#: src/ui/keyboard.md:37
-msgid "è"
-msgstr ""
-
-#: src/ui/keyboard.md:37
-msgid "```E `` ```"
-msgstr ""
-
-#: src/ui/keyboard.md:37
-msgid "È"
-msgstr ""
-
-#: src/ui/keyboard.md:38
-msgid "`i '`"
-msgstr ""
-
-#: src/ui/keyboard.md:38
-msgid "í"
-msgstr ""
-
-#: src/ui/keyboard.md:38
-msgid "`I '`"
-msgstr ""
-
-#: src/ui/keyboard.md:38
-msgid "Í"
-msgstr ""
-
-#: src/ui/keyboard.md:38
-msgid "```i `` ```"
-msgstr ""
-
-#: src/ui/keyboard.md:38
-msgid "ì"
-msgstr ""
-
-#: src/ui/keyboard.md:38
-msgid "```I `` ```"
-msgstr ""
-
-#: src/ui/keyboard.md:38
-msgid "Ì"
-msgstr ""
-
-#: src/ui/keyboard.md:39
-msgid "`o '`"
-msgstr ""
-
-#: src/ui/keyboard.md:39
-msgid "ó"
-msgstr ""
-
-#: src/ui/keyboard.md:39
-msgid "`O '`"
-msgstr ""
-
-#: src/ui/keyboard.md:39
-msgid "Ó"
-msgstr ""
-
-#: src/ui/keyboard.md:39
-msgid "```o `` ```"
-msgstr ""
-
-#: src/ui/keyboard.md:39
-msgid "ò"
-msgstr ""
-
-#: src/ui/keyboard.md:39
-msgid "```O `` ```"
-msgstr ""
-
-#: src/ui/keyboard.md:39
-msgid "Ò"
-msgstr ""
-
-#: src/ui/keyboard.md:40
-msgid "`u '`"
-msgstr ""
-
-#: src/ui/keyboard.md:40
-msgid "ú"
-msgstr ""
-
-#: src/ui/keyboard.md:40
-msgid "`U '`"
-msgstr ""
-
-#: src/ui/keyboard.md:40
-msgid "Ú"
-msgstr ""
-
-#: src/ui/keyboard.md:40
-msgid "```u `` ```"
-msgstr ""
-
-#: src/ui/keyboard.md:40
-msgid "ù"
-msgstr ""
-
-#: src/ui/keyboard.md:40
-msgid "```U `` ```"
-msgstr ""
-
-#: src/ui/keyboard.md:40
-msgid "Ù"
-msgstr ""
-
-#: src/ui/keyboard.md:41
-msgid "`y '`"
-msgstr ""
-
-#: src/ui/keyboard.md:41
-msgid "ý"
-msgstr ""
-
-#: src/ui/keyboard.md:41
-msgid "`Y '`"
-msgstr ""
-
-#: src/ui/keyboard.md:41
-msgid "Ý"
-msgstr ""
-
-#: src/ui/keyboard.md:41
-msgid "`u \"`"
-msgstr ""
-
-#: src/ui/keyboard.md:41
-msgid "ű"
-msgstr ""
-
-#: src/ui/keyboard.md:41
-msgid "`U \"`"
-msgstr ""
-
-#: src/ui/keyboard.md:41
-msgid "Ű"
-msgstr ""
-
-#: src/ui/keyboard.md:42
-msgid "`a ^`"
-msgstr ""
-
-#: src/ui/keyboard.md:42
-msgid "â"
-msgstr ""
-
-#: src/ui/keyboard.md:42
-msgid "`A ^`"
-msgstr ""
-
-#: src/ui/keyboard.md:42
-msgid "Â"
-msgstr ""
-
-#: src/ui/keyboard.md:42
-msgid "`o \"`"
-msgstr ""
-
-#: src/ui/keyboard.md:42
-msgid "ő"
-msgstr ""
-
-#: src/ui/keyboard.md:42
-msgid "`O \"`"
-msgstr ""
-
-#: src/ui/keyboard.md:42
-msgid "Ő"
-msgstr ""
-
-#: src/ui/keyboard.md:43
-msgid "`e ^`"
-msgstr ""
-
-#: src/ui/keyboard.md:43
-msgid "ê"
-msgstr ""
-
-#: src/ui/keyboard.md:43
-msgid "`E ^`"
-msgstr ""
-
-#: src/ui/keyboard.md:43
-msgid "Ê"
-msgstr ""
-
-#: src/ui/keyboard.md:43
-msgid "`a :`"
-msgstr ""
-
-#: src/ui/keyboard.md:43
-msgid "ä"
-msgstr ""
-
-#: src/ui/keyboard.md:43
-msgid "`A :`"
-msgstr ""
-
-#: src/ui/keyboard.md:43
-msgid "Ä"
-msgstr ""
-
-#: src/ui/keyboard.md:44
-msgid "`i ^`"
-msgstr ""
-
-#: src/ui/keyboard.md:44
-msgid "î"
-msgstr ""
-
-#: src/ui/keyboard.md:44
-msgid "`I ^`"
-msgstr ""
-
-#: src/ui/keyboard.md:44
-msgid "Î"
-msgstr ""
-
-#: src/ui/keyboard.md:44
-msgid "`e :`"
-msgstr ""
-
-#: src/ui/keyboard.md:44
-msgid "ë"
-msgstr ""
-
-#: src/ui/keyboard.md:44
-msgid "`E :`"
-msgstr ""
-
-#: src/ui/keyboard.md:44
-msgid "Ë"
-msgstr ""
-
-#: src/ui/keyboard.md:45
-msgid "`o ^`"
-msgstr ""
-
-#: src/ui/keyboard.md:45
-msgid "ô"
-msgstr ""
-
-#: src/ui/keyboard.md:45
-msgid "`O ^`"
-msgstr ""
-
-#: src/ui/keyboard.md:45
-msgid "Ô"
-msgstr ""
-
-#: src/ui/keyboard.md:45
-msgid "`i :`"
-msgstr ""
-
-#: src/ui/keyboard.md:45
-msgid "ï"
-msgstr ""
-
-#: src/ui/keyboard.md:45
-msgid "`I :`"
-msgstr ""
-
-#: src/ui/keyboard.md:45
-msgid "Ï"
-msgstr ""
-
-#: src/ui/keyboard.md:46
-msgid "`u ^`"
-msgstr ""
-
-#: src/ui/keyboard.md:46
-msgid "û"
-msgstr ""
-
-#: src/ui/keyboard.md:46
-msgid "`U ^`"
-msgstr ""
-
-#: src/ui/keyboard.md:46
-msgid "Û"
-msgstr ""
-
-#: src/ui/keyboard.md:46
-msgid "`o :`"
-msgstr ""
-
-#: src/ui/keyboard.md:46
-msgid "ö"
-msgstr ""
-
-#: src/ui/keyboard.md:46
-msgid "`O :`"
-msgstr ""
-
-#: src/ui/keyboard.md:46
-msgid "Ö"
-msgstr ""
-
-#: src/ui/keyboard.md:47
-msgid "`w ^`"
-msgstr ""
-
-#: src/ui/keyboard.md:47
-msgid "ŵ"
-msgstr ""
-
-#: src/ui/keyboard.md:47
-msgid "`W ^`"
-msgstr ""
-
-#: src/ui/keyboard.md:47
-msgid "Ŵ"
-msgstr ""
-
-#: src/ui/keyboard.md:47
-msgid "`u :`"
-msgstr ""
-
-#: src/ui/keyboard.md:47
-msgid "ü"
-msgstr ""
-
-#: src/ui/keyboard.md:47
-msgid "`U :`"
-msgstr ""
-
-#: src/ui/keyboard.md:47
-msgid "Ü"
-msgstr ""
-
-#: src/ui/keyboard.md:48
-msgid "`y ^`"
-msgstr ""
-
-#: src/ui/keyboard.md:48
-msgid "ŷ"
-msgstr ""
-
-#: src/ui/keyboard.md:48
-msgid "`Y ^`"
-msgstr ""
-
-#: src/ui/keyboard.md:48
-msgid "Ŷ"
-msgstr ""
-
-#: src/ui/keyboard.md:48
-msgid "`y :`"
-msgstr ""
-
-#: src/ui/keyboard.md:48
-msgid "ÿ"
-msgstr ""
-
-#: src/ui/keyboard.md:49
-msgid "`a ~`"
-msgstr ""
-
-#: src/ui/keyboard.md:49
-msgid "ã"
-msgstr ""
-
-#: src/ui/keyboard.md:49
-msgid "`A ~`"
-msgstr ""
-
-#: src/ui/keyboard.md:49
-msgid "Ã"
-msgstr ""
-
-#: src/ui/keyboard.md:49
-msgid "`c ,`"
-msgstr ""
-
-#: src/ui/keyboard.md:49
-msgid "ç"
-msgstr ""
-
-#: src/ui/keyboard.md:49
-msgid "`C ,`"
-msgstr ""
-
-#: src/ui/keyboard.md:49
-msgid "Ç"
-msgstr ""
-
-#: src/ui/keyboard.md:50
-msgid "`o ~`"
-msgstr ""
-
-#: src/ui/keyboard.md:50
-msgid "õ"
-msgstr ""
-
-#: src/ui/keyboard.md:50
-msgid "`O ~`"
-msgstr ""
-
-#: src/ui/keyboard.md:50
-msgid "Õ"
-msgstr ""
-
-#: src/ui/keyboard.md:50
-msgid "`c '`"
-msgstr ""
-
-#: src/ui/keyboard.md:50
-msgid "ć"
-msgstr ""
-
-#: src/ui/keyboard.md:50
-msgid "`C '`"
-msgstr ""
-
-#: src/ui/keyboard.md:50
-msgid "Ć"
-msgstr ""
-
-#: src/ui/keyboard.md:51
-msgid "`n ~`"
-msgstr ""
-
-#: src/ui/keyboard.md:51
-msgid "ñ"
-msgstr ""
-
-#: src/ui/keyboard.md:51
-msgid "`N ~`"
-msgstr ""
-
-#: src/ui/keyboard.md:51
-msgid "Ñ"
-msgstr ""
-
-#: src/ui/keyboard.md:51
-msgid "`z '`"
-msgstr ""
-
-#: src/ui/keyboard.md:51
-msgid "ź"
-msgstr ""
-
-#: src/ui/keyboard.md:51
-msgid "`Z '`"
-msgstr ""
-
-#: src/ui/keyboard.md:51
-msgid "Ź"
-msgstr ""
-
-#: src/ui/keyboard.md:52
-msgid "`a ;`"
-msgstr ""
-
-#: src/ui/keyboard.md:52
-msgid "ą"
-msgstr ""
-
-#: src/ui/keyboard.md:52
-msgid "`A ;`"
-msgstr ""
-
-#: src/ui/keyboard.md:52
-msgid "Ą"
-msgstr ""
-
-#: src/ui/keyboard.md:52
-msgid "`s '`"
-msgstr ""
-
-#: src/ui/keyboard.md:52
-msgid "ś"
-msgstr ""
-
-#: src/ui/keyboard.md:52
-msgid "`S '`"
-msgstr ""
-
-#: src/ui/keyboard.md:52
-msgid "Ś"
-msgstr ""
-
-#: src/ui/keyboard.md:53
-msgid "`e ;`"
-msgstr ""
-
-#: src/ui/keyboard.md:53
-msgid "ę"
-msgstr ""
-
-#: src/ui/keyboard.md:53
-msgid "`E ;`"
-msgstr ""
-
-#: src/ui/keyboard.md:53
-msgid "Ę"
-msgstr ""
-
-#: src/ui/keyboard.md:53
-msgid "`n '`"
-msgstr ""
-
-#: src/ui/keyboard.md:53
-msgid "ń"
-msgstr ""
-
-#: src/ui/keyboard.md:53
-msgid "`N '`"
-msgstr ""
-
-#: src/ui/keyboard.md:53
-msgid "Ń"
-msgstr ""
-
-#: src/ui/keyboard.md:54
-msgid "`z .`"
-msgstr ""
-
-#: src/ui/keyboard.md:54
-msgid "ż"
-msgstr ""
-
-#: src/ui/keyboard.md:54
-msgid "`Z .`"
-msgstr ""
-
-#: src/ui/keyboard.md:54
-msgid "Ż"
-msgstr ""
-
-#: src/ui/keyboard.md:54
-msgid "`t h`"
-msgstr ""
-
-#: src/ui/keyboard.md:54
-msgid "þ"
-msgstr ""
-
-#: src/ui/keyboard.md:54
-msgid "`T h`"
-msgstr ""
-
-#: src/ui/keyboard.md:54
-msgid "Þ"
-msgstr ""
-
-#: src/ui/keyboard.md:55
-msgid "`a o`"
-msgstr ""
-
-#: src/ui/keyboard.md:55
-msgid "å"
-msgstr ""
-
-#: src/ui/keyboard.md:55
-msgid "`A o`"
-msgstr ""
-
-#: src/ui/keyboard.md:55
-msgid "Å"
-msgstr ""
-
-#: src/ui/keyboard.md:55
-msgid "`l /`"
-msgstr ""
-
-#: src/ui/keyboard.md:55
-msgid "ł"
-msgstr ""
-
-#: src/ui/keyboard.md:55
-msgid "`L /`"
-msgstr ""
-
-#: src/ui/keyboard.md:55
-msgid "Ł"
-msgstr ""
-
-#: src/ui/keyboard.md:56
-msgid "`d /`"
-msgstr ""
-
-#: src/ui/keyboard.md:56
-msgid "đ"
-msgstr ""
-
-#: src/ui/keyboard.md:56
-msgid "`D /`"
-msgstr ""
-
-#: src/ui/keyboard.md:56
-msgid "Đ"
-msgstr ""
-
-#: src/ui/keyboard.md:56
-msgid "`o /`"
-msgstr ""
-
-#: src/ui/keyboard.md:56
-msgid "ø"
-msgstr ""
-
-#: src/ui/keyboard.md:56
-msgid "`O /`"
-msgstr ""
-
-#: src/ui/keyboard.md:56
-msgid "Ø"
-msgstr ""
-
-#: src/ui/keyboard.md:57
-msgid "`o e`"
-msgstr ""
-
-#: src/ui/keyboard.md:57
-msgid "œ"
-msgstr ""
-
-#: src/ui/keyboard.md:57
-msgid "`O e`"
-msgstr ""
-
-#: src/ui/keyboard.md:57
-msgid "Œ"
-msgstr ""
-
-#: src/ui/keyboard.md:57
-msgid "`a e`"
-msgstr ""
-
-#: src/ui/keyboard.md:57
-msgid "æ"
-msgstr ""
-
-#: src/ui/keyboard.md:57
-msgid "`A E`"
-msgstr ""
-
-#: src/ui/keyboard.md:57
-msgid "Æ"
-msgstr ""
-
-#: src/ui/keyboard.md:58
-msgid "`s s`"
-msgstr ""
-
-#: src/ui/keyboard.md:58
-msgid "ß"
-msgstr ""
-
-#: src/ui/keyboard.md:58
-msgid "`S s`"
-msgstr ""
-
-#: src/ui/keyboard.md:58
-msgid "ẞ"
-msgstr ""
-
-#: src/ui/keyboard.md:58
-msgid "`m u`"
-msgstr ""
-
-#: src/ui/keyboard.md:58
-msgid "µ"
-msgstr ""
-
-#: src/ui/keyboard.md:58
-msgid "`l -`"
-msgstr ""
-
-#: src/ui/keyboard.md:58
-msgid "£"
-msgstr ""
-
-#: src/ui/keyboard.md:59
-msgid "`p p`"
-msgstr ""
-
-#: src/ui/keyboard.md:59
-msgid "¶"
-msgstr ""
-
-#: src/ui/keyboard.md:59
-msgid "`s o`"
-msgstr ""
-
-#: src/ui/keyboard.md:59
-msgid "§"
-msgstr ""
-
-#: src/ui/keyboard.md:59
-msgid "`o _`"
-msgstr ""
-
-#: src/ui/keyboard.md:59
-msgid "º"
-msgstr ""
-
-#: src/ui/keyboard.md:59
-msgid "`a _`"
-msgstr ""
-
-#: src/ui/keyboard.md:59
-msgid "ª"
-msgstr ""
-
-#: src/ui/keyboard.md:60
-msgid "`o o`"
-msgstr ""
-
-#: src/ui/keyboard.md:60
-msgid "°"
-msgstr ""
-
-#: src/ui/keyboard.md:60
-msgid "`e =`"
-msgstr ""
-
-#: src/ui/keyboard.md:60
-msgid "€"
-msgstr ""
-
-#: src/ui/keyboard.md:60
-msgid "`o r`"
-msgstr ""
-
-#: src/ui/keyboard.md:60
-msgid "®"
-msgstr ""
-
-#: src/ui/keyboard.md:60
-msgid "`o c`"
-msgstr ""
-
-#: src/ui/keyboard.md:60
-msgid "©"
-msgstr ""
-
-#: src/ui/keyboard.md:61
-msgid "`o p`"
-msgstr ""
-
-#: src/ui/keyboard.md:61
-msgid "℗"
-msgstr ""
-
-#: src/ui/keyboard.md:61
-msgid "`t m`"
-msgstr ""
-
-#: src/ui/keyboard.md:61
-msgid "™"
-msgstr ""
-
-#: src/ui/keyboard.md:61
-msgid "`] ]`"
-msgstr ""
-
-#: src/ui/keyboard.md:61
-msgid "⟧"
-msgstr ""
-
-#: src/ui/keyboard.md:61
-msgid "`[ [`"
-msgstr ""
-
-#: src/ui/keyboard.md:61
-msgid "⟦"
-msgstr ""
-
-#: src/ui/keyboard.md:62
-msgid "`\\| -`"
-msgstr ""
-
-#: src/ui/keyboard.md:62
-msgid "†"
-msgstr ""
-
-#: src/ui/keyboard.md:62
-msgid "`\\| =`"
-msgstr ""
-
-#: src/ui/keyboard.md:62
-msgid "‡"
-msgstr ""
-
-#: src/ui/keyboard.md:62
-msgid "`- ,`"
-msgstr ""
-
-#: src/ui/keyboard.md:62
-msgid "¬"
-msgstr ""
-
-#: src/ui/keyboard.md:62
-msgid "`~ ~`"
-msgstr ""
-
-#: src/ui/keyboard.md:62
-msgid "≈"
-msgstr ""
-
-#: src/ui/keyboard.md:63
-msgid "`< <`"
-msgstr ""
-
-#: src/ui/keyboard.md:63
-msgid "«"
-msgstr ""
-
-#: src/ui/keyboard.md:63
-msgid "`> >`"
-msgstr ""
-
-#: src/ui/keyboard.md:63
-msgid "»"
-msgstr ""
-
-#: src/ui/keyboard.md:63
-msgid "`! !`"
-msgstr ""
-
-#: src/ui/keyboard.md:63
-msgid "¡"
-msgstr ""
-
-#: src/ui/keyboard.md:63
-msgid "`? ?`"
-msgstr ""
-
-#: src/ui/keyboard.md:63
-msgid "¿"
-msgstr ""
-
-#: src/ui/keyboard.md:64
-msgid "`. -`"
-msgstr ""
-
-#: src/ui/keyboard.md:64
-msgid "·"
-msgstr ""
-
-#: src/ui/keyboard.md:64
-msgid "`. =`"
-msgstr ""
-
-#: src/ui/keyboard.md:64
-msgid "•"
-msgstr ""
-
-#: src/ui/keyboard.md:64
-msgid "`. >`"
-msgstr ""
-
-#: src/ui/keyboard.md:64
-msgid "›"
-msgstr ""
-
-#: src/ui/keyboard.md:64
-msgid "`. <`"
-msgstr ""
-
-#: src/ui/keyboard.md:64
-msgid "‹"
-msgstr ""
-
-#: src/ui/keyboard.md:65
-msgid "`' 1`"
-msgstr ""
-
-#: src/ui/keyboard.md:65
-msgid "′"
-msgstr ""
-
-#: src/ui/keyboard.md:65
-msgid "`' 2`"
-msgstr ""
-
-#: src/ui/keyboard.md:65
-msgid "″"
-msgstr ""
-
-#: src/ui/keyboard.md:65
-msgid "`+ -`"
-msgstr ""
-
-#: src/ui/keyboard.md:65
-msgid "±"
-msgstr ""
-
-#: src/ui/keyboard.md:65
-msgid "`- :`"
-msgstr ""
-
-#: src/ui/keyboard.md:65
-msgid "÷"
-msgstr ""
-
-#: src/ui/keyboard.md:66
-msgid "`< =`"
-msgstr ""
-
-#: src/ui/keyboard.md:66
-msgid "≤"
-msgstr ""
-
-#: src/ui/keyboard.md:66
-msgid "`> =`"
-msgstr ""
-
-#: src/ui/keyboard.md:66
-msgid "≥"
-msgstr ""
-
-#: src/ui/keyboard.md:66
-msgid "`= /`"
-msgstr ""
-
-#: src/ui/keyboard.md:66
-msgid "≠"
-msgstr ""
-
-#: src/ui/keyboard.md:66
-msgid "`% o`"
-msgstr ""
-
-#: src/ui/keyboard.md:66
-msgid "‰"
-msgstr ""
-
-#: src/ui/keyboard.md:67
-msgid "`# f`"
-msgstr ""
-
-#: src/ui/keyboard.md:67
-msgid "♭"
-msgstr ""
-
-#: src/ui/keyboard.md:67
-msgid "`# n`"
-msgstr ""
-
-#: src/ui/keyboard.md:67
-msgid "♮"
-msgstr ""
-
-#: src/ui/keyboard.md:67
-msgid "`# s`"
-msgstr ""
-
-#: src/ui/keyboard.md:67
-msgid "♯"
-msgstr ""
-
-#: src/ui/keyboard.md:68
-msgid "`1 2`"
-msgstr ""
-
-#: src/ui/keyboard.md:68
-msgid "½"
-msgstr ""
-
-#: src/ui/keyboard.md:68
-msgid "`1 3`"
-msgstr ""
-
-#: src/ui/keyboard.md:68
-msgid "⅓"
-msgstr ""
-
-#: src/ui/keyboard.md:68
-msgid "`2 3`"
-msgstr ""
-
-#: src/ui/keyboard.md:68
-msgid "⅔"
-msgstr ""
-
-#: src/ui/keyboard.md:68
-msgid "`1 4`"
-msgstr ""
-
-#: src/ui/keyboard.md:68
-msgid "¼"
-msgstr ""
-
-#: src/ui/keyboard.md:69
-msgid "`3 4`"
-msgstr ""
-
-#: src/ui/keyboard.md:69
-msgid "¾"
-msgstr ""
-
-#: src/ui/keyboard.md:69
-msgid "`1 5`"
-msgstr ""
-
-#: src/ui/keyboard.md:69
-msgid "⅕"
-msgstr ""
-
-#: src/ui/keyboard.md:69
-msgid "`2 5`"
-msgstr ""
-
-#: src/ui/keyboard.md:69
-msgid "⅖"
-msgstr ""
-
-#: src/ui/keyboard.md:69
-msgid "`3 5`"
-msgstr ""
-
-#: src/ui/keyboard.md:69
-msgid "⅗"
-msgstr ""
-
-#: src/ui/keyboard.md:70
-msgid "`4 5`"
-msgstr ""
-
-#: src/ui/keyboard.md:70
-msgid "⅘"
-msgstr ""
-
-#: src/ui/keyboard.md:70
-msgid "`1 6`"
-msgstr ""
-
-#: src/ui/keyboard.md:70
-msgid "⅙"
-msgstr ""
-
-#: src/ui/keyboard.md:70
-msgid "`5 6`"
-msgstr ""
-
-#: src/ui/keyboard.md:70
-msgid "⅚"
-msgstr ""
-
-#: src/ui/keyboard.md:70
-msgid "`1 8`"
-msgstr ""
-
-#: src/ui/keyboard.md:70
-msgid "⅛"
-msgstr ""
-
-#: src/ui/keyboard.md:71
-msgid "`3 8`"
-msgstr ""
-
-#: src/ui/keyboard.md:71
-msgid "⅜"
-msgstr ""
-
-#: src/ui/keyboard.md:71
-msgid "`5 8`"
-msgstr ""
-
-#: src/ui/keyboard.md:71
-msgid "⅝"
-msgstr ""
-
-#: src/ui/keyboard.md:71
-msgid "`7 8`"
-msgstr ""
-
-#: src/ui/keyboard.md:71
-msgid "⅞"
-msgstr ""
-
-#: src/ui/keyboard.md:73
+#: src/ui/keyboard.md:77
 msgid "Custom Keyboard Layouts"
 msgstr ""
 
-#: src/ui/keyboard.md:75
+#: src/ui/keyboard.md:79
 msgid "Keyboard layouts are defined as JSON files with the following structure:"
 msgstr ""
 
-#: src/ui/keyboard.md:77
+#: src/ui/keyboard.md:81
 msgid "**name** — Display name shown in the keyboard layouts menu."
 msgstr ""
 
-#: src/ui/keyboard.md:78
+#: src/ui/keyboard.md:82
 msgid ""
 "**outputs** — List of output keys for each modifier combination (_none_, "
 "_shift_, _alt_, _shift+alt_)."
 msgstr ""
 
-#: src/ui/keyboard.md:80
+#: src/ui/keyboard.md:84
 msgid ""
 "**keys** — Description of each key. Special key names: _Shift_ (_Sft_), "
 "_Return_ (_Ret_), _Alternate_ (_Alt_), _Combine_ (_Cmb_), _MoveFwd_ "
@@ -3229,7 +1850,7 @@ msgid ""
 "_DelBwd_ (_DelB_, _DB_), _Space_ (_Spc_). Use _▢_ to mark output keys."
 msgstr ""
 
-#: src/ui/keyboard.md:84
+#: src/ui/keyboard.md:88
 msgid "**widths** — Width/height ratio for each key. The key gap ratio is 0.06."
 msgstr ""
 
@@ -3506,38 +2127,13 @@ msgid ""
 "device has an SD card and whether you are using a test build:"
 msgstr ""
 
-#: src/ui/settings/dictionaries.md:105
-msgid "**On devices with an SD card**:"
-msgstr ""
-
-#: src/ui/settings/dictionaries.md:106
-msgid "Production: `/mnt/sd/.cadmus/dictionaries/reader-dict/<lang>/`"
-msgstr ""
-
-#: src/ui/settings/dictionaries.md:107
-msgid "Test build: `/mnt/sd/.cadmus-tst/dictionaries/reader-dict/<lang>/`"
-msgstr ""
-
-#: src/ui/settings/dictionaries.md:108
-msgid "**On devices without an SD card**:"
-msgstr ""
-
-#: src/ui/settings/dictionaries.md:109
-msgid "Production: `/mnt/onboard/.adds/cadmus/dictionaries/reader-dict/<lang>/`"
-msgstr ""
-
-#: src/ui/settings/dictionaries.md:110
-msgid ""
-"Test build: `/mnt/onboard/.adds/cadmus-tst/dictionaries/reader-dict/<lang>/`"
-msgstr ""
-
-#: src/ui/settings/dictionaries.md:112
+#: src/ui/settings/dictionaries.md:116
 msgid ""
 "Each language gets its own subfolder containing a `.dict.dz` (or `.dict`) "
 "and a `.index` file."
 msgstr ""
 
-#: src/ui/settings/dictionaries.md:115
+#: src/ui/settings/dictionaries.md:119
 msgid ""
 "If your SD card is already inserted when you upgrade Cadmus, your "
 "dictionaries are moved to the SD card automatically on the next boot. If you "
@@ -3632,7 +2228,6 @@ msgid ""
 msgstr ""
 
 #: src/time-sync.md:6 src/auto-frontlight.md:6 src/database-backup.md:5
-#: src/contributing/translations/source-code.md:7
 msgid "How it works"
 msgstr ""
 
@@ -3668,40 +2263,40 @@ msgstr ""
 msgid "You can also enable it manually in your settings file:"
 msgstr ""
 
-#: src/time-sync.md:26
+#: src/time-sync.md:30
 msgid "Manual sync"
 msgstr ""
 
-#: src/time-sync.md:28
+#: src/time-sync.md:32
 msgid "You can trigger a one-time sync without enabling the automatic option:"
 msgstr ""
 
-#: src/time-sync.md:30
+#: src/time-sync.md:34
 msgid "Tap the clock in the top bar."
 msgstr ""
 
-#: src/time-sync.md:31
+#: src/time-sync.md:35
 msgid "Select **Sync Time**."
 msgstr ""
 
-#: src/time-sync.md:33
+#: src/time-sync.md:37
 msgid ""
 "If the sync fails (for example, WiFi is not connected), a notification will "
 "let you know."
 msgstr ""
 
-#: src/time-sync.md:36 src/auto-frontlight.md:75
+#: src/time-sync.md:40 src/auto-frontlight.md:87
 msgid "Privacy"
 msgstr ""
 
-#: src/time-sync.md:39
+#: src/time-sync.md:43
 msgid ""
 "Time syncing sends a request to `ipapi.co` to determine your timezone based "
 "on your IP address. No personal data is sent — only your device's public IP "
 "address is visible to that service as part of the network request."
 msgstr ""
 
-#: src/time-sync.md:43
+#: src/time-sync.md:47
 msgid ""
 "The actual time is fetched from `time.cloudflare.com` using the standard NTP "
 "protocol."
@@ -3752,28 +2347,28 @@ msgstr ""
 msgid "You can also enable it directly in your settings file:"
 msgstr ""
 
-#: src/auto-frontlight.md:31
+#: src/auto-frontlight.md:35
 msgid ""
 "See [`auto-frontlight`](settings/index.md#auto-frontlight) and related "
 "entries in the Settings reference for all available options."
 msgstr ""
 
-#: src/auto-frontlight.md:34
+#: src/auto-frontlight.md:38
 msgid "Manual adjustments pause automation"
 msgstr ""
 
-#: src/auto-frontlight.md:36
+#: src/auto-frontlight.md:40
 msgid ""
 "If you manually change the frontlight level while automatic adjustment is "
 "running, Cadmus stops the background task so your chosen level is preserved. "
 "Automatic adjustment resumes the next time the app is started."
 msgstr ""
 
-#: src/auto-frontlight.md:40
+#: src/auto-frontlight.md:44
 msgid "Location detection"
 msgstr ""
 
-#: src/auto-frontlight.md:42
+#: src/auto-frontlight.md:46
 msgid ""
 "Sun position is calculated from your geographic coordinates. Cadmus obtains "
 "these automatically during each [time sync](time-sync.md): the same "
@@ -3782,48 +2377,48 @@ msgid ""
 "settings file."
 msgstr ""
 
-#: src/auto-frontlight.md:47
+#: src/auto-frontlight.md:51
 msgid ""
 "If no coordinates are available yet (for example, before the first "
 "successful time sync), automatic adjustment is skipped until a location is "
 "known."
 msgstr ""
 
-#: src/auto-frontlight.md:50
+#: src/auto-frontlight.md:54
 msgid "Manual coordinates override"
 msgstr ""
 
-#: src/auto-frontlight.md:52
+#: src/auto-frontlight.md:56
 msgid ""
 "If you prefer not to rely on IP-based location, or if the detected location "
 "is inaccurate, you can set your own coordinates:"
 msgstr ""
 
-#: src/auto-frontlight.md:59
+#: src/auto-frontlight.md:67
 msgid "Manual coordinates take priority over auto-detected ones."
 msgstr ""
 
-#: src/auto-frontlight.md:61
+#: src/auto-frontlight.md:69
 msgid ""
 "You can also edit this in **Main Menu → Settings → General** under **Auto "
 "Frontlight Manual Coordinates**."
 msgstr ""
 
-#: src/auto-frontlight.md:64
+#: src/auto-frontlight.md:72
 msgid "Night brightness"
 msgstr ""
 
-#: src/auto-frontlight.md:66
+#: src/auto-frontlight.md:74
 msgid ""
 "The brightness level used after sunset defaults to `1.0` (1%). You can raise "
 "this if you find the screen too dim for nighttime reading:"
 msgstr ""
 
-#: src/auto-frontlight.md:73
+#: src/auto-frontlight.md:85
 msgid "The value is a percentage from `0.0` to `100.0`."
 msgstr ""
 
-#: src/auto-frontlight.md:78
+#: src/auto-frontlight.md:90
 msgid ""
 "When [automatic time syncing](time-sync.md) is enabled, a request is sent to "
 "`ipapi.co` to resolve your timezone. That same response includes an "
@@ -3879,36 +2474,36 @@ msgid ""
 "same folder tracks every backup."
 msgstr ""
 
-#: src/database-backup.md:35
+#: src/database-backup.md:39
 msgid ""
 "Each backup file is named after the Cadmus version that created it, for "
 "example `cadmus-v1.2.3.sqlite`."
 msgstr ""
 
-#: src/database-backup.md:38
+#: src/database-backup.md:42
 msgid "Downgrade protection"
 msgstr ""
 
-#: src/database-backup.md:40
+#: src/database-backup.md:44
 msgid ""
 "When you install an older version of Cadmus on top of a newer one, the "
 "database already on disk was written by the newer version."
 msgstr ""
 
-#: src/database-backup.md:43
+#: src/database-backup.md:47
 msgid ""
 "Cadmus checks whether the older version uses the same database layout as the "
 "newer version. If it does, Cadmus keeps using the database normally."
 msgstr ""
 
-#: src/database-backup.md:46
+#: src/database-backup.md:50
 msgid ""
 "If the database layout changed, Cadmus automatically restores the most "
 "recent backup that is compatible with the older version. Data such as "
 "reading progress that was only written on the newer version will be lost."
 msgstr ""
 
-#: src/database-backup.md:50
+#: src/database-backup.md:54
 msgid ""
 "Before the restore happens, the current database file is renamed to "
 "`cadmus-<newer-version>-demoted.sqlite` in the `backups/` folder. This "
@@ -3916,29 +2511,29 @@ msgid ""
 "deletes it automatically, so you can recover it manually if you ever need to."
 msgstr ""
 
-#: src/database-backup.md:55
+#: src/database-backup.md:59
 msgid "Corruption recovery"
 msgstr ""
 
-#: src/database-backup.md:57
+#: src/database-backup.md:61
 msgid ""
 "If the database file fails its integrity check, Cadmus restores the most "
 "recent backup and re-runs migrations. The corrupt file is replaced and "
 "Cadmus continues normally."
 msgstr ""
 
-#: src/database-backup.md:62
+#: src/database-backup.md:66
 msgid ""
 "If the database is corrupted _and_ no backup exists (for example on a fresh "
 "install), Cadmus cannot start. You would have to manually delete the "
 "database file to allow Cadmus to start."
 msgstr ""
 
-#: src/database-backup.md:66
+#: src/database-backup.md:70
 msgid "Controlling how many backups to keep"
 msgstr ""
 
-#: src/database-backup.md:68
+#: src/database-backup.md:72
 msgid ""
 "Use the `db-backup-retention` setting to control how many backup files are "
 "kept on disk. When a new backup is created and the total number of backups "
@@ -3962,31 +2557,7 @@ msgid ""
 "platform:"
 msgstr ""
 
-#: src/troubleshooting/index.md:13 src/investigations/index.md:7
-msgid "Platform"
-msgstr ""
-
-#: src/troubleshooting/index.md:13
-msgid "Stable build"
-msgstr ""
-
-#: src/troubleshooting/index.md:13
-msgid "Test build"
-msgstr ""
-
-#: src/troubleshooting/index.md:15 src/investigations/index.md:9
-msgid "Kobo"
-msgstr ""
-
-#: src/troubleshooting/index.md:15
-msgid "`/mnt/onboard/.adds/cadmus/logs`"
-msgstr ""
-
-#: src/troubleshooting/index.md:15
-msgid "`/mnt/onboard/.adds/cadmus-tst/logs`"
-msgstr ""
-
-#: src/troubleshooting/index.md:17
+#: src/troubleshooting/index.md:21
 msgid ""
 "Each time you start Cadmus, it creates a new log file with a unique ID. By "
 "default, only the 3 most recent log files are kept — older ones are deleted "
@@ -3994,105 +2565,105 @@ msgid ""
 "[`logging.max-files`](../settings/index.md#loggingmax-files) setting."
 msgstr ""
 
-#: src/troubleshooting/index.md:22
+#: src/troubleshooting/index.md:26
 msgid "The log files look like this:"
 msgstr ""
 
-#: src/troubleshooting/index.md:28
+#: src/troubleshooting/index.md:36
 msgid "Finding your run ID"
 msgstr ""
 
-#: src/troubleshooting/index.md:30
+#: src/troubleshooting/index.md:38
 msgid ""
 "Every time Cadmus starts, it prints a run ID to help you identify which log "
 "file belongs to that session. You can find this in:"
 msgstr ""
 
-#: src/troubleshooting/index.md:34
+#: src/troubleshooting/index.md:42
 msgid ""
 "**info.log** - The startup log in the Cadmus folder. Look for the line that "
 "says `Cadmus run started with ID:` followed by a string of letters and "
 "numbers."
 msgstr ""
 
-#: src/troubleshooting/index.md:37
+#: src/troubleshooting/index.md:45
 msgid "For example:"
 msgstr ""
 
-#: src/troubleshooting/index.md:43
+#: src/troubleshooting/index.md:55
 msgid ""
 "Copy only the UUID part — the string of letters and numbers between `ID:` "
 "and the `(version` text."
 msgstr ""
 
-#: src/troubleshooting/index.md:46
+#: src/troubleshooting/index.md:58
 msgid ""
 "**Console output** - If you're running Cadmus from a terminal, the same run "
 "ID is printed when it starts."
 msgstr ""
 
-#: src/troubleshooting/index.md:49
+#: src/troubleshooting/index.md:61
 msgid "Kernel logs"
 msgstr ""
 
-#: src/troubleshooting/index.md:51
+#: src/troubleshooting/index.md:63
 msgid ""
 "Kernel logs can be useful to debug lower level system issues, for example a "
 "kernel panic, which triggers a device reboot."
 msgstr ""
 
-#: src/troubleshooting/index.md:54
+#: src/troubleshooting/index.md:66
 msgid ""
 "Kernel logs are only available in [test "
 "builds](../installation/test-builds.md). If you're using a test build and "
 "want to include kernel logs:"
 msgstr ""
 
-#: src/troubleshooting/index.md:57
+#: src/troubleshooting/index.md:69
 msgid "Open **Main Menu → Settings**"
 msgstr ""
 
-#: src/troubleshooting/index.md:58
+#: src/troubleshooting/index.md:70
 msgid "Go to `Telemetry`"
 msgstr ""
 
-#: src/troubleshooting/index.md:59
+#: src/troubleshooting/index.md:71
 msgid "Enable kernel logs"
 msgstr ""
 
-#: src/troubleshooting/index.md:60
+#: src/troubleshooting/index.md:72
 msgid "Restart Cadmus"
 msgstr ""
 
-#: src/troubleshooting/index.md:62
+#: src/troubleshooting/index.md:74
 msgid "Kernel logs will then be saved in the same log file as your Cadmus logs."
 msgstr ""
 
-#: src/troubleshooting/index.md:65
+#: src/troubleshooting/index.md:77
 msgid ""
 "Kernel logs will use more disk space, so don't forget to turn it back off."
 msgstr ""
 
-#: src/troubleshooting/index.md:67
+#: src/troubleshooting/index.md:79
 msgid "Crashloop recovery"
 msgstr ""
 
-#: src/troubleshooting/index.md:69
+#: src/troubleshooting/index.md:81
 msgid ""
 "If Cadmus crashes 3 times in a row, it will exit back to Nickel instead of "
 "restarting. This prevents the device from getting stuck in an infinite loop "
 "of crashes."
 msgstr ""
 
-#: src/troubleshooting/index.md:73
+#: src/troubleshooting/index.md:85
 msgid "When this happens:"
 msgstr ""
 
-#: src/troubleshooting/index.md:75
+#: src/troubleshooting/index.md:87
 msgid "Check `info.log` in the Cadmus folder for the panic error"
 msgstr ""
 
-#: src/troubleshooting/index.md:76
+#: src/troubleshooting/index.md:88
 msgid ""
 "The crash counter resets when you start Cadmus manually (using the restart "
 "option in the menu or rebooting)"
@@ -4100,3593 +2671,5 @@ msgstr ""
 
 #: src/CHANGELOG.md:1
 msgid "Changelog"
-msgstr ""
-
-#: src/contributing/devenv-setup.md:1
-msgid "Development Environment Setup"
-msgstr ""
-
-#: src/contributing/devenv-setup.md:3
-msgid ""
-"Cadmus uses [devenv](https://devenv.sh/) with Nix to provide a reproducible "
-"development environment. This guide covers setup on both Linux and macOS."
-msgstr ""
-
-#: src/contributing/devenv-setup.md:6 src/contributing/translations/docs.md:6
-msgid "Prerequisites"
-msgstr ""
-
-#: src/contributing/devenv-setup.md:8
-msgid ""
-"Install Nix with flakes enabled. The easiest way is using the [Determinate "
-"Nix Installer](https://github.com/DeterminateSystems/nix-installer)."
-msgstr ""
-
-#: src/contributing/devenv-setup.md:9
-msgid "Install [devenv](https://devenv.sh/getting-started)."
-msgstr ""
-
-#: src/contributing/devenv-setup.md:11
-msgid "Quick Start"
-msgstr ""
-
-#: src/contributing/devenv-setup.md:13
-msgid "Clone the repository and enter the devenv shell:"
-msgstr ""
-
-#: src/contributing/devenv-setup.md:21
-msgid "Download the packaged runtime assets used by Kobo builds:"
-msgstr ""
-
-#: src/contributing/devenv-setup.md:28
-msgid ""
-"`cadmus-core` generates some compile-time metadata from the bundled asset "
-"directories. For Kobo builds, make sure `bin/`, `resources/`, and "
-"`hyphenation-patterns/` are present before `cargo xtask build-kobo` so the "
-"generated asset list is complete."
-msgstr ""
-
-#: src/contributing/devenv-setup.md:33
-msgid ""
-"Thirdparty C/C++ dependencies (MuPDF, libwebp, zlib, etc.) are tracked as "
-"git submodules and built automatically by `build.rs` when you run `cargo "
-"build` or `cargo xtask run-emulator`. No separate setup step is required."
-msgstr ""
-
-#: src/contributing/devenv-setup.md:37
-msgid "Run the emulator:"
-msgstr ""
-
-#: src/contributing/devenv-setup.md:43
-msgid "Available Commands"
-msgstr ""
-
-#: src/contributing/devenv-setup.md:45
-msgid "Once inside the devenv shell, these commands are available:"
-msgstr ""
-
-#: src/contributing/devenv-setup.md:47
-msgid "Command"
-msgstr ""
-
-#: src/contributing/devenv-setup.md:49
-msgid "`cargo xtask download-assets`"
-msgstr ""
-
-#: src/contributing/devenv-setup.md:49
-msgid "Download packaged Plato runtime assets"
-msgstr ""
-
-#: src/contributing/devenv-setup.md:50
-msgid "`cargo xtask test`"
-msgstr ""
-
-#: src/contributing/devenv-setup.md:50
-msgid "Run the test suite across the feature matrix"
-msgstr ""
-
-#: src/contributing/devenv-setup.md:51
-msgid "`cargo xtask run-emulator`"
-msgstr ""
-
-#: src/contributing/devenv-setup.md:51
-msgid "Run the emulator"
-msgstr ""
-
-#: src/contributing/devenv-setup.md:52
-msgid "`cargo xtask build-kobo`"
-msgstr ""
-
-#: src/contributing/devenv-setup.md:52
-msgid "Cross-compile for Kobo device"
-msgstr ""
-
-#: src/contributing/devenv-setup.md:53
-msgid "`cargo xtask dist`"
-msgstr ""
-
-#: src/contributing/devenv-setup.md:53
-msgid "Assemble the Kobo distribution directory"
-msgstr ""
-
-#: src/contributing/devenv-setup.md:54
-msgid "`cargo xtask bundle`"
-msgstr ""
-
-#: src/contributing/devenv-setup.md:54
-msgid "Package KoboRoot.tgz for installation"
-msgstr ""
-
-#: src/contributing/devenv-setup.md:55
-msgid "`cadmus-dev-otel`"
-msgstr ""
-
-#: src/contributing/devenv-setup.md:55
-msgid "Run emulator with tracing and profiling enabled"
-msgstr ""
-
-#: src/contributing/devenv-setup.md:56
-msgid "`devenv up`"
-msgstr ""
-
-#: src/contributing/devenv-setup.md:56
-msgid "Start observability stack (Grafana, Tempo, Loki)"
-msgstr ""
-
-#: src/contributing/devenv-setup.md:57
-msgid "`cargo xtask docs`"
-msgstr ""
-
-#: src/contributing/devenv-setup.md:57
-msgid "Build documentation portal (mdBook + Cargo docs)"
-msgstr ""
-
-#: src/contributing/devenv-setup.md:58
-msgid "`cadmus-docs-serve`"
-msgstr ""
-
-#: src/contributing/devenv-setup.md:58
-msgid "Serve documentation portal locally on port 1111"
-msgstr ""
-
-#: src/contributing/devenv-setup.md:59
-msgid "`cadmus-translate`"
-msgstr ""
-
-#: src/contributing/devenv-setup.md:59
-msgid "Generate the docs translation template (.pot)"
-msgstr ""
-
-#: src/contributing/devenv-setup.md:61
-msgid ""
-"Run `cargo xtask --help` to see all available subcommands, or `cargo xtask "
-"<cmd> --help` for options on a specific command."
-msgstr ""
-
-#: src/contributing/devenv-setup.md:64
-msgid ""
-"Or have a look at the rustdocs for `xtask` <a href=\"/api/xtask/\">here</a>."
-msgstr ""
-
-#: src/contributing/devenv-setup.md:66
-msgid "Tasks"
-msgstr ""
-
-#: src/contributing/devenv-setup.md:68
-msgid ""
-"The devenv environment uses [tasks](https://devenv.sh/tasks/) to manage "
-"build dependencies. Tasks are defined in `devenv.nix` and can be run with "
-"`devenv tasks run <task>`."
-msgstr ""
-
-#: src/contributing/devenv-setup.md:71
-msgid "Available Tasks"
-msgstr ""
-
-#: src/contributing/devenv-setup.md:73
-msgid "Task"
-msgstr ""
-
-#: src/contributing/devenv-setup.md:73
-msgid "Dependencies"
-msgstr ""
-
-#: src/contributing/devenv-setup.md:75 src/contributing/devenv-setup.md:76
-msgid "`docs:build`"
-msgstr ""
-
-#: src/contributing/devenv-setup.md:75
-msgid "Build documentation EPUB (only rebuilds if files changed)"
-msgstr ""
-
-#: src/contributing/devenv-setup.md:75
-msgid "None"
-msgstr ""
-
-#: src/contributing/devenv-setup.md:76
-msgid "`build:kobo`"
-msgstr ""
-
-#: src/contributing/devenv-setup.md:76
-msgid "Build for Kobo device"
-msgstr ""
-
-#: src/contributing/devenv-setup.md:78
-msgid "All tasks delegate to `cargo xtask` under the hood."
-msgstr ""
-
-#: src/contributing/devenv-setup.md:80
-msgid "How Tasks Work"
-msgstr ""
-
-#: src/contributing/devenv-setup.md:82
-msgid ""
-"Tasks with dependencies automatically run their dependencies first. For "
-"example:"
-msgstr ""
-
-#: src/contributing/devenv-setup.md:85
-msgid "# This will first run docs:build (if needed), then build for Kobo\n"
-msgstr ""
-
-#: src/contributing/devenv-setup.md:89
-msgid ""
-"The `docs:build` task uses `execIfModified` to only rebuild when "
-"documentation files have actually changed."
-msgstr ""
-
-#: src/contributing/devenv-setup.md:91
-msgid "Kobo Build Notes"
-msgstr ""
-
-#: src/contributing/devenv-setup.md:93
-msgid "`cargo xtask download-assets` must run before `cargo xtask build-kobo`."
-msgstr ""
-
-#: src/contributing/devenv-setup.md:94
-msgid ""
-"OTA updates delete Cadmus-owned bundled files before reboot, then Kobo "
-"extracts the new `KoboRoot.tgz` over the install directory."
-msgstr ""
-
-#: src/contributing/devenv-setup.md:96
-msgid ""
-"User files outside the generated Cadmus-owned asset list must be preserved."
-msgstr ""
-
-#: src/contributing/devenv-setup.md:98
-msgid "Documentation Portal"
-msgstr ""
-
-#: src/contributing/devenv-setup.md:100
-msgid ""
-"Cadmus provides a unified documentation portal that combines user guides, "
-"API reference, and contribution guides in one place."
-msgstr ""
-
-#: src/contributing/devenv-setup.md:103
-msgid "Building and Serving Locally"
-msgstr ""
-
-#: src/contributing/devenv-setup.md:105
-msgid "To build the documentation portal:"
-msgstr ""
-
-#: src/contributing/devenv-setup.md:111
-msgid "This runs the full build pipeline:"
-msgstr ""
-
-#: src/contributing/devenv-setup.md:113
-msgid "Builds the mdBook user guide (`docs/book/html/`)"
-msgstr ""
-
-#: src/contributing/devenv-setup.md:114
-msgid "Generates Rust API documentation (`target/doc/`)"
-msgstr ""
-
-#: src/contributing/devenv-setup.md:115
-msgid "Builds the Zola landing page and integrates all documentation"
-msgstr ""
-
-#: src/contributing/devenv-setup.md:117
-msgid "To serve the portal locally with live reload:"
-msgstr ""
-
-#: src/contributing/devenv-setup.md:123
-msgid ""
-"The portal will be available at <http://localhost:1111> with automatic "
-"rebuilds when you change documentation files or Rust code."
-msgstr ""
-
-#: src/contributing/devenv-setup.md:126
-msgid "Documentation Structure"
-msgstr ""
-
-#: src/contributing/devenv-setup.md:128
-msgid "The portal provides three integrated sections:"
-msgstr ""
-
-#: src/contributing/devenv-setup.md:130
-msgid "**Landing Page** (`/`) - Overview and feature highlights"
-msgstr ""
-
-#: src/contributing/devenv-setup.md:131
-msgid "**User Guide** (`/guide/`) - User-facing documentation from mdBook"
-msgstr ""
-
-#: src/contributing/devenv-setup.md:132
-msgid "**API Reference** (`/api/`) - Auto-generated Rust API documentation"
-msgstr ""
-
-#: src/contributing/devenv-setup.md:134
-msgid ""
-"All three sections are deployed as a single artifact to GitHub Pages at "
-"<https://ogkevin.github.io/cadmus/>."
-msgstr ""
-
-#: src/contributing/devenv-setup.md:137
-msgid "Continuous Integration"
-msgstr ""
-
-#: src/contributing/devenv-setup.md:139
-msgid ""
-"Documentation is automatically built and validated on every pull request and "
-"deployed on push to `main` or `master`. The CI pipeline checks:"
-msgstr ""
-
-#: src/contributing/devenv-setup.md:142
-msgid "mdBook documentation compiles"
-msgstr ""
-
-#: src/contributing/devenv-setup.md:143
-msgid "Rust code documentation is valid"
-msgstr ""
-
-#: src/contributing/devenv-setup.md:144
-msgid "Zola landing page builds successfully"
-msgstr ""
-
-#: src/contributing/devenv-setup.md:146
-msgid "Running Tests"
-msgstr ""
-
-#: src/contributing/devenv-setup.md:148
-msgid ""
-"Tests require the `TEST_ROOT_DIR` environment variable to be set. The "
-"easiest way to run the full test matrix is:"
-msgstr ""
-
-#: src/contributing/devenv-setup.md:155
-msgid ""
-"This sets `TEST_ROOT_DIR` automatically and runs tests across all feature "
-"combinations. To run a single feature combination:"
-msgstr ""
-
-#: src/contributing/devenv-setup.md:159
-msgid "\"emulator + test\""
-msgstr ""
-
-#: src/contributing/devenv-setup.md:162
-msgid "Or to run tests manually without xtask:"
-msgstr ""
-
-#: src/contributing/devenv-setup.md:165 src/contributing/devenv-setup.md:233
-msgid "$(pwd)"
-msgstr ""
-
-#: src/contributing/devenv-setup.md:168
-msgid ""
-"`TEST_ROOT_DIR` is automatically configured in CI but must be set manually "
-"when running `cargo test` directly."
-msgstr ""
-
-#: src/contributing/devenv-setup.md:171
-msgid "Platform Support"
-msgstr ""
-
-#: src/contributing/devenv-setup.md:173
-msgid "Linux (Full Support)"
-msgstr ""
-
-#: src/contributing/devenv-setup.md:175
-msgid "Linux provides full development capabilities including:"
-msgstr ""
-
-#: src/contributing/devenv-setup.md:177 src/contributing/devenv-setup.md:187
-msgid "Native development (emulator, tests)"
-msgstr ""
-
-#: src/contributing/devenv-setup.md:178 src/contributing/devenv-setup.md:188
-msgid "Cross-compilation for Kobo devices using the Linaro ARM toolchain"
-msgstr ""
-
-#: src/contributing/devenv-setup.md:179 src/contributing/devenv-setup.md:189
-msgid "Git hooks (actionlint, shellcheck, shfmt, markdownlint, prettier)"
-msgstr ""
-
-#: src/contributing/devenv-setup.md:181
-msgid ""
-"The Linaro toolchain is automatically added to `PATH` and provides "
-"`arm-linux-gnueabihf-*` commands."
-msgstr ""
-
-#: src/contributing/devenv-setup.md:183
-msgid "macOS (Full Support)"
-msgstr ""
-
-#: src/contributing/devenv-setup.md:185
-msgid "macOS supports full development capabilities including:"
-msgstr ""
-
-#: src/contributing/devenv-setup.md:191
-msgid "macOS-Specific Notes"
-msgstr ""
-
-#: src/contributing/devenv-setup.md:193
-msgid ""
-"**MuPDF build**: On macOS, the native build script manually gathers "
-"pkg-config CFLAGS for system libraries because MuPDF's build system doesn't "
-"properly detect them on Darwin."
-msgstr ""
-
-#: src/contributing/devenv-setup.md:196
-msgid "Observability Stack"
-msgstr ""
-
-#: src/contributing/devenv-setup.md:198
-msgid "The devenv includes a full observability stack for development:"
-msgstr ""
-
-#: src/contributing/devenv-setup.md:201
-msgid "# Start all services\n"
-msgstr ""
-
-#: src/contributing/devenv-setup.md:203
-msgid "# In another terminal, run the instrumented emulator\n"
-msgstr ""
-
-#: src/contributing/devenv-setup.md:208
-msgid "Services available after `devenv up`:"
-msgstr ""
-
-#: src/contributing/devenv-setup.md:210
-msgid "Service"
-msgstr ""
-
-#: src/contributing/devenv-setup.md:210
-msgid "URL"
-msgstr ""
-
-#: src/contributing/devenv-setup.md:210
-msgid "Purpose"
-msgstr ""
-
-#: src/contributing/devenv-setup.md:212
-msgid "Grafana"
-msgstr ""
-
-#: src/contributing/devenv-setup.md:212
-msgid "<http://localhost:3000>"
-msgstr ""
-
-#: src/contributing/devenv-setup.md:212
-msgid "Dashboards and exploration"
-msgstr ""
-
-#: src/contributing/devenv-setup.md:213
-msgid "Tempo"
-msgstr ""
-
-#: src/contributing/devenv-setup.md:213
-msgid "<http://localhost:3200>"
-msgstr ""
-
-#: src/contributing/devenv-setup.md:213
-msgid "Distributed tracing"
-msgstr ""
-
-#: src/contributing/devenv-setup.md:214
-msgid "Loki"
-msgstr ""
-
-#: src/contributing/devenv-setup.md:214
-msgid "<http://localhost:3100>"
-msgstr ""
-
-#: src/contributing/devenv-setup.md:214
-msgid "Log aggregation"
-msgstr ""
-
-#: src/contributing/devenv-setup.md:215
-msgid "Prometheus"
-msgstr ""
-
-#: src/contributing/devenv-setup.md:215
-msgid "<http://localhost:9090>"
-msgstr ""
-
-#: src/contributing/devenv-setup.md:215
-msgid "Metrics"
-msgstr ""
-
-#: src/contributing/devenv-setup.md:216
-msgid "OTLP Collector"
-msgstr ""
-
-#: src/contributing/devenv-setup.md:216
-msgid "<http://localhost:4318>"
-msgstr ""
-
-#: src/contributing/devenv-setup.md:216
-msgid "Telemetry ingestion"
-msgstr ""
-
-#: src/contributing/devenv-setup.md:217
-msgid "Pyroscope"
-msgstr ""
-
-#: src/contributing/devenv-setup.md:217
-msgid "<http://localhost:4040>"
-msgstr ""
-
-#: src/contributing/devenv-setup.md:217
-msgid "Continuous profiling"
-msgstr ""
-
-#: src/contributing/devenv-setup.md:219
-msgid "For more details on telemetry, see [Telemetry](telemetry/index.md)."
-msgstr ""
-
-#: src/contributing/devenv-setup.md:223
-msgid "Shell takes a long time to start"
-msgstr ""
-
-#: src/contributing/devenv-setup.md:225
-msgid ""
-"The first `devenv shell` invocation downloads and builds dependencies, which "
-"can take several minutes. Subsequent invocations are cached and should be "
-"fast."
-msgstr ""
-
-#: src/contributing/devenv-setup.md:228
-msgid "Tests fail with \"TEST_ROOT_DIR must be set\""
-msgstr ""
-
-#: src/contributing/devenv-setup.md:230
-msgid "Set the environment variable before running tests:"
-msgstr ""
-
-#: src/contributing/devenv-setup.md:236
-msgid "Local Configuration"
-msgstr ""
-
-#: src/contributing/devenv-setup.md:238
-msgid ""
-"Create `devenv.local.nix` to override settings without modifying the tracked "
-"configuration:"
-msgstr ""
-
-#: src/contributing/devenv-setup.md:240
-msgid ""
-"```nix\n"
-"{ pkgs, ... }:\n"
-"\n"
-"{\n"
-"  env = {\n"
-"    # Example: Set TEST_ROOT_DIR automatically\n"
-"    TEST_ROOT_DIR = builtins.getEnv \"PWD\";\n"
-"  };\n"
-"}\n"
-"```"
-msgstr ""
-
-#: src/contributing/devenv-setup.md:251
-msgid "This file is gitignored and won't affect other contributors."
-msgstr ""
-
-#: src/contributing/code-style.md:3
-msgid ""
-"Cadmus enforces a consistent code style across all languages using "
-"[treefmt](https://treefmt.com/) for formatting and several linters for "
-"static analysis. The pre-commit hooks run all checks automatically, and CI "
-"enforces the same rules on every pull request."
-msgstr ""
-
-#: src/contributing/code-style.md:8
-msgid "Formatters and Linters"
-msgstr ""
-
-#: src/contributing/code-style.md:10
-msgid "Tool"
-msgstr ""
-
-#: src/contributing/code-style.md:10
-msgid "Languages / Files"
-msgstr ""
-
-#: src/contributing/code-style.md:10
-msgid "Key Configuration"
-msgstr ""
-
-#: src/contributing/code-style.md:12
-msgid "`rustfmt`"
-msgstr ""
-
-#: src/contributing/code-style.md:12
-msgid "Rust (`*.rs`)"
-msgstr ""
-
-#: src/contributing/code-style.md:12
-msgid "Workspace `rustfmt.toml`"
-msgstr ""
-
-#: src/contributing/code-style.md:13
-msgid "`prettier`"
-msgstr ""
-
-#: src/contributing/code-style.md:13
-msgid "JSON, YAML, Markdown, CSS, JS"
-msgstr ""
-
-#: src/contributing/code-style.md:13
-msgid "`.prettierrc.json`"
-msgstr ""
-
-#: src/contributing/code-style.md:14
-msgid "`shfmt`"
-msgstr ""
-
-#: src/contributing/code-style.md:14 src/contributing/code-style.md:15
-msgid "Shell (`*.sh`, `*.bash`)"
-msgstr ""
-
-#: src/contributing/code-style.md:14
-msgid "`-i 2 -ci` (2-space, case-indent)"
-msgstr ""
-
-#: src/contributing/code-style.md:15
-msgid "`shellcheck`"
-msgstr ""
-
-#: src/contributing/code-style.md:15
-msgid "`.editorconfig`"
-msgstr ""
-
-#: src/contributing/code-style.md:16
-msgid "`yamllint`"
-msgstr ""
-
-#: src/contributing/code-style.md:16
-msgid "YAML"
-msgstr ""
-
-#: src/contributing/code-style.md:16
-msgid "`extends: default`, several rules disabled"
-msgstr ""
-
-#: src/contributing/code-style.md:17
-msgid "`rumdl`"
-msgstr ""
-
-#: src/contributing/code-style.md:17
-msgid "Markdown (`*.md`)"
-msgstr ""
-
-#: src/contributing/code-style.md:17
-msgid "Default rules"
-msgstr ""
-
-#: src/contributing/code-style.md:18
-msgid "`actionlint`"
-msgstr ""
-
-#: src/contributing/code-style.md:18
-msgid "GitHub Actions workflows"
-msgstr ""
-
-#: src/contributing/code-style.md:18
-msgid "`-ignore \"rust-toolchain\"`"
-msgstr ""
-
-#: src/contributing/code-style.md:19
-msgid "`clippy`"
-msgstr ""
-
-#: src/contributing/code-style.md:19
-msgid "Rust"
-msgstr ""
-
-#: src/contributing/code-style.md:19
-msgid "`-D warnings`"
-msgstr ""
-
-#: src/contributing/code-style.md:21
-msgid "Running treefmt"
-msgstr ""
-
-#: src/contributing/code-style.md:23
-msgid "All formatters run through `treefmt`. Inside the devenv shell:"
-msgstr ""
-
-#: src/contributing/code-style.md:26
-msgid "# Format all files tracked by treefmt\n"
-msgstr ""
-
-#: src/contributing/code-style.md:28
-msgid "# Check without writing (dry run)\n"
-msgstr ""
-
-#: src/contributing/code-style.md:33
-msgid ""
-"The pre-commit hook (`git-hooks.hooks.treefmt`) runs `treefmt "
-"--fail-on-change` automatically on every commit, so format issues are caught "
-"before they reach CI."
-msgstr ""
-
-#: src/contributing/code-style.md:36
-msgid "Rust Style"
-msgstr ""
-
-#: src/contributing/code-style.md:38
-msgid "Formatting"
-msgstr ""
-
-#: src/contributing/code-style.md:40
-msgid ""
-"`rustfmt` with the workspace configuration handles formatting automatically. "
-"Run it via treefmt or directly:"
-msgstr ""
-
-#: src/contributing/code-style.md:47
-msgid "Linting (Clippy)"
-msgstr ""
-
-#: src/contributing/code-style.md:49
-msgid "Clippy runs with `-D warnings` — all warnings are errors:"
-msgstr ""
-
-#: src/contributing/code-style.md:55
-msgid ""
-"Clippy runs across every feature flag combination in CI. When adding a new "
-"feature flag, update `.github/workflows/cargo.yml` to include the new matrix "
-"entries."
-msgstr ""
-
-#: src/contributing/code-style.md:59
-msgid "Key Conventions"
-msgstr ""
-
-#: src/contributing/code-style.md:61
-msgid "Prefer `?` over `unwrap()` / `expect()` in library and app code."
-msgstr ""
-
-#: src/contributing/code-style.md:62
-msgid "Use iterators over index-based loops."
-msgstr ""
-
-#: src/contributing/code-style.md:63
-msgid ""
-"Use `&str` over `String` in function parameters when ownership is not needed."
-msgstr ""
-
-#: src/contributing/code-style.md:64
-msgid "Prefer borrowing over cloning."
-msgstr ""
-
-#: src/contributing/code-style.md:65
-msgid "Avoid premature `collect()` — keep iterators lazy."
-msgstr ""
-
-#: src/contributing/code-style.md:66
-msgid "Use newtype wrappers over raw primitives for domain concepts."
-msgstr ""
-
-#: src/contributing/code-style.md:68
-msgid "Shell Style"
-msgstr ""
-
-#: src/contributing/code-style.md:70
-msgid ""
-"Shell scripts are formatted with `shfmt` (`-i 2 -ci`) and checked with "
-"`shellcheck`. The `-ci` flag indents `case` statement arms relative to the "
-"`case` keyword:"
-msgstr ""
-
-#: src/contributing/code-style.md:75
-msgid "# Correct — case arms indented with -ci\n"
-msgstr ""
-
-#: src/contributing/code-style.md:76
-msgid "\"${VAR}\""
-msgstr ""
-
-#: src/contributing/code-style.md:86
-msgid "Scripts must declare their shell variant. For bash scripts, use:"
-msgstr ""
-
-#: src/contributing/code-style.md:89
-msgid "#! /bin/bash\n"
-msgstr ""
-
-#: src/contributing/code-style.md:92
-msgid "Structured Logging"
-msgstr ""
-
-#: src/contributing/code-style.md:94
-msgid ""
-"Use the `tracing` crate with structured fields — never string formatting for "
-"log data:"
-msgstr ""
-
-#: src/contributing/code-style.md:98
-msgid "// Correct\n"
-msgstr ""
-
-#: src/contributing/code-style.md:99
-msgid "\"Found artifacts\""
-msgstr ""
-
-#: src/contributing/code-style.md:100
-msgid "// Wrong\n"
-msgstr ""
-
-#: src/contributing/code-style.md:102
-msgid "\"[OTA] Found {} artifacts for PR #{}\""
-msgstr ""
-
-#: src/contributing/code-style.md:105
-msgid "See [Logging](telemetry/logging.md) for log level guidance."
-msgstr ""
-
-#: src/contributing/code-style.md:107
-msgid "Comments"
-msgstr ""
-
-#: src/contributing/code-style.md:109
-msgid ""
-"Comment **why**, not **what**. Most code needs no comments — good naming is "
-"preferred. The rules:"
-msgstr ""
-
-#: src/contributing/code-style.md:112
-msgid ""
-"No inline comments — if one feels necessary, extract the code into a "
-"well-named function instead."
-msgstr ""
-
-#: src/contributing/code-style.md:114
-msgid "No commented-out code."
-msgstr ""
-
-#: src/contributing/code-style.md:115
-msgid "No changelog comments (`Modified by X on date`)."
-msgstr ""
-
-#: src/contributing/code-style.md:116
-msgid "No decorative dividers (`//=====`)."
-msgstr ""
-
-#: src/contributing/code-style.md:117
-msgid "`TODO`, `FIXME`, `HACK`, `NOTE` annotations are fine with context."
-msgstr ""
-
-#: src/contributing/code-style.md:119
-msgid "Public API items must have doc comments."
-msgstr ""
-
-#: src/contributing/code-style.md:121
-msgid "CI Checks"
-msgstr ""
-
-#: src/contributing/code-style.md:123
-msgid "The following CI workflows enforce style:"
-msgstr ""
-
-#: src/contributing/code-style.md:125
-msgid "Workflow"
-msgstr ""
-
-#: src/contributing/code-style.md:125
-msgid "What it checks"
-msgstr ""
-
-#: src/contributing/code-style.md:127
-msgid "`cargo.yml`"
-msgstr ""
-
-#: src/contributing/code-style.md:127
-msgid "`rustfmt`, `clippy` (full feature matrix), tests"
-msgstr ""
-
-#: src/contributing/code-style.md:128
-msgid "`shell.yml`"
-msgstr ""
-
-#: src/contributing/code-style.md:128
-msgid "`shellcheck`, `shfmt` (changed lines only)"
-msgstr ""
-
-#: src/contributing/code-style.md:129
-msgid "`docs-lint.yml`"
-msgstr ""
-
-#: src/contributing/code-style.md:129
-msgid "`prettier`, `markdownlint` (docs and markdown files)"
-msgstr ""
-
-#: src/contributing/code-style.md:131
-msgid ""
-"CI uses `filter_mode: added` for shell checks, meaning only lines changed in "
-"the PR are flagged. Running `treefmt` locally before pushing will catch "
-"everything."
-msgstr ""
-
-#: src/contributing/event-system.md:3
-msgid ""
-"Cadmus uses a tree-based event system where views are organized "
-"hierarchically and events flow through two distinct channels: the **Hub** "
-"and the **Bus**. Understanding the difference between these channels is "
-"essential for implementing correct event handling in views."
-msgstr ""
-
-#: src/contributing/event-system.md:8
-msgid ""
-"CSS is hard, this page might render better on 80% zoom on smaller screens. I "
-"tried to make the mermaid diagrams as big as possible to make them easier to "
-"read, which made them overflow a bit."
-msgstr ""
-
-#: src/contributing/event-system.md:12
-msgid "You might also want to hide the sidebar."
-msgstr ""
-
-#: src/contributing/event-system.md:16
-msgid ""
-"The UI is a tree of `View` objects. Each view can have children, forming a "
-"hierarchy like:"
-msgstr ""
-
-#: src/contributing/event-system.md:18
-msgid ""
-"```mermaid\n"
-"flowchart TD\n"
-"    Home[\"Home (root view)\"]\n"
-"    TopBar[\"TopBar\"]\n"
-"    Shelf[\"Shelf\"]\n"
-"    Book1[\"Book\"]\n"
-"    Book2[\"Book\"]\n"
-"    BottomBar[\"BottomBar\"]\n"
-"    Dialog[\"Dialog ← overlay child\"]\n"
-"    Label[\"Label\"]\n"
-"    Button[\"Button\"]\n"
-"\n"
-"    Home --> TopBar\n"
-"    Home --> Shelf\n"
-"    Home --> BottomBar\n"
-"    Home --> Dialog\n"
-"    Shelf --> Book1\n"
-"    Shelf --> Book2\n"
-"    Dialog --> Label\n"
-"    Dialog --> Button\n"
-"```"
-msgstr ""
-
-#: src/contributing/event-system.md:40
-msgid ""
-"Events enter the tree from the main loop and travel **top-down** (root to "
-"leaves), with the highest z-level children checked first. Views can "
-"communicate back **up** the tree via the bus, or **globally** via the hub."
-msgstr ""
-
-#: src/contributing/event-system.md:44
-msgid "Hub vs Bus"
-msgstr ""
-
-#: src/contributing/event-system.md:46
-msgid "The two channels serve fundamentally different purposes:"
-msgstr ""
-
-#: src/contributing/event-system.md:48
-msgid ""
-"```mermaid\n"
-"flowchart TB\n"
-"    subgraph MainLoop[\"Main Loop\"]\n"
-"        rx[\"rx.recv()\"]\n"
-"        match[\"match evt { ... }\"]\n"
-"        handle[\"handle_event(root, &evt, &tx, &bus, ...)\"]\n"
-"        Hub[\"Hub (tx)\"]\n"
-"        Bus[\"Bus (VecDeque)\"]\n"
-"\n"
-"        rx --> match\n"
-"        match -->|dispatches to view tree| handle\n"
-"        handle --> Hub\n"
-"        handle --> Bus\n"
-"        Bus -->|unhandled bus events forwarded to hub| Hub\n"
-"    end\n"
-"```"
-msgstr ""
-
-#: src/contributing/event-system.md:65
-msgid "Hub (`Sender<Event>`)"
-msgstr ""
-
-#: src/contributing/event-system.md:67
-msgid ""
-"The hub is an `mpsc::Sender<Event>` — a global channel that sends events to "
-"the **main loop**. Events sent to the hub are processed in the **next "
-"iteration** of the main loop, not immediately."
-msgstr ""
-
-#: src/contributing/event-system.md:70
-msgid "**Use the hub when:**"
-msgstr ""
-
-#: src/contributing/event-system.md:72
-msgid ""
-"The event needs to be handled by the main loop directly (e.g., "
-"`Event::Close`, `Event::Open`, `Event::Notification`)"
-msgstr ""
-
-#: src/contributing/event-system.md:74
-msgid ""
-"The event should reach all views in a future dispatch cycle (e.g., "
-"`Event::Focus`)"
-msgstr ""
-
-#: src/contributing/event-system.md:75
-msgid "You need to communicate across unrelated parts of the view tree"
-msgstr ""
-
-#: src/contributing/event-system.md:78
-msgid "// Close a view — handled by the main loop's match statement\n"
-msgstr ""
-
-#: src/contributing/event-system.md:80
-msgid "// Show a notification — main loop creates the Notification view\n"
-msgstr ""
-
-#: src/contributing/event-system.md:83
-msgid "// Set focus — dispatched to all views in the next loop iteration\n"
-msgstr ""
-
-#: src/contributing/event-system.md:88
-msgid "Bus (`VecDeque<Event>`)"
-msgstr ""
-
-#: src/contributing/event-system.md:90
-msgid ""
-"The bus is a local `VecDeque<Event>` that passes events **from a child to "
-"its parent**. Events placed on the bus are handled synchronously during the "
-"current dispatch cycle."
-msgstr ""
-
-#: src/contributing/event-system.md:93
-msgid "**Use the bus when:**"
-msgstr ""
-
-#: src/contributing/event-system.md:95
-msgid "A child needs to communicate with its direct parent"
-msgstr ""
-
-#: src/contributing/event-system.md:96
-msgid ""
-"The parent is expected to handle the event (e.g., a button telling its "
-"parent dialog it was pressed)"
-msgstr ""
-
-#: src/contributing/event-system.md:98
-msgid "The event should bubble up through the view hierarchy"
-msgstr ""
-
-#: src/contributing/event-system.md:101
-msgid "// Child tells parent about a submission\n"
-msgstr ""
-
-#: src/contributing/event-system.md:103
-msgid "// Child requests parent to close it\n"
-msgstr ""
-
-#: src/contributing/event-system.md:108
-msgid "Bus Bubbling"
-msgstr ""
-
-#: src/contributing/event-system.md:110
-msgid ""
-"When a bus event is not handled by any ancestor view, it reaches the root "
-"and gets **forwarded to the hub** for processing in the next main loop "
-"iteration:"
-msgstr ""
-
-#: src/contributing/event-system.md:114
-msgid "// End of main loop iteration — unhandled bus events become hub events\n"
-msgstr ""
-
-#: src/contributing/event-system.md:120
-msgid "Event Dispatch"
-msgstr ""
-
-#: src/contributing/event-system.md:122
-msgid ""
-"The core dispatch function in `view/mod.rs` controls how events flow through "
-"the tree:"
-msgstr ""
-
-#: src/contributing/event-system.md:124
-msgid ""
-"```mermaid\n"
-"flowchart TD\n"
-"    Start[\"handle_event(view, event)\"] --> CheckLeaf{\"Is view a "
-"leaf<br/>(no children)?\"}\n"
-"\n"
-"    CheckLeaf -->|YES| HandleDirect[\"call view.handle_event()<br/>return "
-"result\"]\n"
-"    CheckLeaf -->|NO| ReverseIter[\"Step 1 - Iterate children in REVERSE "
-"order<br/>(highest z-level first)\"]\n"
-"\n"
-"    ReverseIter --> CheckChildren[\"For each child:<br/>call "
-"handle_event(child, event)\"]\n"
-"    CheckChildren --> Captured{\"Child returns true?\"}\n"
-"    Captured -->|YES| SetCaptured[\"captured = true<br/>BREAK\"]\n"
-"    Captured -->|NO| NextChild[\"Next child\"]\n"
-"    NextChild --> CheckChildren\n"
-"\n"
-"    SetCaptured --> ProcessBus[\"Step 2 - Process child_bus events\"]\n"
-"    CheckChildren -->|No more children| ProcessBus\n"
-"\n"
-"    ProcessBus --> BusEvent{\"For each event<br/>on child_bus\"}\n"
-"    BusEvent --> HandleBus[\"call view.handle_event(child_evt)\"]\n"
-"    HandleBus --> ViewHandles{\"View handles it?\"}\n"
-"    ViewHandles -->|YES| RemoveBus[\"remove from bus\"]\n"
-"    ViewHandles -->|NO| KeepBus[\"keep on bus<br/>(bubbles up)\"]\n"
-"    RemoveBus --> BusEvent\n"
-"    KeepBus --> BusEvent\n"
-"\n"
-"    BusEvent -->|No more bus events| CheckCaptured{\"NOT captured<br/>by any "
-"child?\"}\n"
-"    CheckCaptured -->|YES| HandleParent[\"Step 3 - call "
-"view.handle_event(event)<br/>return captured || view's result\"]\n"
-"    CheckCaptured -->|NO| ReturnCaptured[\"return captured\"]\n"
-"```"
-msgstr ""
-
-#: src/contributing/event-system.md:153
-msgid "Key Rules"
-msgstr ""
-
-#: src/contributing/event-system.md:155
-msgid ""
-"**Reverse iteration**: Children are checked from last to first (highest "
-"z-level first). This ensures overlays like dialogs and menus receive events "
-"before the views beneath them."
-msgstr ""
-
-#: src/contributing/event-system.md:158
-msgid ""
-"**Short-circuit on capture**: Once a child returns `true`, no other children "
-"or the parent view receive the event. This is why the Dialog's outside-tap "
-"handler works — it returns `true` to prevent the event from reaching views "
-"behind it."
-msgstr ""
-
-#: src/contributing/event-system.md:162
-msgid ""
-"**Parent only runs if uncaptured**: The parent's `handle_event` is only "
-"called if no child captured the event (`captured || "
-"view.handle_event(...)`). If `captured` is `true`, the parent is "
-"short-circuited."
-msgstr ""
-
-#: src/contributing/event-system.md:166
-msgid "Main Loop Event Handling"
-msgstr ""
-
-#: src/contributing/event-system.md:168
-msgid ""
-"The main loop (`app.rs`) receives events from the hub and handles them in "
-"two stages. First, `TaskManager` gets a chance to observe every event — this "
-"is where `ImportLibrary`, `ImportFinished`, and `ReindexDictionaries` are "
-"intercepted to schedule or coalesce background tasks. Then the event enters "
-"the large `match` statement, where some events are dispatched into the view "
-"tree and others are handled directly:"
-msgstr ""
-
-#: src/contributing/event-system.md:175
-msgid ""
-"```mermaid\n"
-"flowchart TB\n"
-"    subgraph MainLoop[\"Main Loop\"]\n"
-"        direction TB\n"
-"\n"
-"        Recv[\"rx.recv() → evt\"]\n"
-"        TaskManager[\"TaskManager::handle_event()<br/>(ImportLibrary, "
-"ImportFinished, ReindexDictionaries)\"]\n"
-"\n"
-"        Gesture[\"Event::Gesture(Tap/Swipe/...)\"]\n"
-"        GestureAction[\"Dispatched into view tree via handle_event()\"]\n"
-"\n"
-"        Close[\"Event::Close(id)\"]\n"
-"        CloseAction[\"Handled directly:<br/>locate_by_id() + remove\"]\n"
-"\n"
-"        Notification[\"Event::Notification(...)\"]\n"
-"        NotificationAction[\"Handled directly:<br/>create/update "
-"Notification\"]\n"
-"\n"
-"        Open[\"Event::Open(info)\"]\n"
-"        OpenAction[\"Handled directly:<br/>push Reader onto history\"]\n"
-"\n"
-"        Focus[\"Event::Focus(...)\"]\n"
-"        FocusAction[\"Dispatched into view tree via handle_event()\"]\n"
-"\n"
-"        Select[\"Event::Select(...)\"]\n"
-"        SelectAction[\"Some handled directly,<br/>some dispatched\"]\n"
-"\n"
-"        ImportLibrary[\"Event::ImportLibrary / ImportFinished / "
-"ReindexDictionaries\"]\n"
-"        ImportAction[\"Handled by TaskManager<br/>(schedules/coalesces "
-"tasks)\"]\n"
-"\n"
-"        Recv --> TaskManager\n"
-"        TaskManager --> Gesture\n"
-"        TaskManager --> Close\n"
-"        TaskManager --> Notification\n"
-"        TaskManager --> Open\n"
-"        TaskManager --> Focus\n"
-"        TaskManager --> Select\n"
-"        TaskManager --> ImportLibrary\n"
-"\n"
-"        Gesture --> GestureAction\n"
-"        Close --> CloseAction\n"
-"        Notification --> NotificationAction\n"
-"        Open --> OpenAction\n"
-"        Focus --> FocusAction\n"
-"        Select --> SelectAction\n"
-"        ImportLibrary --> ImportAction\n"
-"    end\n"
-"```"
-msgstr ""
-
-#: src/contributing/event-system.md:223
-msgid "Event::Close"
-msgstr ""
-
-#: src/contributing/event-system.md:225
-msgid ""
-"`Event::Close(ViewId)` is handled **directly** by the main loop using "
-"`locate_by_id()`, which searches only the **top-level children** of the root "
-"view:"
-msgstr ""
-
-#: src/contributing/event-system.md:238
-msgid ""
-"**Key limitation**: The main loop can only remove **direct children of the "
-"root**. To close nested views, either:"
-msgstr ""
-
-#: src/contributing/event-system.md:241
-msgid ""
-"**Use the parent's ViewId** (via hub): Removes the entire parent container"
-msgstr ""
-
-#: src/contributing/event-system.md:242
-msgid ""
-"**Use the bus**: Parent handles the close and removes just the specific child"
-msgstr ""
-
-#: src/contributing/event-system.md:244
-msgid ""
-"See [Why ViewId Matters for Close](#why-viewid-matters-for-close) and "
-"[Closing Nested Views via the Bus](#closing-nested-views-via-the-bus) for "
-"details."
-msgstr ""
-
-#: src/contributing/event-system.md:247
-msgid "Practical Example: Dialog Outside-Tap"
-msgstr ""
-
-#: src/contributing/event-system.md:249
-msgid ""
-"When a `Dialog` is tapped outside its bounds, the following sequence occurs:"
-msgstr ""
-
-#: src/contributing/event-system.md:278
-msgid "Why ViewId Matters for Close"
-msgstr ""
-
-#: src/contributing/event-system.md:280
-msgid ""
-"When using the **hub** to close views, `locate_by_id()` only finds top-level "
-"children. If a dialog is nested inside a parent, you must use the "
-"**parent's** `ViewId` — this removes the entire parent:"
-msgstr ""
-
-#: src/contributing/event-system.md:284
-msgid ""
-"```mermaid\n"
-"flowchart TD\n"
-"    Root[\"Root View\"]\n"
-"    Home[\"Home\"]\n"
-"    OtaView[\"OtaView (top-level)\"]\n"
-"    Dialog[\"Dialog (nested)\"]\n"
-"\n"
-"    Root --> Home\n"
-"    Root --> OtaView\n"
-"    OtaView --> Dialog\n"
-"\n"
-"    Note[\"hub.send(Event::Close(ViewId::Ota(Main)))<br/>→ Removes OtaView + "
-"Dialog\"]\n"
-"```"
-msgstr ""
-
-#: src/contributing/event-system.md:298
-msgid ""
-"To close just the nested view without affecting siblings, use the **bus** "
-"instead (see below)."
-msgstr ""
-
-#: src/contributing/event-system.md:300
-msgid "Closing Nested Views via the Bus"
-msgstr ""
-
-#: src/contributing/event-system.md:302
-msgid ""
-"Send `Event::Close` via the **bus** to close nested views. Parents handle "
-"bus events synchronously and can remove any child directly:"
-msgstr ""
-
-#: src/contributing/event-system.md:306
-msgid "// Child sends close via bus\n"
-msgstr ""
-
-#: src/contributing/event-system.md:323
-msgid "**Comparison:**"
-msgstr ""
-
-#: src/contributing/event-system.md:325
-msgid "Method"
-msgstr ""
-
-#: src/contributing/event-system.md:325
-msgid "Code"
-msgstr ""
-
-#: src/contributing/event-system.md:325
-msgid "Handler"
-msgstr ""
-
-#: src/contributing/event-system.md:325 src/contributing/event-system.md:349
-msgid "Scope"
-msgstr ""
-
-#: src/contributing/event-system.md:327
-msgid "Hub close"
-msgstr ""
-
-#: src/contributing/event-system.md:327
-msgid "`hub.send(Event::Close(id))`"
-msgstr ""
-
-#: src/contributing/event-system.md:327
-msgid "Main loop"
-msgstr ""
-
-#: src/contributing/event-system.md:327
-msgid "Top-level children only"
-msgstr ""
-
-#: src/contributing/event-system.md:328
-msgid "Bus close"
-msgstr ""
-
-#: src/contributing/event-system.md:328
-msgid "`bus.push_back(Event::Close(id))`"
-msgstr ""
-
-#: src/contributing/event-system.md:328
-msgid "Parent view"
-msgstr ""
-
-#: src/contributing/event-system.md:328
-msgid "Any child"
-msgstr ""
-
-#: src/contributing/event-system.md:330
-msgid "**Example implementation:**"
-msgstr ""
-
-#: src/contributing/event-system.md:336
-msgid "// Return false to bubble up so grandparent removes us\n"
-msgstr ""
-
-#: src/contributing/event-system.md:344
-#: src/investigations/kobo/issue-51-dhcp-investigation.md:10
-msgid "Summary"
-msgstr ""
-
-#: src/contributing/event-system.md:346
-msgid "Aspect"
-msgstr ""
-
-#: src/contributing/event-system.md:346
-msgid "Hub"
-msgstr ""
-
-#: src/contributing/event-system.md:346
-msgid "Bus"
-msgstr ""
-
-#: src/contributing/event-system.md:348
-#: src/investigations/kobo/issue-51-dhcp-investigation.md:147
-msgid "Type"
-msgstr ""
-
-#: src/contributing/event-system.md:348
-msgid "`mpsc::Sender<Event>`"
-msgstr ""
-
-#: src/contributing/event-system.md:348
-msgid "`VecDeque<Event>`"
-msgstr ""
-
-#: src/contributing/event-system.md:349
-msgid "Global (main loop)"
-msgstr ""
-
-#: src/contributing/event-system.md:349
-msgid "Local (parent-child)"
-msgstr ""
-
-#: src/contributing/event-system.md:350
-msgid "Timing"
-msgstr ""
-
-#: src/contributing/event-system.md:350
-msgid "Next loop iteration"
-msgstr ""
-
-#: src/contributing/event-system.md:350
-msgid "Current dispatch cycle"
-msgstr ""
-
-#: src/contributing/event-system.md:351
-msgid "Direction"
-msgstr ""
-
-#: src/contributing/event-system.md:351
-msgid "View → Main loop"
-msgstr ""
-
-#: src/contributing/event-system.md:351
-msgid "Child → Parent"
-msgstr ""
-
-#: src/contributing/event-system.md:352
-msgid "Unhandled events"
-msgstr ""
-
-#: src/contributing/event-system.md:352
-msgid "Processed by main loop `match`"
-msgstr ""
-
-#: src/contributing/event-system.md:352
-msgid "Forwarded to hub"
-msgstr ""
-
-#: src/contributing/event-system.md:353
-msgid "Use for"
-msgstr ""
-
-#: src/contributing/event-system.md:353
-msgid "Close, Focus, Notifications"
-msgstr ""
-
-#: src/contributing/event-system.md:353
-msgid "Submit, child-to-parent signals"
-msgstr ""
-
-#: src/contributing/telemetry/index.md:3
-msgid "Cadmus has three related observability paths:"
-msgstr ""
-
-#: src/contributing/telemetry/index.md:5
-msgid "`logging` for structured log export and local log files"
-msgstr ""
-
-#: src/contributing/telemetry/index.md:6
-msgid "`tracing` for distributed tracing and OTLP export"
-msgstr ""
-
-#: src/contributing/telemetry/index.md:7
-msgid "`profiling` for continuous profiling with Pyroscope"
-msgstr ""
-
-#: src/contributing/telemetry/index.md:9
-msgid ""
-"Use this section when you need to understand how those features fit "
-"together, what each one depends on, and how to run them locally."
-msgstr ""
-
-#: src/contributing/telemetry/index.md:12
-msgid ""
-"Cadmus assigns each run a unique Run ID using UUID v7. That Run ID ties "
-"together local log files, OTLP exports, and profiling data for the same app "
-"session."
-msgstr ""
-
-#: src/contributing/telemetry/index.md:16
-msgid "Pages"
-msgstr ""
-
-#: src/contributing/telemetry/index.md:18
-#: src/contributing/telemetry/tracing.md:109
-msgid "[Logging](logging.md)"
-msgstr ""
-
-#: src/contributing/telemetry/index.md:19
-#: src/contributing/telemetry/logging.md:80
-msgid "[Tracing](tracing.md)"
-msgstr ""
-
-#: src/contributing/telemetry/index.md:20
-#: src/contributing/telemetry/logging.md:81
-#: src/contributing/telemetry/tracing.md:110
-msgid "[Profiling](profiling.md)"
-msgstr ""
-
-#: src/contributing/telemetry/index.md:22
-#: src/contributing/telemetry/profiling.md:12
-msgid "Feature flags"
-msgstr ""
-
-#: src/contributing/telemetry/index.md:24
-msgid "`tracing` enables structured logs, distributed traces, and OTLP export."
-msgstr ""
-
-#: src/contributing/telemetry/index.md:25
-msgid "`profiling` enables heap and CPU profiling with Pyroscope."
-msgstr ""
-
-#: src/contributing/telemetry/index.md:26
-msgid "`telemetry` enables both `tracing` and `profiling` together in the app."
-msgstr ""
-
-#: src/contributing/telemetry/index.md:28
-msgid "Architecture"
-msgstr ""
-
-#: src/contributing/telemetry/index.md:30
-msgid "The telemetry stack is split into three layers:"
-msgstr ""
-
-#: src/contributing/telemetry/index.md:32
-msgid ""
-"Logging writes newline-delimited JSON to disk and can export log records "
-"over OTLP."
-msgstr ""
-
-#: src/contributing/telemetry/index.md:34
-msgid ""
-"Tracing creates spans around instrumented operations and exports them over "
-"OTLP."
-msgstr ""
-
-#: src/contributing/telemetry/index.md:36
-msgid "Profiling samples CPU and heap activity and pushes profiles to Pyroscope."
-msgstr ""
-
-#: src/contributing/telemetry/index.md:38
-msgid ""
-"When `telemetry` is enabled, Cadmus runs all three paths together. In local "
-"development this matches the default observability stack exposed by `devenv "
-"up`."
-msgstr ""
-
-#: src/contributing/telemetry/index.md:42
-msgid "Local setup"
-msgstr ""
-
-#: src/contributing/telemetry/index.md:44
-msgid ""
-"The development environment includes a full observability stack. Use the "
-"`cadmus-dev-otel` command to run the emulator with telemetry enabled."
-msgstr ""
-
-#: src/contributing/telemetry/logging.md:3
-msgid ""
-"Cadmus writes structured JSON logs to disk and can export logs to an OTLP "
-"backend when the `tracing` feature is enabled."
-msgstr ""
-
-#: src/contributing/telemetry/logging.md:6
-#: src/contributing/telemetry/tracing.md:6
-#: src/contributing/telemetry/profiling.md:6
-msgid "What it does"
-msgstr ""
-
-#: src/contributing/telemetry/logging.md:8
-msgid "Writes newline-delimited JSON log files to the configured log directory"
-msgstr ""
-
-#: src/contributing/telemetry/logging.md:9
-msgid ""
-"Adds run metadata so a single app session can be traced through log output"
-msgstr ""
-
-#: src/contributing/telemetry/logging.md:10
-msgid "Optionally exports logs to an OpenTelemetry collector"
-msgstr ""
-
-#: src/contributing/telemetry/logging.md:12
-#: src/contributing/telemetry/tracing.md:12
-msgid "Feature flag"
-msgstr ""
-
-#: src/contributing/telemetry/logging.md:14
-msgid "`tracing` enables OTLP log export and shared tracing/logging context"
-msgstr ""
-
-#: src/contributing/telemetry/logging.md:16
-msgid "Log file format"
-msgstr ""
-
-#: src/contributing/telemetry/logging.md:18
-msgid "Cadmus writes newline-delimited JSON files named like this:"
-msgstr ""
-
-#: src/contributing/telemetry/logging.md:24
-msgid "Each record includes these fields:"
-msgstr ""
-
-#: src/contributing/telemetry/logging.md:26
-msgid "`timestamp`"
-msgstr ""
-
-#: src/contributing/telemetry/logging.md:27
-msgid "`level`"
-msgstr ""
-
-#: src/contributing/telemetry/logging.md:28
-msgid "`target`"
-msgstr ""
-
-#: src/contributing/telemetry/logging.md:29
-msgid "`fields`"
-msgstr ""
-
-#: src/contributing/telemetry/logging.md:30
-msgid "`spans`"
-msgstr ""
-
-#: src/contributing/telemetry/logging.md:32
-msgid ""
-"The `spans` array carries active tracing context so log records can be "
-"matched back to the traced operation that emitted them."
-msgstr ""
-
-#: src/contributing/telemetry/logging.md:35
-#: src/contributing/telemetry/tracing.md:84
-msgid "Resource attributes"
-msgstr ""
-
-#: src/contributing/telemetry/logging.md:37
-msgid ""
-"When OTLP export is enabled, log records include the same resource metadata "
-"as traces:"
-msgstr ""
-
-#: src/contributing/telemetry/logging.md:40
-#: src/contributing/telemetry/tracing.md:88
-msgid "`service.name = cadmus`"
-msgstr ""
-
-#: src/contributing/telemetry/logging.md:41
-#: src/contributing/telemetry/tracing.md:89
-msgid "`service.version = <git describe output>`"
-msgstr ""
-
-#: src/contributing/telemetry/logging.md:42
-#: src/contributing/telemetry/tracing.md:90
-msgid "`cadmus.run_id = <uuid-v7>`"
-msgstr ""
-
-#: src/contributing/telemetry/logging.md:43
-#: src/contributing/telemetry/tracing.md:91
-msgid "`hostname = <system hostname>`"
-msgstr ""
-
-#: src/contributing/telemetry/logging.md:45
-#: src/contributing/telemetry/tracing.md:93
-#: src/contributing/telemetry/profiling.md:27
-msgid "Configuration"
-msgstr ""
-
-#: src/contributing/telemetry/logging.md:47
-msgid ""
-"See the [settings reference](../../settings/index.md#logging) for the full "
-"logging configuration. The main options are:"
-msgstr ""
-
-#: src/contributing/telemetry/logging.md:53
-msgid "`logging.directory`"
-msgstr ""
-
-#: src/contributing/telemetry/logging.md:56
-#: src/contributing/telemetry/tracing.md:98
-msgid ""
-"`OTEL_EXPORTER_OTLP_ENDPOINT` overrides `logging.otlp-endpoint` when both "
-"are set."
-msgstr ""
-
-#: src/contributing/telemetry/logging.md:59
-msgid ""
-"`RUST_LOG` overrides the configured log level. This is useful when you need "
-"trace-level output for a single subsystem without editing `Settings.toml`."
-msgstr ""
-
-#: src/contributing/telemetry/logging.md:63
-msgid "# Enable debug logs globally\n"
-msgstr ""
-
-#: src/contributing/telemetry/logging.md:64
-msgid "debug"
-msgstr ""
-
-#: src/contributing/telemetry/logging.md:65
-msgid "# Enable trace logs for a specific module\n"
-msgstr ""
-
-#: src/contributing/telemetry/logging.md:70
-#: src/contributing/telemetry/profiling.md:17
-msgid "Runtime behavior"
-msgstr ""
-
-#: src/contributing/telemetry/logging.md:72
-msgid ""
-"When `tracing` is enabled, log export is initialized during app startup and "
-"shut down during app exit."
-msgstr ""
-
-#: src/contributing/telemetry/logging.md:75
-msgid ""
-"Cadmus always writes local JSON logs. OTLP export is an additional sink "
-"layered on top when an endpoint is configured."
-msgstr ""
-
-#: src/contributing/telemetry/logging.md:78
-#: src/contributing/telemetry/tracing.md:107
-msgid "Related docs"
-msgstr ""
-
-#: src/contributing/telemetry/tracing.md:3
-msgid ""
-"Cadmus uses `tracing` instrumentation to capture execution flow through the "
-"app and export spans to an OTLP backend."
-msgstr ""
-
-#: src/contributing/telemetry/tracing.md:8
-msgid "Adds spans around key operations in the app and core crates"
-msgstr ""
-
-#: src/contributing/telemetry/tracing.md:9
-msgid "Captures timing, fields, and parent-child relationships between spans"
-msgstr ""
-
-#: src/contributing/telemetry/tracing.md:10
-msgid "Exports traces to an OpenTelemetry collector when configured"
-msgstr ""
-
-#: src/contributing/telemetry/tracing.md:14
-msgid "`tracing` enables tracing support in the codebase"
-msgstr ""
-
-#: src/contributing/telemetry/tracing.md:16
-msgid "Instrumentation"
-msgstr ""
-
-#: src/contributing/telemetry/tracing.md:18
-msgid ""
-"Most view and runtime chokepoints are instrumented with conditional "
-"compilation so tracing can be compiled out when the feature is disabled."
-msgstr ""
-
-#: src/contributing/telemetry/tracing.md:21
-msgid "Each instrumented function can capture:"
-msgstr ""
-
-#: src/contributing/telemetry/tracing.md:23
-msgid "function and module name"
-msgstr ""
-
-#: src/contributing/telemetry/tracing.md:24
-msgid "selected input fields"
-msgstr ""
-
-#: src/contributing/telemetry/tracing.md:25
-msgid "execution duration"
-msgstr ""
-
-#: src/contributing/telemetry/tracing.md:26
-msgid "return values at `TRACE` level"
-msgstr ""
-
-#: src/contributing/telemetry/tracing.md:27
-msgid "parent-child span relationships"
-msgstr ""
-
-#: src/contributing/telemetry/tracing.md:29
-msgid "View code is instrumented around two high-value paths:"
-msgstr ""
-
-#: src/contributing/telemetry/tracing.md:31
-msgid "`handle_event` methods for event flow through the UI tree"
-msgstr ""
-
-#: src/contributing/telemetry/tracing.md:32
-msgid "`render` methods for rendering and layout timing"
-msgstr ""
-
-#: src/contributing/telemetry/tracing.md:34
-msgid ""
-"For detailed instrumentation conventions, see "
-"`.github/instructions/rust-instrumentation.instructions.md`."
-msgstr ""
-
-#: src/contributing/telemetry/tracing.md:37
-msgid "Example: instrument a function"
-msgstr ""
-
-#: src/contributing/telemetry/tracing.md:39
-msgid ""
-"Use `#[cfg_attr(feature = \"tracing\", tracing::instrument(...))]` on "
-"functions that should create a span for each call."
-msgstr ""
-
-#: src/contributing/telemetry/tracing.md:44
-msgid "\"tracing\""
-msgstr ""
-
-#: src/contributing/telemetry/tracing.md:48
-msgid "\"Saving cover image\""
-msgstr ""
-
-#: src/contributing/telemetry/tracing.md:56
-msgid ""
-"Use `skip(...)` for large values, borrowed buffers, or types with noisy "
-"`Debug` output. Add `fields(...)` for the identifiers you will actually "
-"query in Tempo or logs."
-msgstr ""
-
-#: src/contributing/telemetry/tracing.md:60
-msgid "Example: instrument a closure"
-msgstr ""
-
-#: src/contributing/telemetry/tracing.md:62
-msgid ""
-"For a short synchronous closure, create a span and run the closure inside it "
-"with `in_scope()`."
-msgstr ""
-
-#: src/contributing/telemetry/tracing.md:66
-msgid "\"sorting\""
-msgstr ""
-
-#: src/contributing/telemetry/tracing.md:73
-msgid ""
-"This is the usual pattern when you want to time a single closure body "
-"without extracting it into a separate function."
-msgstr ""
-
-#: src/contributing/telemetry/tracing.md:76
-msgid "OTLP export"
-msgstr ""
-
-#: src/contributing/telemetry/tracing.md:78
-msgid ""
-"When `tracing` is enabled, Cadmus initializes a tracer provider that exports "
-"to `<endpoint>/v1/traces` using batch span processors."
-msgstr ""
-
-#: src/contributing/telemetry/tracing.md:81
-msgid ""
-"This gives you distributed traces in backends like Tempo, Jaeger, or any "
-"other OTLP-compatible collector."
-msgstr ""
-
-#: src/contributing/telemetry/tracing.md:86
-msgid "Each exported span includes shared process metadata:"
-msgstr ""
-
-#: src/contributing/telemetry/tracing.md:95
-msgid ""
-"See the [settings reference](../../settings/index.md#logging) for the full "
-"logging and OTLP configuration. The main option is `logging.otlp-endpoint`."
-msgstr ""
-
-#: src/contributing/telemetry/tracing.md:101
-msgid "To build Cadmus with tracing support:"
-msgstr ""
-
-#: src/contributing/telemetry/profiling.md:3
-msgid ""
-"Cadmus supports continuous profiling with Pyroscope when the `profiling` "
-"feature is enabled."
-msgstr ""
-
-#: src/contributing/telemetry/profiling.md:8
-msgid "Uses jemalloc heap profiling for allocation data"
-msgstr ""
-
-#: src/contributing/telemetry/profiling.md:9
-msgid "Uses pprof for CPU profiling data"
-msgstr ""
-
-#: src/contributing/telemetry/profiling.md:10
-msgid "Pushes both profile types to Pyroscope"
-msgstr ""
-
-#: src/contributing/telemetry/profiling.md:14
-msgid "`profiling` enables profiling support in the codebase"
-msgstr ""
-
-#: src/contributing/telemetry/profiling.md:15
-msgid "`telemetry` enables profiling together with tracing"
-msgstr ""
-
-#: src/contributing/telemetry/profiling.md:19
-msgid ""
-"Profiling is initialized during app startup and shut down during app exit. "
-"If a Pyroscope endpoint is configured, Cadmus starts collecting profiles "
-"right away so early startup work is included."
-msgstr ""
-
-#: src/contributing/telemetry/profiling.md:23
-msgid ""
-"The app configures jemalloc as the global allocator when `profiling` is "
-"enabled and enables heap profiling at process startup. CPU profiling runs "
-"alongside it through the Pyroscope agent."
-msgstr ""
-
-#: src/contributing/telemetry/profiling.md:29
-msgid ""
-"See the [settings reference](../../settings/index.md#logging) for the full "
-"logging and profiling configuration."
-msgstr ""
-
-#: src/contributing/telemetry/profiling.md:33
-msgid "`PYROSCOPE_SERVER_URL`"
-msgstr ""
-
-#: src/contributing/telemetry/profiling.md:35
-msgid ""
-"`PYROSCOPE_SERVER_URL` overrides `logging.pyroscope-endpoint` when both are "
-"set."
-msgstr ""
-
-#: src/contributing/telemetry/profiling.md:38
-msgid "To build Cadmus with profiling support:"
-msgstr ""
-
-#: src/contributing/telemetry/profiling.md:44
-msgid "To build Cadmus with tracing and profiling together:"
-msgstr ""
-
-#: src/contributing/telemetry/profiling.md:50
-msgid "Profile types"
-msgstr ""
-
-#: src/contributing/telemetry/profiling.md:52
-msgid "Cadmus currently exports:"
-msgstr ""
-
-#: src/contributing/telemetry/profiling.md:54
-msgid "heap allocation profiles via jemalloc"
-msgstr ""
-
-#: src/contributing/telemetry/profiling.md:55
-msgid "CPU profiles via pprof-rs"
-msgstr ""
-
-#: src/contributing/telemetry/profiling.md:57
-msgid "Both profile streams are pushed to the configured Pyroscope server."
-msgstr ""
-
-#: src/contributing/telemetry/profiling.md:59
-msgid "Local development"
-msgstr ""
-
-#: src/contributing/telemetry/profiling.md:61
-msgid ""
-"The `cadmus-dev-otel` command starts the emulator with profiling enabled and "
-"the local Pyroscope service available at <http://localhost:4040>."
-msgstr ""
-
-#: src/contributing/telemetry/profiling.md:64
-msgid ""
-"With the full devenv stack running, traces go to Tempo, logs go to Loki, and "
-"profiles go to Pyroscope. That makes it possible to correlate a single run "
-"across all three observability backends."
-msgstr ""
-
-#: src/contributing/documentation.md:1
-msgid "Documentation Deployment"
-msgstr ""
-
-#: src/contributing/documentation.md:3
-msgid "Cadmus documentation is deployed to Cloudflare Pages."
-msgstr ""
-
-#: src/contributing/documentation.md:5
-msgid "URLs"
-msgstr ""
-
-#: src/contributing/documentation.md:7
-msgid "**Production**: <https://cadmus-dt6.pages.dev/>"
-msgstr ""
-
-#: src/contributing/documentation.md:8
-msgid "**PR Preview**: `https://pr-{NUMBER}.cadmus-dt6.pages.dev/`"
-msgstr ""
-
-#: src/contributing/documentation.md:10
-msgid "Reviewing Documentation Changes"
-msgstr ""
-
-#: src/contributing/documentation.md:12
-msgid ""
-"When you open a pull request that modifies documentation files, a preview "
-"deployment is automatically created. The PR will show a deployment status "
-"with a link to the preview URL."
-msgstr ""
-
-#: src/contributing/documentation.md:14
-msgid ""
-"Preview URLs follow the pattern: `https://pr-{NUMBER}.cadmus-dt6.pages.dev/`"
-msgstr ""
-
-#: src/contributing/documentation.md:16
-msgid "Local Development"
-msgstr ""
-
-#: src/contributing/documentation.md:18
-msgid "Building and Serving"
-msgstr ""
-
-#: src/contributing/documentation.md:20
-msgid "Build and serve documentation locally:"
-msgstr ""
-
-#: src/contributing/documentation.md:24
-msgid "# Build all documentation\n"
-msgstr ""
-
-#: src/contributing/documentation.md:25
-msgid "# Serve at http://localhost:1111\n"
-msgstr ""
-
-#: src/contributing/documentation.md:28
-msgid ""
-"`cargo xtask docs` handles the full pipeline: installing Mermaid assets, "
-"building mdBook, generating Rust API docs, and assembling the Zola portal. "
-"Pass `--mdbook-only` to skip the Zola step when you only need to check the "
-"mdBook output."
-msgstr ""
-
-#: src/contributing/documentation.md:32
-msgid "To serve with live reload after building:"
-msgstr ""
-
-#: src/contributing/documentation.md:38
-msgid "Build Process"
-msgstr ""
-
-#: src/contributing/documentation.md:40
-msgid "Documentation is built from three sources:"
-msgstr ""
-
-#: src/contributing/documentation.md:42
-msgid "**mdBook** (`docs/`) - User and contributor guides"
-msgstr ""
-
-#: src/contributing/documentation.md:43
-msgid "**Cargo doc** (`crates/`) - Rust API documentation"
-msgstr ""
-
-#: src/contributing/documentation.md:44
-msgid "**Zola** (`docs-portal/`) - Documentation portal that combines everything"
-msgstr ""
-
-#: src/contributing/documentation.md:46
-msgid ""
-"The build is orchestrated by `cargo xtask docs` (see "
-"`xtask/src/tasks/docs.rs`). The GitHub Actions workflow "
-"(`.github/workflows/cadmus-docs.yml`) runs this command automatically on "
-"every push to `main` and for every pull request."
-msgstr ""
-
-#: src/contributing/translations/index.md:3
-msgid ""
-"Cadmus has two separate translation systems, each covering a different part "
-"of the project."
-msgstr ""
-
-#: src/contributing/translations/index.md:6
-msgid "What"
-msgstr ""
-
-#: src/contributing/translations/index.md:6
-msgid "System"
-msgstr ""
-
-#: src/contributing/translations/index.md:6
-msgid "Files"
-msgstr ""
-
-#: src/contributing/translations/index.md:8
-msgid "[Documentation](docs.md)"
-msgstr ""
-
-#: src/contributing/translations/index.md:8
-msgid "GNU gettext / PO"
-msgstr ""
-
-#: src/contributing/translations/index.md:8
-msgid "`docs/po/*.po`"
-msgstr ""
-
-#: src/contributing/translations/index.md:9
-msgid "[UI strings](source-code.md)"
-msgstr ""
-
-#: src/contributing/translations/index.md:9
-msgid "Fluent (FTL)"
-msgstr ""
-
-#: src/contributing/translations/index.md:9
-msgid "`crates/core/i18n/**/*.ftl`"
-msgstr ""
-
-#: src/contributing/translations/index.md:11
-msgid "Pick the guide that matches what you want to translate."
-msgstr ""
-
-#: src/contributing/translations/source-code.md:1
-msgid "Translating Source Strings"
-msgstr ""
-
-#: src/contributing/translations/source-code.md:3
-msgid ""
-"The Cadmus UI uses [Fluent](https://projectfluent.org) for all user-visible "
-"strings. Translations are embedded directly into the binary at compile time "
-"— no external files are needed on the device."
-msgstr ""
-
-#: src/contributing/translations/source-code.md:9
-msgid "FTL files live under `crates/core/i18n/<lang-tag>/cadmus_core.ftl`."
-msgstr ""
-
-#: src/contributing/translations/source-code.md:10
-msgid ""
-"The fallback language is **en-GB**; any string missing from a translation "
-"falls back to the English text automatically."
-msgstr ""
-
-#: src/contributing/translations/source-code.md:12
-msgid ""
-"`crates/core/src/i18n.rs` loads the correct language at startup based on "
-"`settings.locale`."
-msgstr ""
-
-#: src/contributing/translations/source-code.md:14
-msgid "The `fl!(\"message-id\")` macro resolves message IDs at **compile time**."
-msgstr ""
-
-#: src/contributing/translations/source-code.md:16
-#: src/contributing/translations/docs.md:19
-msgid "Adding a new language"
-msgstr ""
-
-#: src/contributing/translations/source-code.md:18
-msgid "1. Create the FTL file"
-msgstr ""
-
-#: src/contributing/translations/source-code.md:20
-msgid "Create a new file at the path matching the BCP 47 tag for your language:"
-msgstr ""
-
-#: src/contributing/translations/source-code.md:26
-msgid "For example, for French:"
-msgstr ""
-
-#: src/contributing/translations/source-code.md:32
-msgid "2. Copy and translate the English strings"
-msgstr ""
-
-#: src/contributing/translations/source-code.md:34
-msgid "Use the English fallback file as your starting point:"
-msgstr ""
-
-#: src/contributing/translations/source-code.md:40
-msgid ""
-"Translate each message value. The message ID (left of `=`) must stay "
-"unchanged — only the value (right of `=`) changes:"
-msgstr ""
-
-#: src/contributing/translations/source-code.md:51
-msgid "3. Set the locale in Settings"
-msgstr ""
-
-#: src/contributing/translations/source-code.md:53
-msgid ""
-"To activate the new language locally during development, add a `locale` key "
-"to your `Settings.toml`:"
-msgstr ""
-
-#: src/contributing/translations/source-code.md:56
-msgid ""
-"```toml\n"
-"locale = \"fr\"\n"
-"```"
-msgstr ""
-
-#: src/contributing/translations/source-code.md:60
-msgid "4. Build and verify"
-msgstr ""
-
-#: src/contributing/translations/source-code.md:66
-msgid ""
-"The `fl!()` macro validates all message IDs at compile time. A successful "
-"build confirms the FTL file is well-formed and all IDs referenced in code "
-"are present."
-msgstr ""
-
-#: src/contributing/translations/source-code.md:69
-msgid "Adding a string to the source code"
-msgstr ""
-
-#: src/contributing/translations/source-code.md:71
-msgid "When you add a new UI string:"
-msgstr ""
-
-#: src/contributing/translations/source-code.md:73
-msgid ""
-"Add the message to `en-GB`, and any other languages you know how to "
-"translate it into."
-msgstr ""
-
-#: src/contributing/translations/source-code.md:75
-msgid "Use the `fl!()` macro in the Rust source:"
-msgstr ""
-
-#: src/contributing/translations/source-code.md:78
-msgid "\"my-new-message\""
-msgstr ""
-
-#: src/contributing/translations/source-code.md:81
-msgid "For messages with variables, use named arguments:"
-msgstr ""
-
-#: src/contributing/translations/source-code.md:89
-msgid "\"books-loaded\""
-msgstr ""
-
-#: src/contributing/translations/source-code.md:92
-msgid "FTL file format"
-msgstr ""
-
-#: src/contributing/translations/source-code.md:94
-msgid "Fluent uses a straightforward syntax. A few rules to keep in mind:"
-msgstr ""
-
-#: src/contributing/translations/source-code.md:96
-msgid "Message IDs use `kebab-case`."
-msgstr ""
-
-#: src/contributing/translations/source-code.md:97
-msgid "Values can span multiple lines by indenting continuation lines."
-msgstr ""
-
-#: src/contributing/translations/source-code.md:98
-msgid "Use Unicode characters directly — no escaping needed."
-msgstr ""
-
-#: src/contributing/translations/source-code.md:99
-msgid "Comments start with `#`."
-msgstr ""
-
-#: src/contributing/translations/source-code.md:101
-msgid ""
-"For the full syntax reference see the [Fluent syntax "
-"guide](https://projectfluent.org/fluent/guide/)."
-msgstr ""
-
-#: src/contributing/translations/docs.md:1
-msgid "Translating Cadmus Documentation"
-msgstr ""
-
-#: src/contributing/translations/docs.md:3
-msgid ""
-"This guide explains how to translate the Cadmus documentation into other "
-"languages. Translations live in `docs/po/` as standard GNU gettext PO files."
-msgstr ""
-
-#: src/contributing/translations/docs.md:8
-msgid ""
-"If you are using the `devenv` environment, all required tools are already "
-"available:"
-msgstr ""
-
-#: src/contributing/translations/docs.md:11
-msgid ""
-"`mdbook-xgettext` / `mdbook-gettext` — string extraction and preprocessing"
-msgstr ""
-
-#: src/contributing/translations/docs.md:12
-msgid "`msginit` / `msgmerge` / `msgfmt` — gettext utilities (from `gettext`)"
-msgstr ""
-
-#: src/contributing/translations/docs.md:13
-msgid "`poedit` — graphical PO editor"
-msgstr ""
-
-#: src/contributing/translations/docs.md:15
-msgid ""
-"Install them outside devenv from the vendored fork with `cargo install "
-"--path thirdparty/mdbook-i18n-helpers/i18n-helpers --locked` and your "
-"system's `gettext` package."
-msgstr ""
-
-#: src/contributing/translations/docs.md:21
-msgid "1. Extract the POT template"
-msgstr ""
-
-#: src/contributing/translations/docs.md:23
-msgid "Run the `cadmus-translate` script (devenv) or the equivalent command:"
-msgstr ""
-
-#: src/contributing/translations/docs.md:29
-msgid ""
-"This writes `docs/po/messages.pot` — the source template every translation "
-"derives from. Commit this file whenever the English source changes so "
-"translators have an up-to-date starting point."
-msgstr ""
-
-#: src/contributing/translations/docs.md:33
-msgid "2. Create a PO file for your locale"
-msgstr ""
-
-#: src/contributing/translations/docs.md:36
-msgid "# Replace 'fr' with the BCP 47 language tag you are adding.\n"
-msgstr ""
-
-#: src/contributing/translations/docs.md:42
-msgid ""
-"Open `docs/po/fr.po` and set the `Language-Name` header so the language "
-"picker displays a readable label:"
-msgstr ""
-
-#: src/contributing/translations/docs.md:45
-msgid ""
-"```po\n"
-"\"Language-Name: Français\\n"
-"\"\n"
-"```"
-msgstr ""
-
-#: src/contributing/translations/docs.md:49
-msgid ""
-"The xtask reads this header when generating `locales.json`; without it the "
-"locale code (e.g. `fr`) is shown instead."
-msgstr ""
-
-#: src/contributing/translations/docs.md:52
-msgid "3. Translate the strings"
-msgstr ""
-
-#: src/contributing/translations/docs.md:54
-msgid "Open the PO file in Poedit or any text editor and fill in each `msgstr`:"
-msgstr ""
-
-#: src/contributing/translations/docs.md:56
-msgid ""
-"```po\n"
-"msgid \"Welcome to Cadmus!\"\n"
-"msgstr \"Bienvenue dans Cadmus !\"\n"
-"```"
-msgstr ""
-
-#: src/contributing/translations/docs.md:61
-msgid ""
-"Preserve Markdown formatting — bold, code spans, links — exactly as in the "
-"`msgid`. Untranslated or _fuzzy_ entries fall back to the English source."
-msgstr ""
-
-#: src/contributing/translations/docs.md:64
-msgid "4. Build and preview"
-msgstr ""
-
-#: src/contributing/translations/docs.md:67
-msgid "# Build everything including translated books\n"
-msgstr ""
-
-#: src/contributing/translations/docs.md:69
-msgid "# Serve\n"
-msgstr ""
-
-#: src/contributing/translations/docs.md:75
-msgid ""
-"Navigate to `http://localhost:1111/guide/` and use the language picker in "
-"the sidebar to switch to your locale."
-msgstr ""
-
-#: src/contributing/translations/docs.md:78
-msgid "Keeping translations up to date"
-msgstr ""
-
-#: src/contributing/translations/docs.md:80
-msgid ""
-"When English source files change, regenerate the template and merge new "
-"strings into existing PO files:"
-msgstr ""
-
-#: src/contributing/translations/docs.md:84
-msgid "# regenerate docs/po/messages.pot\n"
-msgstr ""
-
-#: src/contributing/translations/docs.md:88
-msgid "Excluding content from extraction"
-msgstr ""
-
-#: src/contributing/translations/docs.md:90
-msgid ""
-"Wrap any block you want to keep in English with `<!-- i18n:skip -->` "
-"comments:"
-msgstr ""
-
-#: src/contributing/translations/docs.md:100
-msgid "How the build works"
-msgstr ""
-
-#: src/contributing/translations/docs.md:102
-msgid ""
-"`cargo xtask docs` calls `mdbook build -d book/<lang>` for each `.po` file "
-"found in `docs/po/`, passing `MDBOOK_BOOK__LANGUAGE=<lang>`."
-msgstr ""
-
-#: src/contributing/translations/docs.md:104
-msgid ""
-"The `[preprocessor.gettext]` in `docs/book.toml` substitutes translated "
-"strings at build time."
-msgstr ""
-
-#: src/contributing/translations/docs.md:106
-msgid ""
-"`locales.json` is written to `docs/book/html/` with the available locales; "
-"`lang-picker.js` fetches it at runtime to populate the language dropdown."
-msgstr ""
-
-#: src/contributing/translations/docs.md:108
-msgid ""
-"Symlinks under `docs-portal/static/guide/<lang>/` expose each locale build "
-"to Zola so it is served at `/guide/<lang>/`."
-msgstr ""
-
-#: src/contributing/sqlite-sqlx.md:3
-msgid ""
-"Cadmus uses [SQLite](https://sqlite.org) as its embedded database and "
-"[SQLx](https://github.com/launchbadge/sqlx) as the Rust database library. "
-"SQLx provides **compile-time SQL verification** — every query is checked "
-"against the real schema before the code ships."
-msgstr ""
-
-#: src/contributing/sqlite-sqlx.md:8
-msgid "The `.sqlx` directory"
-msgstr ""
-
-#: src/contributing/sqlite-sqlx.md:10
-msgid ""
-"The `.sqlx/` directory at the repository root contains one JSON metadata "
-"file per SQL query. Each file stores the resolved column names, types, and "
-"parameter types that SQLx inferred from the live database schema at the time "
-"`cargo sqlx prepare` was last run."
-msgstr ""
-
-#: src/contributing/sqlite-sqlx.md:22
-msgid "Regenerating query metadata"
-msgstr ""
-
-#: src/contributing/sqlite-sqlx.md:24
-msgid "After adding or changing any SQL query, regenerate the metadata:"
-msgstr ""
-
-#: src/contributing/sqlite-sqlx.md:30
-msgid ""
-"This connects to the database, re-introspects every query macro in the "
-"workspace, and rewrites the `.sqlx/` JSON files. Commit the updated files "
-"alongside your code change."
-msgstr ""
-
-#: src/contributing/sqlite-sqlx.md:35
-msgid ""
-"If you forget to run `cargo sqlx prepare`, the CI `check` job will fail "
-"because the cached metadata will be out of date with your query changes."
-msgstr ""
-
-#: src/contributing/sqlite-sqlx.md:38
-msgid "Compile-time SQL checking"
-msgstr ""
-
-#: src/contributing/sqlite-sqlx.md:40
-msgid ""
-"SQLx's typed query macros (`query!`, `query_as!`, `query_scalar!`) verify "
-"SQL at compile time using the metadata in `.sqlx/`. This means:"
-msgstr ""
-
-#: src/contributing/sqlite-sqlx.md:43
-msgid "Typos in column names are **compiler errors**, not runtime panics."
-msgstr ""
-
-#: src/contributing/sqlite-sqlx.md:44
-msgid "Binding the wrong type to a `?` placeholder is a **type error**."
-msgstr ""
-
-#: src/contributing/sqlite-sqlx.md:45
-msgid ""
-"Adding or removing a column in a migration without updating queries is "
-"caught **before deployment**."
-msgstr ""
-
-#: src/contributing/sqlite-sqlx.md:48
-msgid ""
-"The macros require the `DATABASE_URL` environment variable to point at a "
-"live database when running `cargo sqlx prepare`, but **not** during regular "
-"`cargo build` or `cargo check` — those use the pre-generated `.sqlx/` files."
-msgstr ""
-
-#: src/contributing/sqlite-sqlx.md:53
-msgid ""
-"`.sqlx/` is only used when the `SQLX_OFFLINE=true` field is set which is the "
-"default if you're using devenv.nix."
-msgstr ""
-
-#: src/contributing/sqlite-sqlx.md:56
-msgid "Review rules"
-msgstr ""
-
-#: src/contributing/sqlite-sqlx.md:58
-msgid "The following rules are enforced during code review for all SQLx queries."
-msgstr ""
-
-#: src/contributing/sqlite-sqlx.md:60
-msgid "Use typed macros only"
-msgstr ""
-
-#: src/contributing/sqlite-sqlx.md:62
-msgid ""
-"Always use the typed macros. Never call the untyped `query()`, `query_as()`, "
-"or `query_scalar()` functions:"
-msgstr ""
-
-#: src/contributing/sqlite-sqlx.md:65
-msgid "Goal"
-msgstr ""
-
-#: src/contributing/sqlite-sqlx.md:65
-msgid "Use"
-msgstr ""
-
-#: src/contributing/sqlite-sqlx.md:67
-msgid "`INSERT`, `UPDATE`, `DELETE`, raw `SELECT`"
-msgstr ""
-
-#: src/contributing/sqlite-sqlx.md:67
-msgid "`sqlx::query!`"
-msgstr ""
-
-#: src/contributing/sqlite-sqlx.md:68
-msgid "`SELECT` mapped into a named struct"
-msgstr ""
-
-#: src/contributing/sqlite-sqlx.md:68
-msgid "`sqlx::query_as!`"
-msgstr ""
-
-#: src/contributing/sqlite-sqlx.md:69
-msgid "Single-column `SELECT`"
-msgstr ""
-
-#: src/contributing/sqlite-sqlx.md:69
-msgid "`sqlx::query_scalar!`"
-msgstr ""
-
-#: src/contributing/sqlite-sqlx.md:71
-msgid ""
-"When the column is nullable, call `.flatten()` on the result to collapse "
-"`Option<Option<T>>` into `Option<T>`:"
-msgstr ""
-
-#: src/contributing/sqlite-sqlx.md:76
-msgid "\"SELECT id FROM libraries WHERE path = ?\""
-msgstr ""
-
-#: src/contributing/sqlite-sqlx.md:82
-msgid "List explicit column names"
-msgstr ""
-
-#: src/contributing/sqlite-sqlx.md:84
-msgid "Never use `SELECT *`. Always name every column you need:"
-msgstr ""
-
-#: src/contributing/sqlite-sqlx.md:87 src/contributing/sqlite-sqlx.md:100
-msgid "-- ✅ Good\n"
-msgstr ""
-
-#: src/contributing/sqlite-sqlx.md:89 src/contributing/sqlite-sqlx.md:102
-msgid "-- ❌ Bad\n"
-msgstr ""
-
-#: src/contributing/sqlite-sqlx.md:94
-msgid "Store timestamps as Unix epoch integers"
-msgstr ""
-
-#: src/contributing/sqlite-sqlx.md:96
-msgid ""
-"All date/time values must be stored as `INTEGER NOT NULL` (Unix epoch "
-"seconds). Do not use `TEXT` columns for timestamps:"
-msgstr ""
-
-#: src/contributing/sqlite-sqlx.md:104
-msgid "'now'"
-msgstr ""
-
-#: src/contributing/sqlite-sqlx.md:107
-msgid "Add only indexes that are actively used"
-msgstr ""
-
-#: src/contributing/sqlite-sqlx.md:109
-msgid ""
-"Every index must be used by at least one query in the codebase. Unused "
-"indexes waste write performance and storage without any read benefit. Before "
-"adding an index, verify a query filters, sorts, or joins on the indexed "
-"column(s)."
-msgstr ""
-
-#: src/contributing/sqlite-sqlx.md:113
-msgid "Keep schema migration files stable"
-msgstr ""
-
-#: src/contributing/sqlite-sqlx.md:115
-msgid ""
-"`cadmus-core` hashes every file under `crates/core/migrations/` at build "
-"time and stores that hash in the database version stamp. Downgrade "
-"protection uses the hash to allow newer-to-older app version moves only when "
-"both builds have the same schema migration set."
-msgstr ""
-
-#: src/contributing/sqlite-sqlx.md:120
-msgid ""
-"Do not edit a schema migration after it has shipped. Add a new numbered "
-"migration instead so existing databases keep passing SQLx migration checksum "
-"validation."
-msgstr ""
-
-#: src/contributing/sqlite-sqlx.md:124
-#: src/contributing/runtime-migrations.md:165
-msgid "API reference"
-msgstr ""
-
-#: src/contributing/sqlite-sqlx.md:126
-msgid "The primary database types live in the `cadmus_core::db` module:"
-msgstr ""
-
-#: src/contributing/sqlite-sqlx.md:128
-msgid ""
-"<a "
-"href=\"/api/cadmus_core/db/struct.Database\">`cadmus_core::db::Database`</a> "
-"— the top-level sync/async bridge that owns the connection pool"
-msgstr ""
-
-#: src/contributing/sqlite-sqlx.md:130
-msgid ""
-"<a "
-"href=\"/api/cadmus_core/db/migrations/struct.MigrationRunner\">`cadmus_core::db::migrations::MigrationRunner`</a> "
-"— executes all pending runtime migrations"
-msgstr ""
-
-#: src/contributing/sqlite-sqlx.md:132
-msgid ""
-"<a href=\"/api/cadmus_core/macro.migration\">`cadmus_core::migration!`</a> — "
-"macro for declaring one-time runtime migrations"
-msgstr ""
-
-#: src/contributing/sqlite-sqlx.md:135
-msgid ""
-"See [Library Database](library-database.md) for how the library subsystem "
-"uses the database, and [Runtime Migrations](runtime-migrations.md) for how "
-"to write one-time data migrations."
-msgstr ""
-
-#: src/contributing/library-database.md:3
-msgid ""
-"Cadmus stores library roots, scanned files, book metadata, reading progress, "
-"thumbnails, and table-of-contents data in SQLite. This page explains where "
-"each category of library data belongs and how scans move data from disk into "
-"the database."
-msgstr ""
-
-#: src/contributing/library-database.md:8
-msgid "Core Shape"
-msgstr ""
-
-#: src/contributing/library-database.md:10
-msgid "The library database separates four concerns:"
-msgstr ""
-
-#: src/contributing/library-database.md:28
-msgid ""
-"`libraries` represents scan roots. A row answers: \"which directory did "
-"Cadmus index as a library?\""
-msgstr ""
-
-#: src/contributing/library-database.md:31
-msgid ""
-"Keep library-level data here only when it describes the library itself, such "
-"as its path, display name, or creation metadata."
-msgstr ""
-
-#: src/contributing/library-database.md:34
-msgid "Library Membership"
-msgstr ""
-
-#: src/contributing/library-database.md:36
-msgid ""
-"`library_books` connects a library to the book files found under it. It is "
-"the place for data that depends on a specific file within a specific library "
-"scan, including relative paths, absolute paths, timestamps, sizes, and other "
-"scan-cache metadata."
-msgstr ""
-
-#: src/contributing/library-database.md:41
-msgid ""
-"This table is deliberately separate from `books` because one canonical book "
-"can appear in more than one library or at more than one path over time. "
-"File-system state belongs to the membership row, not to the canonical book "
-"row."
-msgstr ""
-
-#: src/contributing/library-database.md:45
-msgid "Canonical Books"
-msgstr ""
-
-#: src/contributing/library-database.md:47
-msgid ""
-"`books` is the canonical per-book record, keyed by fingerprint. It holds "
-"data that should be the same regardless of which library found the file, "
-"such as title and file kind."
-msgstr ""
-
-#: src/contributing/library-database.md:51
-msgid ""
-"Per-book tables reference `books` and are removed with the book when "
-"cascading deletes apply. New per-book data should usually live in a "
-"dedicated table rather than being mixed into library membership."
-msgstr ""
-
-#: src/contributing/library-database.md:55
-msgid "Derived Per-Book Data"
-msgstr ""
-
-#: src/contributing/library-database.md:57
-msgid ""
-"Authors, categories, reading state, thumbnails, and table-of-contents "
-"entries are derived from either metadata extraction, reader state, or "
-"generated assets. They are tied to the canonical book fingerprint, not to a "
-"specific library path."
-msgstr ""
-
-#: src/contributing/library-database.md:61
-msgid ""
-"Use join tables for many-to-many relationships such as authors and "
-"categories. Use child tables for optional or repeatable data such as reading "
-"state, thumbnails, and TOC entries."
-msgstr ""
-
-#: src/contributing/library-database.md:65
-msgid "Scan Flow"
-msgstr ""
-
-#: src/contributing/library-database.md:67
-msgid "Library scans move from the filesystem toward canonical book data:"
-msgstr ""
-
-#: src/contributing/library-database.md:78
-msgid ""
-"The membership row is checked before expensive work. If the scan-cache data "
-"says the file has not changed, Cadmus can skip re-fingerprinting and "
-"metadata extraction. If the file is new or changed, Cadmus updates the "
-"canonical book row and any derived data collected during import."
-msgstr ""
-
-#: src/contributing/library-database.md:83
-msgid "What Goes Where"
-msgstr ""
-
-#: src/contributing/library-database.md:85
-msgid "Use these rules when adding or reviewing library database changes:"
-msgstr ""
-
-#: src/contributing/library-database.md:87
-msgid "Data kind"
-msgstr ""
-
-#: src/contributing/library-database.md:87
-msgid "Belongs in"
-msgstr ""
-
-#: src/contributing/library-database.md:89
-msgid "Library root path or display name"
-msgstr ""
-
-#: src/contributing/library-database.md:89
-msgid "`libraries`"
-msgstr ""
-
-#: src/contributing/library-database.md:90
-msgid "File path inside one scanned library"
-msgstr ""
-
-#: src/contributing/library-database.md:90
-#: src/contributing/library-database.md:91
-msgid "`library_books`"
-msgstr ""
-
-#: src/contributing/library-database.md:91
-msgid "File modification or size cache"
-msgstr ""
-
-#: src/contributing/library-database.md:92
-msgid "Stable book identity or extracted title"
-msgstr ""
-
-#: src/contributing/library-database.md:92
-msgid "`books`"
-msgstr ""
-
-#: src/contributing/library-database.md:93
-msgid "Data shared by all copies of a book"
-msgstr ""
-
-#: src/contributing/library-database.md:93
-msgid "`books` or a per-book child table"
-msgstr ""
-
-#: src/contributing/library-database.md:94
-msgid "Many-to-many metadata"
-msgstr ""
-
-#: src/contributing/library-database.md:94
-msgid "Named entity table plus join table"
-msgstr ""
-
-#: src/contributing/library-database.md:95
-msgid "Reading progress"
-msgstr ""
-
-#: src/contributing/library-database.md:95
-msgid "`reading_states`"
-msgstr ""
-
-#: src/contributing/library-database.md:96
-msgid "Generated cover image"
-msgstr ""
-
-#: src/contributing/library-database.md:96
-msgid "`thumbnails`"
-msgstr ""
-
-#: src/contributing/library-database.md:97
-msgid "Nested table of contents"
-msgstr ""
-
-#: src/contributing/library-database.md:97
-msgid "`toc_entries`, using parent references and positions"
-msgstr ""
-
-#: src/contributing/library-database.md:98
-msgid "Migration bookkeeping"
-msgstr ""
-
-#: src/contributing/library-database.md:98
-msgid "Migration tables managed by the migration runner"
-msgstr ""
-
-#: src/contributing/library-database.md:100
-msgid ""
-"If data describes a file's current location, put it in library membership. "
-"If it describes the book identified by its fingerprint, put it in canonical "
-"book data or a per-book child table."
-msgstr ""
-
-#: src/contributing/library-database.md:104
-msgid "Schema Details"
-msgstr ""
-
-#: src/contributing/library-database.md:106
-msgid ""
-"For exact schema details, read the migrations in `crates/core/migrations/` "
-"in order. They define the tables, views, indexes, constraints, and data "
-"migrations that exist at each database version."
-msgstr ""
-
-#: src/contributing/library-database.md:110
-msgid "Data Access"
-msgstr ""
-
-#: src/contributing/library-database.md:112
-msgid ""
-"The <a "
-"href=\"/api/cadmus_core/library/db/struct.Db\">`cadmus_core::library::db::Db`</a> "
-"type is the entry point for library database operations. It wraps the shared "
-"SQLite pool and presents a synchronous API to the rest of the app."
-msgstr ""
-
-#: src/contributing/library-database.md:117
-msgid ""
-"Keep database access behind this layer so callers work with domain types "
-"instead of raw SQL rows. For SQLx conventions, type overrides, and migration "
-"review rules, see the related pages below."
-msgstr ""
-
-#: src/contributing/library-database.md:121
-msgid "Related Pages"
-msgstr ""
-
-#: src/contributing/library-database.md:123
-msgid ""
-"[SQLite & SQLx](sqlite-sqlx.md) — compile-time query verification and review "
-"rules"
-msgstr ""
-
-#: src/contributing/library-database.md:125
-msgid ""
-"[Runtime Migrations](runtime-migrations.md) — one-time data migrations using "
-"the `migration!` macro"
-msgstr ""
-
-#: src/contributing/runtime-migrations.md:3
-msgid "Cadmus has two distinct migration pipelines:"
-msgstr ""
-
-#: src/contributing/runtime-migrations.md:5
-msgid ""
-"**Schema migrations** — plain `.sql` files in `crates/core/migrations/`, "
-"applied by SQLx's `migrate!` macro at startup. Use these for `CREATE TABLE`, "
-"`ALTER TABLE`, and similar DDL changes. The core build script hashes these "
-"files and embeds the hash in the database version stamp."
-msgstr ""
-
-#: src/contributing/runtime-migrations.md:9
-msgid ""
-"**Runtime migrations** — Rust `async fn` blocks declared with the "
-"`migration!` macro. Use these for one-time **data** operations: backfilling "
-"columns, importing legacy files, cleaning up obsolete rows, or any "
-"procedural work that goes beyond SQL DDL."
-msgstr ""
-
-#: src/contributing/runtime-migrations.md:14
-msgid "How runtime migrations work"
-msgstr ""
-
-#: src/contributing/runtime-migrations.md:16
-msgid ""
-"```mermaid\n"
-"flowchart TD\n"
-"    ctor[\"#[ctor] runs at process start\"]\n"
-"    registry[\"Global REGISTRY HashMap<br>(migration id → async fn)\"]\n"
-"    startup[\"Database::migrate() called on startup\"]\n"
-"    schema[\"sqlx::migrate!() — applies .sql files\"]\n"
-"    runner[\"MigrationRunner::run_all()\"]\n"
-"    table[\"_cadmus_migrations table<br>(id, executed_at, status)\"]\n"
-"    pending[\"Filter: id NOT IN already-succeeded rows\"]\n"
-"    exec[\"Execute each pending migration in id order\"]\n"
-"    record[\"Record success or failure in _cadmus_migrations\"]\n"
-"\n"
-"    ctor --> registry\n"
-"    startup --> schema\n"
-"    schema --> runner\n"
-"    runner --> table\n"
-"    table --> pending\n"
-"    pending --> exec\n"
-"    exec --> record\n"
-"```"
-msgstr ""
-
-#: src/contributing/runtime-migrations.md:37
-msgid ""
-"At process start the `#[ctor]` attribute runs for every `migration!` call "
-"and inserts the migration function into a global `HashMap`. When "
-"`Database::migrate` is called during application startup, it first applies "
-"all pending SQL schema migrations, then calls `MigrationRunner::run_all()`, "
-"which:"
-msgstr ""
-
-#: src/contributing/runtime-migrations.md:42
-msgid "Reads `_cadmus_migrations` and collects IDs that already succeeded."
-msgstr ""
-
-#: src/contributing/runtime-migrations.md:43
-msgid "Skips those; runs the remaining ones sorted by ID."
-msgstr ""
-
-#: src/contributing/runtime-migrations.md:44
-msgid "Records each result (`success` or `failed`) before moving on."
-msgstr ""
-
-#: src/contributing/runtime-migrations.md:45
-msgid "Continues past failures so one broken migration does not block others."
-msgstr ""
-
-#: src/contributing/runtime-migrations.md:47
-msgid ""
-"A failed migration can be retried by deleting its tracking row (see "
-"[Re-running a migration](#re-running-a-migration))."
-msgstr ""
-
-#: src/contributing/runtime-migrations.md:50
-msgid "The `migration!` macro"
-msgstr ""
-
-#: src/contributing/runtime-migrations.md:52
-msgid ""
-"<a href=\"/api/cadmus_core/macro.migration\">`cadmus_core::migration!`</a> "
-"takes a stable string ID and an `async fn` definition:"
-msgstr ""
-
-#: src/contributing/runtime-migrations.md:57
-msgid "/// One-line doc comment forwarded to rustdoc.\n    \"v1_my_migration\""
-msgstr ""
-
-#: src/contributing/runtime-migrations.md:60
-msgid "\"UPDATE books SET title = TRIM(title)\""
-msgstr ""
-
-#: src/contributing/runtime-migrations.md:68
-msgid "The macro:"
-msgstr ""
-
-#: src/contributing/runtime-migrations.md:70
-msgid "Generates the `async fn` with the provided body."
-msgstr ""
-
-#: src/contributing/runtime-migrations.md:71
-msgid ""
-"Creates a public submodule named after the function that exposes a "
-"`MIGRATION_ID` constant — useful for tests and cross-references."
-msgstr ""
-
-#: src/contributing/runtime-migrations.md:73
-msgid ""
-"Registers the function in the global `REGISTRY` via `#[ctor]` so it runs "
-"automatically without any manual wiring."
-msgstr ""
-
-#: src/contributing/runtime-migrations.md:75
-msgid "Forwards doc comments onto the generated items so rustdoc picks them up."
-msgstr ""
-
-#: src/contributing/runtime-migrations.md:76
-msgid "Appends the migration ID and a re-run SQL snippet to the generated docs."
-msgstr ""
-
-#: src/contributing/runtime-migrations.md:78
-msgid "Where to put migration code"
-msgstr ""
-
-#: src/contributing/runtime-migrations.md:80
-msgid ""
-"Co-locate migrations with the feature they belong to. The library "
-"subsystem's migrations live in `crates/core/src/library/migrations.rs`; a "
-"hypothetical reader subsystem would put its migrations in "
-"`crates/core/src/reader/migrations.rs`."
-msgstr ""
-
-#: src/contributing/runtime-migrations.md:85
-msgid ""
-"The module only needs to be declared once so the `#[ctor]` registration "
-"runs. There is no central registry file to update."
-msgstr ""
-
-#: src/contributing/runtime-migrations.md:88
-msgid "Writing a migration step by step"
-msgstr ""
-
-#: src/contributing/runtime-migrations.md:90
-msgid "1. Choose a stable ID"
-msgstr ""
-
-#: src/contributing/runtime-migrations.md:92
-msgid ""
-"The ID is the primary key in `_cadmus_migrations`. Once a migration has been "
-"deployed it must never be renamed, because existing installations track it "
-"by this string."
-msgstr ""
-
-#: src/contributing/runtime-migrations.md:96
-msgid ""
-"Convention: `v<N>_<short_description>`, for example "
-"`v1_backfill_book_language`."
-msgstr ""
-
-#: src/contributing/runtime-migrations.md:98
-msgid "2. Create the migration file (or add to an existing one)"
-msgstr ""
-
-#: src/contributing/runtime-migrations.md:101
-msgid "// crates/core/src/my_feature/migrations.rs\n"
-msgstr ""
-
-#: src/contributing/runtime-migrations.md:106
-msgid ""
-"/// Backfills the `language` column for books that were imported before\n"
-"    /// language detection was added.\n"
-"    \"v1_backfill_book_language\""
-msgstr ""
-
-#: src/contributing/runtime-migrations.md:111
-msgid ""
-"\"UPDATE books SET language = 'en' WHERE language = '' OR language IS NULL\""
-msgstr ""
-
-#: src/contributing/runtime-migrations.md:121
-msgid "3. Use SQLx typed macros"
-msgstr ""
-
-#: src/contributing/runtime-migrations.md:123
-msgid ""
-"All SQL inside a migration must use the typed macros for compile-time "
-"verification (see [SQLite & SQLx](sqlite-sqlx.md)):"
-msgstr ""
-
-#: src/contributing/runtime-migrations.md:127
-msgid "// ✅ Good — compile-time checked\n"
-msgstr ""
-
-#: src/contributing/runtime-migrations.md:128
-#: src/contributing/runtime-migrations.md:133
-msgid "\"DELETE FROM books WHERE file_path = ?\""
-msgstr ""
-
-#: src/contributing/runtime-migrations.md:131
-msgid "// ❌ Bad — untyped, bypasses verification\n"
-msgstr ""
-
-#: src/contributing/runtime-migrations.md:139
-msgid "4. Make it idempotent"
-msgstr ""
-
-#: src/contributing/runtime-migrations.md:141
-msgid ""
-"Use `INSERT OR IGNORE`, `ON CONFLICT DO NOTHING`, or guard with a `WHERE` "
-"clause so the migration is safe to re-run without corrupting data."
-msgstr ""
-
-#: src/contributing/runtime-migrations.md:144
-msgid "5. Regenerate `.sqlx` metadata"
-msgstr ""
-
-#: src/contributing/runtime-migrations.md:146
-msgid ""
-"After adding or changing any query in the migration, regenerate the "
-"compile-time metadata:"
-msgstr ""
-
-#: src/contributing/runtime-migrations.md:153
-msgid "Commit the updated `.sqlx/` files alongside your migration code."
-msgstr ""
-
-#: src/contributing/runtime-migrations.md:155
-msgid "Re-running a migration"
-msgstr ""
-
-#: src/contributing/runtime-migrations.md:157
-msgid "Delete the tracking row, then restart the application:"
-msgstr ""
-
-#: src/contributing/runtime-migrations.md:160
-msgid "'v1_my_migration'"
-msgstr ""
-
-#: src/contributing/runtime-migrations.md:163
-msgid "The next startup will treat the migration as pending and run it again."
-msgstr ""
-
-#: src/contributing/runtime-migrations.md:167
-msgid ""
-"<a href=\"/api/cadmus_core/macro.migration\">`cadmus_core::migration!`</a> — "
-"macro for declaring runtime migrations"
-msgstr ""
-
-#: src/contributing/runtime-migrations.md:169
-msgid ""
-"<a "
-"href=\"/api/cadmus_core/db/migrations/struct.MigrationRunner\">`cadmus_core::db::migrations::MigrationRunner`</a> "
-"— executes all pending registered migrations"
-msgstr ""
-
-#: src/contributing/runtime-migrations.md:171
-msgid ""
-"<a "
-"href=\"/api/cadmus_core/db/struct.Database\">`cadmus_core::db::Database`</a> "
-"— owns the connection pool and orchestrates both migration stages"
-msgstr ""
-
-#: src/investigations/index.md:3
-msgid ""
-"When something needs investigating, the investigation and its results are "
-"documented here. This is to ensure that the investigation is not lost and "
-"can be referred to in the future if needed."
-msgstr ""
-
-#: src/investigations/index.md:7
-msgid "Date"
-msgstr ""
-
-#: src/investigations/index.md:7
-msgid "Title"
-msgstr ""
-
-#: src/investigations/index.md:9
-msgid "2026-03-24"
-msgstr ""
-
-#: src/investigations/index.md:9
-msgid ""
-"[DHCP IP Address Changes on WiFi "
-"Toggle](./kobo/issue-51-dhcp-investigation.md)"
-msgstr ""
-
-#: src/investigations/kobo/issue-51-dhcp-investigation.md:3
-msgid ""
-"After identifying that killing the original `dhcpcd` and replacing it with "
-"`udhcpc` caused the issue reported in "
-"[\\#51](https://github.com/OGKevin/cadmus/issues/51), I confirmed the fix "
-"works in testing but wanted to understand the root cause before finalising "
-"PR [\\#299](https://github.com/OGKevin/cadmus/pull/299)."
-msgstr ""
-
-#: src/investigations/kobo/issue-51-dhcp-investigation.md:12
-msgid ""
-"Investigated the DHCP behaviour by inspecting the running device alongside "
-"the KOReader source tree and the original Plato shell scripts."
-msgstr ""
-
-#: src/investigations/kobo/issue-51-dhcp-investigation.md:15
-msgid "What is actually running on the device"
-msgstr ""
-
-#: src/investigations/kobo/issue-51-dhcp-investigation.md:23
-msgid ""
-"Nickel uses **`dhcpcd`**, not `udhcpc`. There is no `udhcpc` running under "
-"normal operation."
-msgstr ""
-
-#: src/investigations/kobo/issue-51-dhcp-investigation.md:25
-msgid "Why the old script caused a new IP every toggle"
-msgstr ""
-
-#: src/investigations/kobo/issue-51-dhcp-investigation.md:27
-msgid ""
-"The original "
-"[`scripts/wifi-enable.sh`](https://github.com/OGKevin/cadmus/blob/253edbe8958a44d108676d57b85942f21bb7c899/scripts/wifi-enable.sh#L92-L93) "
-"(inherited from Plato) always spawned a fresh `udhcpc`:"
-msgstr ""
-
-#: src/investigations/kobo/issue-51-dhcp-investigation.md:53
-msgid ""
-"'t request any options (unless -O is given)\n"
-" -O OPT  Request option OPT from server (cumulative)\n"
-" -x OPT:VAL Include option OPT in sent packets (cumulative)\n"
-"   Examples of string, numeric, and hex byte opts:\n"
-"   -x hostname:bbox - option 12\n"
-"   -x lease:3600 - option 51 (lease time)\n"
-"   -x 0x3d:0100BEEFC0FFEE - option 61 (client id)\n"
-"   -x 14:'\"dumpfile\"' - option 14 (shell-quoted)\n"
-" -F NAME  Ask server to update DNS mapping for NAME\n"
-" -V VENDOR Vendor identifier (default '"
-msgstr ""
-
-#: src/investigations/kobo/issue-51-dhcp-investigation.md:62
-msgid "')\n -C  Don'"
-msgstr ""
-
-#: src/investigations/kobo/issue-51-dhcp-investigation.md:71
-msgid "\"$INTERFACE\""
-msgstr ""
-
-#: src/investigations/kobo/issue-51-dhcp-investigation.md:74
-msgid ""
-"The `-q` flag is the core issue. It tells `udhcpc` to **quit immediately "
-"after obtaining a lease**. The full lifecycle on every WiFi toggle was:"
-msgstr ""
-
-#: src/investigations/kobo/issue-51-dhcp-investigation.md:77
-msgid ""
-"`udhcpc` spawned → sends `DISCOVER` → gets `OFFER` → sends `REQUEST` → gets "
-"`ACK` → runs `default.script bound` (sets IP, rewrites `resolv.conf`) → "
-"**process exits**"
-msgstr ""
-
-#: src/investigations/kobo/issue-51-dhcp-investigation.md:79
-msgid ""
-"WiFi disabled → `killall udhcpc default.script` → nothing to kill anyway, "
-"already exited"
-msgstr ""
-
-#: src/investigations/kobo/issue-51-dhcp-investigation.md:80
-msgid ""
-"WiFi enabled again → repeat from step 1 with **zero memory of the previous "
-"lease**"
-msgstr ""
-
-#: src/investigations/kobo/issue-51-dhcp-investigation.md:82
-msgid ""
-"Because the process exits after getting the lease, there is no daemon to "
-"renew it and no lease file written anywhere. Busybox's `udhcpc` has no lease "
-"persistence mechanism. On the next cycle it sends a bare `DISCOVER` with no "
-"preferred-IP hint (no DHCP Option 50), so the DHCP server is free to hand "
-"out any address from its pool."
-msgstr ""
-
-#: src/investigations/kobo/issue-51-dhcp-investigation.md:87
-msgid ""
-"Additionally, "
-"[`cadmus.sh`](https://github.com/OGKevin/cadmus/blob/253edbe8958a44d108676d57b85942f21bb7c899/contrib/cadmus.sh#L18-L20) "
-"(previously `plato.sh`) was killing Nickel's already-running `dhcpcd` at "
-"startup:"
-msgstr ""
-
-#: src/investigations/kobo/issue-51-dhcp-investigation.md:93
-msgid ""
-"So even the stateful daemon that Nickel had set up (which _would_ have "
-"requested the same IP again) was torn down before Cadmus replaced it with a "
-"stateless `udhcpc -q`."
-msgstr ""
-
-#: src/investigations/kobo/issue-51-dhcp-investigation.md:96
-msgid "What `default.script` does"
-msgstr ""
-
-#: src/investigations/kobo/issue-51-dhcp-investigation.md:98
-msgid ""
-"`/etc/udhcpc.d/default.script` is a minimal Busybox hook called by `udhcpc` "
-"on lease events. The relevant part:"
-msgstr ""
-
-#: src/investigations/kobo/issue-51-dhcp-investigation.md:102
-msgid "\"$1\""
-msgstr ""
-
-#: src/investigations/kobo/issue-51-dhcp-investigation.md:105
-msgid "# ... deletes all default routes, adds new ones from $router ...\n"
-msgstr ""
-
-#: src/investigations/kobo/issue-51-dhcp-investigation.md:106
-msgid "# ← truncates resolv.conf to zero\n"
-msgstr ""
-
-#: src/investigations/kobo/issue-51-dhcp-investigation.md:112
-msgid "\"$ip\""
-msgstr ""
-
-#: src/investigations/kobo/issue-51-dhcp-investigation.md:115
-msgid "Notable behaviours:"
-msgstr ""
-
-#: src/investigations/kobo/issue-51-dhcp-investigation.md:117
-msgid ""
-"**Wipes `resolv.conf` on every `bound` event.** This is why KOReader's "
-"[`disable-wifi.sh`](https://github.com/koreader/koreader/blob/d98dd9f244c5697c08a3bb9ac068f381d70b42c4/platform/kobo/disable-wifi.sh#L3-L6) "
-"saves and restores `resolv.conf` with an md5 check. This is a safety net "
-"against `udhcpc`'s script wiping DNS on lease release."
-msgstr ""
-
-#: src/investigations/kobo/issue-51-dhcp-investigation.md:120
-msgid ""
-"**Writes to `/tmp/nickel-hardware-status`**, which is a FIFO Nickel listens "
-"on for network events. [KOReader explicitly removes this "
-"FIFO](https://github.com/koreader/koreader/blob/d98dd9f244c5697c08a3bb9ac068f381d70b42c4/platform/kobo/koreader.sh#L232-L233) "
-"(`rm -f /tmp/nickel-hardware-status`) to prevent scripts hanging when Nickel "
-"is not running."
-msgstr ""
-
-#: src/investigations/kobo/issue-51-dhcp-investigation.md:124
-msgid "Why `dhcpcd` produces stable IPs"
-msgstr ""
-
-#: src/investigations/kobo/issue-51-dhcp-investigation.md:126
-msgid "`dhcpcd` writes a per-SSID lease file to **`/var/db/`**:"
-msgstr ""
-
-#: src/investigations/kobo/issue-51-dhcp-investigation.md:135
-msgid ""
-"`/var/db` lives on the root eMMC partition (`/dev/mmcblk0p10`), not a tmpfs. "
-"It survives reboots."
-msgstr ""
-
-#: src/investigations/kobo/issue-51-dhcp-investigation.md:137
-msgid ""
-"When reconnecting to a known SSID, `dhcpcd` reads the matching `.lease` "
-"file, parses the previously-held IP, and sends a DHCP `REQUEST` directly for "
-"that IP (DHCP Option 50: Requested IP Address), skipping `DISCOVER` entirely "
-"if the lease has not expired. The DHCP server sees a familiar MAC + familiar "
-"IP request and simply ACKs it."
-msgstr ""
-
-#: src/investigations/kobo/issue-51-dhcp-investigation.md:142
-msgid ""
-"The lease file for the current network encodes `192.x.x.x` in the `yiaddr` "
-"field of the saved BOOTREPLY, which is exactly the IP the device is using "
-"right now."
-msgstr ""
-
-#: src/investigations/kobo/issue-51-dhcp-investigation.md:145
-msgid "Filesystem layout: what is ephemeral vs persistent"
-msgstr ""
-
-#: src/investigations/kobo/issue-51-dhcp-investigation.md:147
-msgid "Path"
-msgstr ""
-
-#: src/investigations/kobo/issue-51-dhcp-investigation.md:147
-msgid "Persistent?"
-msgstr ""
-
-#: src/investigations/kobo/issue-51-dhcp-investigation.md:149
-msgid "`/tmp`"
-msgstr ""
-
-#: src/investigations/kobo/issue-51-dhcp-investigation.md:149
-msgid "`tmpfs`"
-msgstr ""
-
-#: src/investigations/kobo/issue-51-dhcp-investigation.md:149
-#: src/investigations/kobo/issue-51-dhcp-investigation.md:150
-#: src/investigations/kobo/issue-51-dhcp-investigation.md:151
-#: src/investigations/kobo/issue-51-dhcp-investigation.md:152
-msgid "No"
-msgstr ""
-
-#: src/investigations/kobo/issue-51-dhcp-investigation.md:150
-msgid "`/var/lib`"
-msgstr ""
-
-#: src/investigations/kobo/issue-51-dhcp-investigation.md:150
-#: src/investigations/kobo/issue-51-dhcp-investigation.md:152
-msgid "`tmpfs` (16 KiB)"
-msgstr ""
-
-#: src/investigations/kobo/issue-51-dhcp-investigation.md:151
-msgid "`/var/run`"
-msgstr ""
-
-#: src/investigations/kobo/issue-51-dhcp-investigation.md:151
-msgid "`tmpfs` (128 KiB)"
-msgstr ""
-
-#: src/investigations/kobo/issue-51-dhcp-investigation.md:152
-msgid "`/var/log`"
-msgstr ""
-
-#: src/investigations/kobo/issue-51-dhcp-investigation.md:153
-msgid "`/var/db`"
-msgstr ""
-
-#: src/investigations/kobo/issue-51-dhcp-investigation.md:153
-msgid "eMMC (`mmcblk0p10`)"
-msgstr ""
-
-#: src/investigations/kobo/issue-51-dhcp-investigation.md:153
-#: src/investigations/kobo/issue-51-dhcp-investigation.md:154
-msgid "**Yes**"
-msgstr ""
-
-#: src/investigations/kobo/issue-51-dhcp-investigation.md:154
-msgid "`/etc`"
-msgstr ""
-
-#: src/investigations/kobo/issue-51-dhcp-investigation.md:154
-msgid "eMMC"
-msgstr ""
-
-#: src/investigations/kobo/issue-51-dhcp-investigation.md:156
-msgid ""
-"`dhcpcd`'s runtime state (`/var/run/dhcpcd.pid`, `/var/run/dhcpcd.sock`) is "
-"ephemeral as expected, but the lease database in `/var/db/` persists. That "
-"is the architectural key."
-msgstr ""
-
-#: src/investigations/kobo/issue-51-dhcp-investigation.md:159
-msgid ""
-"Why KOReader kills `dhcpcd` in its startup script but still gets stable IPs"
-msgstr ""
-
-#: src/investigations/kobo/issue-51-dhcp-investigation.md:161
-msgid ""
-"From "
-"[`koreader.sh`](https://github.com/koreader/koreader/blob/d98dd9f244c5697c08a3bb9ac068f381d70b42c4/platform/kobo/koreader.sh#L216-L220):"
-msgstr ""
-
-#: src/investigations/kobo/issue-51-dhcp-investigation.md:164
-msgid "# NOTE: We kill Nickel's master dhcpcd daemon on purpose,\n"
-msgstr ""
-
-#: src/investigations/kobo/issue-51-dhcp-investigation.md:165
-msgid ""
-"#       A SIGTERM does not break anything, it'll just prevent automatic "
-"lease renewal\n"
-msgstr ""
-
-#: src/investigations/kobo/issue-51-dhcp-investigation.md:167
-msgid ""
-"'ll do)...\n"
-"killall -q -TERM nickel ... dhcpcd-dbus dhcpcd ...\n"
-msgstr ""
-
-#: src/investigations/kobo/issue-51-dhcp-investigation.md:171
-msgid ""
-"KOReader kills Nickel's `dhcpcd` because it wants to start its own instance "
-"with custom arguments later via "
-"[`obtain-ip.sh`](https://github.com/koreader/koreader/blob/d98dd9f244c5697c08a3bb9ac068f381d70b42c4/platform/kobo/obtain-ip.sh#L54-L60). "
-"Crucially, `obtain-ip.sh` prefers `dhcpcd` over `udhcpc`:"
-msgstr ""
-
-#: src/investigations/kobo/issue-51-dhcp-investigation.md:175
-msgid ""
-"# NOTE: Prefer dhcpcd over udhcpc if available. That's what Nickel uses,\n"
-msgstr ""
-
-#: src/investigations/kobo/issue-51-dhcp-investigation.md:177
-msgid "\"/sbin/dhcpcd\""
-msgstr ""
-
-#: src/investigations/kobo/issue-51-dhcp-investigation.md:178
-#: src/investigations/kobo/issue-51-dhcp-investigation.md:180
-msgid "\"${INTERFACE}\""
-msgstr ""
-
-#: src/investigations/kobo/issue-51-dhcp-investigation.md:184
-msgid ""
-"The new `dhcpcd` instance KOReader starts reads the same `/var/db/*.lease` "
-"files and requests the same IP. Stable address despite the kill/restart "
-"cycle."
-msgstr ""
-
-#: src/investigations/kobo/issue-51-dhcp-investigation.md:187
-msgid ""
-"Why the fix in PR [\\#299](https://github.com/OGKevin/cadmus/pull/299) works"
-msgstr ""
-
-#: src/investigations/kobo/issue-51-dhcp-investigation.md:189
-msgid "The fix is twofold:"
-msgstr ""
-
-#: src/investigations/kobo/issue-51-dhcp-investigation.md:191
-msgid ""
-"**Remove `dhcpcd` from the kill list in "
-"[`cadmus.sh`](https://github.com/OGKevin/cadmus/blob/253edbe8958a44d108676d57b85942f21bb7c899/contrib/cadmus.sh#L18-L20)**. "
-"Nickel's running `dhcpcd -d -z wlan0` instance survives into the Cadmus "
-"session, continuously managing the lease."
-msgstr ""
-
-#: src/investigations/kobo/issue-51-dhcp-investigation.md:194
-msgid ""
-"**Do not start `udhcpc` at all in the native Rust WiFi implementation**. No "
-"new DHCP client is spawned on toggle, so the already-running `dhcpcd` is "
-"never displaced."
-msgstr ""
-
-#: src/investigations/kobo/issue-51-dhcp-investigation.md:197
-msgid ""
-"The result: one long-lived `dhcpcd` daemon manages the lease for the entire "
-"session, renews it in the background, and requests the same IP on every "
-"reconnect using the persisted `/var/db/*.lease` file."
 msgstr ""
 

--- a/docs/src/auto-frontlight.md
+++ b/docs/src/auto-frontlight.md
@@ -24,9 +24,13 @@ Open **Main Menu → Settings → General** and turn on **Auto Frontlight**.
 
 You can also enable it directly in your settings file:
 
+<!-- i18n:skip-start -->
+
 ```toml
 auto-frontlight = true
 ```
+
+<!-- i18n:skip-end -->
 
 See [`auto-frontlight`](settings/index.md#auto-frontlight) and related entries
 in the Settings reference for all available options.
@@ -52,9 +56,13 @@ time sync), automatic adjustment is skipped until a location is known.
 If you prefer not to rely on IP-based location, or if the detected location is
 inaccurate, you can set your own coordinates:
 
+<!-- i18n:skip-start -->
+
 ```toml
 auto-frontlight-manual-coordinates = [51.5074, -0.1278]
 ```
+
+<!-- i18n:skip-end -->
 
 Manual coordinates take priority over auto-detected ones.
 
@@ -66,9 +74,13 @@ Frontlight Manual Coordinates**.
 The brightness level used after sunset defaults to `1.0` (1%). You can raise
 this if you find the screen too dim for nighttime reading:
 
+<!-- i18n:skip-start -->
+
 ```toml
 auto-frontlight-night-brightness = 10.0
 ```
+
+<!-- i18n:skip-end -->
 
 The value is a percentage from `0.0` to `100.0`.
 

--- a/docs/src/contributing/code-style.md
+++ b/docs/src/contributing/code-style.md
@@ -1,3 +1,5 @@
+<!-- i18n:skip-start -->
+
 # Code Style and Linting
 
 Cadmus enforces a consistent code style across all languages using
@@ -131,3 +133,5 @@ The following CI workflows enforce style:
 CI uses `filter_mode: added` for shell checks, meaning only lines changed in
 the PR are flagged. Running `treefmt` locally before pushing will catch
 everything.
+
+<!-- i18n:skip-end -->

--- a/docs/src/contributing/devenv-setup.md
+++ b/docs/src/contributing/devenv-setup.md
@@ -1,3 +1,5 @@
+<!-- i18n:skip-start -->
+
 # Development Environment Setup
 
 Cadmus uses [devenv](https://devenv.sh/) with Nix to provide a reproducible development environment.
@@ -249,3 +251,5 @@ Create `devenv.local.nix` to override settings without modifying the tracked con
 ```
 
 This file is gitignored and won't affect other contributors.
+
+<!-- i18n:skip-end -->

--- a/docs/src/contributing/documentation.md
+++ b/docs/src/contributing/documentation.md
@@ -1,3 +1,5 @@
+<!-- i18n:skip-start -->
+
 # Documentation Deployment
 
 Cadmus documentation is deployed to Cloudflare Pages.
@@ -46,3 +48,5 @@ Documentation is built from three sources:
 The build is orchestrated by `cargo xtask docs` (see `xtask/src/tasks/docs.rs`). The GitHub
 Actions workflow (`.github/workflows/cadmus-docs.yml`) runs this command automatically on every
 push to `main` and for every pull request.
+
+<!-- i18n:skip-end -->

--- a/docs/src/contributing/event-system.md
+++ b/docs/src/contributing/event-system.md
@@ -1,3 +1,5 @@
+<!-- i18n:skip-start -->
+
 # Event System
 
 Cadmus uses a tree-based event system where views are organized hierarchically and events flow
@@ -351,3 +353,5 @@ impl View for Dialog {
 | Direction        | View → Main loop               | Child → Parent                  |
 | Unhandled events | Processed by main loop `match` | Forwarded to hub                |
 | Use for          | Close, Focus, Notifications    | Submit, child-to-parent signals |
+
+<!-- i18n:skip-end -->

--- a/docs/src/contributing/library-database.md
+++ b/docs/src/contributing/library-database.md
@@ -1,3 +1,5 @@
+<!-- i18n:skip-start -->
+
 # Library Database
 
 Cadmus stores library roots, scanned files, book metadata, reading progress,
@@ -124,3 +126,5 @@ rules, see the related pages below.
   rules
 - [Runtime Migrations](runtime-migrations.md) — one-time data migrations using
   the `migration!` macro
+
+<!-- i18n:skip-end -->

--- a/docs/src/contributing/runtime-migrations.md
+++ b/docs/src/contributing/runtime-migrations.md
@@ -1,3 +1,5 @@
+<!-- i18n:skip-start -->
+
 # Runtime Migrations
 
 Cadmus has two distinct migration pipelines:
@@ -170,3 +172,5 @@ The next startup will treat the migration as pending and run it again.
   executes all pending registered migrations
 - <a href="/api/cadmus_core/db/struct.Database">`cadmus_core::db::Database`</a> —
   owns the connection pool and orchestrates both migration stages
+
+<!-- i18n:skip-end -->

--- a/docs/src/contributing/sqlite-sqlx.md
+++ b/docs/src/contributing/sqlite-sqlx.md
@@ -1,3 +1,5 @@
+<!-- i18n:skip-start -->
+
 # SQLite & SQLx
 
 Cadmus uses [SQLite](https://sqlite.org) as its embedded database and
@@ -135,3 +137,5 @@ The primary database types live in the `cadmus_core::db` module:
 See [Library Database](library-database.md) for how the library subsystem uses
 the database, and [Runtime Migrations](runtime-migrations.md) for how to write
 one-time data migrations.
+
+<!-- i18n:skip-end -->

--- a/docs/src/contributing/ssh.md
+++ b/docs/src/contributing/ssh.md
@@ -1,3 +1,5 @@
+<!-- i18n:skip-start -->
+
 # SSH-ing into your Kobo
 
 To enable SSH, mount your kobo normally, and follow the instructions in the file
@@ -22,3 +24,5 @@ allowing convenient passwordless login using your key.
 
 As of May 2026, the SSH implementation is
 OpenSSH (Currently OpenSSH_8.9p1, OpenSSL 3.0.8 7 Feb 2023).
+
+<!-- i18n:skip-end -->

--- a/docs/src/contributing/telemetry/index.md
+++ b/docs/src/contributing/telemetry/index.md
@@ -1,3 +1,5 @@
+<!-- i18n:skip-start -->
+
 # Telemetry
 
 Cadmus has three related observability paths:
@@ -43,3 +45,5 @@ development this matches the default observability stack exposed by
 
 The development environment includes a full observability stack. Use the
 `cadmus-dev-otel` command to run the emulator with telemetry enabled.
+
+<!-- i18n:skip-end -->

--- a/docs/src/contributing/telemetry/logging.md
+++ b/docs/src/contributing/telemetry/logging.md
@@ -1,3 +1,5 @@
+<!-- i18n:skip-start -->
+
 # Logging
 
 Cadmus writes structured JSON logs to disk and can export logs to an OTLP
@@ -79,3 +81,5 @@ on top when an endpoint is configured.
 
 - [Tracing](tracing.md)
 - [Profiling](profiling.md)
+
+<!-- i18n:skip-end -->

--- a/docs/src/contributing/telemetry/profiling.md
+++ b/docs/src/contributing/telemetry/profiling.md
@@ -1,3 +1,5 @@
+<!-- i18n:skip-start -->
+
 # Profiling
 
 Cadmus supports continuous profiling with Pyroscope when the `profiling`
@@ -64,3 +66,5 @@ the local Pyroscope service available at <http://localhost:4040>.
 With the full devenv stack running, traces go to Tempo, logs go to Loki, and
 profiles go to Pyroscope. That makes it possible to correlate a single run
 across all three observability backends.
+
+<!-- i18n:skip-end -->

--- a/docs/src/contributing/telemetry/tracing.md
+++ b/docs/src/contributing/telemetry/tracing.md
@@ -1,3 +1,5 @@
+<!-- i18n:skip-start -->
+
 # Tracing
 
 Cadmus uses `tracing` instrumentation to capture execution flow through the
@@ -108,3 +110,5 @@ cargo build --features tracing
 
 - [Logging](logging.md)
 - [Profiling](profiling.md)
+
+<!-- i18n:skip-end -->

--- a/docs/src/contributing/translations/docs.md
+++ b/docs/src/contributing/translations/docs.md
@@ -1,3 +1,5 @@
+<!-- i18n:skip-start -->
+
 # Translating Cadmus Documentation
 
 This guide explains how to translate the Cadmus documentation into other
@@ -87,7 +89,11 @@ msgmerge --update docs/po/fr.po docs/po/messages.pot
 
 ## Excluding content from extraction
 
-Wrap any block you want to keep in English with `<!-- i18n:skip -->` comments:
+Two forms are available depending on how much content you need to skip.
+
+### Single block
+
+Use `<!-- i18n:skip -->` before a single block (paragraph, code block, table):
 
 <!-- i18n:skip -->
 
@@ -95,6 +101,43 @@ Wrap any block you want to keep in English with `<!-- i18n:skip -->` comments:
 <!-- i18n:skip -->
 
 This paragraph will not appear in the POT file.
+```
+
+### Range
+
+Use `<!-- i18n:skip-start -->` / `<!-- i18n:skip-end -->` to exclude multiple
+consecutive blocks, or an entire file section:
+
+<!-- i18n:skip -->
+
+```markdown
+<!-- i18n:skip-start -->
+
+This paragraph is excluded.
+
+And so is this one.
+
+<!-- i18n:skip-end -->
+```
+
+When the skip directives appear inside an ordered or unordered list, indent
+them to match the list continuation level so markdownlint does not treat them
+as list-breaking elements:
+
+<!-- i18n:skip -->
+
+```markdown
+1. Step one.
+
+   <!-- i18n:skip-start -->
+
+   | Path | Value |
+   | ---- | ----- |
+   | `/mnt/onboard` | stable |
+
+   <!-- i18n:skip-end -->
+
+2. Step two.
 ```
 
 ## How the build works
@@ -107,3 +150,5 @@ This paragraph will not appear in the POT file.
    `lang-picker.js` fetches it at runtime to populate the language dropdown.
 4. Symlinks under `docs-portal/static/guide/<lang>/` expose each locale build
    to Zola so it is served at `/guide/<lang>/`.
+
+<!-- i18n:skip-end -->

--- a/docs/src/contributing/translations/index.md
+++ b/docs/src/contributing/translations/index.md
@@ -1,3 +1,5 @@
+<!-- i18n:skip-start -->
+
 # Translations
 
 Cadmus has two separate translation systems, each covering a different part of
@@ -9,3 +11,5 @@ the project.
 | [UI strings](source-code.md) | Fluent (FTL)     | `crates/core/i18n/**/*.ftl` |
 
 Pick the guide that matches what you want to translate.
+
+<!-- i18n:skip-end -->

--- a/docs/src/contributing/translations/source-code.md
+++ b/docs/src/contributing/translations/source-code.md
@@ -1,3 +1,5 @@
+<!-- i18n:skip-start -->
+
 # Translating Source Strings
 
 The Cadmus UI uses [Fluent] for all user-visible strings. Translations are
@@ -102,3 +104,5 @@ For the full syntax reference see the [Fluent syntax guide].
 
 [Fluent]: https://projectfluent.org
 [Fluent syntax guide]: https://projectfluent.org/fluent/guide/
+
+<!-- i18n:skip-end -->

--- a/docs/src/database-backup.md
+++ b/docs/src/database-backup.md
@@ -23,6 +23,8 @@ Backups live in a `backups/` folder inside the directory that contains
 `cadmus.sqlite`. A small index file called `.cadmus-db-index.toml` in that same
 folder tracks every backup.
 
+<!-- i18n:skip-start -->
+
 ```tree
 <data dir>/
 ├── cadmus.sqlite
@@ -31,6 +33,8 @@ folder tracks every backup.
     ├── cadmus-v1.2.0.sqlite
     └── cadmus-v1.3.0.sqlite
 ```
+
+<!-- i18n:skip-end -->
 
 Each backup file is named after the Cadmus version that created it, for example
 `cadmus-v1.2.3.sqlite`.
@@ -72,6 +76,10 @@ exceed this limit, the oldest backups are deleted automatically.
 - Default: `2`
 - Set to `0` to disable backups entirely.
 
+<!-- i18n:skip-start -->
+
 ```toml
 db-backup-retention = 2
 ```
+
+<!-- i18n:skip-end -->

--- a/docs/src/installation/index.md
+++ b/docs/src/installation/index.md
@@ -4,12 +4,16 @@ Cadmus comes in different packages. Pick the one that matches your needs.
 
 ## Available packages
 
+<!-- i18n:skip-start -->
+
 | Package                | What's included         | Installs to                     |
 | ---------------------- | ----------------------- | ------------------------------- |
 | `KoboRoot.tgz`         | Cadmus only             | `/mnt/onboard/.adds/cadmus`     |
 | `KoboRoot-nm.tgz`      | Cadmus + NickelMenu     | `/mnt/onboard/.adds/cadmus`     |
 | `KoboRoot-test.tgz`    | Test build only         | `/mnt/onboard/.adds/cadmus-tst` |
 | `KoboRoot-nm-test.tgz` | Test build + NickelMenu | `/mnt/onboard/.adds/cadmus-tst` |
+
+<!-- i18n:skip-end -->
 
 ## Which one should I pick?
 

--- a/docs/src/installation/kfmon.md
+++ b/docs/src/installation/kfmon.md
@@ -19,21 +19,31 @@ blocks other launches while Cadmus is already running.
 
 1. Place the Cadmus icon somewhere on your Kobo, for example:
 
+   <!-- i18n:skip-start -->
+
    ```text
    /mnt/onboard/icons/cadmus.png
    ```
+
+   <!-- i18n:skip-end -->
 
    If you don't have an icon, create or copy a PNG image to use as the
    launcher icon.
 
 2. Create a new file on your Kobo:
 
+   <!-- i18n:skip-start -->
+
    ```text
    /mnt/onboard/.adds/kfmon/config/cadmus.ini
    ```
 
+   <!-- i18n:skip-end -->
+
 3. Paste this into the file, changing the `filename` value to match your icon
    path:
+
+   <!-- i18n:skip-start -->
 
    ```ini
    [watch]
@@ -54,6 +64,8 @@ blocks other launches while Cadmus is already running.
    do_db_update = 0
    ```
 
+   <!-- i18n:skip-end -->
+
 4. Reboot your Kobo.
 
 > [!IMPORTANT]
@@ -73,12 +85,20 @@ Using both can create duplicate icons and make conflicts harder to diagnose.
 If you need to stop KFMon from launching anything for a short time — for
 example, while troubleshooting — you can create a blank `BLOCK` file:
 
+<!-- i18n:skip-start -->
+
 ```sh
 touch /mnt/onboard/.adds/kfmon/config/BLOCK
 ```
 
+<!-- i18n:skip-end -->
+
 Remove the file when you want KFMon to work again:
+
+<!-- i18n:skip-start -->
 
 ```sh
 rm /mnt/onboard/.adds/kfmon/config/BLOCK
 ```
+
+<!-- i18n:skip-end -->

--- a/docs/src/installation/migration.md
+++ b/docs/src/installation/migration.md
@@ -5,10 +5,14 @@ migrating is mostly a matter of copying your settings file across.
 
 ## Copy your settings
 
+<!-- i18n:skip-start -->
+
 | Build  | Plato settings                           | Cadmus settings                               |
 | ------ | ---------------------------------------- | --------------------------------------------- |
 | Stable | `/mnt/onboard/.adds/plato/Settings.toml` | `/mnt/onboard/.adds/cadmus/Settings.toml`     |
 | Test   | `/mnt/onboard/.adds/plato/Settings.toml` | `/mnt/onboard/.adds/cadmus-tst/Settings.toml` |
+
+<!-- i18n:skip-end -->
 
 Copy the file as-is into the Cadmus folder so it is named `Settings.toml` (for example, `/mnt/onboard/.adds/cadmus/Settings.toml` or `/mnt/onboard/.adds/cadmus-tst/Settings.toml`).
 The `[[libraries]]` section is the most important part, it tells Cadmus where your books live and drives the reading-progress import on
@@ -24,12 +28,16 @@ first launch. On first launch, Cadmus will move this file into its `Settings/` f
 > migration will not run. You will need to copy your data manually — see
 > [Moving data to an SD card](#moving-data-to-an-sd-card) below.
 
+<!-- i18n:skip-start -->
+
 ```toml
 [[libraries]]
 name = "On Board"
 path = "/mnt/onboard"
 mode = "database"
 ```
+
+<!-- i18n:skip-end -->
 
 > [!IMPORTANT]
 > Make sure each `[[libraries]]` entry has the correct `path` and `name`.
@@ -68,10 +76,14 @@ settings), you can start it fresh:
 
 1. Delete the Cadmus SQLite database:
 
+   <!-- i18n:skip-start -->
+
    | Build  | Database path (with SD card)        | Database path (without SD card)               |
    | ------ | ----------------------------------- | --------------------------------------------- |
    | Stable | `/mnt/sd/.cadmus/cadmus.sqlite`     | `/mnt/onboard/.adds/cadmus/cadmus.sqlite`     |
    | Test   | `/mnt/sd/.cadmus-tst/cadmus.sqlite` | `/mnt/onboard/.adds/cadmus-tst/cadmus.sqlite` |
+
+   <!-- i18n:skip-end -->
 
 2. Restart Cadmus — the import will run again from scratch.
 

--- a/docs/src/installation/uninstall.md
+++ b/docs/src/installation/uninstall.md
@@ -5,18 +5,26 @@ To remove Cadmus from your Kobo:
 1. Connect your Kobo to your computer via USB.
 2. Delete the Cadmus folder from `.adds`:
 
+   <!-- i18n:skip-start -->
+
    | Build  | Folder to delete                |
    | ------ | ------------------------------- |
    | Stable | `/mnt/onboard/.adds/cadmus`     |
    | Test   | `/mnt/onboard/.adds/cadmus-tst` |
 
+   <!-- i18n:skip-end -->
+
 3. If you installed a package that included NickelMenu, delete the Cadmus menu
    entry too:
+
+   <!-- i18n:skip-start -->
 
    | Build  | NickelMenu entry to delete         |
    | ------ | ---------------------------------- |
    | Stable | `/mnt/onboard/.adds/nm/cadmus`     |
    | Test   | `/mnt/onboard/.adds/nm/cadmus-tst` |
+
+   <!-- i18n:skip-end -->
 
 4. Eject the device and disconnect the USB cable.
 

--- a/docs/src/investigations/index.md
+++ b/docs/src/investigations/index.md
@@ -1,3 +1,5 @@
+<!-- i18n:skip-start -->
+
 # Investigations
 
 When something needs investigating, the investigation and its results are
@@ -7,3 +9,5 @@ referred to in the future if needed.
 | Date       | Platform | Title                                                                           |
 | ---------- | -------- | ------------------------------------------------------------------------------- |
 | 2026-03-24 | Kobo     | [DHCP IP Address Changes on WiFi Toggle](./kobo/issue-51-dhcp-investigation.md) |
+
+<!-- i18n:skip-end -->

--- a/docs/src/investigations/kobo/issue-51-dhcp-investigation.md
+++ b/docs/src/investigations/kobo/issue-51-dhcp-investigation.md
@@ -1,3 +1,5 @@
+<!-- i18n:skip-start -->
+
 # DHCP IP Address Changes on WiFi Toggle
 
 After identifying that killing the original `dhcpcd` and replacing it with
@@ -196,3 +198,5 @@ The fix is twofold:
 
 The result: one long-lived `dhcpcd` daemon manages the lease for the entire session, renews it in the
 background, and requests the same IP on every reconnect using the persisted `/var/db/*.lease` file.
+
+<!-- i18n:skip-end -->

--- a/docs/src/settings/index.md
+++ b/docs/src/settings/index.md
@@ -35,9 +35,13 @@ Keyboard layout to use for text input.
 
 - Possible values: `"English"`, `"Russian"`.
 
+<!-- i18n:skip-start -->
+
 ```toml
 keyboard-layout = "English"
 ```
+
+<!-- i18n:skip-end -->
 
 ### `sleep-cover`
 
@@ -45,9 +49,13 @@ keyboard-layout = "English"
 
 Handle the magnetic sleep cover event.
 
+<!-- i18n:skip-start -->
+
 ```toml
 sleep-cover = true
 ```
+
+<!-- i18n:skip-end -->
 
 ### `auto-share`
 
@@ -60,9 +68,13 @@ Automatically enter shared mode when connected to a computer, skipping the
 > Turn this on if you update Cadmus via USB often — you won't have to
 > confirm the sharing dialog each time you plug in.
 
+<!-- i18n:skip-start -->
+
 ```toml
 auto-share = false
 ```
+
+<!-- i18n:skip-end -->
 
 ### `auto-time`
 
@@ -70,9 +82,13 @@ auto-share = false
 
 Automatically synchronize the device time via NTP when WiFi connects. This will also set the correct timezone. Uses time.cloudflare.com and ipapi.co.
 
+<!-- i18n:skip-start -->
+
 ```toml
 auto-time = false
 ```
+
+<!-- i18n:skip-end -->
 
 ### `auto-frontlight`
 
@@ -86,9 +102,13 @@ Automatically adjust the frontlight warmth and brightness based on the sun's pos
 
 Coordinates are auto-detected during each time sync (via ipapi.co) and stored in `auto-frontlight-last-coordinates`. Set `auto-frontlight-manual-coordinates` to override the detected location.
 
+<!-- i18n:skip-start -->
+
 ```toml
 auto-frontlight = false
 ```
+
+<!-- i18n:skip-end -->
 
 ### `auto-frontlight-night-brightness`
 
@@ -98,9 +118,13 @@ Frontlight brightness level (0.0–100.0) applied when the sun is below the hori
 
 This setting is optional. When not set, a default of `1.0` is used.
 
+<!-- i18n:skip-start -->
+
 ```toml
 auto-frontlight-night-brightness = 10.0
 ```
+
+<!-- i18n:skip-end -->
 
 ### `auto-frontlight-manual-coordinates`
 
@@ -110,9 +134,13 @@ GPS coordinates `[latitude, longitude]` to use for sun-position calculations ins
 
 This setting is optional.
 
+<!-- i18n:skip-start -->
+
 ```toml
 auto-frontlight-manual-coordinates = [51.5074, -0.1278]
 ```
+
+<!-- i18n:skip-end -->
 
 ### `auto-frontlight-last-coordinates`
 
@@ -120,9 +148,13 @@ GPS coordinates `[latitude, longitude]` last detected during a time sync. Writte
 
 This setting is optional and managed automatically.
 
+<!-- i18n:skip-start -->
+
 ```toml
 # auto-frontlight-last-coordinates = [48.8566, 2.3522]
 ```
+
+<!-- i18n:skip-end -->
 
 ### `auto-suspend`
 
@@ -132,9 +164,13 @@ Number of minutes of inactivity after which the device will automatically go to 
 
 - Zero means never.
 
+<!-- i18n:skip-start -->
+
 ```toml
 auto-suspend = 30.0
 ```
+
+<!-- i18n:skip-end -->
 
 ### `auto-power-off`
 
@@ -144,9 +180,13 @@ Delay in days after which a suspended device will power off.
 
 - Zero means never.
 
+<!-- i18n:skip-start -->
+
 ```toml
 auto-power-off = 3.0
 ```
+
+<!-- i18n:skip-end -->
 
 ### `button-scheme`
 
@@ -156,9 +196,13 @@ Defines how the back and forward buttons are mapped to page forward and page bac
 
 - Possible values: `"natural"`, `"inverted"`.
 
+<!-- i18n:skip-start -->
+
 ```toml
 button-scheme = "natural"
 ```
+
+<!-- i18n:skip-end -->
 
 ### `locale`
 
@@ -168,9 +212,13 @@ The preferred language for the user interface, using BCP 47 format (e.g., `"en-U
 
 This setting is optional. When not set, `en-GB` is used.
 
+<!-- i18n:skip-start -->
+
 ```toml
 locale = "en-GB"
 ```
+
+<!-- i18n:skip-end -->
 
 ### `startup-mode`
 
@@ -182,9 +230,13 @@ What to show when Cadmus starts.
 - `"last-file"` — re-open the last book you were reading. If there is no
   unfinished book in the selected library, the home screen is shown instead.
 
+<!-- i18n:skip-start -->
+
 ```toml
 startup-mode = "home"
 ```
+
+<!-- i18n:skip-end -->
 
 ## Reader
 
@@ -202,10 +254,14 @@ Possible values:
 - `"close"` (close the book and go back)
 - `"go-to-next"` (open the next book in the library).
 
+<!-- i18n:skip-start -->
+
 ```toml
 [reader]
 finished = "close"
 ```
+
+<!-- i18n:skip-end -->
 
 ### `reader.dithered-kinds`
 
@@ -213,10 +269,14 @@ finished = "close"
 
 File extensions rendered with dithering by default.
 
+<!-- i18n:skip-start -->
+
 ```toml
 [reader]
 dithered-kinds = ["cbz", "png", "jpg", "jpeg", "webp"]
 ```
+
+<!-- i18n:skip-end -->
 
 ## Libraries
 
@@ -224,12 +284,16 @@ dithered-kinds = ["cbz", "png", "jpg", "jpeg", "webp"]
 
 Document library configuration. Each library has a name, path, and mode.
 
+<!-- i18n:skip-start -->
+
 ```toml
 [[libraries]]
 name = "On Board"
 path = "/mnt/onboard"
 mode = "database"
 ```
+
+<!-- i18n:skip-end -->
 
 ### `libraries.name`
 
@@ -265,6 +329,8 @@ Possible values:
 - `"go-to-next"`.
 - Leave unset to inherit the global `reader.finished` setting.
 
+<!-- i18n:skip-start -->
+
 ```toml
 [[libraries]]
 name = "KePub"
@@ -272,11 +338,15 @@ path = "/mnt/onboard/.kobo/kepub"
 finished = "go-to-next"
 ```
 
+<!-- i18n:skip-end -->
+
 ## Intermissions
 
 ✏️
 
 Defines the images displayed when entering an intermission state.
+
+<!-- i18n:skip-start -->
 
 ```toml
 [intermissions]
@@ -284,6 +354,8 @@ suspend = "logo:"
 power-off = "logo:"
 share = "logo:"
 ```
+
+<!-- i18n:skip-end -->
 
 ### `intermissions.suspend`
 
@@ -328,19 +400,27 @@ To trigger a full re-scan of all files regardless of cached values, use the **Fo
 
 Re-extract metadata (title, author, etc.) whenever a document changes.
 
+<!-- i18n:skip-start -->
+
 ```toml
 [import]
 sync-metadata = true
 ```
 
+<!-- i18n:skip-end -->
+
 ### `import.metadata-kinds`
 
 File extensions of documents whose metadata is extracted during import.
+
+<!-- i18n:skip-start -->
 
 ```toml
 [import]
 metadata-kinds = ["epub", "pdf", "djvu"]
 ```
+
+<!-- i18n:skip-end -->
 
 ### `import.allowed-kinds`
 
@@ -348,10 +428,14 @@ metadata-kinds = ["epub", "pdf", "djvu"]
 
 File extensions of documents considered during the import process.
 
+<!-- i18n:skip-start -->
+
 ```toml
 [import]
 allowed-kinds = ["djvu", "xps", "fb2", "txt", "pdf", "oxps", "cbz", "epub"]
 ```
+
+<!-- i18n:skip-end -->
 
 ## OTA
 
@@ -382,6 +466,8 @@ These settings are available in the **Settings → Telemetry** menu.
 
 ### `logging`
 
+<!-- i18n:skip-start -->
+
 ```toml
 [logging]
 enabled = true
@@ -391,16 +477,22 @@ directory = "logs"
 # otlp-endpoint = "https://otel.example.com:4318"
 ```
 
+<!-- i18n:skip-end -->
+
 ### `logging.enabled`
 
 ✏️
 
 Enable or disable structured JSON logging.
 
+<!-- i18n:skip-start -->
+
 ```toml
 [logging]
 enabled = true
 ```
+
+<!-- i18n:skip-end -->
 
 ### `logging.level`
 
@@ -410,10 +502,14 @@ Minimum log level to record.
 
 - Possible values: `"trace"`, `"debug"`, `"info"`, `"warn"`, `"error"`.
 
+<!-- i18n:skip-start -->
+
 ```toml
 [logging]
 level = "info"
 ```
+
+<!-- i18n:skip-end -->
 
 ### `logging.max-files`
 
@@ -423,10 +519,14 @@ are deleted automatically when Cadmus starts.
 - Default: `3`
 - Set to `0` to keep all log files.
 
+<!-- i18n:skip-start -->
+
 ```toml
 [logging]
 max-files = 3
 ```
+
+<!-- i18n:skip-end -->
 
 ### `logging.otlp-endpoint`
 
@@ -434,10 +534,14 @@ max-files = 3
 
 Optional OTLP endpoint for exporting logs to an OpenTelemetry collector.
 
+<!-- i18n:skip-start -->
+
 ```toml
 [logging]
 otlp-endpoint = "https://otel.example.com:4318"
 ```
+
+<!-- i18n:skip-end -->
 
 Environment override:
 
@@ -451,10 +555,14 @@ Optional Pyroscope server URL for continuous profiling. When set, Cadmus starts
 both a heap profiling agent (via jemalloc) and a CPU profiling agent (via
 pprof) that push profiles to this endpoint.
 
+<!-- i18n:skip-start -->
+
 ```toml
 [logging]
 pyroscope-endpoint = "http://localhost:4040"
 ```
+
+<!-- i18n:skip-end -->
 
 Environment override:
 
@@ -467,10 +575,14 @@ Environment override:
 Captures kernel logs via `logread -F` and forwards them to structured logging
 with the target `cadmus_core::logging:kern`.
 
+<!-- i18n:skip-start -->
+
 ```toml
 [logging]
 enable-kern-log = false
 ```
+
+<!-- i18n:skip-end -->
 
 ### `logging.enable-dbus-log`
 
@@ -479,10 +591,14 @@ enable-kern-log = false
 Captures D-Bus signals via the built-in zbus-based DbusMonitorTask and forwards
 them to structured logging.
 
+<!-- i18n:skip-start -->
+
 ```toml
 [logging]
 enable-dbus-log = false
 ```
+
+<!-- i18n:skip-end -->
 
 ## Settings Retention
 
@@ -496,9 +612,13 @@ Number of recent version settings files to keep. Only the most recent N version 
 - Default: `3`
 - Set to `0` to keep all version files
 
+<!-- i18n:skip-start -->
+
 ```toml
 settings-retention = 3
 ```
+
+<!-- i18n:skip-end -->
 
 ### `db-backup-retention`
 
@@ -510,6 +630,10 @@ would exceed this limit, the oldest backups are deleted automatically.
 
 See [Database Backup](../database-backup.md) for more details.
 
+<!-- i18n:skip-start -->
+
 ```toml
 db-backup-retention = 2
 ```
+
+<!-- i18n:skip-end -->

--- a/docs/src/time-sync.md
+++ b/docs/src/time-sync.md
@@ -19,9 +19,13 @@ Open **Main Menu → Settings → General** and turn on **Auto Time**.
 
 You can also enable it manually in your settings file:
 
+<!-- i18n:skip-start -->
+
 ```toml
 auto-time = true
 ```
+
+<!-- i18n:skip-end -->
 
 ## Manual sync
 

--- a/docs/src/troubleshooting/index.md
+++ b/docs/src/troubleshooting/index.md
@@ -10,9 +10,13 @@ If you're reporting an issue, sharing your logs makes it much easier to debug.
 
 Cadmus saves logs in a `logs` folder. Here's where to find it on each platform:
 
+<!-- i18n:skip-start -->
+
 | Platform | Stable build                     | Test build                           |
 | -------- | -------------------------------- | ------------------------------------ |
 | Kobo     | `/mnt/onboard/.adds/cadmus/logs` | `/mnt/onboard/.adds/cadmus-tst/logs` |
+
+<!-- i18n:skip-end -->
 
 Each time you start Cadmus, it creates a new log file with a unique ID. By
 default, only the 3 most recent log files are kept — older ones are deleted
@@ -21,9 +25,13 @@ automatically. You can change this with the
 
 The log files look like this:
 
+<!-- i18n:skip-start -->
+
 ```txt
 cadmus-019cf7e3-ef3a-7752-846f-83b92ac90634.json
 ```
+
+<!-- i18n:skip-end -->
 
 ### Finding your run ID
 
@@ -36,9 +44,13 @@ You can find this in:
 
    For example:
 
+<!-- i18n:skip-start -->
+
    ```txt
    Cadmus run started with ID: 019cf7e3-ef3a-7752-846f-83b92ac90634 (version 0.10.0)
    ```
+
+<!-- i18n:skip-end -->
 
    Copy only the UUID part — the string of letters and numbers between `ID:` and
    the `(version` text.

--- a/docs/src/ui/keyboard.md
+++ b/docs/src/ui/keyboard.md
@@ -31,6 +31,8 @@ Example: `CMB e '` produces **é**.
 Press _CMB_ followed by the two keys listed below to produce the corresponding
 character.
 
+<!-- i18n:skip-start -->
+
 | Keys   | Result | Keys   | Result | Keys    | Result | Keys    | Result |
 | ------ | ------ | ------ | ------ | ------- | ------ | ------- | ------ |
 | `a '`  | á      | `A '`  | Á      | `a `` ` | à      | `A `` ` | À      |
@@ -69,6 +71,8 @@ character.
 | `3 4`  | ¾      | `1 5`  | ⅕      | `2 5`   | ⅖      | `3 5`   | ⅗      |
 | `4 5`  | ⅘      | `1 6`  | ⅙      | `5 6`   | ⅚      | `1 8`   | ⅛      |
 | `3 8`  | ⅜      | `5 8`  | ⅝      | `7 8`   | ⅞      |         |        |
+
+<!-- i18n:skip-end -->
 
 ## Custom Keyboard Layouts
 

--- a/docs/src/ui/settings/dictionaries.md
+++ b/docs/src/ui/settings/dictionaries.md
@@ -102,12 +102,16 @@ whenever the dictionary files change.
 Cadmus stores dictionaries in different locations depending on whether your
 device has an SD card and whether you are using a test build:
 
+<!-- i18n:skip-start -->
+
 - **On devices with an SD card**:
   - Production: `/mnt/sd/.cadmus/dictionaries/reader-dict/<lang>/`
   - Test build: `/mnt/sd/.cadmus-tst/dictionaries/reader-dict/<lang>/`
 - **On devices without an SD card**:
   - Production: `/mnt/onboard/.adds/cadmus/dictionaries/reader-dict/<lang>/`
   - Test build: `/mnt/onboard/.adds/cadmus-tst/dictionaries/reader-dict/<lang>/`
+
+<!-- i18n:skip-end -->
 
 Each language gets its own subfolder containing a `.dict.dz` (or `.dict`) and a `.index` file.
 


### PR DESCRIPTION
Scope translations to the user guide only. Contributing and investigations sections are developer-facing and need no translation.

- Wrap all contributing/ files in i18n:skip-start/end
- Wrap all investigations/ files in i18n:skip-start/end
- Skip keyboard combination-sequences table in ui/keyboard.md
- Skip TOML/ini/sh/txt code blocks in user-facing docs
- Skip path-only tables in installation, migration, uninstall,

Change-Id: 524d0bb168317d4b08e723aa84959b33
Change-Id-Short: uxvmzooytrwy