### PR TITLE
dev: enforce patch coverage via status check

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,6 +1,4 @@
-comment:
-  layout: "condensed_header, condensed_files, condensed_footer"
-  hide_project_coverage: true
+comment: false
 
 ignore:
   - "thirdparty/**"
@@ -12,7 +10,9 @@ coverage:
     project:
       default:
         informational: true
-        threshold: 1%
+        threshold: 10%
     patch:
       default:
-        informational: true
+        target: auto
+        threshold: 10%
+        only_pulls: true


### PR DESCRIPTION
Disable Codecov PR comments and gate merges on codecov/patch with auto target and 10% threshold; keep project coverage informational.

Change-Id: fea9cd94283a21b29e01e738b3cb03ab
Change-Id-Short: klpqnmqvxrwp