### PR TITLE
ci: workflow refactor to use auto-merge

### DIFF
--- a/.github/workflows/AGENTS.md
+++ b/.github/workflows/AGENTS.md
@@ -1,0 +1,59 @@
+# GitHub Actions
+
+## Workflow permissions
+
+Set a strict default at workflow scope and elevate only in jobs that need more.
+This follows [GitHub's recommended hardening](https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication#permissions-for-the-github_token)
+and keeps new jobs safe by default.
+
+```yaml
+permissions:
+  contents: read
+```
+
+Job-level `permissions` **replace** the workflow default — they do not merge.
+When overriding a job, list every scope that job needs (including `contents:
+read` if it still checks out code).
+
+### Per-job elevation
+
+Add only what a job requires:
+
+```yaml
+  actionlint:
+    permissions:
+      contents: read
+      pull-requests: write
+```
+
+Common elevations: `pull-requests: write` (reviewdog), `pages: write` +
+`id-token: write` (Pages deploy), `contents: write` (push branches).
+
+### Rollup jobs
+
+`required` and other pass/fail-only rollup jobs should revoke token access:
+
+```yaml
+  required:
+    permissions: {}
+```
+
+Without this, they inherit the workflow `contents: read` grant unnecessarily.
+
+### Read-only checkouts
+
+Path-filter and validate jobs only need a read-only checkout. Prefer:
+
+```yaml
+      - uses: actions/checkout@…
+        with:
+          persist-credentials: false
+```
+
+Skip this on jobs that use reviewdog or other tools that rely on persisted
+credentials for PR comments.
+
+## Formatting
+
+Lint with **rumdl** (via `treefmt` locally, `docs-lint.yml` in CI). See
+`.rumdl.toml`.

--- a/.github/workflows/actions-lint.yml
+++ b/.github/workflows/actions-lint.yml
@@ -2,21 +2,37 @@ name: Actions lint
 
 on:
   pull_request:
-    paths:
-      - ".github/workflows/**"
-      - ".github/actions/**"
-      - ".github/lint/package.json"
-      - ".github/workflows/actions-lint.yml"
 
 permissions:
   contents: read
-  pull-requests: write
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      workflows: ${{ steps.filter.outputs.workflows }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          persist-credentials: false
+      - uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590
+        id: filter
+        with:
+          filters: |
+            workflows:
+              - '.github/workflows/**'
+              - '.github/actions/**'
+              - '.github/lint/package.json'
+
   actionlint:
+    needs: changes
+    if: needs.changes.outputs.workflows == 'true'
+    permissions:
+      contents: read
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           fetch-depth: 0
 
@@ -28,12 +44,16 @@ jobs:
           filter_mode: added
 
   prettier:
-    runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.workflows == 'true'
     permissions:
       contents: read
       pull-requests: write
+    runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          persist-credentials: false
 
       - name: Prettier
         uses: EPMatt/reviewdog-action-prettier@v1
@@ -43,3 +63,14 @@ jobs:
           fail_level: error
           prettier_flags: ../.github/workflows/**/*.yml ../.github/actions/**/*.yml
           workdir: .github/lint
+
+  required:
+    name: required
+    permissions: {}
+    needs: [changes, actionlint, prettier]
+    if: ${{ always() && (cancelled() || contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')) }}
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          echo "::error::One or more required jobs failed or were cancelled"
+          exit 1

--- a/.github/workflows/cadmus-docs.yml
+++ b/.github/workflows/cadmus-docs.yml
@@ -19,27 +19,40 @@ on:
       - package-lock.json
   pull_request:
     types: [opened, synchronize, reopened]
-    paths:
-      - docs/**
-      - website/**
-      - crates/**/*.rs
-      - .github/actions/install-doc-tools/**
-      - .github/workflows/cadmus-docs.yml
-      - package.json
-      - package-lock.json
   workflow_dispatch:
 
 permissions:
   contents: read
-  pages: write
-  id-token: write
 
 concurrency:
   group: "cadmus-docs-${{ github.event_name }}-${{ github.event.number || github.ref }}"
   cancel-in-progress: true
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      docs: ${{ steps.filter.outputs.docs }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          persist-credentials: false
+      - uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590
+        id: filter
+        with:
+          filters: |
+            docs:
+              - 'docs/**'
+              - 'website/**'
+              - 'crates/**/*.rs'
+              - '.github/actions/install-doc-tools/**'
+              - '.github/workflows/cadmus-docs.yml'
+              - 'package.json'
+              - 'package-lock.json'
+
   build:
+    needs: changes
+    if: github.event_name != 'pull_request' || needs.changes.outputs.docs == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
@@ -105,6 +118,10 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master')
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
     environment:
       name: cloudflare-pages-production
       url: https://cadmus-dt6.pages.dev/
@@ -131,6 +148,10 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     if: github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
     environment:
       name: cloudflare-pages-preview
       url: ${{ steps.deploy.outputs.pages-deployment-alias-url }}
@@ -159,6 +180,10 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master')
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
@@ -177,3 +202,14 @@ jobs:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128
+
+  required:
+    name: required
+    permissions: {}
+    needs: [changes, build, deploy-cloudflare-preview]
+    if: ${{ always() && github.event_name == 'pull_request' && (cancelled() || contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')) }}
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          echo "::error::One or more required jobs failed or were cancelled"
+          exit 1

--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -12,33 +12,53 @@ on:
   push:
     branches: [main, master, "release/*"]
   pull_request:
-    paths:
-      - "**/*.rs"
-      - crates/core/i18n/**
-      - "Cargo.*"
-      - "**/Cargo.*"
-      - ".github/workflows/cargo.yml"
-      - ".github/actions/apt/**"
-      - ".github/actions/build-kobo/**"
-      - ".github/actions/build-docs-epub/**"
-      - ".github/actions/cargo-cache/**"
-      - ".github/actions/install-doc-tools/**"
-      - "build-scripts/**"
-      - ".gitmodules"
-      - "mupdf_wrapper/**"
-      - "thirdparty/**"
 
 concurrency:
   group: "cargo-${{ github.event_name }}-${{ github.event.number || github.ref }}"
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      cargo: ${{ steps.filter.outputs.cargo }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          persist-credentials: false
+      - uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590
+        id: filter
+        with:
+          filters: |
+            cargo:
+              - '**/*.rs'
+              - 'crates/core/i18n/**'
+              - 'Cargo.*'
+              - '**/Cargo.*'
+              - '.github/workflows/cargo.yml'
+              - '.github/actions/apt/**'
+              - '.github/actions/build-kobo/**'
+              - '.github/actions/build-docs-epub/**'
+              - '.github/actions/cargo-cache/**'
+              - '.github/actions/install-doc-tools/**'
+              - 'build-scripts/**'
+              - '.gitmodules'
+              - 'mupdf_wrapper/**'
+              - 'thirdparty/**'
+
   format:
+    needs: changes
+    if: github.event_name != 'pull_request' || needs.changes.outputs.cargo == 'true'
     permissions:
       contents: read
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          persist-credentials: false
       - uses: dtolnay/rust-toolchain@stable
         id: rust-toolchain
         with:
@@ -51,6 +71,8 @@ jobs:
         run: cargo xtask fmt
 
   generate-matrix:
+    needs: changes
+    if: github.event_name != 'pull_request' || needs.changes.outputs.cargo == 'true'
     permissions:
       contents: read
     runs-on: ubuntu-latest
@@ -58,7 +80,9 @@ jobs:
       matrix: ${{ steps.matrix.outputs.matrix }}
       test-matrix: ${{ steps.matrix.outputs.test-matrix }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          persist-credentials: false
       - uses: dtolnay/rust-toolchain@stable
         id: rust-toolchain
       - name: Restore shared cargo cache
@@ -70,11 +94,15 @@ jobs:
         run: cargo xtask ci matrix
 
   build-docs-epub:
+    needs: changes
+    if: github.event_name != 'pull_request' || needs.changes.outputs.cargo == 'true'
     permissions:
       contents: read
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          persist-credentials: false
       - uses: dtolnay/rust-toolchain@stable
         id: rust-toolchain
       - name: Restore shared cargo cache
@@ -87,12 +115,15 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
 
   cache-warmup:
-    needs: build-docs-epub
+    needs: [changes, build-docs-epub]
+    if: github.event_name != 'pull_request' || needs.changes.outputs.cargo == 'true'
     permissions:
       contents: read
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          persist-credentials: false
       - uses: dtolnay/rust-toolchain@stable
         id: rust-toolchain
         with:
@@ -187,8 +218,8 @@ jobs:
         run: cargo build --release --target arm-unknown-linux-gnueabihf -p cadmus
 
   clippy:
-    if: github.event_name == 'pull_request'
-    needs: [generate-matrix, build-docs-epub, cache-warmup]
+    if: github.event_name == 'pull_request' && needs.changes.outputs.cargo == 'true'
+    needs: [changes, generate-matrix, build-docs-epub, cache-warmup]
     permissions:
       contents: read
 
@@ -201,7 +232,9 @@ jobs:
     name: clippy (${{ matrix.label }}, ${{ matrix.os }})
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          persist-credentials: false
       - uses: dtolnay/rust-toolchain@stable
         id: rust-toolchain
         with:
@@ -233,8 +266,8 @@ jobs:
           retention-days: 1
 
   clippy-report:
-    if: github.event_name == 'pull_request'
-    needs: clippy
+    if: github.event_name == 'pull_request' && needs.changes.outputs.cargo == 'true'
+    needs: [changes, clippy]
 
     permissions:
       contents: read
@@ -244,7 +277,9 @@ jobs:
     name: clippy-report
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          persist-credentials: false
       - uses: dtolnay/rust-toolchain@stable
         id: rust-toolchain
         with:
@@ -270,7 +305,8 @@ jobs:
           REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   test:
-    needs: [generate-matrix, build-docs-epub, cache-warmup]
+    needs: [changes, generate-matrix, build-docs-epub, cache-warmup]
+    if: github.event_name != 'pull_request' || needs.changes.outputs.cargo == 'true'
     permissions:
       contents: read
     env:
@@ -285,10 +321,11 @@ jobs:
     name: test (${{ matrix.label }}, ${{ matrix.os }})
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           fetch-depth: 0
           fetch-tags: true
+          persist-credentials: false
       - uses: dtolnay/rust-toolchain@stable
         id: rust-toolchain
         with:
@@ -411,7 +448,8 @@ jobs:
           fail_ci_if_error: false
 
   build-kobo:
-    needs: [cache-warmup, build-docs-epub]
+    needs: [changes, cache-warmup, build-docs-epub]
+    if: github.event_name != 'pull_request' || needs.changes.outputs.cargo == 'true'
     runs-on: ubuntu-latest
 
     permissions: &build-permissions
@@ -420,10 +458,11 @@ jobs:
       attestations: write
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           fetch-depth: 0
           fetch-tags: true
+          persist-credentials: false
 
       - *set-build-metadata
 
@@ -484,16 +523,18 @@ jobs:
           retention-days: 7
 
   build-kobo-test:
-    needs: [cache-warmup, build-docs-epub]
+    needs: [changes, cache-warmup, build-docs-epub]
+    if: github.event_name != 'pull_request' || needs.changes.outputs.cargo == 'true'
     runs-on: ubuntu-latest
 
     permissions: *build-permissions
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           fetch-depth: 0
           fetch-tags: true
+          persist-credentials: false
 
       - *set-build-metadata
 
@@ -530,3 +571,24 @@ jobs:
           name: cadmus-kobo-test-${{ steps.artifact.outputs.suffix }}
           path: release-artifacts/*
           retention-days: 7
+
+  required:
+    name: required
+    permissions: {}
+    needs:
+      - changes
+      - format
+      - generate-matrix
+      - build-docs-epub
+      - cache-warmup
+      - clippy
+      - clippy-report
+      - test
+      - build-kobo
+      - build-kobo-test
+    if: ${{ always() && github.event_name == 'pull_request' && (cancelled() || contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')) }}
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          echo "::error::One or more required jobs failed or were cancelled"
+          exit 1

--- a/.github/workflows/coderabbit-config.yml
+++ b/.github/workflows/coderabbit-config.yml
@@ -1,10 +1,6 @@
 name: CodeRabbit config validation
 on:
   pull_request:
-    paths:
-      - ".coderabbit.yaml"
-      - ".yamllint.yml"
-      - ".github/workflows/coderabbit-config.yml"
 
 permissions:
   contents: read
@@ -13,15 +9,38 @@ jobs:
   validate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          persist-credentials: false
+
+      - uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590
+        id: filter
+        with:
+          filters: |
+            config:
+              - '.coderabbit.yaml'
+              - '.yamllint.yml'
+              - '.github/workflows/coderabbit-config.yml'
+
       - name: Setup Python
+        if: steps.filter.outputs.config == 'true'
         uses: actions/setup-python@v6
         with:
           python-version: "3.x"
+
       - name: Install YAML validation tools
+        if: steps.filter.outputs.config == 'true'
         run: pip install yamllint check-jsonschema
+
       - name: Lint YAML files
+        if: steps.filter.outputs.config == 'true'
         run: yamllint .coderabbit.yaml
+
       - name: Validate CodeRabbit schema
+        if: steps.filter.outputs.config == 'true'
         run: >-
           check-jsonschema --schemafile https://coderabbit.ai/integrations/schema.v2.json .coderabbit.yaml
+
+      - name: No relevant changes
+        if: steps.filter.outputs.config != 'true'
+        run: echo "No CodeRabbit config changes — skipping"

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -1,3 +1,5 @@
+name: Prepare Copilot Agent Environment
+
 env:
   NODE_VERSION: "24"
   SQLX_OFFLINE: true
@@ -6,8 +8,9 @@ env:
 on:
   workflow_call:
   pull_request:
-    paths:
-      - .github/workflows/copilot-setup-steps.yml
+
+permissions:
+  contents: read
 
 jobs:
   copilot-setup-steps:
@@ -15,11 +18,20 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           fetch-depth: 0
+          persist-credentials: false
+
+      - uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590
+        id: filter
+        with:
+          filters: |
+            workflow:
+              - '.github/workflows/copilot-setup-steps.yml'
 
       - name: Install Rust toolchain
+        if: &run-copilot-steps steps.filter.outputs.workflow == 'true' || github.event_name == 'workflow_call'
         uses: dtolnay/rust-toolchain@stable
         id: rust-toolchain
         with:
@@ -27,11 +39,13 @@ jobs:
           targets: arm-unknown-linux-gnueabihf
 
       - uses: ./.github/actions/cargo-cache
+        if: *run-copilot-steps
         with:
           cachekey: ${{ steps.rust-toolchain.outputs.cachekey }}
           mode: restore
 
       - name: Restore Linaro toolchain
+        if: *run-copilot-steps
         id: cache-linaro
         uses: actions/cache@v5
         with:
@@ -39,13 +53,14 @@ jobs:
           key: linaro-gcc-4.9.4-2017.01
 
       - name: Install system packages
+        if: *run-copilot-steps
         uses: awalsh128/cache-apt-pkgs-action@latest
         with:
           packages: git wget curl pkg-config gcc g++ make cmake meson ninja-build autoconf automake libtool gperf python3 zlib1g-dev libbz2-dev libpng-dev libjpeg-dev libopenjp2-7-dev libjbig2dec0-dev libgumbo-dev libfreetype6-dev libharfbuzz-dev libdjvulibre-dev libsdl2-dev shellcheck zip unzip ca-certificates jq patchelf
           version: 1.0
 
       - name: Download Linaro toolchain
-        if: steps.cache-linaro.outputs.cache-hit != 'true'
+        if: (steps.filter.outputs.workflow == 'true' || github.event_name == 'workflow_call') && steps.cache-linaro.outputs.cache-hit != 'true'
         run: |
           mkdir -p ~/linaro-toolchain
           cd ~/linaro-toolchain
@@ -54,36 +69,45 @@ jobs:
           rm gcc-linaro-4.9.4-2017.01-x86_64_arm-linux-gnueabihf.tar.xz
 
       - name: Setup Linaro toolchain
+        if: *run-copilot-steps
         run: |
           echo "$HOME/linaro-toolchain/bin" >> "$GITHUB_PATH"
 
       - name: Setup Node.js
+        if: *run-copilot-steps
         uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: "npm"
 
       - name: Setup Python
+        if: *run-copilot-steps
         uses: actions/setup-python@v6
         with:
           python-version: "3.x"
 
       - name: Install npm dependencies
+        if: *run-copilot-steps
         run: npm ci
 
       - name: Install mdBook tools
+        if: *run-copilot-steps
         uses: ./.github/actions/install-doc-tools
 
       - name: Install mdbook-mermaid assets
+        if: *run-copilot-steps
         run: mdbook-mermaid install docs
 
       - name: Build documentation
+        if: *run-copilot-steps
         run: cargo xtask docs --mdbook-only
 
       - name: Install reviewdog
+        if: *run-copilot-steps
         uses: reviewdog/action-setup@v1
 
       - name: Verify installation
+        if: *run-copilot-steps
         run: |
           rustc --version || true
           cargo --version || true
@@ -100,3 +124,7 @@ jobs:
           # Verify native test setup
           ls -la target/mupdf_wrapper/Linux/ || true
           cargo xtask --help || true
+
+      - name: No relevant changes
+        if: steps.filter.outputs.workflow != 'true' && github.event_name != 'workflow_call'
+        run: echo "No Copilot setup workflow changes — skipping"

--- a/.github/workflows/crowdin.yml
+++ b/.github/workflows/crowdin.yml
@@ -4,12 +4,10 @@ on:
   push:
     branches: [main, master]
   pull_request:
-    paths:
-      - "crates/core/i18n/**"
-      - "docs/po/**"
-      - "website/messages/**"
-      - ".github/workflows/crowdin.yml"
     branches: [main, master]
+
+permissions:
+  contents: read
 
 concurrency:
   group: "crowdin-${{ github.event_name }}-${{ github.event.number || github.ref }}"
@@ -25,11 +23,22 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           ref: ${{ github.head_ref || github.ref_name }}
 
+      - uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590
+        id: filter
+        with:
+          filters: |
+            i18n:
+              - 'crates/core/i18n/**'
+              - 'docs/po/**'
+              - 'website/messages/**'
+              - '.github/workflows/crowdin.yml'
+
       - name: Upload sources and existing translations, download new translations
+        if: steps.filter.outputs.i18n == 'true' || github.event_name == 'push'
         uses: crowdin/github-action@v2
         with:
           dryrun_action: ${{ github.event_name == 'pull_request' }}
@@ -59,3 +68,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CROWDIN_PROJECT_ID: ${{ secrets.CROWDIN_PROJECT_ID }}
           CROWDIN_PERSONAL_TOKEN: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}
+
+      - name: No relevant changes
+        if: steps.filter.outputs.i18n != 'true' && github.event_name == 'pull_request'
+        run: echo "No i18n changes — skipping"

--- a/.github/workflows/devenv-test.yml
+++ b/.github/workflows/devenv-test.yml
@@ -2,10 +2,6 @@ name: "Test devenv shell"
 
 on:
   pull_request:
-    paths:
-      - "devenv.nix"
-      - "devenv.lock"
-      - ".github/workflows/devenv-test.yml"
   push:
     branches:
       - main
@@ -14,8 +10,30 @@ on:
       - "devenv.lock"
       - ".github/workflows/devenv-test.yml"
 
+permissions:
+  contents: read
+
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      devenv: ${{ steps.filter.outputs.devenv }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          persist-credentials: false
+      - uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590
+        id: filter
+        with:
+          filters: |
+            devenv:
+              - 'devenv.nix'
+              - 'devenv.lock'
+              - '.github/workflows/devenv-test.yml'
+
   devenv:
+    needs: changes
+    if: github.event_name != 'pull_request' || needs.changes.outputs.devenv == 'true'
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
@@ -25,7 +43,7 @@ jobs:
       cancel-in-progress: true
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           fetch-depth: 0
           submodules: recursive
@@ -42,3 +60,14 @@ jobs:
 
       - name: Test devenv shell builds correctly
         run: devenv shell whoami
+
+  required:
+    name: required
+    permissions: {}
+    needs: [changes, devenv]
+    if: ${{ always() && github.event_name == 'pull_request' && (cancelled() || contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')) }}
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          echo "::error::One or more required jobs failed or were cancelled"
+          exit 1

--- a/.github/workflows/docs-lint.yml
+++ b/.github/workflows/docs-lint.yml
@@ -2,17 +2,9 @@ name: Docs lint
 
 on:
   pull_request:
-    paths:
-      - "docs/**"
-      - ".agents/skills/**"
-      - "**/AGENTS.md"
-      - "**/REVIEW.md"
-      - ".rumdl.toml"
-      - ".prettierignore"
-      - "thirdparty/**/*-kobo.md"
-      - "thirdparty/**/*-cadmus.md"
-      - ".github/actions/rumdl-lint/**"
-      - ".github/workflows/docs-lint.yml"
+
+permissions:
+  contents: read
 
 jobs:
   lint:
@@ -21,9 +13,28 @@ jobs:
       contents: read
       pull-requests: write
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          persist-credentials: false
+
+      - uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590
+        id: filter
+        with:
+          filters: |
+            docs:
+              - 'docs/**'
+              - '.agents/skills/**'
+              - '**/AGENTS.md'
+              - '**/REVIEW.md'
+              - '.rumdl.toml'
+              - '.prettierignore'
+              - 'thirdparty/**/*-kobo.md'
+              - 'thirdparty/**/*-cadmus.md'
+              - '.github/actions/rumdl-lint/**'
+              - '.github/workflows/docs-lint.yml'
 
       - name: Collect markdown files
+        if: steps.filter.outputs.docs == 'true'
         id: files
         run: |
           shopt -s globstar nullglob
@@ -36,6 +47,7 @@ jobs:
           echo "list=${files[*]}" >> "$GITHUB_OUTPUT"
 
       - name: rumdl
+        if: steps.filter.outputs.docs == 'true'
         uses: ./.github/actions/rumdl-lint
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -43,3 +55,7 @@ jobs:
           fail_level: error
           filter_mode: added
           rumdl_flags: ${{ steps.files.outputs.list }}
+
+      - name: No relevant changes
+        if: steps.filter.outputs.docs != 'true'
+        run: echo "No doc changes — skipping"

--- a/.github/workflows/renovate-config.yml
+++ b/.github/workflows/renovate-config.yml
@@ -2,27 +2,45 @@ name: Renovate config validation
 
 on:
   pull_request:
-    paths:
-      - "renovate.json"
+
+permissions:
+  contents: read
 
 jobs:
   validate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          persist-credentials: false
+
+      - uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590
+        id: filter
+        with:
+          filters: |
+            config:
+              - 'renovate.json'
+              - '.github/workflows/renovate-config.yml'
 
       - name: Setup Node
+        if: steps.filter.outputs.config == 'true'
         uses: actions/setup-node@v6
         with:
           cache: "npm"
 
       - name: Cache npx
+        if: steps.filter.outputs.config == 'true'
         uses: actions/cache@v5
         with:
           path: ~/.npm/_npx
           key: ${{ runner.os }}-npx-renovate
 
       - name: Validate Renovate config
+        if: steps.filter.outputs.config == 'true'
         uses: suzuki-shunsuke/github-action-renovate-config-validator@v2.1.0
         with:
           config_file_path: renovate.json
+
+      - name: No relevant changes
+        if: steps.filter.outputs.config != 'true'
+        run: echo "No Renovate config changes — skipping"

--- a/.github/workflows/shell.yml
+++ b/.github/workflows/shell.yml
@@ -2,19 +2,36 @@ name: Shell
 
 on:
   pull_request:
-    paths:
-      - "**/*.sh"
-      - ".github/workflows/shell.yml"
 
 permissions:
   contents: read
-  pull-requests: write
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      shell: ${{ steps.filter.outputs.shell }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          persist-credentials: false
+      - uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590
+        id: filter
+        with:
+          filters: |
+            shell:
+              - '**/*.sh'
+              - '.github/workflows/shell.yml'
+
   shellcheck:
+    needs: changes
+    if: needs.changes.outputs.shell == 'true'
+    permissions:
+      contents: read
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           fetch-depth: 0
 
@@ -26,9 +43,14 @@ jobs:
           filter_mode: added
 
   shfmt:
+    needs: changes
+    if: needs.changes.outputs.shell == 'true'
+    permissions:
+      contents: read
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           fetch-depth: 0
 
@@ -37,3 +59,14 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           filter_mode: added
+
+  required:
+    name: required
+    permissions: {}
+    needs: [changes, shellcheck, shfmt]
+    if: ${{ always() && (cancelled() || contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')) }}
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          echo "::error::One or more required jobs failed or were cancelled"
+          exit 1


### PR DESCRIPTION
By removing all the paths filter from the workflow and moving it to a job level detection, the workflows are created all the time and can be used as branch rules checks.

This makes it possibler to properly use auto-merge.

Change-Id: f33791538a0e2fa604f9cd5f84a3cf55
Change-Id-Short: kwwsqyuwrpzl