### PR TITLE
dev(xtask): skip submodule init when SQLite cache is warm

### DIFF
--- a/crates/build-deps/src/build/sqlite.rs
+++ b/crates/build-deps/src/build/sqlite.rs
@@ -68,6 +68,30 @@ pub struct SqliteArtifacts {
     pub include_dir: PathBuf,
 }
 
+const SQLITE_SUBMODULE: &str = "thirdparty/sqlite";
+
+fn sqlite_paths(root: &Path, target: &str) -> (PathBuf, PathBuf, PathBuf) {
+    let build_root = root.join("target/cadmus-build-deps").join(target);
+    let build_dir = build_root.join("sqlite");
+    let lib_dir = build_dir.join("lib");
+    let include_dir = build_dir.join("include");
+    (build_dir, lib_dir, include_dir)
+}
+
+/// Returns `true` when SQLite artefacts for `target` are already on
+/// disk and match the current `thirdparty/sqlite` gitlink SHA.
+///
+/// Does not access `thirdparty/sqlite` on disk, so callers can use
+/// this to skip `git submodule update` on warm CI caches.
+#[must_use]
+pub fn is_cached(root: &Path, target: &str) -> bool {
+    let (build_dir, lib_dir, include_dir) = sqlite_paths(root, target);
+    markers::is_built(root, &build_dir, SQLITE_SUBMODULE)
+        && lib_dir.join("libsqlite3.a").exists()
+        && include_dir.join("sqlite3.h").exists()
+        && lib_dir.join("pkgconfig/sqlite3.pc").exists()
+}
+
 /// Build SQLite from the canonical source for the given target,
 /// placing artefacts under `target/cadmus-build-deps/<target>/sqlite/`.
 ///
@@ -88,22 +112,13 @@ pub struct SqliteArtifacts {
 /// Returns an error if TCL is not installed, `./configure` fails, or
 /// any of the compilation steps fail.
 pub fn ensure_sqlite(root: &Path, target: &str) -> Result<SqliteArtifacts> {
-    let build_root = root.join("target/cadmus-build-deps").join(target);
-    let build_dir = build_root.join("sqlite");
-    let lib_dir = build_dir.join("lib");
-    let include_dir = build_dir.join("include");
+    let (build_dir, lib_dir, include_dir) = sqlite_paths(root, target);
 
-    let submodule_path = "thirdparty/sqlite";
-    let sqlite_version = std::fs::read_to_string(root.join(submodule_path).join("VERSION"))
-        .context("failed to read thirdparty/sqlite/VERSION")?;
-    let sqlite_version = sqlite_version.trim();
-
-    if markers::is_built(root, &build_dir, submodule_path)
-        && lib_dir.join("libsqlite3.a").exists()
-        && include_dir.join("sqlite3.h").exists()
-    {
+    if is_cached(root, target) {
+        let sqlite_version = read_pkgconfig_version(&lib_dir)
+            .or_else(|_| read_submodule_version(root, SQLITE_SUBMODULE))?;
         println!("Skipping sqlite (already built for {target})...");
-        write_pkgconfig(&lib_dir, &include_dir, sqlite_version)
+        write_pkgconfig(&lib_dir, &include_dir, &sqlite_version)
             .context("failed to write sqlite3.pc for cached build")?;
         return Ok(SqliteArtifacts {
             lib_dir,
@@ -111,12 +126,16 @@ pub fn ensure_sqlite(root: &Path, target: &str) -> Result<SqliteArtifacts> {
         });
     }
 
-    let src_dir = root.join(submodule_path);
-    if !src_dir.exists() {
+    let version_file = root.join(SQLITE_SUBMODULE).join("VERSION");
+    if !version_file.exists() {
         anyhow::bail!(
-            "{submodule_path} not found — run `git submodule update --init --recursive` first"
+            "{SQLITE_SUBMODULE} not found — run `git submodule update --init --recursive` first"
         );
     }
+
+    let sqlite_version = read_submodule_version(root, SQLITE_SUBMODULE)?;
+
+    let src_dir = root.join(SQLITE_SUBMODULE);
 
     println!("Building sqlite for {target}...");
 
@@ -134,15 +153,33 @@ pub fn ensure_sqlite(root: &Path, target: &str) -> Result<SqliteArtifacts> {
     std::fs::create_dir_all(&include_dir)?;
     compile_amalgamation(&build_dir, &lib_dir, &include_dir, target)?;
 
-    write_pkgconfig(&lib_dir, &include_dir, sqlite_version)
+    write_pkgconfig(&lib_dir, &include_dir, &sqlite_version)
         .context("failed to write sqlite3.pc")?;
 
-    markers::mark_built(root, &build_dir, "sqlite", submodule_path)?;
+    markers::mark_built(root, &build_dir, "sqlite", SQLITE_SUBMODULE)?;
 
     Ok(SqliteArtifacts {
         lib_dir,
         include_dir,
     })
+}
+
+fn read_submodule_version(root: &Path, submodule_path: &str) -> Result<String> {
+    let version = std::fs::read_to_string(root.join(submodule_path).join("VERSION"))
+        .with_context(|| format!("failed to read {submodule_path}/VERSION"))?;
+    Ok(version.trim().to_owned())
+}
+
+fn read_pkgconfig_version(lib_dir: &Path) -> Result<String> {
+    let pc_path = lib_dir.join("pkgconfig/sqlite3.pc");
+    let contents = std::fs::read_to_string(&pc_path)
+        .with_context(|| format!("failed to read {}", pc_path.display()))?;
+    contents
+        .lines()
+        .find_map(|line| line.strip_prefix("Version:").map(str::trim))
+        .filter(|version| !version.is_empty())
+        .map(ToOwned::to_owned)
+        .with_context(|| format!("no Version field in {}", pc_path.display()))
 }
 
 /// Writes a `pkgconfig/sqlite3.pc` file describing the custom static build.

--- a/xtask/src/tasks/build_kobo.rs
+++ b/xtask/src/tasks/build_kobo.rs
@@ -10,7 +10,7 @@
 //!
 //! 1. Verify the Linaro ARM toolchain (`arm-linux-gnueabihf-gcc`)
 //!    is on `PATH`.
-//! 2. Initialize git submodules.
+//! 2. Initialize git submodules when SQLite is not already cached.
 //! 3. Build SQLite from source with UDL support for the ARM target
 //!    (placed in `target/cadmus-build-deps/arm-unknown-linux-gnueabihf/sqlite/`).
 //!
@@ -58,7 +58,9 @@ pub fn run(args: BuildKoboArgs) -> Result<()> {
 
     ensure_linaro_toolchain()?;
 
-    build_deps::ensure_submodules(&root).context("failed to initialise git submodules")?;
+    if !sqlite::is_cached(&root, sqlite::KOBO_TARGET) {
+        build_deps::ensure_submodules(&root).context("failed to initialise git submodules")?;
+    }
     sqlite::ensure_sqlite(&root, sqlite::KOBO_TARGET).context("failed to build SQLite for Kobo")?;
 
     cargo_build_kobo(&root, args.features.as_deref())?;

--- a/xtask/src/tasks/setup.rs
+++ b/xtask/src/tasks/setup.rs
@@ -61,10 +61,12 @@ pub struct SetupArgs {
 /// - The SQLite build fails.
 pub fn run(args: SetupArgs) -> Result<()> {
     let root = workspace::root()?;
-
-    build_deps::ensure_submodules(&root).context("failed to initialise git submodules")?;
-
     let targets = resolve_targets(&args);
+
+    let all_cached = targets.iter().all(|t| sqlite::is_cached(&root, t));
+    if !all_cached {
+        build_deps::ensure_submodules(&root).context("failed to initialise git submodules")?;
+    }
 
     for target in &targets {
         let artifacts = sqlite::ensure_sqlite(&root, target).context("failed to build sqlite")?;


### PR DESCRIPTION
Check for build markers before running git submodule update in setup and build-kobo so warm caches avoid re-cloning thirdparty trees.

Change-Id: e43b4e28cec1225bcd28b7653383e898
Change-Id-Short: lvwovlxrnlny