### PR TITLE
dev: pass arguments from cadmus-build-kobo to xtask build-kobo

### DIFF
--- a/devenv.nix
+++ b/devenv.nix
@@ -761,7 +761,7 @@ in
 
     # Build for Kobo device
     cadmus-build-kobo.exec = ''
-      cargo xtask build-kobo
+      cargo xtask build-kobo "$@"
       cargo xtask dist
     '';
 


### PR DESCRIPTION
This makes it more ergonomic to pass options like --features to the build.