### PR TITLE
docs: Correct references to default feature to emulator/kobo

### DIFF
--- a/.agents/skills/build-cadmus-native/SKILL.md
+++ b/.agents/skills/build-cadmus-native/SKILL.md
@@ -47,36 +47,46 @@ automatically by `build.rs` when you run any Cargo command that compiles
 
 ## Daily workflow commands
 
-| Goal                           | Command                                                             |
-| ------------------------------ | ------------------------------------------------------------------- |
-| Check formatting               | `cargo xtask fmt`                                                   |
-| Run clippy                     | `cargo xtask clippy`                                                |
-| Run tests (default features)   | `cargo xtask test --features default`                               |
-| Run tests with coverage        | `cadmus-test-coverage --features default` (devenv)                  |
-| View coverage (project-wide)   | `cadmus-coverage-show` (after test-coverage)                        |
-| View coverage (patch diff)     | `cadmus-coverage-diff` (after test-coverage)                        |
-| Run tests with telemetry       | `cargo xtask test --features "profiling + test + tracing"`          |
-| Run the emulator               | `cargo xtask run-emulator` (builds the EPUB first if missing)       |
-| Install the importer CLI       | `cargo xtask install-importer`                                      |
-| Build docs portal (full)       | `cargo xtask docs`                                                  |
+| Goal                          | Command                                                               |
+| ----------------------------- | --------------------------------------------------------------------- |
+| Check formatting              | `cargo xtask fmt`                                                     |
+| Run clippy                    | `cargo xtask clippy`                                                  |
+| Run tests (emulator features) | `cargo xtask test --features emulator`                                |
+| Run tests with coverage       | `cadmus-test-coverage --features emulator` (devenv)                   |
+| View coverage (project-wide)  | `cadmus-coverage-show` (after test-coverage)                          |
+| View coverage (patch diff)    | `cadmus-coverage-diff` (after test-coverage)                          |
+| Run tests with telemetry      | `cargo xtask test --features "emulator + profiling + test + tracing"` |
+| Run the emulator              | `cargo xtask run-emulator` (builds the EPUB first if missing)         |
+| Install the importer CLI      | `cargo xtask install-importer`                                        |
+| Build docs portal (full)      | `cargo xtask docs`                                                    |
+
+### A device feature is required
+
+`cadmus-core` emits `compile_error!("A device feature must be enabled")`
+(`crates/core/src/lib.rs`) unless one of `emulator`, `kobo`, or `deviceless`
+is enabled. The merged `cadmus` crate has `default = []`, so plain `cargo
+build`, `--features default`, and `cargo xtask test --features default` all
+fail. For native host development use `emulator` (what `run-emulator` uses);
+use `kobo` only via the `build-kobo` skill (it cross-compiles for ARM).
 
 ### Testing locally
 
 The full feature matrix is large and slow. Run the complete matrix only in CI.
-Locally, test the feature combination you are actively working with:
+Locally, test the feature combination you are actively working with — every
+combination must include a device feature:
 
 ```bash
-# Default features — fastest, covers most code
-cargo xtask test --features default
+# Emulator device feature — fastest, covers most code
+cargo xtask test --features emulator
 
-# Specific feature you are adding or modifying
-cargo xtask test --features "profiling + test + tracing"
+# Add the feature you are modifying on top of a device feature
+cargo xtask test --features "emulator + profiling + test + tracing"
 ```
 
 > [!NOTE]
 > The `telemetry` feature is excluded from the xtask matrix because it aliases
 > `tracing + profiling` with no separate `cfg` branches. Use the expanded form
-> (`profiling + test + tracing`) instead.
+> (`emulator + profiling + test + tracing`) instead.
 
 Use `cargo xtask ci matrix` to see all available feature combinations if you
 need to verify a specific one.
@@ -94,7 +104,7 @@ cadmus-coverage-diff
 Without devenv:
 
 ```bash
-cargo xtask test --coverage --features default
+cargo xtask test --coverage --features emulator
 ```
 
 This writes `target/coverage/lcov.info`. Project HTML uses `cargo llvm-cov report --html`.
@@ -110,11 +120,12 @@ Patch HTML uses `diff-cover` (see `devenv.nix` scripts).
 
 ## Common mistakes
 
-| Mistake                                                       | Result                                                        | Fix                                                      |
-| ------------------------------------------------------------- | ------------------------------------------------------------- | -------------------------------------------------------- |
-| Running `cargo check` before `cargo xtask docs --mdbook-only` | `RustEmbed` folder-not-found error                            | Generate the EPUB first                                  |
-| Running bare `cargo clippy` / `cargo test` directly           | May miss feature-gated code or use wrong feature combinations | Prefer `cargo xtask clippy` and `cargo xtask test`       |
-| Running `cargo xtask test` without `--features`               | Runs the full (slow) CI matrix locally                        | Pass `--features default` or the specific combo you need |
+| Mistake                                                       | Result                                                                | Fix                                                                                  |
+| ------------------------------------------------------------- | --------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
+| Running `cargo check` before `cargo xtask docs --mdbook-only` | `RustEmbed` folder-not-found error                                    | Generate the EPUB first                                                              |
+| Running bare `cargo clippy` / `cargo test` directly           | May miss feature-gated code or use wrong feature combinations         | Prefer `cargo xtask clippy` and `cargo xtask test`                                   |
+| Running `cargo xtask test` without `--features`               | Runs the full (slow) CI matrix locally                                | Pass `--features emulator` (or `kobo`/`deviceless`) plus any specific combo you need |
+| Running `cargo build` / `cargo test` without a device feature | `compile_error!("A device feature must be enabled")` in `cadmus-core` | Pass `--features emulator` (or `kobo`/`deviceless`)                                  |
 
 ## Platform notes
 

--- a/.agents/skills/clippy-diff-report/SKILL.md
+++ b/.agents/skills/clippy-diff-report/SKILL.md
@@ -23,35 +23,38 @@ You can run the same filter locally before pushing.
 ## Run clippy filtered to your diff
 
 ```bash
-cargo xtask clippy --features default --github-report --diff-branch master
+cargo xtask clippy --features emulator --github-report --diff-branch master
 ```
 
 This:
 
-1. Runs `cargo clippy --message-format=short` for the `default` feature set
+1. Runs `cargo clippy --message-format=short` for the `emulator` feature set
 2. Pipes output through `reviewdog` with `-filter-mode=added`
 3. Reviewdog diffs against `master` and prints only warnings on changed lines
 
-### Why `--features default`
+### Why `--features emulator`
 
-The full feature matrix is large and slow. Run the complete matrix only in CI.
-Locally, lint the feature combination you are actively working with. Use
-`cargo xtask ci matrix` to see all available labels if you need a specific one.
+`cadmus-core` requires a device feature (`emulator`, `kobo`, or `deviceless`)
+to compile — `default` is empty and `--features default` fails. For native
+host linting use `emulator` (it matches what `run-emulator` builds). The full
+feature matrix is large and slow; run it only in CI. Use `cargo xtask ci
+matrix` to see all available labels if you need a specific one.
 
 ### Check all feature combinations you touched
 
 If your changes span multiple feature sets (e.g. you added `#[cfg(feature =
-"tracing")]` code), run clippy for each relevant combination:
+"tracing")]` code), run clippy for each relevant combination — every
+combination must include a device feature:
 
 ```bash
-cargo xtask clippy --features default --github-report --diff-branch master
-cargo xtask clippy --features "profiling + test + tracing" --github-report --diff-branch master
+cargo xtask clippy --features emulator --github-report --diff-branch master
+cargo xtask clippy --features "emulator + profiling + test + tracing" --github-report --diff-branch master
 ```
 
 > [!NOTE]
 > The `telemetry` feature is excluded from the xtask matrix because it aliases
 > `tracing + profiling` with no separate `cfg` branches. Use the expanded form
-> (`profiling + test + tracing`) instead.
+> (`emulator + profiling + test + tracing`) instead.
 
 ## How it works
 
@@ -73,12 +76,12 @@ reviewdog \
 
 ## Common use cases
 
-| Goal                                                   | Command                                                                                           |
-| ------------------------------------------------------ | ------------------------------------------------------------------------------------------------- |
-| Check default-feature changes before pushing           | `cargo xtask clippy --features default --github-report --diff-branch master`                      |
-| Check telemetry-related changes                        | `cargo xtask clippy --features "profiling + test + tracing" --github-report --diff-branch master` |
-| See raw (unfiltered) clippy output for one feature set | `cargo xtask clippy --features default`                                                           |
-| Run the full matrix (slow — CI only)                   | `cargo xtask clippy --github-report --diff-branch master` (omits `--features`)                    |
+| Goal                                                   | Command                                                                                                      |
+| ------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------ |
+| Check emulator-feature changes before pushing          | `cargo xtask clippy --features emulator --github-report --diff-branch master`                                |
+| Check telemetry-related changes                        | `cargo xtask clippy --features "emulator + profiling + test + tracing" --github-report --diff-branch master` |
+| See raw (unfiltered) clippy output for one feature set | `cargo xtask clippy --features emulator`                                                                     |
+| Run the full matrix (slow — CI only)                   | `cargo xtask clippy --github-report --diff-branch master` (omits `--features`)                               |
 
 ## Troubleshooting
 

--- a/.github/agents/clippy-resolver.agent.md
+++ b/.github/agents/clippy-resolver.agent.md
@@ -50,8 +50,12 @@ Also check inline PR review annotations posted by reviewdog.
 ## Verify
 
 ```bash
-cargo build --workspace --all-targets
-cargo xtask test --features default
-cargo clippy --workspace --all-targets -- -D warnings
+cargo build --workspace --all-targets --features emulator
+cargo xtask test --features emulator
+cargo clippy --workspace --all-targets --features emulator -- -D warnings
 cargo fmt --check
 ```
+
+A device feature (`emulator`, `kobo`, or `deviceless`) is **required** to
+compile `cadmus-core` — plain `cargo build` fails with `compile_error!("A
+device feature must be enabled")`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -263,7 +263,9 @@ After code changes, complete every step before considering work done:
 
 1. Formatting — `fmt` skill
 2. Lint — `clippy-diff-report` or `build-cadmus-native` skill
-3. Tests — `build-cadmus-native` skill (`--features default` locally)
+3. Tests — `build-cadmus-native` skill (`--features emulator` locally; a
+   device feature — `emulator`, `kobo`, or `deviceless` — is **required** to
+   compile `cadmus-core`)
 4. Kobo ARM build — `build-kobo` skill (**required**; host builds can pass while
    ARM fails)
 

--- a/devenv.nix
+++ b/devenv.nix
@@ -821,7 +821,7 @@ in
     cadmus-test-coverage.exec = ''
       cd "$DEVENV_ROOT"
       if [ $# -eq 0 ]; then
-        set -- --features default
+        set -- --features emulator
       fi
       cargo xtask test --coverage "$@"
     '';
@@ -995,8 +995,8 @@ in
     };
     cargo-test = {
       enable = true;
-      name = "cargo test (default features)";
-      entry = "cargo test --workspace --features default";
+      name = "cargo test (emulator features)";
+      entry = "cargo xtask test --features emulator";
       files = "\\.rs$";
       pass_filenames = false;
       language = "system";

--- a/docs/src/contributing/devenv-setup.md
+++ b/docs/src/contributing/devenv-setup.md
@@ -158,8 +158,13 @@ cadmus-coverage-diff main         # or pass an explicit base branch
 Outside devenv, the equivalent xtask invocation is:
 
 ```bash
-cargo xtask test --coverage --features default
+cargo xtask test --coverage --features emulator
 ```
+
+A device feature (`emulator`, `kobo`, or `deviceless`) is **required** to
+compile `cadmus-core` — plain `cargo test` and `--features default` fail with
+`compile_error!("A device feature must be enabled")`. Use `emulator` on the
+host; use `kobo` only via the `build-kobo` skill (cross-compiles for ARM).
 
 CI uploads require a `CODECOV_TOKEN` repository secret (one-time setup on codecov.io).
 


### PR DESCRIPTION
Agents spend a lot of time repeatedly figuring out that --features default will no longer work and they must use --features emulator or --features kobo.