### PR TITLE
dev(agent): set up Cursor Cloud dev environment

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -233,9 +233,10 @@ misses `#[cfg(not(feature = "..."))]` paths.
 This environment is provisioned without Nix/devenv. The Cursor snapshot already
 has the full native host toolchain baked in (latest stable Rust via `rustup`,
 the SDL2/MuPDF/DjVuLibre/gcc build stack, `mdbook` + `mdbook-epub` +
-`mdbook-mermaid` + `mdbook-gettext`, and `cargo-nextest`). The startup update
-script only runs `git submodule update --init --recursive` to keep the vendored
-`thirdparty/` native sources in sync with the checked-out revision.
+`mdbook-mermaid` + `mdbook-gettext`, `cargo-nextest`, and the Kobo ARM
+cross toolchain — see below). The startup update script only runs
+`git submodule update --init --recursive` to keep the vendored `thirdparty/`
+native sources in sync with the checked-out revision.
 
 ### Build environment variables (already exported in `~/.bashrc`)
 
@@ -248,6 +249,9 @@ script only runs `git submodule update --init --recursive` to keep the vendored
   `target/cadmus-build-deps/x86_64-unknown-linux-gnu/sqlite/{lib,include}`
 - `PKG_CONFIG_PATH_x86_64_unknown_linux_gnu` → that sqlite `lib/pkgconfig`
 - `SQLX_OFFLINE=true`
+- Kobo cross-build vars: `PATH` includes `~/linaro-toolchain/bin`,
+  `PKG_CONFIG_ALLOW_CROSS=1`, and `PKG_CONFIG_PATH_arm_unknown_linux_gnueabihf`
+  → the ARM sqlite `lib/pkgconfig`.
 
 If a shell does not have them (e.g. a non-login shell), re-source `~/.bashrc` or
 export them manually before building.
@@ -265,6 +269,41 @@ export them manually before building.
   harmless; `mmdc` from npm is optional and only affects EPUB diagram images).
 - MuPDF/libwebp native artifacts are built lazily by `cadmus-core`'s `build.rs`
   the first time you build; they self-rebuild when their submodule SHA changes.
+
+### Kobo (ARM) cross-compilation
+
+The env is set up to cross-compile the device binary for Kobo
+(`arm-unknown-linux-gnueabihf`). Baked into the snapshot:
+
+- The Linaro GCC 4.9.4 (2017.01) toolchain in `~/linaro-toolchain/` (same
+  toolchain CI and Kobo use), on `PATH` via `~/.bashrc`.
+- The `arm-unknown-linux-gnueabihf` Rust std target (`rustup target add`).
+- `meson`, `ninja-build`, and `gperf` (needed to build the ARM thirdparty
+  libraries, e.g. harfbuzz/freetype, from source).
+- The Plato-sourced asset dirs `bin/`, `resources/`, `hyphenation-patterns/`
+  (via `cargo xtask download-assets`). Unlike the emulator, the `cadmus` device
+  binary's `build.rs` hard-requires these; without them the Kobo build panics
+  with "required asset directory missing". They are gitignored and persist in
+  the snapshot; re-run `cargo xtask download-assets` if they are absent.
+
+Build with `cargo xtask build-kobo` (add `--features test` for the test
+variant). It builds the ARM SQLite/MuPDF/thirdparty libs on first run
+(cached afterwards) and emits `target/arm-unknown-linux-gnueabihf/release/cadmus`
+(a 32-bit ARM ELF). The `-Ctarget-feature v7/vfp3/neon` warnings are expected.
+
+### Testing strategy — always verify the Kobo build
+
+Cadmus ships to Kobo e-readers, so after making changes you MUST confirm the
+Kobo cross build still compiles as part of testing (in addition to host
+`fmt`/`clippy`/`test`):
+
+```sh
+cargo xtask build-kobo
+```
+
+A clean host build can still break the ARM build (different target-cfg,
+thirdparty linkage, `#[cfg(...)]` paths), so treat a green `build-kobo` as a
+required check before considering a change done.
 
 ### Running the emulator
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -227,3 +227,57 @@ misses `#[cfg(not(feature = "..."))]` paths.
   sure `bin/`, `resources/`, and `hyphenation-patterns/` are present before the
   Kobo build starts. In CI, `cargo xtask download-assets` must run before
   `cargo xtask build-kobo` for the generated asset list to stay accurate.
+
+## Cursor Cloud specific instructions
+
+This environment is provisioned without Nix/devenv. The Cursor snapshot already
+has the full native host toolchain baked in (latest stable Rust via `rustup`,
+the SDL2/MuPDF/DjVuLibre/gcc build stack, `mdbook` + `mdbook-epub` +
+`mdbook-mermaid` + `mdbook-gettext`, and `cargo-nextest`). The startup update
+script only runs `git submodule update --init --recursive` to keep the vendored
+`thirdparty/` native sources in sync with the checked-out revision.
+
+### Build environment variables (already exported in `~/.bashrc`)
+
+`cargo build` and every `cargo xtask` command require these; they point
+`libsqlite3-sys` at the custom SQLite (built with
+`SQLITE_ENABLE_UPDATE_DELETE_LIMIT`) and use the cached offline sqlx metadata:
+
+- `SQLITE3_STATIC=1`
+- `SQLITE3_LIB_DIR` / `SQLITE3_INCLUDE_DIR` →
+  `target/cadmus-build-deps/x86_64-unknown-linux-gnu/sqlite/{lib,include}`
+- `PKG_CONFIG_PATH_x86_64_unknown_linux_gnu` → that sqlite `lib/pkgconfig`
+- `SQLX_OFFLINE=true`
+
+If a shell does not have them (e.g. a non-login shell), re-source `~/.bashrc` or
+export them manually before building.
+
+### Non-obvious build prerequisites (persist in the snapshot; rebuild only if stale)
+
+- `cargo xtask setup --host` builds the custom static SQLite. `libsqlite3-sys`
+  runs before `cadmus-core`'s `build.rs`, so this MUST be done before any
+  `cargo build`. It is idempotent (skips when the submodule SHA is unchanged).
+  Re-run it if `thirdparty/sqlite` moves.
+- `cargo xtask docs --mdbook-only` generates
+  `docs/book/epub/Cadmus Documentation.epub`, which `cadmus-core` embeds at
+  compile time via `rust-embed`. Without it every `cargo build`/`check`/`test`
+  fails. Re-run only when `docs/src/**` changes (mermaid→PNG warnings are
+  harmless; `mmdc` from npm is optional and only affects EPUB diagram images).
+- MuPDF/libwebp native artifacts are built lazily by `cadmus-core`'s `build.rs`
+  the first time you build; they self-rebuild when their submodule SHA changes.
+
+### Running the emulator
+
+- The desktop X server is on `DISPLAY=:1`. Run the SDL2 GUI with
+  `DISPLAY=:1 ./target/debug/cadmus-emulator` (or `cargo xtask run-emulator`)
+  from the workspace root — the emulator loads `fonts/`, `icons/`, `css/`, and
+  `keyboard-layouts/` relative to the current directory, and its default
+  emulator library path is `.` (the workspace root).
+
+### Standard lint/test/build commands
+
+Use the existing `cargo xtask` wrappers (see `.agents/skills/` and the
+`build-cadmus-native` skill): `cargo xtask fmt`, `cargo xtask clippy --features
+default`, `cargo xtask test --features default`. Note the installed clippy is
+newer than CI's and may emit extra style warnings; they are non-fatal (CI
+filters to the diff via reviewdog).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Sets up and documents the Cadmus development environment for Cursor Cloud agents (non-Nix/devenv host) and verifies it end to end by building/running the emulator and cross-compiling for Kobo (ARM).

The only committed change is an `AGENTS.md` addition under `## Cursor Cloud specific instructions`. All toolchain/dependency installation is captured in the VM snapshot + startup update script rather than in repo code.

## Environment setup performed

- System deps: `build-essential`, `cmake`, `autoconf`/`automake`/`libtool`, `meson`, `ninja-build`, `gperf`, `tcl`, `pkg-config`, `libsdl2-dev`, `libdjvulibre-dev`, MuPDF system libs (freetype/harfbuzz/jpeg/openjpeg/zlib/jbig2dec/gumbo/png/bz2), `libsqlite3-dev`, `clang`/`libclang-dev`, and `libstdc++-14-dev` (matches default gcc-14 so `-lstdc++` resolves).
- Toolchain: updated Rust to latest stable via `rustup` (crates use `edition = "2024"`); installed `mdbook` + `mdbook-epub` + `mdbook-mermaid` + `mdbook-gettext` and `cargo-nextest`.
- Kobo cross-compilation: downloaded the Linaro GCC 4.9.4 (2017.01) toolchain to `~/linaro-toolchain` (same as CI/Kobo), added `arm-unknown-linux-gnueabihf` Rust std target, and pulled the Plato asset dirs (`bin/`, `resources/`, `hyphenation-patterns/`) via `cargo xtask download-assets`.
- Initialized `thirdparty/` git submodules (recursive); built custom SQLite (`cargo xtask setup --host`) and the docs EPUB (`cargo xtask docs --mdbook-only`) — both compile-time prerequisites.
- Persisted required build/cross env vars (`SQLITE3_*`, `PKG_CONFIG_PATH_*`, `SQLX_OFFLINE`, Linaro `PATH`) in the agent's `~/.bashrc`.

Startup update script: `git submodule update --init --recursive` (idempotent).

## Verification

- ✅ `cargo xtask fmt`
- ✅ `cargo xtask clippy --features default`
- ✅ `cargo xtask test --features default` (43 tests + doctests pass)
- ✅ `cargo build -p emulator` and ran it on `DISPLAY=:1`, opened a document in the reader
- ✅ `cargo xtask build-kobo` → produces `target/arm-unknown-linux-gnueabihf/release/cadmus` (32-bit ARM ELF)

The Kobo cross build is documented as a required testing step: after changes, run `cargo xtask build-kobo` to confirm the device build still compiles.

[cadmus_emulator_open_document.mp4](https://cursor.com/agents/bc-1802d7ea-ae2a-4901-9bca-8a33f3ae397b/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcadmus_emulator_open_document.mp4)

Home library screen:
![Cadmus emulator home screen](https://cursor.com/artifacts/c/art-4bf414e3-08ce-4271-b5b9-8421bc97d81b)

Document rendered in reader view:
![Document open in Cadmus reader](https://cursor.com/artifacts/c/art-e9189fd2-cfc7-4d68-a349-e90408f36119)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1802d7ea-ae2a-4901-9bca-8a33f3ae397b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1802d7ea-ae2a-4901-9bca-8a33f3ae397b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

