### PR TITLE
chore: add automated label to bot PR configs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,10 @@ updates:
     open-pull-requests-limit: 10
     reviewers:
       - "OGKevin"
+    labels:
+      - "automated"
+      - "dependencies"
+      - "github-actions"
     commit-message:
       prefix: "ci"
       include: "scope"
@@ -23,6 +27,10 @@ updates:
     open-pull-requests-limit: 10
     reviewers:
       - "OGKevin"
+    labels:
+      - "automated"
+      - "dependencies"
+      - "npm"
     commit-message:
       prefix: "chore"
       include: "scope"

--- a/.github/workflows/crowdin.yml
+++ b/.github/workflows/crowdin.yml
@@ -52,7 +52,7 @@ jobs:
 
             To help with translations, please visit [Crowdin](https://crowdin.com/project/cadmus).
           pull_request_base_branch_name: ${{ github.ref_name }}
-          pull_request_labels: l10n, crowdin
+          pull_request_labels: automated, l10n, crowdin
           pull_request_reviewers: OGkevin
 
         env:

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -4,6 +4,7 @@
   "bump-patch-for-minor-pre-major": true,
   "include-component-in-tag": true,
   "draft": true,
+  "extra-label": "automated",
   "force-tag-creation": true,
   "group-pull-request-title-pattern": "chore${scope}: release cadmus ${version}",
   "packages": {

--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,7 @@
 {
   "extends": ["config:recommended"],
   "minimumReleaseAge": "7 days",
-  "labels": ["dependencies"],
+  "labels": ["automated", "dependencies"],
   "reviewers": ["OGKevin"],
   "git-submodules": {
     "enabled": true


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds the `automated` label to all four bot PR sources so they can be filtered with `label:automated` in GitHub.

## Changes

| Bot | Config | Label change |
|-----|--------|--------------|
| Renovate | `renovate.json` | `automated` added to global labels |
| Dependabot | `.github/dependabot.yml` | `automated` added to both github-actions and npm entries |
| Crowdin | `.github/workflows/crowdin.yml` | `automated` added to `pull_request_labels` |
| release-please | `release-please-config.json` | `extra-label: automated` (preserves `autorelease:*` state labels) |

## Prerequisite before merge

The `automated` label must exist in the repository before these configs take effect — undefined labels are silently ignored by bots. Create it once:

```bash
gh label create automated --description "Opened by an automated bot or workflow" --color BFD4F2
```

## Notes

- Config-only change; no build/test impact.
- Existing open bot PRs are not backfilled — only new/updated PRs will receive the label.
- Dependabot custom labels replace defaults, so `dependencies` and ecosystem labels are preserved alongside `automated`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-88b08373-bbbe-4cee-a6ed-8bd989b32e15"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-88b08373-bbbe-4cee-a6ed-8bd989b32e15"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

