### PR TITLE
test(frontlight): make auto frontlight tests timezone-robust

### DIFF
--- a/crates/core/src/frontlight/auto.rs
+++ b/crates/core/src/frontlight/auto.rs
@@ -6,11 +6,19 @@
 use crate::geolocation::Coordinates;
 
 use super::{LightLevel, LightLevels};
-use chrono::{DateTime, Local, NaiveDateTime, Timelike};
+use chrono::{DateTime, NaiveDate, TimeDelta, Utc};
 
-const MINUTES_PER_DAY: f64 = 24.0 * 60.0;
+const WARMTH_TRANSITION_MINUTES: i64 = 90;
 
-const WARMTH_TRANSITION_HOURS: f64 = 1.5;
+/// Covers adjacent UTC dates at extreme longitudes and neighboring high-latitude
+/// solar days where a sunrise or sunset may be unavailable.
+const SOLAR_BOUNDARY_SEARCH_DAYS: i64 = 2;
+
+#[derive(Clone, Copy)]
+struct SolarBoundary {
+    time: DateTime<Utc>,
+    event: sunrise::SolarEvent,
+}
 
 /// Computes the frontlight levels that should be active at the given time.
 ///
@@ -23,97 +31,119 @@ const WARMTH_TRANSITION_HOURS: f64 = 1.5;
 /// falls back to constant levels: polar night (no sunrise) returns
 /// `night_brightness` with full warmth, polar day (no sunset) returns
 /// `current_intensity` with zero warmth.
-pub fn compute_auto_frontlight_levels(
-    now: DateTime<Local>,
+pub fn compute_auto_frontlight_levels<Tz: chrono::TimeZone>(
+    now: DateTime<Tz>,
     coordinates: Coordinates,
     night_brightness: LightLevel,
     current_intensity: LightLevel,
 ) -> LightLevels {
+    let now = now.with_timezone(&Utc);
     let today = now.date_naive();
-    let coords: sunrise::Coordinates = coordinates.into();
-    let solar_day = sunrise::SolarDay::new(coords, today);
-    let sunrise_utc = solar_day.event_time(sunrise::SolarEvent::Sunrise);
-    let sunset_utc = solar_day.event_time(sunrise::SolarEvent::Sunset);
+    let solar_coordinates: sunrise::Coordinates = coordinates.into();
+    let solar_day = sunrise::SolarDay::new(solar_coordinates, today);
+    let sunrise = solar_day.event_time(sunrise::SolarEvent::Sunrise);
+    let sunset = solar_day.event_time(sunrise::SolarEvent::Sunset);
 
-    let (sunrise_utc, sunset_utc) = match (sunrise_utc, sunset_utc) {
-        (Some(sr), Some(ss)) => (sr, ss),
-        (None, None) | (None, Some(_)) => {
-            return LightLevels {
-                intensity: night_brightness,
-                warmth: LightLevel::from_fraction(1.0),
-            };
-        }
-        (Some(_), None) => {
-            return LightLevels {
-                intensity: current_intensity,
-                warmth: LightLevel::from_fraction(0.0),
-            };
-        }
+    if sunrise.is_none() {
+        return light_levels(night_brightness, 1.0);
+    }
+    if sunset.is_none() {
+        return light_levels(current_intensity, 0.0);
+    }
+
+    let (previous, next) = surrounding_solar_boundaries(now, solar_coordinates, today);
+    let is_daytime = match (previous, next) {
+        (Some(boundary), _) => boundary.event == sunrise::SolarEvent::Sunrise,
+        (None, Some(boundary)) => boundary.event == sunrise::SolarEvent::Sunset,
+        (None, None) => false,
     };
-
-    let minutes_since_midnight =
-        |dt: NaiveDateTime| -> f64 { (dt.hour() as f64 * 60.0) + dt.minute() as f64 };
-
-    let now_min = (now.hour() as f64 * 60.0) + now.minute() as f64;
-    let offset = *now.offset();
-    let sr_local = sunrise_utc.with_timezone(&offset).naive_local();
-    let ss_local = sunset_utc.with_timezone(&offset).naive_local();
-    let sr_min = minutes_since_midnight(sr_local);
-    let ss_min = minutes_since_midnight(ss_local);
-    let transition_min = WARMTH_TRANSITION_HOURS * 60.0;
-
-    let sun_is_down = now_min < sr_min || now_min > ss_min;
-
-    let intensity = if sun_is_down {
-        night_brightness
-    } else {
+    let intensity = if is_daytime {
         current_intensity
+    } else {
+        night_brightness
     };
-
-    let evening_ramp_start = ss_min - transition_min;
-    let evening_ramp_end = ss_min;
-    let morning_ramp_start = sr_min - transition_min;
-    let morning_ramp_end = sr_min;
-
-    let normalized_minute = |minute: f64| minute.rem_euclid(MINUTES_PER_DAY);
-    let minute_in_wrapped_range = |minute: f64, start: f64, end: f64| {
-        let minute = normalized_minute(minute);
-        let start = normalized_minute(start);
-        let end = normalized_minute(end);
-
-        if start <= end {
-            minute >= start && minute < end
-        } else {
-            minute >= start || minute < end
+    let warmth_fraction = match (is_daytime, next) {
+        (true, Some(boundary)) if boundary.event == sunrise::SolarEvent::Sunset => {
+            transition_progress(now, boundary.time)
         }
-    };
-    let wrapped_range_progress = |minute: f64, start: f64, end: f64| {
-        let span = (end - start).rem_euclid(MINUTES_PER_DAY);
-        let elapsed = (minute - start).rem_euclid(MINUTES_PER_DAY);
-        elapsed / span
+        (false, Some(boundary)) if boundary.event == sunrise::SolarEvent::Sunrise => {
+            1.0 - transition_progress(now, boundary.time)
+        }
+        (true, _) => 0.0,
+        (false, _) => 1.0,
     };
 
-    let warmth_fraction: f32 =
-        if minute_in_wrapped_range(now_min, evening_ramp_end, morning_ramp_start) {
-            1.0
-        } else if minute_in_wrapped_range(now_min, morning_ramp_end, evening_ramp_start) {
-            0.0
-        } else if minute_in_wrapped_range(now_min, evening_ramp_start, evening_ramp_end) {
-            wrapped_range_progress(now_min, evening_ramp_start, evening_ramp_end) as f32
-        } else {
-            1.0 - wrapped_range_progress(now_min, morning_ramp_start, morning_ramp_end) as f32
-        };
+    light_levels(intensity, warmth_fraction)
+}
 
+fn light_levels(intensity: LightLevel, warmth_fraction: f32) -> LightLevels {
     LightLevels {
         intensity,
         warmth: LightLevel::from_fraction(warmth_fraction),
     }
 }
 
+fn surrounding_solar_boundaries(
+    now: DateTime<Utc>,
+    coordinates: sunrise::Coordinates,
+    center_date: NaiveDate,
+) -> (Option<SolarBoundary>, Option<SolarBoundary>) {
+    let boundaries = solar_boundaries(coordinates, center_date);
+    (
+        boundaries
+            .iter()
+            .rev()
+            .find(|boundary| boundary.time <= now)
+            .copied(),
+        boundaries
+            .iter()
+            .find(|boundary| boundary.time > now)
+            .copied(),
+    )
+}
+
+fn solar_boundaries(
+    coordinates: sunrise::Coordinates,
+    center_date: NaiveDate,
+) -> Vec<SolarBoundary> {
+    let mut boundaries = Vec::with_capacity(10);
+
+    for offset in -SOLAR_BOUNDARY_SEARCH_DAYS..=SOLAR_BOUNDARY_SEARCH_DAYS {
+        let Some(date) = center_date.checked_add_signed(TimeDelta::days(offset)) else {
+            continue;
+        };
+        let solar_day = sunrise::SolarDay::new(coordinates, date);
+
+        for event in [sunrise::SolarEvent::Sunrise, sunrise::SolarEvent::Sunset] {
+            if let Some(time) = solar_day.event_time(event) {
+                boundaries.push(SolarBoundary { time, event });
+            }
+        }
+    }
+
+    boundaries.sort_by_key(|boundary| boundary.time);
+    boundaries
+}
+
+fn transition_progress(now: DateTime<Utc>, boundary: DateTime<Utc>) -> f32 {
+    let transition = TimeDelta::minutes(WARMTH_TRANSITION_MINUTES);
+    let start = boundary - transition;
+
+    ((now - start).num_seconds() as f32 / transition.num_seconds() as f32).clamp(0.0, 1.0)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
-    use chrono::TimeZone;
+    use chrono::{FixedOffset, TimeZone};
+
+    fn test_timezone() -> FixedOffset {
+        FixedOffset::east_opt(60 * 60).unwrap()
+    }
+
+    fn wrapped_test_timezone() -> FixedOffset {
+        FixedOffset::west_opt(4 * 60 * 60).unwrap()
+    }
 
     fn london() -> Coordinates {
         Coordinates::new(51.5074, -0.1278).unwrap()
@@ -123,35 +153,66 @@ mod tests {
         Coordinates::new(69.6492, 18.9553).unwrap()
     }
 
-    fn make_dt(date: &str, time: &str) -> DateTime<Local> {
+    fn make_dt(date: &str, time: &str) -> DateTime<FixedOffset> {
         let naive =
             chrono::NaiveDateTime::parse_from_str(&format!("{date} {time}"), "%Y-%m-%d %H:%M:%S")
                 .unwrap();
-        Local.from_local_datetime(&naive).single().unwrap()
+        test_timezone()
+            .from_local_datetime(&naive)
+            .single()
+            .unwrap()
     }
 
-    fn compute_expected_sun_times(date: chrono::NaiveDate, coords: Coordinates) -> (f64, f64) {
-        let day = sunrise::SolarDay::new(coords.into(), date);
-        let sr = day
-            .event_time(sunrise::SolarEvent::Sunrise)
-            .expect("test location must have sunrise")
-            .with_timezone(&Local)
-            .naive_local();
-        let ss = day
-            .event_time(sunrise::SolarEvent::Sunset)
-            .expect("test location must have sunset")
-            .with_timezone(&Local)
-            .naive_local();
-        (
-            (sr.hour() as f64 * 60.0) + sr.minute() as f64,
-            (ss.hour() as f64 * 60.0) + ss.minute() as f64,
-        )
+    fn solar_event(
+        date: NaiveDate,
+        coords: Coordinates,
+        event: sunrise::SolarEvent,
+        timezone: FixedOffset,
+    ) -> DateTime<FixedOffset> {
+        sunrise::SolarDay::new(coords.into(), date)
+            .event_time(event)
+            .expect("test location must have the solar event")
+            .with_timezone(&timezone)
+    }
+
+    fn sunrise_at(
+        date: NaiveDate,
+        coords: Coordinates,
+        timezone: FixedOffset,
+    ) -> DateTime<FixedOffset> {
+        solar_event(date, coords, sunrise::SolarEvent::Sunrise, timezone)
+    }
+
+    fn sunset_at(
+        date: NaiveDate,
+        coords: Coordinates,
+        timezone: FixedOffset,
+    ) -> DateTime<FixedOffset> {
+        solar_event(date, coords, sunrise::SolarEvent::Sunset, timezone)
+    }
+
+    fn midpoint(start: DateTime<FixedOffset>, end: DateTime<FixedOffset>) -> DateTime<FixedOffset> {
+        start + (end - start) / 2
+    }
+
+    fn summer_solstice() -> NaiveDate {
+        NaiveDate::from_ymd_opt(2025, 6, 21).unwrap()
+    }
+
+    fn levels_at<Tz: chrono::TimeZone>(now: DateTime<Tz>, coordinates: Coordinates) -> LightLevels {
+        compute_auto_frontlight_levels(now, coordinates, 10.0.into(), 50.0.into())
     }
 
     #[test]
     fn night_brightness_is_applied_when_sun_is_down() {
-        let midnight = make_dt("2025-06-21", "00:00:00");
-        let levels = compute_auto_frontlight_levels(midnight, london(), 10.0.into(), 50.0.into());
+        let sunset = sunset_at(summer_solstice(), london(), test_timezone());
+        let sunrise = sunrise_at(
+            summer_solstice().succ_opt().unwrap(),
+            london(),
+            test_timezone(),
+        );
+        let nighttime = midpoint(sunset, sunrise);
+        let levels = levels_at(nighttime, london());
         assert_eq!(
             levels.intensity, 10.0,
             "night brightness should be night_brightness"
@@ -160,8 +221,10 @@ mod tests {
 
     #[test]
     fn day_brightness_preserves_current_intensity() {
-        let noon = make_dt("2025-06-21", "12:00:00");
-        let levels = compute_auto_frontlight_levels(noon, london(), 10.0.into(), 50.0.into());
+        let sunrise = sunrise_at(summer_solstice(), london(), test_timezone());
+        let sunset = sunset_at(summer_solstice(), london(), test_timezone());
+        let daytime = midpoint(sunrise, sunset);
+        let levels = levels_at(daytime, london());
         assert_eq!(
             levels.intensity, 50.0,
             "day brightness should be current_intensity"
@@ -169,15 +232,26 @@ mod tests {
     }
 
     #[test]
+    fn wrapped_solar_day_uses_daytime_levels() {
+        let timezone = wrapped_test_timezone();
+        let sunrise = sunrise_at(summer_solstice(), london(), timezone);
+        let sunset = sunset_at(summer_solstice(), london(), timezone);
+        assert!(
+            sunrise.time() > sunset.time(),
+            "test setup must produce a wrapped solar day"
+        );
+
+        let daytime = midpoint(sunrise, sunset);
+        let levels = levels_at(daytime, london());
+
+        assert_eq!(levels.intensity, 50.0);
+        assert!(levels.warmth < 1.0);
+    }
+
+    #[test]
     fn warmth_is_zero_at_sunrise() {
-        let sr_utc = sunrise::SolarDay::new(
-            london().into(),
-            chrono::NaiveDate::from_ymd_opt(2025, 6, 21).unwrap(),
-        )
-        .event_time(sunrise::SolarEvent::Sunrise)
-        .expect("London must have sunrise");
-        let sr_local = sr_utc.with_timezone(&Local);
-        let levels = compute_auto_frontlight_levels(sr_local, london(), 10.0.into(), 50.0.into());
+        let sunrise = sunrise_at(summer_solstice(), london(), test_timezone());
+        let levels = levels_at(sunrise, london());
         assert!(
             levels.warmth < 1.0,
             "at sunrise warmth should be ~0, got {}",
@@ -187,14 +261,8 @@ mod tests {
 
     #[test]
     fn warmth_is_one_hundred_at_sunset() {
-        let ss_utc = sunrise::SolarDay::new(
-            london().into(),
-            chrono::NaiveDate::from_ymd_opt(2025, 6, 21).unwrap(),
-        )
-        .event_time(sunrise::SolarEvent::Sunset)
-        .expect("London must have sunset");
-        let ss_local = ss_utc.with_timezone(&Local);
-        let levels = compute_auto_frontlight_levels(ss_local, london(), 10.0.into(), 50.0.into());
+        let sunset = sunset_at(summer_solstice(), london(), test_timezone());
+        let levels = levels_at(sunset, london());
         assert!(
             (levels.warmth - 100.0).abs() < 1.0,
             "at sunset warmth should be ~100, got {}",
@@ -204,8 +272,10 @@ mod tests {
 
     #[test]
     fn warmth_is_zero_during_middle_of_day() {
-        let noon = make_dt("2025-06-21", "12:00:00");
-        let levels = compute_auto_frontlight_levels(noon, london(), 10.0.into(), 50.0.into());
+        let sunrise = sunrise_at(summer_solstice(), london(), test_timezone());
+        let sunset = sunset_at(summer_solstice(), london(), test_timezone());
+        let daytime = midpoint(sunrise, sunset);
+        let levels = levels_at(daytime, london());
         assert!(
             levels.warmth < 1.0,
             "midday warmth should be ~0, got {}",
@@ -215,8 +285,14 @@ mod tests {
 
     #[test]
     fn warmth_is_one_hundred_during_middle_of_night() {
-        let midnight = make_dt("2025-06-21", "00:00:00");
-        let levels = compute_auto_frontlight_levels(midnight, london(), 10.0.into(), 50.0.into());
+        let sunset = sunset_at(summer_solstice(), london(), test_timezone());
+        let sunrise = sunrise_at(
+            summer_solstice().succ_opt().unwrap(),
+            london(),
+            test_timezone(),
+        );
+        let nighttime = midpoint(sunset, sunrise);
+        let levels = levels_at(nighttime, london());
         assert!(
             (levels.warmth - 100.0).abs() < 1.0,
             "midnight warmth should be ~100, got {}",
@@ -226,28 +302,19 @@ mod tests {
 
     #[test]
     fn warmth_ramps_from_zero_to_one_hundred_in_evening_transition() {
-        let (_, ss) = compute_expected_sun_times(
-            chrono::NaiveDate::from_ymd_opt(2025, 6, 21).unwrap(),
-            london(),
-        );
-        let transition = 90.0;
+        let sunset = sunset_at(summer_solstice(), london(), test_timezone());
+        let transition = TimeDelta::minutes(90);
 
-        let ramp_start = (ss - transition) as i64;
-        let h = ramp_start / 60;
-        let m = ramp_start % 60;
-        let t = make_dt("2025-06-21", &format!("{h:02}:{m:02}:00"));
-        let levels = compute_auto_frontlight_levels(t, london(), 10.0.into(), 50.0.into());
+        let t = sunset - transition;
+        let levels = levels_at(t, london());
         assert!(
             levels.warmth < 2.0,
             "evening ramp start: warmth should be ~0, got {}",
             levels.warmth
         );
 
-        let midpoint = (ss - transition / 2.0) as i64;
-        let h = midpoint / 60;
-        let m = midpoint % 60;
-        let t = make_dt("2025-06-21", &format!("{h:02}:{m:02}:00"));
-        let levels = compute_auto_frontlight_levels(t, london(), 10.0.into(), 50.0.into());
+        let t = sunset - transition / 2;
+        let levels = levels_at(t, london());
         assert!(
             (levels.warmth - 50.0).abs() < 6.0,
             "evening ramp midpoint: warmth should be ~50, got {}",
@@ -257,28 +324,19 @@ mod tests {
 
     #[test]
     fn warmth_ramps_from_one_hundred_to_zero_in_morning_transition() {
-        let (sr, _) = compute_expected_sun_times(
-            chrono::NaiveDate::from_ymd_opt(2025, 6, 21).unwrap(),
-            london(),
-        );
-        let transition = 90.0;
+        let sunrise = sunrise_at(summer_solstice(), london(), test_timezone());
+        let transition = TimeDelta::minutes(90);
 
-        let ramp_start = (sr - transition) as i64;
-        let h = ramp_start / 60;
-        let m = ramp_start % 60;
-        let t = make_dt("2025-06-21", &format!("{h:02}:{m:02}:00"));
-        let levels = compute_auto_frontlight_levels(t, london(), 10.0.into(), 50.0.into());
+        let t = sunrise - transition;
+        let levels = levels_at(t, london());
         assert!(
             (levels.warmth - 100.0).abs() < 2.0,
             "morning ramp start: warmth should be ~100, got {}",
             levels.warmth
         );
 
-        let midpoint = (sr - transition / 2.0) as i64;
-        let h = midpoint / 60;
-        let m = midpoint % 60;
-        let t = make_dt("2025-06-21", &format!("{h:02}:{m:02}:00"));
-        let levels = compute_auto_frontlight_levels(t, london(), 10.0.into(), 50.0.into());
+        let t = sunrise - transition / 2;
+        let levels = levels_at(t, london());
         assert!(
             (levels.warmth - 50.0).abs() < 6.0,
             "morning ramp midpoint: warmth should be ~50, got {}",
@@ -288,15 +346,9 @@ mod tests {
 
     #[test]
     fn evening_brightness_is_night_level() {
-        let (_, ss) = compute_expected_sun_times(
-            chrono::NaiveDate::from_ymd_opt(2025, 6, 21).unwrap(),
-            london(),
-        );
-        let post_sunset_min = ss + 30.0;
-        let h = post_sunset_min as i64 / 60;
-        let m = post_sunset_min as i64 % 60;
-        let t = make_dt("2025-06-21", &format!("{h:02}:{m:02}:00"));
-        let levels = compute_auto_frontlight_levels(t, london(), 10.0.into(), 50.0.into());
+        let sunset = sunset_at(summer_solstice(), london(), test_timezone());
+        let t = sunset + TimeDelta::minutes(30);
+        let levels = levels_at(t, london());
         assert_eq!(
             levels.intensity, 10.0,
             "post-sunset brightness should be night_brightness"
@@ -305,19 +357,26 @@ mod tests {
 
     #[test]
     fn morning_brightness_is_night_level_before_sunrise() {
-        let (sr, _) = compute_expected_sun_times(
-            chrono::NaiveDate::from_ymd_opt(2025, 6, 21).unwrap(),
-            london(),
-        );
-        let pre_sunrise_min = sr - 120.0;
-        let h = pre_sunrise_min as i64 / 60;
-        let m = pre_sunrise_min as i64 % 60;
-        let t = make_dt("2025-06-21", &format!("{h:02}:{m:02}:00"));
-        let levels = compute_auto_frontlight_levels(t, london(), 10.0.into(), 50.0.into());
+        let sunrise = sunrise_at(summer_solstice(), london(), test_timezone());
+        let t = sunrise - TimeDelta::minutes(120);
+        let levels = levels_at(t, london());
         assert_eq!(
             levels.intensity, 10.0,
             "pre-sunrise brightness should be night_brightness"
         );
+    }
+
+    #[test]
+    fn same_instant_produces_same_levels_in_different_timezones() {
+        let sunrise = sunrise_at(summer_solstice(), london(), test_timezone());
+        let sunset = sunset_at(summer_solstice(), london(), test_timezone());
+        let now = midpoint(sunrise, sunset);
+
+        let local_levels = levels_at(now, london());
+        let shifted_levels = levels_at(now.with_timezone(&wrapped_test_timezone()), london());
+
+        assert_eq!(local_levels.intensity, shifted_levels.intensity);
+        assert_eq!(local_levels.warmth, shifted_levels.warmth);
     }
 
     #[test]
@@ -326,10 +385,8 @@ mod tests {
         let before_midnight = make_dt("2025-05-15", "23:59:00");
         let after_midnight = make_dt("2025-05-16", "00:00:00");
 
-        let before_levels =
-            compute_auto_frontlight_levels(before_midnight, coordinates, 10.0.into(), 50.0.into());
-        let after_levels =
-            compute_auto_frontlight_levels(after_midnight, coordinates, 10.0.into(), 50.0.into());
+        let before_levels = levels_at(before_midnight, coordinates);
+        let after_levels = levels_at(after_midnight, coordinates);
 
         assert!(
             (f32::from(before_levels.warmth) - f32::from(after_levels.warmth)).abs() < 4.0,


### PR DESCRIPTION
This pull request significantly refactors the automatic frontlight adjustment logic to improve correctness, clarity, and testability, especially around time zone handling and solar event transitions. The main changes include a complete rewrite of the algorithm for determining light levels based on solar events, improved handling of edge cases (such as polar day/night and time zone boundaries), and a major overhaul of the test suite for clarity and robustness.

**Algorithm and Logic Improvements**
- Rewrote the core function `compute_auto_frontlight_levels` to use a more robust algorithm that determines the current and next solar boundaries (sunrise/sunset) across multiple days, improving correctness for edge cases (e.g., polar night/day, time zone crossings). The function now works generically with any `chrono::TimeZone`, always converts to UTC internally, and uses a new `SolarBoundary` struct for clarity. [[1]](diffhunk://#diff-0bffc32a88fcf7291cd5fea5d48c4cf9c4516f09d6bf18b2d57887afcd3fe5e4L9-R21) [[2]](diffhunk://#diff-0bffc32a88fcf7291cd5fea5d48c4cf9c4516f09d6bf18b2d57887afcd3fe5e4L26-R146)

**Test Suite Overhaul**
- Refactored the test suite to use new helper functions for creating test datetimes, calculating solar events in arbitrary time zones, and computing midpoints. This makes tests more readable and robust, and ensures that the same instant in different time zones produces consistent results. [[1]](diffhunk://#diff-0bffc32a88fcf7291cd5fea5d48c4cf9c4516f09d6bf18b2d57887afcd3fe5e4L126-R215) [[2]](diffhunk://#diff-0bffc32a88fcf7291cd5fea5d48c4cf9c4516f09d6bf18b2d57887afcd3fe5e4L163-R254) [[3]](diffhunk://#diff-0bffc32a88fcf7291cd5fea5d48c4cf9c4516f09d6bf18b2d57887afcd3fe5e4L207-R278) [[4]](diffhunk://#diff-0bffc32a88fcf7291cd5fea5d48c4cf9c4516f09d6bf18b2d57887afcd3fe5e4L218-R295) [[5]](diffhunk://#diff-0bffc32a88fcf7291cd5fea5d48c4cf9c4516f09d6bf18b2d57887afcd3fe5e4L229-R317) [[6]](diffhunk://#diff-0bffc32a88fcf7291cd5fea5d48c4cf9c4516f09d6bf18b2d57887afcd3fe5e4L260-R339) [[7]](diffhunk://#diff-0bffc32a88fcf7291cd5fea5d48c4cf9c4516f09d6bf18b2d57887afcd3fe5e4L291-R351) [[8]](diffhunk://#diff-0bffc32a88fcf7291cd5fea5d48c4cf9c4516f09d6bf18b2d57887afcd3fe5e4L308-R389)

**Edge Case Handling**
- Improved handling of wrapped solar days (where sunrise and sunset cross midnight in local time), ensuring correct light and warmth transitions even in unusual time zones or at extreme latitudes.

**Transition Logic Simplification**
- Replaced complex "minutes since midnight" and range-wrapping logic with a more straightforward approach using UTC datetimes and deltas, making the transition ramps for warmth (morning/evening) easier to follow and less error-prone.

**Consistency and Clarity**
- Ensured the same instant produces the same light levels regardless of time zone, and clarified test intent by using explicit solar event calculations rather than hardcoded times.

These changes collectively make the frontlight auto-adjustment feature more reliable, maintainable, and easier to reason about, especially in challenging situations involving time zones and extreme latitudes.