### PR TITLE
feat(Frontlight): increment, decrement buttons for finegrain control

### DIFF
--- a/crates/core/src/view/frontlight.rs
+++ b/crates/core/src/view/frontlight.rs
@@ -3,7 +3,7 @@ use super::common::shift;
 use super::icon::Icon;
 use super::label::Label;
 use super::presets_list::PresetsList;
-use super::slider::Slider;
+use super::slider::{Slider, SliderWithButtons};
 use super::{
     Align, Bus, EntryId, Event, Hub, ID_FEEDER, Id, RenderData, RenderQueue, SliderId, View, ViewId,
 };
@@ -137,7 +137,7 @@ impl FrontlightWindow {
                     levels.warmth
                 };
 
-                let slider = Slider::new(
+                let slider = SliderWithButtons::new(
                     rect![
                         rect.min.x + max_label_width + 3 * padding,
                         min_y,
@@ -155,7 +155,7 @@ impl FrontlightWindow {
             button_y += small_height;
         } else {
             let min_y = rect.min.y + small_height;
-            let slider = Slider::new(
+            let slider = SliderWithButtons::new(
                 rect![
                     rect.min.x + padding,
                     min_y,

--- a/crates/core/src/view/frontlight.rs
+++ b/crates/core/src/view/frontlight.rs
@@ -281,7 +281,8 @@ impl FrontlightWindow {
             if let Some(slider_warmth) = self.child_mut(5).downcast_mut::<SliderWithButtons>() {
                 slider_warmth.slider().update(warmth.into(), rq);
             }
-        } else if let Some(slider_intensity) = self.child_mut(2).downcast_mut::<SliderWithButtons>() {
+        } else if let Some(slider_intensity) = self.child_mut(2).downcast_mut::<SliderWithButtons>()
+        {
             slider_intensity.slider().update(intensity.into(), rq);
         }
     }

--- a/crates/core/src/view/frontlight.rs
+++ b/crates/core/src/view/frontlight.rs
@@ -3,7 +3,7 @@ use super::common::shift;
 use super::icon::Icon;
 use super::label::Label;
 use super::presets_list::PresetsList;
-use super::slider::{Slider, SliderWithButtons};
+use super::slider::SliderWithButtons;
 use super::{
     Align, Bus, EntryId, Event, Hub, ID_FEEDER, Id, RenderData, RenderQueue, SliderId, View, ViewId,
 };
@@ -275,14 +275,14 @@ impl FrontlightWindow {
         self.frontlight_levels = frontlight_levels;
         let LightLevels { intensity, warmth } = frontlight_levels;
         if context.device.has_natural_light() {
-            if let Some(slider_intensity) = self.child_mut(3).downcast_mut::<Slider>() {
-                slider_intensity.update(intensity.into(), rq);
+            if let Some(slider_intensity) = self.child_mut(3).downcast_mut::<SliderWithButtons>() {
+                slider_intensity.slider().update(intensity.into(), rq);
             }
-            if let Some(slider_warmth) = self.child_mut(5).downcast_mut::<Slider>() {
-                slider_warmth.update(warmth.into(), rq);
+            if let Some(slider_warmth) = self.child_mut(5).downcast_mut::<SliderWithButtons>() {
+                slider_warmth.slider().update(warmth.into(), rq);
             }
-        } else if let Some(slider_intensity) = self.child_mut(2).downcast_mut::<Slider>() {
-            slider_intensity.update(intensity.into(), rq);
+        } else if let Some(slider_intensity) = self.child_mut(2).downcast_mut::<SliderWithButtons>() {
+            slider_intensity.slider().update(intensity.into(), rq);
         }
     }
 

--- a/crates/core/src/view/mod.rs
+++ b/crates/core/src/view/mod.rs
@@ -449,10 +449,12 @@ pub enum Event {
     Submit(ViewId, String),
     Slider(SliderId, f32, FingerStatus),
 
-    // WARNING! For use internal to SliderWithButtons only! It doesn't
-    // carry an identifier indicating which slider needs updating,
-    // so if used outside this relationship, it can lead to funny behaviour.
-    // e.g. updating all sliders in the view tree
+    /// WARNING! For use internal to SliderWithButtons only! It doesn't
+    /// carry an identifier indicating which slider needs updating,
+    /// so if used outside this relationship, it can lead to funny behaviour.
+    /// e.g. updating all sliders in the view tree.
+    ///
+    /// Used to indicate the increment or decrement button has been pressed.
     SliderIncrement(f32),
 
     ToggleNear(ViewId, Rectangle),

--- a/crates/core/src/view/mod.rs
+++ b/crates/core/src/view/mod.rs
@@ -448,7 +448,13 @@ pub enum Event {
     Define(String),
     Submit(ViewId, String),
     Slider(SliderId, f32, FingerStatus),
+
+    // WARNING! For use internal to SliderWithButtons only! It doesn't
+    // carry an identifier indicating which slider needs updating,
+    // so if used outside this relationship, it can lead to funny behaviour.
+    // e.g. updating all sliders in the view tree
     SliderIncrement(f32),
+
     ToggleNear(ViewId, Rectangle),
     ToggleInputHistoryMenu(ViewId, Rectangle),
     ToggleBookMenu(Rectangle, usize),

--- a/crates/core/src/view/mod.rs
+++ b/crates/core/src/view/mod.rs
@@ -448,6 +448,7 @@ pub enum Event {
     Define(String),
     Submit(ViewId, String),
     Slider(SliderId, f32, FingerStatus),
+    SliderIncrement(f32),
     ToggleNear(ViewId, Rectangle),
     ToggleInputHistoryMenu(ViewId, Rectangle),
     ToggleBookMenu(Rectangle, usize),

--- a/crates/core/src/view/slider.rs
+++ b/crates/core/src/view/slider.rs
@@ -271,9 +271,9 @@ impl SliderWithButtons {
         let increment_index = children.len();
         children.push(Box::new(increment));
         SliderWithButtons {
-            rect: rect,
+            rect,
             id: ID_FEEDER.next(),
-            children: children,
+            children,
             decrement_index,
             slider_index,
             increment_index,

--- a/crates/core/src/view/slider.rs
+++ b/crates/core/src/view/slider.rs
@@ -8,6 +8,7 @@ use crate::framebuffer::UpdateMode;
 use crate::geom::{BorderSpec, CornerSpec, Rectangle, halves};
 use crate::input::{DeviceEvent, FingerStatus};
 use crate::unit::scale_by_dpi;
+use crate::view::handle_event;
 use crate::view::icon::Icon;
 
 const PROGRESS_HEIGHT: f32 = 7.0;
@@ -309,5 +310,63 @@ impl View for SliderWithButtons {
     }
     fn id(&self) -> Id {
         self.id
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    use super::*;
+    use crate::context::test_helpers::create_test_context;
+    use crate::geom::Point;
+    use crate::gesture::GestureEvent;
+    use std::collections::VecDeque;
+    use std::sync::mpsc::channel;
+
+    #[test]
+    fn test_tap_decrements_value_and_emits_event() {
+        let bounds = rect![0, 0, 200, 50];
+        let mut slider = SliderWithButtons::new(bounds, SliderId::LightIntensity, 7.0, 5.0, 6.0);
+
+        let (hub, _receiver) = channel();
+        let mut bus = VecDeque::new();
+        let mut rq = RenderQueue::new();
+        let mut context = create_test_context();
+
+        let dec_bounds = slider.child(0).rect();
+        let point = Point::new(
+            dec_bounds.min.x + dec_bounds.max.x / 2,
+            dec_bounds.min.y + dec_bounds.max.y / 2,
+        );
+        let tap_event = Event::Gesture(GestureEvent::Tap(point));
+        crate::view::handle_event(
+            slider.child_mut(0),
+            &tap_event,
+            &hub,
+            &mut bus,
+            &mut rq,
+            &mut context,
+        );
+        assert_eq!(bus.len(), 1);
+        let increment_event = bus.pop_front().unwrap();
+
+        crate::view::handle_event(
+            &mut slider,
+            &increment_event,
+            &hub,
+            &mut bus,
+            &mut rq,
+            &mut context,
+        );
+        assert_eq!(bus.len(), 1);
+        let update_event = bus.pop_front();
+        assert!(matches!(
+            update_event,
+            Some(Event::Slider(
+                SliderId::LightIntensity,
+                6.0,
+                FingerStatus::Up
+            ))
+        ));
     }
 }

--- a/crates/core/src/view/slider.rs
+++ b/crates/core/src/view/slider.rs
@@ -258,8 +258,19 @@ impl SliderWithButtons {
         SliderWithButtons {
             rect: rect,
             id: ID_FEEDER.next(),
+            // WARNING: Keep in-sync with *_child accessors below.
             children: vec![Box::new(decrement), Box::new(slider), Box::new(increment)],
         }
+    }
+
+    pub fn decrement_child(&mut self) -> &mut Icon {
+        self.children_mut()[0].downcast_mut::<Icon>().unwrap()
+    }
+    pub fn slider_child(&mut self) -> &mut Slider {
+        self.children_mut()[1].downcast_mut::<Slider>().unwrap()
+    }
+    pub fn increment_child(&mut self) -> &mut Icon {
+        self.children_mut()[2].downcast_mut::<Icon>().unwrap()
     }
 }
 
@@ -278,7 +289,7 @@ impl View for SliderWithButtons {
             Event::SliderIncrement(amount) => {
                 let id = self.id;
                 let rect = self.rect;
-                let slider = self.children_mut()[1].downcast_mut::<Slider>().unwrap();
+                let slider = self.slider_child();
                 slider.increment(amount, rq);
                 rq.add(RenderData::new(id, rect, UpdateMode::Gui));
                 bus.push_back(Event::Slider(
@@ -346,14 +357,14 @@ mod tests {
         let mut rq = RenderQueue::new();
         let mut context = create_test_context();
 
-        let dec_bounds = slider.child(0).rect();
+        let dec_bounds = slider.decrement_child().rect();
         let point = Point::new(
             dec_bounds.min.x + dec_bounds.max.x / 2,
             dec_bounds.min.y + dec_bounds.max.y / 2,
         );
         let tap_event = Event::Gesture(GestureEvent::Tap(point));
         crate::view::handle_event(
-            slider.child_mut(0),
+            slider.decrement_child(),
             &tap_event,
             &hub,
             &mut bus,

--- a/crates/core/src/view/slider.rs
+++ b/crates/core/src/view/slider.rs
@@ -227,6 +227,9 @@ pub struct SliderWithButtons {
     id: Id,
     rect: Rectangle,
     children: Vec<Box<dyn View>>,
+    decrement_index: usize,
+    slider_index: usize,
+    increment_index: usize,
 }
 
 impl SliderWithButtons {
@@ -237,6 +240,7 @@ impl SliderWithButtons {
         min_value: f32,
         max_value: f32,
     ) -> SliderWithButtons {
+
         let decrement = Icon::new(
             "minus",
             rect![rect.min.x, rect.min.y, rect.min.x + 40, rect.max.y],
@@ -254,27 +258,28 @@ impl SliderWithButtons {
             min_value,
             max_value,
         );
+
         let increment = Icon::new(
             "plus",
             rect![slider.rect.max.x, rect.min.y, rect.max.x, rect.max.y],
             Event::SliderIncrement(1 as f32),
         );
+
+        let mut children: Vec<Box<dyn View>> = vec![];
+        let decrement_index = children.len();
+        children.push(Box::new(decrement));
+        let slider_index = children.len();
+        children.push(Box::new(slider));
+        let increment_index = children.len();
+        children.push(Box::new(increment));
         SliderWithButtons {
             rect: rect,
             id: ID_FEEDER.next(),
-            // WARNING: Keep in-sync with *_child accessors below.
-            children: vec![Box::new(decrement), Box::new(slider), Box::new(increment)],
+            children: children,
+            decrement_index,
+            slider_index,
+            increment_index
         }
-    }
-
-    pub fn decrement_child(&mut self) -> &mut Icon {
-        self.children_mut()[0].downcast_mut::<Icon>().unwrap()
-    }
-    pub fn slider_child(&mut self) -> &mut Slider {
-        self.children_mut()[1].downcast_mut::<Slider>().unwrap()
-    }
-    pub fn increment_child(&mut self) -> &mut Icon {
-        self.children_mut()[2].downcast_mut::<Icon>().unwrap()
     }
 }
 
@@ -293,7 +298,7 @@ impl View for SliderWithButtons {
             Event::SliderIncrement(amount) => {
                 let id = self.id;
                 let rect = self.rect;
-                let slider = self.slider_child();
+                let slider = self.child_mut(self.slider_index).downcast_mut::<Slider>().unwrap();
                 slider.increment(amount, rq);
                 rq.add(RenderData::new(id, rect, UpdateMode::Gui));
                 bus.push_back(Event::Slider(
@@ -361,14 +366,14 @@ mod tests {
         let mut rq = RenderQueue::new();
         let mut context = create_test_context();
 
-        let dec_bounds = slider.decrement_child().rect();
+        let dec_bounds = slider.child(slider.decrement_index).rect();
         let point = Point::new(
             dec_bounds.min.x + dec_bounds.max.x / 2,
             dec_bounds.min.y + dec_bounds.max.y / 2,
         );
         let tap_event = Event::Gesture(GestureEvent::Tap(point));
         crate::view::handle_event(
-            slider.decrement_child(),
+            slider.child_mut(slider.decrement_index),
             &tap_event,
             &hub,
             &mut bus,

--- a/crates/core/src/view/slider.rs
+++ b/crates/core/src/view/slider.rs
@@ -61,7 +61,7 @@ impl Slider {
     }
 
     /// Update the slider given an x co-ordinate.
-    pub fn update_value(&mut self, x_hit: i32, dpi: u16) {
+    fn update_value(&mut self, x_hit: i32, dpi: u16) {
         let button_diameter = scale_by_dpi(BUTTON_DIAMETER, dpi) as i32;
         let (small_radius, big_radius) = halves(button_diameter);
         let x_offset = x_hit

--- a/crates/core/src/view/slider.rs
+++ b/crates/core/src/view/slider.rs
@@ -8,7 +8,6 @@ use crate::framebuffer::UpdateMode;
 use crate::geom::{BorderSpec, CornerSpec, Rectangle, halves};
 use crate::input::{DeviceEvent, FingerStatus};
 use crate::unit::scale_by_dpi;
-use crate::view::handle_event;
 use crate::view::icon::Icon;
 
 const PROGRESS_HEIGHT: f32 = 7.0;

--- a/crates/core/src/view/slider.rs
+++ b/crates/core/src/view/slider.rs
@@ -243,7 +243,7 @@ impl SliderWithButtons {
         let decrement = Icon::new(
             "minus",
             rect![rect.min.x, rect.min.y, rect.min.x + 40, rect.max.y],
-            Event::SliderIncrement(-1 as f32),
+            Event::SliderIncrement(-1.0),
         );
         let slider = Slider::new(
             rect![
@@ -261,7 +261,7 @@ impl SliderWithButtons {
         let increment = Icon::new(
             "plus",
             rect![slider.rect.max.x, rect.min.y, rect.max.x, rect.max.y],
-            Event::SliderIncrement(1 as f32),
+            Event::SliderIncrement(1.0),
         );
 
         let mut children: Vec<Box<dyn View>> = vec![];

--- a/crates/core/src/view/slider.rs
+++ b/crates/core/src/view/slider.rs
@@ -226,7 +226,7 @@ pub struct SliderWithButtons {
     id: Id,
     rect: Rectangle,
     children: Vec<Box<dyn View>>,
-    #[cfg_attr(not(test), allow(dead_code))]
+    #[cfg(test)]
     decrement_index: usize,
     slider_index: usize,
 }
@@ -264,7 +264,7 @@ impl SliderWithButtons {
         );
 
         let mut children: Vec<Box<dyn View>> = vec![];
-        let decrement_index = children.len();
+        #[cfg(test)] let decrement_index = children.len();
         children.push(Box::new(decrement));
         let slider_index = children.len();
         children.push(Box::new(slider));
@@ -273,7 +273,7 @@ impl SliderWithButtons {
             rect,
             id: ID_FEEDER.next(),
             children,
-            decrement_index,
+            #[cfg(test)] decrement_index,
             slider_index,
         }
     }

--- a/crates/core/src/view/slider.rs
+++ b/crates/core/src/view/slider.rs
@@ -92,7 +92,7 @@ impl View for Slider {
                 FingerStatus::Down if self.rect.includes(position) => {
                     self.active = true;
                     self.update_value(position.x, _context.device.dpi());
-                    rq.add(RenderData::new(self.id, self.rect, UpdateMode::Gui));
+                    rq.add(RenderData::new(self.id, self.rect, UpdateMode::FastMono));
                     bus.push_back(Event::Slider(self.slider_id, self.value, status));
                     self.last_x = position.x;
                     true

--- a/crates/core/src/view/slider.rs
+++ b/crates/core/src/view/slider.rs
@@ -226,9 +226,9 @@ pub struct SliderWithButtons {
     id: Id,
     rect: Rectangle,
     children: Vec<Box<dyn View>>,
+    #[cfg_attr(not(test), allow(dead_code))]
     decrement_index: usize,
     slider_index: usize,
-    increment_index: usize,
 }
 
 impl SliderWithButtons {
@@ -268,7 +268,6 @@ impl SliderWithButtons {
         children.push(Box::new(decrement));
         let slider_index = children.len();
         children.push(Box::new(slider));
-        let increment_index = children.len();
         children.push(Box::new(increment));
         SliderWithButtons {
             rect,
@@ -276,7 +275,6 @@ impl SliderWithButtons {
             children,
             decrement_index,
             slider_index,
-            increment_index,
         }
     }
 }

--- a/crates/core/src/view/slider.rs
+++ b/crates/core/src/view/slider.rs
@@ -264,7 +264,8 @@ impl SliderWithButtons {
         );
 
         let mut children: Vec<Box<dyn View>> = vec![];
-        #[cfg(test)] let decrement_index = children.len();
+        #[cfg(test)]
+        let decrement_index = children.len();
         children.push(Box::new(decrement));
         let slider_index = children.len();
         children.push(Box::new(slider));
@@ -273,7 +274,8 @@ impl SliderWithButtons {
             rect,
             id: ID_FEEDER.next(),
             children,
-            #[cfg(test)] decrement_index,
+            #[cfg(test)]
+            decrement_index,
             slider_index,
         }
     }

--- a/crates/core/src/view/slider.rs
+++ b/crates/core/src/view/slider.rs
@@ -240,7 +240,6 @@ impl SliderWithButtons {
         min_value: f32,
         max_value: f32,
     ) -> SliderWithButtons {
-
         let decrement = Icon::new(
             "minus",
             rect![rect.min.x, rect.min.y, rect.min.x + 40, rect.max.y],
@@ -278,7 +277,7 @@ impl SliderWithButtons {
             children: children,
             decrement_index,
             slider_index,
-            increment_index
+            increment_index,
         }
     }
 }
@@ -298,7 +297,10 @@ impl View for SliderWithButtons {
             Event::SliderIncrement(amount) => {
                 let id = self.id;
                 let rect = self.rect;
-                let slider = self.child_mut(self.slider_index).downcast_mut::<Slider>().unwrap();
+                let slider = self
+                    .child_mut(self.slider_index)
+                    .downcast_mut::<Slider>()
+                    .unwrap();
                 slider.increment(amount, rq);
                 rq.add(RenderData::new(id, rect, UpdateMode::Gui));
                 bus.push_back(Event::Slider(

--- a/crates/core/src/view/slider.rs
+++ b/crates/core/src/view/slider.rs
@@ -65,7 +65,7 @@ impl Slider {
 
     pub fn update(&mut self, value: f32, rq: &mut RenderQueue) {
         if (self.value - value).abs() >= f32::EPSILON {
-            self.value = value;
+            self.value = f32::max(f32::min(value, self.max_value), self.min_value);
             rq.add(RenderData::new(self.id, self.rect, UpdateMode::Gui));
         }
     }
@@ -322,6 +322,19 @@ mod tests {
     use crate::gesture::GestureEvent;
     use std::collections::VecDeque;
     use std::sync::mpsc::channel;
+
+    #[test]
+    fn test_slider_cannot_update_above_max() {
+        let bounds = rect![0, 0, 200, 50];
+        let mut slider = Slider::new(bounds, SliderId::LightIntensity, 7.0, 5.0, 10.0);
+        let mut rq = RenderQueue::new();
+
+        slider.update(100.0, &mut rq);
+        assert_eq!(slider.value, slider.max_value);
+
+        slider.update(0.0, &mut rq);
+        assert_eq!(slider.value, slider.min_value);
+    }
 
     #[test]
     fn test_tap_decrements_value_and_emits_event() {

--- a/crates/core/src/view/slider.rs
+++ b/crates/core/src/view/slider.rs
@@ -277,6 +277,12 @@ impl SliderWithButtons {
             slider_index,
         }
     }
+
+    pub fn slider(&mut self) -> &mut Slider {
+        self.child_mut(self.slider_index)
+            .downcast_mut::<Slider>()
+            .unwrap()
+    }
 }
 
 impl View for SliderWithButtons {
@@ -294,15 +300,11 @@ impl View for SliderWithButtons {
             Event::SliderIncrement(amount) => {
                 let id = self.id;
                 let rect = self.rect;
-                let slider = self
-                    .child_mut(self.slider_index)
-                    .downcast_mut::<Slider>()
-                    .unwrap();
-                slider.increment(amount, rq);
+                self.slider().increment(amount, rq);
                 rq.add(RenderData::new(id, rect, UpdateMode::Gui));
                 bus.push_back(Event::Slider(
-                    slider.slider_id,
-                    slider.value,
+                    self.slider().slider_id,
+                    self.slider().value,
                     FingerStatus::Up,
                 ));
                 true

--- a/crates/core/src/view/slider.rs
+++ b/crates/core/src/view/slider.rs
@@ -8,6 +8,7 @@ use crate::framebuffer::UpdateMode;
 use crate::geom::{BorderSpec, CornerSpec, Rectangle, halves};
 use crate::input::{DeviceEvent, FingerStatus};
 use crate::unit::scale_by_dpi;
+use crate::view::icon::Icon;
 
 const PROGRESS_HEIGHT: f32 = 7.0;
 const BUTTON_DIAMETER: f32 = 46.0;
@@ -43,6 +44,10 @@ impl Slider {
             active: false,
             last_x: -1,
         }
+    }
+
+    pub fn increment(&mut self, amount: f32, rq: &mut RenderQueue) {
+        self.update(self.value + amount, rq)
     }
 
     pub fn update_value(&mut self, x_hit: i32, dpi: u16) {
@@ -208,6 +213,100 @@ impl View for Slider {
         &mut self.children
     }
 
+    fn id(&self) -> Id {
+        self.id
+    }
+}
+
+pub struct SliderWithButtons {
+    id: Id,
+    rect: Rectangle,
+    children: Vec<Box<dyn View>>,
+}
+
+impl SliderWithButtons {
+    pub fn new(
+        rect: Rectangle,
+        slider_id: SliderId,
+        value: f32,
+        min_value: f32,
+        max_value: f32,
+    ) -> SliderWithButtons {
+        let decrement = Icon::new(
+            "minus",
+            rect![rect.min.x, rect.min.y, rect.min.x + 40, rect.max.y],
+            Event::SliderIncrement(-1 as f32),
+        );
+        let slider = Slider::new(
+            rect![
+                decrement.rect.max.x,
+                rect.min.y,
+                rect.max.x - 40,
+                rect.max.y
+            ],
+            slider_id,
+            value,
+            min_value,
+            max_value,
+        );
+        let increment = Icon::new(
+            "plus",
+            rect![slider.rect.max.x, rect.min.y, rect.max.x, rect.max.y],
+            Event::SliderIncrement(1 as f32),
+        );
+        SliderWithButtons {
+            rect: rect,
+            id: ID_FEEDER.next(),
+            children: vec![Box::new(decrement), Box::new(slider), Box::new(increment)],
+        }
+    }
+}
+
+impl View for SliderWithButtons {
+    #[cfg_attr(feature = "tracing", tracing::instrument(skip(self, _hub, bus, rq, _context), fields(event = ?evt
+    ), ret(level=tracing::Level::TRACE)))]
+    fn handle_event(
+        &mut self,
+        evt: &Event,
+        _hub: &Hub,
+        bus: &mut Bus,
+        rq: &mut RenderQueue,
+        _context: &mut AppContext,
+    ) -> bool {
+        match *evt {
+            Event::SliderIncrement(amount) => {
+                let id = self.id;
+                let rect = self.rect;
+                let slider = self.children_mut()[1].downcast_mut::<Slider>().unwrap();
+                slider.increment(amount, rq);
+                rq.add(RenderData::new(id, rect, UpdateMode::Gui));
+                bus.push_back(Event::Slider(
+                    slider.slider_id,
+                    slider.value,
+                    FingerStatus::Up,
+                ));
+                true
+            }
+            _ => false,
+        }
+    }
+
+    #[cfg_attr(feature = "tracing", tracing::instrument(skip(self, _rect, _context), fields(rect = ?_rect)))]
+    fn render(&self, _context: &mut AppContext, _rect: Rectangle) {}
+
+    fn rect(&self) -> &Rectangle {
+        &self.rect
+    }
+
+    fn rect_mut(&mut self) -> &mut Rectangle {
+        &mut self.rect
+    }
+    fn children(&self) -> &Vec<Box<dyn View>> {
+        &self.children
+    }
+    fn children_mut(&mut self) -> &mut Vec<Box<dyn View>> {
+        &mut self.children
+    }
     fn id(&self) -> Id {
         self.id
     }

--- a/crates/core/src/view/slider.rs
+++ b/crates/core/src/view/slider.rs
@@ -47,10 +47,20 @@ impl Slider {
         }
     }
 
+    /// Increment (or decrement for negative amounts) the slider's value.
     pub fn increment(&mut self, amount: f32, rq: &mut RenderQueue) {
-        self.update(self.value + amount, rq)
+        self.update(self.value + amount, rq);
     }
 
+    /// Update the value of the slider, taking into account the bounds.
+    pub fn update(&mut self, value: f32, rq: &mut RenderQueue) {
+        if (self.value - value).abs() >= f32::EPSILON {
+            self.value = f32::max(f32::min(value, self.max_value), self.min_value);
+            rq.add(RenderData::new(self.id, self.rect, UpdateMode::Gui));
+        }
+    }
+
+    /// Update the slider given an x co-ordinate.
     pub fn update_value(&mut self, x_hit: i32, dpi: u16) {
         let button_diameter = scale_by_dpi(BUTTON_DIAMETER, dpi) as i32;
         let (small_radius, big_radius) = halves(button_diameter);
@@ -63,12 +73,6 @@ impl Slider {
         self.value = self.min_value + progress * (self.max_value - self.min_value);
     }
 
-    pub fn update(&mut self, value: f32, rq: &mut RenderQueue) {
-        if (self.value - value).abs() >= f32::EPSILON {
-            self.value = f32::max(f32::min(value, self.max_value), self.min_value);
-            rq.add(RenderData::new(self.id, self.rect, UpdateMode::Gui));
-        }
-    }
 }
 
 impl View for Slider {
@@ -219,6 +223,7 @@ impl View for Slider {
     }
 }
 
+/// A slider view with increment and decrement buttons.
 pub struct SliderWithButtons {
     id: Id,
     rect: Rectangle,

--- a/crates/core/src/view/slider.rs
+++ b/crates/core/src/view/slider.rs
@@ -72,7 +72,6 @@ impl Slider {
             .clamp(0.0, 1.0);
         self.value = self.min_value + progress * (self.max_value - self.min_value);
     }
-
 }
 
 impl View for Slider {


### PR DESCRIPTION
We do this by adding a new view, SliderWithButtons, that wraps a Slider and two Icons. 

Currently, just the frontlight and warmth settings have these buttons, but it could easily be added to other sliders by replacing the class `Slider` with `SliderWithButtons`.

We were forced to create a new Event, `SliderIncrement(amount)`, accessible globally, even though this event should never leave the View. I can't figure out a way around that without resorting to hacks or  convoluted code
.