### PR TITLE
chore(deps): update dependency thirdparty/libwebp to v1.6.0

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -25,7 +25,7 @@
 [submodule "thirdparty/libwebp"]
 	path = thirdparty/libwebp
 	url = https://github.com/webmproject/libwebp
-	branch = v1.2.3
+	branch = v1.6.0
 [submodule "thirdparty/freetype2"]
 	path = thirdparty/freetype2
 	url = https://github.com/freetype/freetype

--- a/crates/build-deps/src/build/kobo/mupdf.rs
+++ b/crates/build-deps/src/build/kobo/mupdf.rs
@@ -55,6 +55,8 @@ pub fn build_mupdf(build_dir: &Path) -> Result<()> {
         "-lz",
         "-L../libwebp/src/.libs",
         "-lwebp",
+        "-L../libwebp/sharpyuv/.libs",
+        "-lsharpyuv",
         "-L../libwebp/src/demux/.libs",
         "-lwebpdemux",
         "-shared",

--- a/crates/build-deps/src/build/native.rs
+++ b/crates/build-deps/src/build/native.rs
@@ -123,6 +123,7 @@ pub(crate) fn native_cache_complete_at(git_root: &Path, artifact_root: &Path) ->
     let libwebp_dir = deps_root.join("libwebp");
     let libwebp_libs_dir = libwebp_dir.join("src/.libs");
     let libwebp_a = libwebp_libs_dir.join("libwebp.a");
+    let libwebp_sharpyuv_libs_dir = libwebp_dir.join("sharpyuv/.libs");
     let libwebp_demux_libs_dir = libwebp_dir.join("src/demux/.libs");
     let mupdf_dir = deps_root.join("mupdf");
     let mupdf_a = mupdf_dir.join("build/release/libmupdf.a");
@@ -132,6 +133,7 @@ pub(crate) fn native_cache_complete_at(git_root: &Path, artifact_root: &Path) ->
     markers::is_built(git_root, &libwebp_dir, "thirdparty/libwebp")
         && libwebp_a.exists()
         && libwebp_libs_dir.is_dir()
+        && libwebp_sharpyuv_libs_dir.is_dir()
         && libwebp_demux_libs_dir.is_dir()
         && markers::is_built(git_root, &mupdf_dir, "thirdparty/mupdf")
         && mupdf_a.exists()
@@ -402,6 +404,7 @@ pub fn build_mupdf_native(root: &Path) -> Result<()> {
 
     let xlibs = format!(
         "-L{root}/target/cadmus-build-deps/{target}/libwebp/src/.libs -lwebp \
+         -L{root}/target/cadmus-build-deps/{target}/libwebp/sharpyuv/.libs -lsharpyuv \
          -L{root}/target/cadmus-build-deps/{target}/libwebp/src/demux/.libs -lwebpdemux",
         root = root.display(),
         target = target
@@ -432,6 +435,7 @@ fn collect_system_cflags() -> Result<String> {
         "libopenjp2",
         "libjpeg",
         "libwebp",
+        "libsharpyuv",
         "zlib",
         "jbig2dec",
         "gumbo",
@@ -566,8 +570,10 @@ mod tests {
         let fixture = NativeMupdfFixture::new(artifact_root.path());
         let libwebp_dir = build_root(artifact_root.path()).join("libwebp");
         let libwebp_libs_dir = libwebp_dir.join("src/.libs");
+        let libwebp_sharpyuv_libs_dir = libwebp_dir.join("sharpyuv/.libs");
         let libwebp_demux_libs_dir = libwebp_dir.join("src/demux/.libs");
         std::fs::create_dir_all(&libwebp_libs_dir).unwrap();
+        std::fs::create_dir_all(&libwebp_sharpyuv_libs_dir).unwrap();
         std::fs::create_dir_all(&libwebp_demux_libs_dir).unwrap();
         std::fs::write(libwebp_libs_dir.join("libwebp.a"), b"").unwrap();
         markers::mark_built(git_root, &libwebp_dir, "libwebp", "thirdparty/libwebp").unwrap();
@@ -583,8 +589,10 @@ mod tests {
         let fixture = NativeMupdfFixture::new(artifact_root.path());
         let libwebp_dir = build_root(artifact_root.path()).join("libwebp");
         let libwebp_libs_dir = libwebp_dir.join("src/.libs");
+        let libwebp_sharpyuv_libs_dir = libwebp_dir.join("sharpyuv/.libs");
         let libwebp_demux_libs_dir = libwebp_dir.join("src/demux/.libs");
         std::fs::create_dir_all(&libwebp_libs_dir).unwrap();
+        std::fs::create_dir_all(&libwebp_sharpyuv_libs_dir).unwrap();
         std::fs::create_dir_all(&libwebp_demux_libs_dir).unwrap();
         std::fs::write(libwebp_libs_dir.join("libwebp.a"), b"").unwrap();
         markers::mark_built(git_root, &libwebp_dir, "libwebp", "thirdparty/libwebp").unwrap();
@@ -601,6 +609,25 @@ mod tests {
         let fixture = NativeMupdfFixture::new(artifact_root.path());
         let libwebp_dir = build_root(artifact_root.path()).join("libwebp");
         let libwebp_libs_dir = libwebp_dir.join("src/.libs");
+        let libwebp_sharpyuv_libs_dir = libwebp_dir.join("sharpyuv/.libs");
+        let libwebp_demux_libs_dir = libwebp_dir.join("src/demux/.libs");
+        std::fs::create_dir_all(&libwebp_libs_dir).unwrap();
+        std::fs::create_dir_all(&libwebp_sharpyuv_libs_dir).unwrap();
+        std::fs::create_dir_all(&libwebp_demux_libs_dir).unwrap();
+        std::fs::write(libwebp_libs_dir.join("libwebp.a"), b"").unwrap();
+        markers::mark_built(git_root, &libwebp_dir, "libwebp", "thirdparty/libwebp").unwrap();
+        markers::mark_built(git_root, &fixture.mupdf_dir, "mupdf", "thirdparty/mupdf").unwrap();
+
+        assert!(native_cache_complete_at(git_root, artifact_root.path()));
+    }
+
+    #[test]
+    fn native_cache_complete_false_when_sharpyuv_libs_missing() {
+        let git_root = workspace_root();
+        let artifact_root = artifact_tempdir();
+        let fixture = NativeMupdfFixture::new(artifact_root.path());
+        let libwebp_dir = build_root(artifact_root.path()).join("libwebp");
+        let libwebp_libs_dir = libwebp_dir.join("src/.libs");
         let libwebp_demux_libs_dir = libwebp_dir.join("src/demux/.libs");
         std::fs::create_dir_all(&libwebp_libs_dir).unwrap();
         std::fs::create_dir_all(&libwebp_demux_libs_dir).unwrap();
@@ -608,7 +635,7 @@ mod tests {
         markers::mark_built(git_root, &libwebp_dir, "libwebp", "thirdparty/libwebp").unwrap();
         markers::mark_built(git_root, &fixture.mupdf_dir, "mupdf", "thirdparty/mupdf").unwrap();
 
-        assert!(native_cache_complete_at(git_root, artifact_root.path()));
+        assert!(!native_cache_complete_at(git_root, artifact_root.path()));
     }
 
     #[test]

--- a/crates/build-deps/src/versions.rs
+++ b/crates/build-deps/src/versions.rs
@@ -51,6 +51,7 @@ pub const SONAMES: &[&str] = &[
     "libharfbuzz.so",
     "libgumbo.so",
     "libwebp.so",
+    "libsharpyuv.so",
     "libwebpdemux.so",
     "libdjvulibre.so",
     "libmupdf.so",
@@ -100,6 +101,10 @@ pub const BUILT_LIBRARY_COPIES: &[(&str, &str)] = &[
     ),
     ("thirdparty/jbig2dec/.libs/libjbig2dec.so", "libjbig2dec.so"),
     ("thirdparty/libwebp/src/.libs/libwebp.so", "libwebp.so"),
+    (
+        "thirdparty/libwebp/sharpyuv/.libs/libsharpyuv.so",
+        "libsharpyuv.so",
+    ),
     (
         "thirdparty/libwebp/src/demux/.libs/libwebpdemux.so",
         "libwebpdemux.so",

--- a/crates/core/build.rs
+++ b/crates/core/build.rs
@@ -141,6 +141,10 @@ fn emit_native_link_directives(root: &Path, target: &str) -> Result<()> {
                 libwebp.display()
             );
             println!(
+                "cargo:rustc-link-search=native={}/sharpyuv/.libs",
+                libwebp.display()
+            );
+            println!(
                 "cargo:rustc-link-search=native={}/src/demux/.libs",
                 libwebp.display()
             );
@@ -150,6 +154,10 @@ fn emit_native_link_directives(root: &Path, target: &str) -> Result<()> {
             println!("cargo:rustc-link-search=target/mupdf_wrapper/Darwin");
             println!(
                 "cargo:rustc-link-search=native={}/src/.libs",
+                libwebp.display()
+            );
+            println!(
+                "cargo:rustc-link-search=native={}/sharpyuv/.libs",
                 libwebp.display()
             );
             println!(
@@ -181,6 +189,7 @@ fn emit_common_link_directives() {
     println!("cargo:rustc-link-lib=openjp2");
     println!("cargo:rustc-link-lib=jbig2dec");
     println!("cargo:rustc-link-lib=webp");
+    println!("cargo:rustc-link-lib=sharpyuv");
     println!("cargo:rustc-link-lib=webpdemux");
 }
 


### PR DESCRIPTION
Includes a fix to pick up a new library they introduced. Confirmed to work on Libra 2 with The Canterville Ghost epub with webp images.