### PR TITLE
ci: checkout PR head for clippy reviewdog

### DIFF
--- a/.github/workflows/AGENTS.md
+++ b/.github/workflows/AGENTS.md
@@ -69,8 +69,10 @@ collection from posting:
    Downloads the artifact by `run-id` and posts via reviewdog with
    `pull-requests: write`.
 
-The privileged workflow must treat artifacts as untrusted data (pipe text into
-reviewdog only). Do not check out or execute the PR head or artifact payloads.
+The privileged workflow may check out the PR head solely so reviewdog can
+resolve `.git` and compute the PR diff for `-filter-mode=added`. Treat
+artifacts as untrusted data (pipe text into reviewdog only). Do not execute
+the PR head or artifact payloads.
 
 ## Action pinning
 

--- a/.github/workflows/clippy-report.yml
+++ b/.github/workflows/clippy-report.yml
@@ -25,15 +25,34 @@ jobs:
           HEAD_REPO: ${{ github.event.workflow_run.head_repository.full_name || github.repository }}
           HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
         run: |
-          PR_NUMBER=$(gh api "repos/$HEAD_REPO/commits/$HEAD_SHA/pulls" \
-            --jq ".[] | select(.base.repo.full_name == \"$BASE_REPO\") | .number" \
+          PR_JSON=$(gh api "repos/$HEAD_REPO/commits/$HEAD_SHA/pulls" \
+            --jq ".[] | select(.base.repo.full_name == \"$BASE_REPO\") | {number, base_ref: .base.ref}" \
             | head -n1)
-          if [ -z "$PR_NUMBER" ]; then
+          if [ -z "$PR_JSON" ]; then
             echo "No open pull request found for $HEAD_REPO@$HEAD_SHA"
             echo "number=" >> "$GITHUB_OUTPUT"
+            echo "base_ref=" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          echo "number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
+          echo "number=$(echo "$PR_JSON" | jq -r .number)" >> "$GITHUB_OUTPUT"
+          echo "base_ref=$(echo "$PR_JSON" | jq -r .base_ref)" >> "$GITHUB_OUTPUT"
+
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        if: steps.identify-pr.outputs.number
+        with:
+          repository: ${{ github.event.workflow_run.head_repository.full_name }}
+          ref: ${{ github.event.workflow_run.head_sha }}
+          fetch-depth: 0
+
+      - name: Fetch PR base for merge-base
+        if: steps.identify-pr.outputs.number
+        env:
+          BASE_REF: ${{ steps.identify-pr.outputs.base_ref }}
+          BASE_REPO: ${{ github.repository }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git remote add upstream "https://x-access-token:${GH_TOKEN}@github.com/${BASE_REPO}.git"
+          git fetch --no-tags upstream "$BASE_REF"
 
       - name: Download reviewdog input artifact
         if: steps.identify-pr.outputs.number


### PR DESCRIPTION
reviewdog needs .git and the PR tree for -filter-mode=added; fetch the base ref so fork merge-base diffs work.

https://github.com/OGKevin/cadmus/actions/runs/30335622249/job/90199749832

Change-Id: 9faeaf88d5f37201173ed309a009ea23
Change-Id-Short: qkplpkrrmukw