### PR TITLE
ci(crowdin): skip sync workflow on fork repositories

### DIFF
--- a/.github/workflows/crowdin.yml
+++ b/.github/workflows/crowdin.yml
@@ -16,6 +16,7 @@ concurrency:
 jobs:
   synchronize-with-crowdin:
     name: Sync translations
+    if: github.event.repository.fork == false
     runs-on: ubuntu-latest
     permissions:
       contents: write # push the l10n branch


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Addresses feedback on #724.

Fork repositories cannot access upstream secrets (`CROWDIN_PROJECT_ID`, `CROWDIN_PERSONAL_TOKEN`), so the Crowdin sync job fails when contributors push to their fork's default branch.

Add a job-level guard so `synchronize-with-crowdin` only runs when `github.event.repository.fork == false`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ef78cd5b-8af8-4264-b92d-a509317ae0ef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ef78cd5b-8af8-4264-b92d-a509317ae0ef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

