### PR TITLE
ci(docs): verify EPUB embeds Mermaid diagrams as PNG images

### DIFF
--- a/.github/actions/build-docs-epub/action.yml
+++ b/.github/actions/build-docs-epub/action.yml
@@ -37,6 +37,10 @@ runs:
       env:
         RUSTDOCFLAGS: "-D warnings"
 
+    - name: Verify Mermaid diagrams are embedded in EPUB
+      shell: bash
+      run: python3 docs/verify-epub-mermaid.py
+
     - name: Upload documentation EPUB
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
       with:

--- a/.github/workflows/cadmus-docs.yml
+++ b/.github/workflows/cadmus-docs.yml
@@ -94,6 +94,9 @@ jobs:
           CADMUS_SKIP_THIRDPARTY_DEPS: "1"
         run: cargo xtask docs
 
+      - name: Verify Mermaid diagrams are embedded in EPUB
+        run: python3 docs/verify-epub-mermaid.py
+
       - name: Upload build artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:

--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -25,6 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       cargo: ${{ steps.filter.outputs.cargo }}
+      docs-epub: ${{ steps.filter.outputs.docs-epub }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -49,6 +50,12 @@ jobs:
               - '.gitmodules'
               - 'mupdf_wrapper/**'
               - 'thirdparty/**'
+            docs-epub:
+              - 'docs/**'
+              - 'package.json'
+              - 'package-lock.json'
+              - '.github/actions/build-docs-epub/**'
+              - '.github/actions/install-doc-tools/**'
 
   format:
     needs: changes
@@ -96,7 +103,7 @@ jobs:
 
   build-docs-epub:
     needs: changes
-    if: github.event_name != 'pull_request' || needs.changes.outputs.cargo == 'true'
+    if: github.event_name != 'pull_request' || needs.changes.outputs.cargo == 'true' || needs.changes.outputs.docs-epub == 'true'
     permissions:
       contents: read
     runs-on: ubuntu-latest

--- a/docs/verify-epub-mermaid.py
+++ b/docs/verify-epub-mermaid.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""Verify that the documentation EPUB embeds Mermaid diagrams as PNG images.
+
+The mdbook-mermaid-png preprocessor should replace every ```mermaid block with an
+<img> reference to a PNG under mermaid-images/. This script fails CI when that
+pipeline regresses (for example after a puppeteer or mermaid-cli upgrade).
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+import zipfile
+from pathlib import Path
+
+MERMAID_FENCE = re.compile(r"^```mermaid\s*$", re.MULTILINE)
+MERMAID_IMG = re.compile(
+    r'<img[^>]+src="[^"]*mermaid-images/[^"]+\.png"[^>]*/?>',
+    re.IGNORECASE,
+)
+MIN_PNG_BYTES = 500
+
+
+def count_mermaid_blocks(src_dir: Path) -> int:
+    total = 0
+    for md_path in sorted(src_dir.rglob("*.md")):
+        content = md_path.read_text(encoding="utf-8")
+        total += len(MERMAID_FENCE.findall(content))
+    return total
+
+
+def chapter_html_path(md_path: Path, src_dir: Path) -> str:
+    rel = md_path.relative_to(src_dir).with_suffix(".html")
+    return f"OEBPS/{rel.as_posix()}"
+
+
+def chapters_with_mermaid(src_dir: Path) -> list[tuple[Path, int]]:
+    chapters: list[tuple[Path, int]] = []
+    for md_path in sorted(src_dir.rglob("*.md")):
+        count = len(MERMAID_FENCE.findall(md_path.read_text(encoding="utf-8")))
+        if count:
+            chapters.append((md_path, count))
+    return chapters
+
+
+def verify_epub(epub_path: Path, src_dir: Path) -> list[str]:
+    errors: list[str] = []
+    expected_blocks = count_mermaid_blocks(src_dir)
+
+    if not epub_path.is_file():
+        return [f"EPUB not found: {epub_path}"]
+
+    with zipfile.ZipFile(epub_path) as archive:
+        names = archive.namelist()
+        png_paths = sorted(
+            name for name in names if "/mermaid-images/" in name and name.endswith(".png")
+        )
+
+        if len(png_paths) < expected_blocks:
+            errors.append(
+                f"expected at least {expected_blocks} mermaid PNG(s) in EPUB, "
+                f"found {len(png_paths)}"
+            )
+
+        for png_path in png_paths:
+            data = archive.read(png_path)
+            if len(data) < MIN_PNG_BYTES:
+                errors.append(
+                    f"{png_path} is only {len(data)} bytes "
+                    f"(minimum {MIN_PNG_BYTES}); diagram may have failed to render"
+                )
+
+        html_paths = {name for name in names if name.endswith(".html")}
+        for md_path, block_count in chapters_with_mermaid(src_dir):
+            html_path = chapter_html_path(md_path, src_dir)
+            if html_path not in html_paths:
+                errors.append(f"missing EPUB chapter for {md_path}: {html_path}")
+                continue
+
+            html = archive.read(html_path).decode("utf-8")
+            if "```mermaid" in html:
+                errors.append(f"{html_path} still contains raw ```mermaid markup")
+
+            img_count = len(MERMAID_IMG.findall(html))
+            if img_count < block_count:
+                errors.append(
+                    f"{html_path} expected {block_count} mermaid image(s), found {img_count}"
+                )
+
+    return errors
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--epub",
+        type=Path,
+        default=Path("docs/book/epub/Cadmus Documentation.epub"),
+        help="Path to the generated documentation EPUB",
+    )
+    parser.add_argument(
+        "--src",
+        type=Path,
+        default=Path("docs/src"),
+        help="Path to mdBook source markdown",
+    )
+    args = parser.parse_args()
+
+    errors = verify_epub(args.epub, args.src)
+    if errors:
+        print("EPUB mermaid verification failed:", file=sys.stderr)
+        for error in errors:
+            print(f"  - {error}", file=sys.stderr)
+        return 1
+
+    block_count = count_mermaid_blocks(args.src)
+    print(
+        f"EPUB mermaid verification passed "
+        f"({block_count} diagram(s) embedded as PNG images)"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds automated verification that the documentation EPUB still embeds Mermaid diagrams as PNG images after dependency changes (for example puppeteer or `@mermaid-js/mermaid-cli` upgrades).

## Problem

The `mdbook-mermaid-png` preprocessor renders diagrams via `mmdc` and puppeteer's `chrome-headless-shell`. A broken upgrade can silently leave raw ` ```mermaid ` blocks in the EPUB instead of embedded images. Renovate PRs that only touch `package-lock.json` previously did not trigger the `cargo` workflow's EPUB build job.

## Solution

- **`docs/verify-epub-mermaid.py`** — post-build check that:
  - counts ` ```mermaid ` blocks in `docs/src/**/*.md`
  - asserts the EPUB contains at least that many PNGs under `mermaid-images/`
  - rejects HTML chapters that still contain raw mermaid markup
  - checks each chapter has the expected number of `<img src="...mermaid-images/...png">` tags
  - flags suspiciously small PNGs (likely failed renders)

- **`build-docs-epub` composite action** — runs the verifier after `cargo xtask docs --mdbook-only`

- **`cargo.yml`** — new `docs-epub` path filter (`docs/**`, `package.json`, `package-lock.json`, doc-tool actions) so the EPUB build + verify job runs on npm doc-rendering dependency changes, even when no Rust files change

- **`cadmus-docs.yml`** — runs the same verifier after the full docs portal build

## Example failure modes caught

- puppeteer/chrome-headless-shell path changes causing `mmdc` to fail
- mermaid-cli API changes leaving diagrams unrendered
- preprocessor regressions that skip PNG generation

## Test plan

- [x] Built EPUB locally and ran `python3 docs/verify-epub-mermaid.py` successfully (11 diagrams embedded)
- [ ] CI `build-docs-epub` job passes on this PR
- [ ] CI `cadmus-docs` job passes on this PR
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2d37584b-54dc-46a5-9817-033e7c771651"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2d37584b-54dc-46a5-9817-033e7c771651"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

