### PR TITLE
ci: give rollup jobs unique check names

### DIFF
--- a/.github/workflows/AGENTS.md
+++ b/.github/workflows/AGENTS.md
@@ -31,10 +31,13 @@ Common elevations: `pull-requests: write` (reviewdog), `pages: write` +
 
 ### Rollup jobs
 
-`required` and other pass/fail-only rollup jobs should revoke token access:
+Rollup job names must be unique across workflows so branch protection can
+require them individually (e.g. `required-cargo`, `required-docs`). These
+pass/fail-only jobs should revoke token access:
 
 ```yaml
-  required:
+  required-cargo:
+    name: required-cargo
     permissions: {}
 ```
 

--- a/.github/workflows/actions-lint.yml
+++ b/.github/workflows/actions-lint.yml
@@ -64,8 +64,8 @@ jobs:
           prettier_flags: ../.github/workflows/**/*.yml ../.github/actions/**/*.yml
           workdir: .github/lint
 
-  required:
-    name: required
+  required-actions-lint:
+    name: required-actions-lint
     permissions: {}
     needs: [changes, actionlint, prettier]
     if: ${{ always() && (cancelled() || contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')) }}

--- a/.github/workflows/cadmus-docs.yml
+++ b/.github/workflows/cadmus-docs.yml
@@ -203,8 +203,8 @@ jobs:
         id: deployment
         uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128
 
-  required:
-    name: required
+  required-docs:
+    name: required-docs
     permissions: {}
     needs: [changes, build, deploy-cloudflare-preview]
     if: ${{ always() && github.event_name == 'pull_request' && (cancelled() || contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')) }}

--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -572,8 +572,8 @@ jobs:
           path: release-artifacts/*
           retention-days: 7
 
-  required:
-    name: required
+  required-cargo:
+    name: required-cargo
     permissions: {}
     needs:
       - changes

--- a/.github/workflows/devenv-test.yml
+++ b/.github/workflows/devenv-test.yml
@@ -61,8 +61,8 @@ jobs:
       - name: Test devenv shell builds correctly
         run: devenv shell whoami
 
-  required:
-    name: required
+  required-devenv:
+    name: required-devenv
     permissions: {}
     needs: [changes, devenv]
     if: ${{ always() && github.event_name == 'pull_request' && (cancelled() || contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')) }}

--- a/.github/workflows/shell.yml
+++ b/.github/workflows/shell.yml
@@ -60,8 +60,8 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           filter_mode: added
 
-  required:
-    name: required
+  required-shell:
+    name: required-shell
     permissions: {}
     needs: [changes, shellcheck, shfmt]
     if: ${{ always() && (cancelled() || contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')) }}


### PR DESCRIPTION
Rename generic `required` jobs to workflow-specific names so branch protection can require them individually for auto-merge.

Change-Id: fdfcc87430fb880d1bc08f572cc0131e
Change-Id-Short: kmknnrsvwzko