### PR TITLE
chore(deps): group mupdf updates in Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -54,6 +54,14 @@
       ],
       "groupName": "mdbook-i18n-helpers",
       "groupSlug": "mdbook-i18n-helpers"
+    },
+    {
+      "description": "Keep mupdf submodule and version pins in sync",
+      "matchManagers": ["git-submodules", "custom.regex"],
+      "matchPackageNames": ["thirdparty/mupdf", "ArtifexSoftware/mupdf"],
+      "groupName": "mupdf",
+      "groupSlug": "mupdf",
+      "addLabels": ["thirdparty"]
     }
   ],
   "customManagers": [
@@ -181,8 +189,8 @@
       "matchStrings": [
         "MUPDF_VERSION: &str = \\\"(?<currentValue>[^\\\"]+)\\\""
       ],
-      "datasourceTemplate": "github-releases",
-      "depNameTemplate": "ArtifexSoftware/mupdf-downloads",
+      "datasourceTemplate": "github-tags",
+      "depNameTemplate": "ArtifexSoftware/mupdf",
       "versioningTemplate": "semver"
     },
     {
@@ -193,8 +201,8 @@
       "matchStrings": [
         "pub const FZ_VERSION: &str = \\\"(?<currentValue>[^\\\"]+)\\\""
       ],
-      "datasourceTemplate": "github-releases",
-      "depNameTemplate": "ArtifexSoftware/mupdf-downloads",
+      "datasourceTemplate": "github-tags",
+      "depNameTemplate": "ArtifexSoftware/mupdf",
       "versioningTemplate": "semver"
     }
   ]


### PR DESCRIPTION
Use ArtifexSoftware/mupdf github-tags as the single version source and group submodule bumps with MUPDF_VERSION and FZ_VERSION pins.

Change-Id: 3f0ac5b1cea9d2f9eac2bc6b6edfbf28
Change-Id-Short: wkzpnuoynlpq

