### PR TITLE
ci: fix clippy reporting from forks

### DIFF
--- a/.github/workflows/AGENTS.md
+++ b/.github/workflows/AGENTS.md
@@ -56,6 +56,22 @@ Path-filter and validate jobs only need a read-only checkout. Prefer:
 Skip this on jobs that use reviewdog or other tools that rely on persisted
 credentials for PR comments.
 
+## Fork PR reviewdog
+
+Public fork pull requests receive a read-only `GITHUB_TOKEN` on `pull_request`,
+so reviewdog cannot post inline review comments from that event. Cadmus splits
+collection from posting:
+
+1. **Cargo** (`pull_request`) — unprivileged. Clippy matrix uploads JSON;
+   `clippy-report` coalesces diagnostics into the `clippy-reviewdog-input`
+   artifact. No PR write permission.
+2. **Clippy report** (`workflow_run` on Cargo) — privileged base-repo context.
+   Downloads the artifact by `run-id` and posts via reviewdog with
+   `pull-requests: write`.
+
+The privileged workflow must treat artifacts as untrusted data (pipe text into
+reviewdog only). Do not check out or execute the PR head or artifact payloads.
+
 ## Action pinning
 
 Pin every third-party action to a full commit SHA with a version comment:

--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -285,7 +285,6 @@ jobs:
 
     permissions:
       contents: read
-      pull-requests: write
 
     runs-on: ubuntu-latest
     name: clippy-report
@@ -310,13 +309,18 @@ jobs:
           path: clippy-json
           merge-multiple: true
 
-      - name: Install reviewdog
-        uses: reviewdog/action-setup@d8a7baabd7f3e8544ee4dbde3ee41d0011c3a93f # v1
+      - name: Coalesce clippy diagnostics for reviewdog
+        run: |
+          cargo xtask ci clippy-report \
+            --artifacts-dir clippy-json \
+            --output clippy-reviewdog-input/diagnostics.txt
 
-      - name: Run clippy-report
-        run: cargo xtask ci clippy-report --artifacts-dir clippy-json
-        env:
-          REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Upload reviewdog input artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: clippy-reviewdog-input
+          path: clippy-reviewdog-input/
+          retention-days: 1
 
   test:
     needs: [changes, generate-matrix, build-docs-epub, cache-warmup]

--- a/.github/workflows/clippy-report.yml
+++ b/.github/workflows/clippy-report.yml
@@ -22,7 +22,7 @@ jobs:
         env:
           BASE_REPO: ${{ github.repository }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          HEAD_REPO: ${{ github.event.workflow_run.head_repository.full_name }}
+          HEAD_REPO: ${{ github.event.workflow_run.head_repository.full_name || github.repository }}
           HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
         run: |
           PR_NUMBER=$(gh api "repos/$HEAD_REPO/commits/$HEAD_SHA/pulls" \

--- a/.github/workflows/clippy-report.yml
+++ b/.github/workflows/clippy-report.yml
@@ -1,0 +1,79 @@
+name: Clippy report
+
+on:
+  workflow_run:
+    workflows: ["Cargo"]
+    types: [completed]
+
+permissions:
+  contents: read
+  actions: read
+  pull-requests: write
+
+jobs:
+  post-review:
+    if: >
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion != 'cancelled'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Identify PR
+        id: identify-pr
+        env:
+          BASE_REPO: ${{ github.repository }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HEAD_REPO: ${{ github.event.workflow_run.head_repository.full_name }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+        run: |
+          PR_NUMBER=$(gh api "repos/$HEAD_REPO/commits/$HEAD_SHA/pulls" \
+            --jq ".[] | select(.base.repo.full_name == \"$BASE_REPO\") | .number" \
+            | head -n1)
+          if [ -z "$PR_NUMBER" ]; then
+            echo "No open pull request found for $HEAD_REPO@$HEAD_SHA"
+            echo "number=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
+
+      - name: Download reviewdog input artifact
+        if: steps.identify-pr.outputs.number
+        id: download
+        continue-on-error: true
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: clippy-reviewdog-input
+          path: clippy-reviewdog-input
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ github.event.workflow_run.id }}
+
+      - name: Check for diagnostics file
+        id: check
+        if: >
+          steps.identify-pr.outputs.number &&
+          steps.download.outcome == 'success' &&
+          hashFiles('clippy-reviewdog-input/diagnostics.txt') != ''
+        run: echo "has_input=true" >> "$GITHUB_OUTPUT"
+
+      - name: Install reviewdog
+        if: steps.check.outputs.has_input == 'true'
+        uses: reviewdog/action-setup@d8a7baabd7f3e8544ee4dbde3ee41d0011c3a93f # v1
+
+      # CI_* vars are reviewdog's manual PR context (for non-pull_request jobs).
+      # Unset GITHUB_ACTIONS so reviewdog uses them instead of workflow_run event
+      # metadata. See: https://github.com/reviewdog/reviewdog#common-jenkins-local-etc
+      - name: Post clippy review comments
+        if: steps.check.outputs.has_input == 'true'
+        env:
+          CI_PULL_REQUEST: ${{ steps.identify-pr.outputs.number }}
+          CI_COMMIT: ${{ github.event.workflow_run.head_sha }}
+          CI_REPO_OWNER: ${{ github.repository_owner }}
+          CI_REPO_NAME: ${{ github.event.repository.name }}
+          CI_BRANCH: ${{ github.event.workflow_run.head_branch }}
+          REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          env -u GITHUB_ACTIONS reviewdog \
+            -f=clippy \
+            -filter-mode=added \
+            -fail-on-error=false \
+            -reporter=github-pr-review \
+            < clippy-reviewdog-input/diagnostics.txt

--- a/xtask/src/tasks/ci/clippy_report.rs
+++ b/xtask/src/tasks/ci/clippy_report.rs
@@ -1,5 +1,5 @@
 //! `cargo xtask ci clippy-report` — deduplicate clippy JSON artifacts and
-//! report via reviewdog.
+//! emit short-format diagnostics for reviewdog.
 //!
 //! ## How it fits into CI
 //!
@@ -9,13 +9,14 @@
 //! downloads all artifacts into a single directory and calls:
 //!
 //! ```text
-//! cargo xtask ci clippy-report --artifacts-dir <dir>
+//! cargo xtask ci clippy-report --artifacts-dir <dir> --output <file>
 //! ```
 //!
 //! This command reads every `.json` file in the directory, deduplicates
-//! diagnostics across feature labels, and pipes the unique set through
-//! `reviewdog` once — so each warning appears as exactly one PR review
-//! comment regardless of how many feature combinations triggered it.
+//! diagnostics across feature labels, and writes short-format lines for
+//! reviewdog.  A separate privileged `workflow_run` workflow (`Clippy report`)
+//! downloads that artifact and posts PR review comments — so fork PRs still
+//! get inline comments despite a read-only `GITHUB_TOKEN` on `pull_request`.
 //!
 //! ## Deduplication key
 //!
@@ -27,9 +28,13 @@
 //!
 //! ## Reviewdog
 //!
-//! Uses the `github-pr-review` reporter.  Requires:
+//! When `--output` is omitted, pipes short-format lines to `reviewdog` with
+//! the `github-pr-review` reporter (local / same-repo use).  Requires:
 //! - `reviewdog` on `PATH`
 //! - `REVIEWDOG_GITHUB_API_TOKEN` set to a token with `pull-requests: write`
+//!
+//! When `--output` is set, writes short-format lines to that file and does not
+//! invoke reviewdog.
 
 use std::collections::HashSet;
 use std::fs;
@@ -48,16 +53,25 @@ pub struct ClippyReportArgs {
     /// `cargo xtask clippy --save-json`.
     #[arg(long)]
     pub artifacts_dir: PathBuf,
+
+    /// Write short-format diagnostics to this file instead of posting via
+    /// reviewdog.
+    ///
+    /// Parent directories are created as needed.  Used by the unprivileged
+    /// Cargo CI job so a privileged `workflow_run` workflow can post comments.
+    #[arg(long)]
+    pub output: Option<PathBuf>,
 }
 
 /// Reads all `.json` files in `artifacts_dir`, deduplicates diagnostics, and
-/// pipes the unique set through `reviewdog` using the `github-pr-review`
-/// reporter.
+/// either writes short-format lines to [`ClippyReportArgs::output`] or pipes
+/// them through `reviewdog` using the `github-pr-review` reporter.
 ///
 /// # Errors
 ///
-/// Returns an error if any artifact file cannot be read, if `reviewdog`
-/// cannot be spawned, or if `reviewdog` exits non-zero.
+/// Returns an error if any artifact file cannot be read, if the output file
+/// cannot be written, if `reviewdog` cannot be spawned, or if `reviewdog`
+/// exits non-zero.
 pub fn run(args: ClippyReportArgs) -> Result<()> {
     let lines = collect_unique_lines(&args.artifacts_dir)?;
 
@@ -66,7 +80,41 @@ pub fn run(args: ClippyReportArgs) -> Result<()> {
         lines.len()
     );
 
-    pipe_to_reviewdog(&lines)
+    if let Some(output) = args.output {
+        write_short_output(&lines, &output)
+    } else {
+        pipe_to_reviewdog(&lines)
+    }
+}
+
+/// Converts deduplicated clippy JSON lines to short format and writes them to
+/// `path`, creating parent directories as needed.
+///
+/// # Errors
+///
+/// Returns an error if directories cannot be created or the file cannot be written.
+fn write_short_output(lines: &[String], path: &Path) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)
+            .with_context(|| format!("failed to create directory {}", parent.display()))?;
+    }
+
+    let mut file =
+        fs::File::create(path).with_context(|| format!("failed to create {}", path.display()))?;
+
+    for line in lines {
+        let short_line = json_to_short(line);
+        writeln!(file, "{short_line}")
+            .with_context(|| format!("failed to write to {}", path.display()))?;
+    }
+
+    println!(
+        "clippy-report: wrote {} lines to {}",
+        lines.len(),
+        path.display()
+    );
+
+    Ok(())
 }
 
 /// Collects all JSON lines from every `.json` file in `dir`, returning only
@@ -528,6 +576,44 @@ mod tests {
         assert_eq!(
             result,
             "src/main.rs:1:1: error: expected `,`, found `{` [E0789]"
+        );
+    }
+
+    #[test]
+    fn output_flag_writes_short_format_without_reviewdog() {
+        let dir = tempdir().unwrap();
+        let warning = serde_json::json!({
+            "reason": "compiler-message",
+            "message": {
+                "message": "unused variable: `x`",
+                "level": "warning",
+                "spans": [
+                    {
+                        "file_name": "src/lib.rs",
+                        "line_start": 10,
+                        "column_start": 5,
+                        "is_primary": true
+                    }
+                ],
+                "code": { "code": "unused_variables" }
+            }
+        })
+        .to_string();
+
+        write_artifact(dir.path(), "default.json", &[&warning]);
+        write_artifact(dir.path(), "test.json", &[&warning]);
+
+        let out = dir.path().join("out").join("diagnostics.txt");
+        run(ClippyReportArgs {
+            artifacts_dir: dir.path().to_path_buf(),
+            output: Some(out.clone()),
+        })
+        .unwrap();
+
+        let contents = fs::read_to_string(&out).unwrap();
+        assert_eq!(
+            contents,
+            "src/lib.rs:10:5: warning: unused variable: `x` [unused_variables]\n"
         );
     }
 }

--- a/xtask/src/tasks/ci/mod.rs
+++ b/xtask/src/tasks/ci/mod.rs
@@ -10,7 +10,7 @@
 //! |------------|-------------|
 //! | `install-doc-tools` | Install mdBook, mdbook-epub, mdbook-mermaid, and optionally Zola |
 //! | `matrix` | Emit a GitHub Actions dynamic feature matrix JSON |
-//! | `clippy-report` | Deduplicate clippy JSON artifacts and report via reviewdog |
+//! | `clippy-report` | Deduplicate clippy JSON artifacts for reviewdog posting |
 
 pub mod clippy_report;
 pub mod install_doc_tools;


### PR DESCRIPTION
Change-Id: 0877aa4f737a8fd85b81f8bb5cedbf8a
Change-Id-Short: zrssppvkswsp

---

#706 has clippy warnings: 

```
clippy-report: 294 unique diagnostics across all feature labels
$ reviewdog -f=clippy -filter-mode=added -fail-on-error=false -reporter=github-pr-review
crates/core/src/view/slider.rs:11:5: warning: unused import: `crate::view::handle_event` [unused_imports]
crates/core/src/view/slider.rs:275:13: warning: redundant field names in struct initialization [clippy::redundant_field_names]
crates/core/src/view/slider.rs:277:13: warning: redundant field names in struct initialization [clippy::redundant_field_names]
crates/core/src/view/slider.rs:230:5: warning: fields `decrement_index` and `increment_index` are never read [dead_code]
crates/core/src/view/slider.rs:232:5: warning: field `increment_index` is never read [dead_code]
crates/core/src/view/slider.rs:246:36: warning: casting integer literal to `f32` is unnecessary [clippy::unnecessary_cast]
crates/core/src/view/slider.rs:264:36: warning: casting integer literal to `f32` is unnecessary [clippy::unnecessary_cast]
time=2026-07-23T04:13:15.974Z level=INFO msg="reviewdog: failed to post a review comment: POST https://api.github.com/repos/OGKevin/cadmus/pulls/706/reviews: 403 Resource not accessible by integration []"
reviewdog: This GitHub Token doesn't have write permission of Review API [1],
so reviewdog will report results via logging command [2] and create annotations similar to
github-pr-check reporter as a fallback.
[1]: https://docs.github.com/en/actions/reference/events-that-trigger-workflows#pull_request_target
[2]: https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions
```

But forks can't publish the feedback. Found out by seeing warnings when building the emulator locally. 