### PR TITLE
docs(ci): generalize Fork PR reviewdog guidance

### DIFF
--- a/.github/workflows/AGENTS.md
+++ b/.github/workflows/AGENTS.md
@@ -60,19 +60,34 @@ credentials for PR comments.
 
 Public fork pull requests receive a read-only `GITHUB_TOKEN` on `pull_request`,
 so reviewdog cannot post inline review comments from that event. Cadmus splits
-collection from posting:
+collection from posting for every reviewdog consumer:
 
-1. **Cargo** (`pull_request`) — unprivileged. Clippy matrix uploads JSON;
-   `clippy-report` coalesces diagnostics into the `clippy-reviewdog-input`
-   artifact. No PR write permission.
-2. **Clippy report** (`workflow_run` on Cargo) — privileged base-repo context.
-   Downloads the artifact by `run-id` and posts via reviewdog with
+1. **Collect** (`pull_request`) — unprivileged. Run the linter, write
+   diagnostics to a `*-reviewdog-input` artifact. No `pull-requests: write`.
+2. **Report** (`workflow_run` on the collect workflow) — privileged base-repo
+   context. Identify the PR, check out the PR head for the diff (see below),
+   download the artifact by `run-id`, and post via reviewdog with
    `pull-requests: write`.
 
-The privileged workflow may check out the PR head solely so reviewdog can
-resolve `.git` and compute the PR diff for `-filter-mode=added`. Treat
-artifacts as untrusted data (pipe text into reviewdog only). Do not execute
-the PR head or artifact payloads.
+| Collect (`pull_request`) | Report (`workflow_run`) | Tools |
+| ------------------------ | ----------------------- | ----- |
+| Cargo | Clippy report | clippy |
+| Actions lint | Actions lint report | actionlint, prettier |
+| Shell | Shell report | shellcheck, shfmt |
+| Website | Website report | prettier, eslint, stylelint |
+| Docs lint | Docs lint report | rumdl |
+
+New reviewdog jobs must follow the same collect/report pair. Keep
+`pull-requests: write` on the report workflow only.
+
+### Privileged checkout and trust
+
+The report workflow may check out the PR head (and fetch the base ref) solely
+so reviewdog can resolve `.git` and compute the PR diff for
+`-filter-mode=added`. That is safe for this use case: the privileged job must
+not build, install, or otherwise execute code from the fork or from artifact
+payloads. Artifacts are untrusted text only — pipe diagnostics into reviewdog
+and nothing else.
 
 ## Action pinning
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Updates the Fork PR reviewdog section in `.github/workflows/AGENTS.md` from a clippy-only description to the general collect/`workflow_run` report pattern.

- Lists collect/report pairs for Cargo, Actions lint, Shell, Website, and Docs lint
- Restates that artifacts are untrusted text only (pipe into reviewdog)
- Documents that privileged PR-head checkout is safe for this use case because fork code and artifact payloads are never executed

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0ce5f7ab-b67e-4193-bd2b-a81a8d14e583"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0ce5f7ab-b67e-4193-bd2b-a81a8d14e583"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

