### PR TITLE
ci: allow unsafe fork PR checkout for clippy report

### DIFF
--- a/.github/workflows/AGENTS.md
+++ b/.github/workflows/AGENTS.md
@@ -74,6 +74,12 @@ resolve `.git` and compute the PR diff for `-filter-mode=added`. Treat
 artifacts as untrusted data (pipe text into reviewdog only). Do not execute
 the PR head or artifact payloads.
 
+`actions/checkout` v7+ refuses fork PR heads on `workflow_run` unless
+`allow-unsafe-pr-checkout: true` is set. Opt in only when the checked-out
+tree is never executed (data for reviewdog / `git` diff only), and keep
+`persist-credentials: false`. See
+https://gh.io/securely-using-pull_request_target.
+
 ## Action pinning
 
 Pin every third-party action to a full commit SHA with a version comment:

--- a/.github/workflows/clippy-report.yml
+++ b/.github/workflows/clippy-report.yml
@@ -37,12 +37,17 @@ jobs:
           echo "number=$(echo "$PR_JSON" | jq -r .number)" >> "$GITHUB_OUTPUT"
           echo "base_ref=$(echo "$PR_JSON" | jq -r .base_ref)" >> "$GITHUB_OUTPUT"
 
+      # Opt in: checkout v7 blocks fork PR heads on workflow_run by default.
+      # Safe here — we never execute the tree; reviewdog only needs .git/diff.
+      # https://gh.io/securely-using-pull_request_target
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         if: steps.identify-pr.outputs.number
         with:
           repository: ${{ github.event.workflow_run.head_repository.full_name }}
           ref: ${{ github.event.workflow_run.head_sha }}
           fetch-depth: 0
+          persist-credentials: false
+          allow-unsafe-pr-checkout: true
 
       - name: Fetch PR base for merge-base
         if: steps.identify-pr.outputs.number


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes [Clippy report #29](https://github.com/OGKevin/cadmus/actions/runs/30417783584): `actions/checkout` v7 refuses to check out fork PR heads from privileged `workflow_run` jobs unless `allow-unsafe-pr-checkout: true` is set.

This opts in for Clippy report only (needed so reviewdog can compute `-filter-mode=added` diffs). The checked-out tree is never executed; credentials are not persisted; artifacts remain text-only input to reviewdog.

Fork-safe report work in #758 should pick up the same inputs on its shared checkout composite after this lands.

## Test plan

- [ ] Merge and re-run Clippy report for a fork PR (e.g. #706), or push to a fork PR and confirm `post-review` gets past checkout
- [ ] Confirm same-repo PRs still get Clippy reviews as before

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fac36-9751-7a7b-ba98-1946780e5c60"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fac36-9751-7a7b-ba98-1946780e5c60"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

