### PR TITLE
dev(xtask): show full clippy output on compile failure

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1947,6 +1947,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "io_tee"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b3f7cef34251886990511df1c61443aa928499d598a9473929ab5a90a527304"
+
+[[package]]
 name = "ipnet"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5265,6 +5271,7 @@ dependencies = [
  "build-deps",
  "clap",
  "flate2",
+ "io_tee",
  "reqwest",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ rustls = { version = "0.23", default-features = false, features = [
   "tls12",
 ] }
 cc = "1"
+io_tee = "0.1"
 rust-embed = "8"
 
 [workspace.lints]

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -17,6 +17,7 @@ anyhow = "1"
 build-deps = { path = "../crates/build-deps" }
 clap = { version = "4", features = ["derive"] }
 flate2 = "1"
+io_tee = { workspace = true }
 reqwest = { version = "0.13", default-features = false, features = [
     "blocking",
     "json",

--- a/xtask/src/tasks/clippy.rs
+++ b/xtask/src/tasks/clippy.rs
@@ -38,12 +38,13 @@
 //! deduplicated and reported in a single `cargo xtask ci clippy-report` run.
 
 use std::fs;
-use std::io::{BufRead, BufReader, Write};
+use std::io::{BufRead, BufReader, Write, copy};
 use std::path::PathBuf;
 use std::process::{Command, Stdio};
 
 use anyhow::{Context, Result, bail};
 use clap::Args;
+use io_tee::WriteExt;
 
 use super::util::{cmd, matrix, workspace};
 
@@ -180,8 +181,8 @@ pub(crate) fn save_json(
 /// reviewdog fetches the PR diff from the GitHub API and posts inline review
 /// comments via the `github-pr-review` reporter.
 ///
-/// Both processes run concurrently via a pipe so neither buffers the full
-/// output in memory.
+/// Clippy output is streamed to reviewdog via a tee; on compile failure the
+/// full output is also printed to stderr before returning an error.
 ///
 /// # Errors
 ///
@@ -219,26 +220,36 @@ fn run_with_reviewdog(
         .args(["-c", &format!("cargo {} 2>&1", clippy_args.join(" "))])
         .current_dir(root)
         .stdout(Stdio::piped())
-        .stderr(Stdio::inherit())
         .spawn()
         .context("failed to spawn `cargo clippy`")?;
 
-    let clippy_stdout = clippy.stdout.take().context("clippy stdout not captured")?;
+    let mut clippy_stdout = clippy.stdout.take().context("clippy stdout not captured")?;
 
     let mut reviewdog = Command::new("reviewdog")
         .args(&reviewdog_args)
         .current_dir(root)
-        .stdin(clippy_stdout)
+        .stdin(Stdio::piped())
         .stdout(Stdio::inherit())
         .stderr(Stdio::inherit())
         .spawn()
         .context("failed to spawn `reviewdog` — is it installed and on PATH?")?;
 
+    let reviewdog_stdin = reviewdog
+        .stdin
+        .take()
+        .context("reviewdog stdin not captured")?;
+    let mut buffer = Vec::new();
+    let mut tee = reviewdog_stdin.tee(&mut buffer);
+    copy(&mut clippy_stdout, &mut tee)?;
+    drop(tee);
+
     let clippy_status = clippy.wait().context("failed to wait for `cargo clippy`")?;
     let reviewdog_status = reviewdog.wait().context("failed to wait for `reviewdog`")?;
 
     if !clippy_status.success() {
-        bail!("`cargo clippy` exited with status {}", clippy_status);
+        eprintln!("\n--- cargo clippy failed (full output) ---\n");
+        eprint!("{}", String::from_utf8_lossy(&buffer));
+        bail!("`cargo clippy` failed to compile for this feature set ({clippy_status})");
     }
     if !reviewdog_status.success() {
         bail!("`reviewdog` exited with status {}", reviewdog_status);

--- a/xtask/src/tasks/clippy.rs
+++ b/xtask/src/tasks/clippy.rs
@@ -38,7 +38,7 @@
 //! deduplicated and reported in a single `cargo xtask ci clippy-report` run.
 
 use std::fs;
-use std::io::{BufRead, BufReader, Write, copy};
+use std::io::{BufRead, BufReader, ErrorKind, Write, copy};
 use std::path::PathBuf;
 use std::process::{Command, Stdio};
 
@@ -240,8 +240,15 @@ fn run_with_reviewdog(
         .context("reviewdog stdin not captured")?;
     let mut buffer = Vec::new();
     let mut tee = reviewdog_stdin.tee(&mut buffer);
-    copy(&mut clippy_stdout, &mut tee)?;
+    let copy_result = copy(&mut clippy_stdout, &mut tee);
     drop(tee);
+    if let Err(e) = copy_result {
+        if e.kind() == ErrorKind::BrokenPipe {
+            let _ = copy(&mut clippy_stdout, &mut buffer);
+        } else {
+            return Err(e).context("failed to stream clippy output to reviewdog");
+        }
+    }
 
     let clippy_status = clippy.wait().context("failed to wait for `cargo clippy`")?;
     let reviewdog_status = reviewdog.wait().context("failed to wait for `reviewdog`")?;


### PR DESCRIPTION
Tee clippy stdout to reviewdog and a buffer so compile failures still print the complete diagnostic output.

Change-Id: c0340f9eb56288b52186cd603a27731f
Change-Id-Short: nzwvzkqloutx