### PR TITLE
feat(wifi): query IP/ESSID via dhcpcd-dbus

### DIFF
--- a/.github/workflows/build-release-candidate.yml
+++ b/.github/workflows/build-release-candidate.yml
@@ -68,7 +68,6 @@ jobs:
           subject-path: |
             dist/cadmus
             dist/*.sh
-            dist/scripts/*
             dist/libs/*.so*
             dist/bin/*
             release-artifacts/*.tgz

--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -552,7 +552,6 @@ jobs:
           subject-path: |
             dist/cadmus
             dist/*.sh
-            dist/scripts/*
             dist/libs/*.so*
             dist/bin/*
             release-artifacts/*.tgz

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,7 +96,6 @@ jobs:
           subject-path: |
             dist/cadmus
             dist/*.sh
-            dist/scripts/*
             dist/libs/*.so*
             dist/bin/*
             release-artifacts/*.tgz

--- a/crates/cadmus/src/app.rs
+++ b/crates/cadmus/src/app.rs
@@ -6,6 +6,7 @@ use cadmus_core::device::AppContext;
 use cadmus_core::device::AppDevice;
 use cadmus_core::device::DeviceHardware as _;
 use cadmus_core::device::DeviceRotation as _;
+use cadmus_core::device::wifi::WifiManager;
 use cadmus_core::device::{
     DeviceIdentity, DeviceInput, DeviceLifecycle, DevicePaths, DeviceRuntime, DeviceTask,
     ExitStatus, HistoryItem, InputSource,
@@ -487,7 +488,17 @@ pub fn run() -> Result<(), Error> {
             }
             Event::Select(EntryId::SystemInfo) => {
                 view.children_mut().retain(|child| !child.is::<Menu>());
-                let html = sys_info_as_html(context.device.model(), context.device.mark());
+                let network = context
+                    .device
+                    .wifi_manager()
+                    .and_then(|wifi| wifi.network_info())
+                    .ok()
+                    .flatten();
+                let html = sys_info_as_html(
+                    context.device.model(),
+                    context.device.mark(),
+                    network.as_ref(),
+                );
                 let r = Reader::from_html(
                     context.device.framebuffer().rect(),
                     &html,

--- a/crates/cadmus/src/app.rs
+++ b/crates/cadmus/src/app.rs
@@ -492,6 +492,9 @@ pub fn run() -> Result<(), Error> {
                     .device
                     .wifi_manager()
                     .and_then(|wifi| wifi.network_info())
+                    .inspect_err(|e| {
+                        tracing::warn!(error = %e, "no network info for system info");
+                    })
                     .ok()
                     .flatten();
                 let html = sys_info_as_html(

--- a/crates/core/build.rs
+++ b/crates/core/build.rs
@@ -35,7 +35,6 @@ const BUNDLED_ASSET_DIRS: &[&str] = &[
     "icons",
     "keyboard-layouts",
     "resources",
-    "scripts",
 ];
 
 /// Set this to any changing value to force build metadata to refresh.

--- a/crates/core/src/db/backup.rs
+++ b/crates/core/src/db/backup.rs
@@ -606,7 +606,7 @@ unsafe fn sqlite_error_message(db: *mut libsqlite3_sys::sqlite3) -> String {
 mod tests {
     use super::*;
     use crate::db::Database;
-    use crate::db::runtime::RUNTIME;
+    use crate::runtime::RUNTIME;
     use std::str::FromStr;
 
     #[test]

--- a/crates/core/src/db/mod.rs
+++ b/crates/core/src/db/mod.rs
@@ -1,12 +1,11 @@
 pub mod backup;
 pub mod migrations;
-pub mod runtime;
 pub mod types;
 pub mod version;
 
+use crate::runtime::RUNTIME;
 use anyhow::{Context, Error};
 use log::LevelFilter;
-use runtime::RUNTIME;
 use sqlx::ConnectOptions;
 use sqlx::sqlite::{SqliteConnectOptions, SqlitePool, SqlitePoolOptions};
 use std::path::{Path, PathBuf};

--- a/crates/core/src/db/runtime.rs
+++ b/crates/core/src/db/runtime.rs
@@ -1,8 +1,0 @@
-use once_cell::sync::Lazy;
-use tokio::runtime::Runtime;
-
-/// Global lazy-initialized Tokio runtime for database operations.
-pub static RUNTIME: Lazy<Runtime> = Lazy::new(|| {
-    tracing::info!("initializing global Tokio runtime for database operations");
-    Runtime::new().expect("failed to create Tokio runtime for database operations")
-});

--- a/crates/core/src/db/version.rs
+++ b/crates/core/src/db/version.rs
@@ -195,7 +195,7 @@ pub async fn check_version_gate(
 mod tests {
     use super::*;
     use crate::db::Database;
-    use crate::db::runtime::RUNTIME;
+    use crate::runtime::RUNTIME;
     use crate::version::get_current_version;
 
     fn different_migration_hash() -> MigrationHash {

--- a/crates/core/src/device/emulator/wifi.rs
+++ b/crates/core/src/device/emulator/wifi.rs
@@ -1,4 +1,4 @@
-use crate::device::wifi::{WifiError, WifiManager};
+use crate::device::wifi::{NetworkInfo, WifiError, WifiManager};
 
 pub struct EmulatorWifiManager;
 
@@ -9,5 +9,16 @@ impl WifiManager for EmulatorWifiManager {
 
     fn disable(&self) -> Result<(), WifiError> {
         unimplemented!("Emulator doesn't support WiFi");
+    }
+
+    fn is_enabled(&self) -> bool {
+        false
+    }
+
+    fn network_info(&self) -> Result<Option<NetworkInfo>, WifiError> {
+        if !self.is_enabled() {
+            return Err(WifiError::Disabled);
+        }
+        Ok(None)
     }
 }

--- a/crates/core/src/device/kobo/lifecycle/device_events.rs
+++ b/crates/core/src/device/kobo/lifecycle/device_events.rs
@@ -142,7 +142,7 @@ fn handle_net_up(
                 .ok();
         }
         Ok(None) => {
-            tracing::warn!("network up but Wi-Fi has no current association");
+            tracing::debug!("network up but Wi-Fi has no current association");
         }
         Err(e) => {
             tracing::warn!(error = %e, "failed to query network info on NetUp");

--- a/crates/core/src/device/kobo/lifecycle/device_events.rs
+++ b/crates/core/src/device/kobo/lifecycle/device_events.rs
@@ -4,14 +4,15 @@ use super::super::input::BATTERY_REFRESH_INTERVAL;
 use super::helpers::{cancel_suspend_if_pending, has_task, is_suspend_active};
 use super::usb_share::disable_usb_share;
 use super::{begin_suspend, schedule_device_task};
+use crate::device::DeviceHardware as _;
 use crate::device::DeviceRotation as _;
+use crate::device::wifi::WifiManager;
 use crate::device::{AppContext, DeviceRuntime, DeviceTaskId, EventOutcome, Orientation};
 use crate::fl;
 use crate::framebuffer::UpdateMode;
 use crate::input::{ButtonCode, ButtonStatus, DeviceEvent, PowerSource};
 use crate::view::dialog::Dialog;
 use crate::view::{EntryId, Event, Hub, NotificationEvent, RenderData, RenderQueue, View, ViewId};
-use std::process::Command;
 use std::time::Instant;
 
 /// Dispatches a lifecycle [`Event`] to the appropriate device-input handler.
@@ -126,25 +127,27 @@ fn handle_net_up(
         return EventOutcome::Handled;
     }
 
-    let ip = Command::new("scripts/ip.sh")
-        .output()
-        .map(|output| {
-            String::from_utf8_lossy(&output.stdout)
-                .trim_end()
-                .to_string()
-        })
-        .unwrap_or_default();
-    let essid = Command::new("scripts/essid.sh")
-        .output()
-        .map(|output| {
-            String::from_utf8_lossy(&output.stdout)
-                .trim_end()
-                .to_string()
-        })
-        .unwrap_or_default();
-    let msg = fl!("notification-network-up", ip = ip, essid = essid);
-    hub.send(Event::Notification(NotificationEvent::Show(msg)))
-        .ok();
+    match context
+        .device
+        .wifi_manager()
+        .and_then(|wifi| wifi.network_info())
+    {
+        Ok(Some(info)) => {
+            let msg = fl!(
+                "notification-network-up",
+                ip = info.ip.to_string(),
+                essid = info.essid.to_string()
+            );
+            hub.send(Event::Notification(NotificationEvent::Show(msg)))
+                .ok();
+        }
+        Ok(None) => {
+            tracing::warn!("network up but Wi-Fi has no current association");
+        }
+        Err(e) => {
+            tracing::warn!(error = %e, "failed to query network info on NetUp");
+        }
+    }
 
     context.online = true;
     EventOutcome::Continue
@@ -397,16 +400,80 @@ mod tests {
 
     #[test]
     fn handle_net_up_sets_online_and_shows_notification() {
+        use crate::device::wifi::{Essid, NetworkInfo};
+        use crate::fl;
+        use std::net::{IpAddr, Ipv4Addr};
+
         let mut harness = LifecycleHarness::new();
+        let ip = IpAddr::V4(Ipv4Addr::new(192, 168, 1, 128));
+        let essid = Essid::new("TestNet");
+        harness
+            .context
+            .device
+            .wifi_manager_for_test()
+            .set_network_info(Ok(Some(NetworkInfo {
+                ip,
+                essid: essid.clone(),
+            })));
+
+        let outcome = harness
+            .with_parts(|hub, _bus, _rq, context, runtime| handle_net_up(hub, context, runtime));
+        assert_eq!(outcome, EventOutcome::Continue);
+        assert!(harness.context.online);
+
+        let expected = fl!(
+            "notification-network-up",
+            ip = ip.to_string(),
+            essid = essid.to_string()
+        );
+        let events = harness.drain_hub();
+        assert!(events.iter().any(|event| {
+            matches!(
+                event,
+                Event::Notification(NotificationEvent::Show(msg)) if msg == &expected
+            )
+        }));
+    }
+
+    #[test]
+    fn handle_net_up_online_without_notification_when_no_association() {
+        let mut harness = LifecycleHarness::new();
+        harness
+            .context
+            .device
+            .wifi_manager_for_test()
+            .set_network_info(Ok(None));
+
         let outcome = harness
             .with_parts(|hub, _bus, _rq, context, runtime| handle_net_up(hub, context, runtime));
         assert_eq!(outcome, EventOutcome::Continue);
         assert!(harness.context.online);
         assert!(
-            harness
+            !harness
                 .drain_hub()
                 .iter()
-                .any(|event| matches!(event, Event::Notification(NotificationEvent::Show(_))))
+                .any(|event| matches!(event, Event::Notification(_)))
+        );
+    }
+
+    #[test]
+    fn handle_net_up_online_without_notification_when_disabled() {
+        let mut harness = LifecycleHarness::new();
+        harness
+            .context
+            .device
+            .wifi_manager_for_test()
+            .set_network_info(Err(crate::device::wifi::WifiError::Disabled));
+
+        let outcome = harness
+            .with_parts(|hub, _bus, _rq, context, runtime| handle_net_up(hub, context, runtime));
+        assert_eq!(outcome, EventOutcome::Continue);
+        assert!(harness.context.online);
+        assert!(
+            !harness
+                .drain_hub()
+                .iter()
+                .any(|event| matches!(event, Event::Notification(_)))
         );
     }
 

--- a/crates/core/src/device/kobo/wifi/dhcpcd.rs
+++ b/crates/core/src/device/kobo/wifi/dhcpcd.rs
@@ -2,12 +2,16 @@
 
 use std::collections::HashMap;
 use std::net::{IpAddr, Ipv4Addr};
+use std::time::Duration;
 
 use crate::device::wifi::{Essid, NetworkInfo, WifiError};
 
-const DHCPCCD_SERVICE: &str = "name.marples.roy.dhcpcd";
-const DHCPCCD_PATH: &str = "/name/marples/roy/dhcpcd";
-const DHCPCCD_INTERFACE: &str = "name.marples.roy.dhcpcd";
+const DHCPCD_SERVICE: &str = "name.marples.roy.dhcpcd";
+const DHCPCD_PATH: &str = "/name/marples/roy/dhcpcd";
+const DHCPCD_INTERFACE: &str = "name.marples.roy.dhcpcd";
+
+/// Reply / overall deadline for dhcpcd-dbus method calls.
+const DHCPCD_METHOD_TIMEOUT: Duration = Duration::from_secs(5);
 
 /// dhcpcd-dbus method: returns interface status maps including `IPAddress`.
 const METHOD_GET_INTERFACES: &str = "GetInterfaces";
@@ -37,12 +41,11 @@ pub(crate) struct ListedNetwork {
     pub flags: String,
 }
 
-pub(crate) trait DhcpcdClient {
-    fn get_interfaces(&self) -> Result<InterfaceIpMap, WifiError>;
-    fn list_networks(&self, interface: &str) -> Result<Vec<ListedNetwork>, WifiError>;
-}
-
-/// Converts a host-endian dhcpcd `IPAddress` u32 to [`Ipv4Addr`].
+/// Converts a dhcpcd `IPAddress` `u32` (native/host byte order) to [`Ipv4Addr`].
+///
+/// dhcpcd encodes the address from an `in_addr` on the device, so decode with
+/// [`u32::to_ne_bytes`]. Kobo targets are little-endian; the sample below holds
+/// on LE hosts only.
 ///
 /// Device example: `2147592384` → `192.168.1.128`.
 #[cfg_attr(feature = "tracing", tracing::instrument(ret(level = tracing::Level::TRACE)))]
@@ -59,28 +62,17 @@ pub(crate) fn current_essid(networks: &[ListedNetwork]) -> Option<Essid> {
         .map(|n| Essid::new(n.ssid.clone()))
 }
 
-/// Assembles [`NetworkInfo`] from a mockable dhcpcd client.
-///
-/// The caller must ensure Wi-Fi is enabled before invoking this; disabled
-/// radio is [`WifiError::Disabled`] at the [`WifiManager`](crate::device::wifi::WifiManager)
-/// boundary, not here.
-#[cfg_attr(
-    feature = "tracing",
-    tracing::instrument(skip(client), fields(interface), ret)
-)]
-pub(crate) fn network_info_with_client(
-    interface: &str,
-    client: &dyn DhcpcdClient,
-) -> Result<Option<NetworkInfo>, WifiError> {
-    tracing::debug!(interface, "listing networks via dhcpcd-dbus");
-    let networks = client.list_networks(interface)?;
-    let Some(essid) = current_essid(&networks) else {
-        tracing::debug!(interface, "no current network");
-        return Ok(None);
-    };
+/// Queries dhcpcd-dbus on one system-bus connection (list + get interfaces).
+#[cfg_attr(feature = "tracing", tracing::instrument(fields(interface), ret))]
+pub(crate) fn network_info_from_zbus(interface: &str) -> Result<Option<NetworkInfo>, WifiError> {
+    block_on_with_timeout(network_info_zbus_async(interface))
+}
 
-    tracing::debug!(interface, essid = %essid, "fetching interfaces via dhcpcd-dbus");
-    let ifaces = client.get_interfaces()?;
+fn assemble_network_info(
+    interface: &str,
+    essid: &Essid,
+    ifaces: &InterfaceIpMap,
+) -> Result<NetworkInfo, WifiError> {
     let Some(&host_ip) = ifaces.get(interface) else {
         tracing::warn!(
             interface,
@@ -94,39 +86,45 @@ pub(crate) fn network_info_with_client(
 
     let ip = IpAddr::V4(ipv4_from_host_u32(host_ip));
     tracing::debug!(interface, ip = %ip, essid = %essid, "assembled network info");
-    Ok(Some(NetworkInfo { ip, essid }))
+    Ok(NetworkInfo {
+        ip,
+        essid: essid.clone(),
+    })
 }
 
-#[derive(Debug)]
-pub(crate) struct ZbusDhcpcdClient;
-
-impl DhcpcdClient for ZbusDhcpcdClient {
-    #[cfg_attr(feature = "tracing", tracing::instrument(ret))]
-    fn get_interfaces(&self) -> Result<InterfaceIpMap, WifiError> {
-        crate::runtime::RUNTIME.block_on(get_interfaces_async())
-    }
-
-    #[cfg_attr(feature = "tracing", tracing::instrument(ret))]
-    fn list_networks(&self, interface: &str) -> Result<Vec<ListedNetwork>, WifiError> {
-        crate::runtime::RUNTIME.block_on(list_networks_async(interface))
-    }
+fn block_on_with_timeout<F, T>(fut: F) -> Result<T, WifiError>
+where
+    F: std::future::Future<Output = Result<T, WifiError>>,
+{
+    crate::runtime::RUNTIME.block_on(async {
+        tokio::time::timeout(DHCPCD_METHOD_TIMEOUT, fut)
+            .await
+            .map_err(|_| {
+                WifiError::Dbus(format!(
+                    "dhcpcd-dbus timed out after {}s",
+                    DHCPCD_METHOD_TIMEOUT.as_secs()
+                ))
+            })?
+    })
 }
 
-#[cfg_attr(feature = "tracing", tracing::instrument(ret))]
-async fn get_interfaces_async() -> Result<InterfaceIpMap, WifiError> {
-    tracing::debug!(method = METHOD_GET_INTERFACES, "connecting to system bus");
-    let connection = zbus::Connection::system()
+async fn dhcpcd_connection() -> Result<zbus::Connection, WifiError> {
+    tracing::debug!("connecting to system bus for dhcpcd-dbus");
+    zbus::connection::Builder::system()
+        .map_err(|e| WifiError::Dbus(format!("system bus builder: {e}")))?
+        .method_timeout(DHCPCD_METHOD_TIMEOUT)
+        .build()
         .await
-        .map_err(|e| WifiError::Dbus(format!("system bus connect: {e}")))?;
-    let proxy = zbus::Proxy::new(
-        &connection,
-        DHCPCCD_SERVICE,
-        DHCPCCD_PATH,
-        DHCPCCD_INTERFACE,
-    )
-    .await
-    .map_err(|e| WifiError::Dbus(format!("dhcpcd proxy: {e}")))?;
+        .map_err(|e| WifiError::Dbus(format!("system bus connect: {e}")))
+}
 
+async fn dhcpcd_proxy<'a>(connection: &'a zbus::Connection) -> Result<zbus::Proxy<'a>, WifiError> {
+    zbus::Proxy::new(connection, DHCPCD_SERVICE, DHCPCD_PATH, DHCPCD_INTERFACE)
+        .await
+        .map_err(|e| WifiError::Dbus(format!("dhcpcd proxy: {e}")))
+}
+
+async fn get_interfaces_with_proxy(proxy: &zbus::Proxy<'_>) -> Result<InterfaceIpMap, WifiError> {
     let raw: HashMap<String, HashMap<String, zbus::zvariant::OwnedValue>> = proxy
         .call(METHOD_GET_INTERFACES, &())
         .await
@@ -148,25 +146,10 @@ async fn get_interfaces_async() -> Result<InterfaceIpMap, WifiError> {
     Ok(map)
 }
 
-#[cfg_attr(feature = "tracing", tracing::instrument(ret))]
-async fn list_networks_async(interface: &str) -> Result<Vec<ListedNetwork>, WifiError> {
-    tracing::debug!(
-        method = METHOD_LIST_NETWORKS,
-        interface,
-        "connecting to system bus"
-    );
-    let connection = zbus::Connection::system()
-        .await
-        .map_err(|e| WifiError::Dbus(format!("system bus connect: {e}")))?;
-    let proxy = zbus::Proxy::new(
-        &connection,
-        DHCPCCD_SERVICE,
-        DHCPCCD_PATH,
-        DHCPCCD_INTERFACE,
-    )
-    .await
-    .map_err(|e| WifiError::Dbus(format!("dhcpcd proxy: {e}")))?;
-
+async fn list_networks_with_proxy(
+    proxy: &zbus::Proxy<'_>,
+    interface: &str,
+) -> Result<Vec<ListedNetwork>, WifiError> {
     let rows: Vec<(i32, String, String, String)> = proxy
         .call(METHOD_LIST_NETWORKS, &(interface,))
         .await
@@ -185,45 +168,29 @@ async fn list_networks_async(interface: &str) -> Result<Vec<ListedNetwork>, Wifi
     Ok(networks)
 }
 
+#[cfg_attr(feature = "tracing", tracing::instrument(fields(interface), ret))]
+async fn network_info_zbus_async(interface: &str) -> Result<Option<NetworkInfo>, WifiError> {
+    tracing::debug!(
+        interface,
+        "querying network info on one dhcpcd-dbus connection"
+    );
+    let connection = dhcpcd_connection().await?;
+    let proxy = dhcpcd_proxy(&connection).await?;
+
+    let networks = list_networks_with_proxy(&proxy, interface).await?;
+    let Some(essid) = current_essid(&networks) else {
+        tracing::debug!(interface, "no current network");
+        return Ok(None);
+    };
+
+    let ifaces = get_interfaces_with_proxy(&proxy).await?;
+    Ok(Some(assemble_network_info(interface, &essid, &ifaces)?))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::cell::RefCell;
     use std::net::Ipv4Addr;
-
-    struct MockDhcpcd {
-        interfaces: Result<InterfaceIpMap, WifiError>,
-        networks: Result<Vec<ListedNetwork>, WifiError>,
-        list_calls: RefCell<u32>,
-        get_calls: RefCell<u32>,
-    }
-
-    impl DhcpcdClient for MockDhcpcd {
-        fn get_interfaces(&self) -> Result<InterfaceIpMap, WifiError> {
-            *self.get_calls.borrow_mut() += 1;
-            match &self.interfaces {
-                Ok(m) => Ok(m.clone()),
-                Err(e) => Err(clone_err(e)),
-            }
-        }
-
-        fn list_networks(&self, _interface: &str) -> Result<Vec<ListedNetwork>, WifiError> {
-            *self.list_calls.borrow_mut() += 1;
-            match &self.networks {
-                Ok(n) => Ok(n.clone()),
-                Err(e) => Err(clone_err(e)),
-            }
-        }
-    }
-
-    fn clone_err(e: &WifiError) -> WifiError {
-        match e {
-            WifiError::Disabled => WifiError::Disabled,
-            WifiError::Dbus(s) => WifiError::Dbus(s.clone()),
-            WifiError::Incomplete(s) => WifiError::Incomplete(s.clone()),
-            other => WifiError::Dbus(other.to_string()),
-        }
-    }
 
     fn network(id: i32, ssid: &str, flags: &str) -> ListedNetwork {
         ListedNetwork {
@@ -272,65 +239,21 @@ mod tests {
     }
 
     #[test]
-    fn assembly_ok_some_when_both_present() {
+    fn assemble_ok_when_ip_present() {
         let mut ifaces = InterfaceIpMap::new();
         ifaces.insert("wlan0".to_string(), 2147592384);
-        let client = MockDhcpcd {
-            interfaces: Ok(ifaces),
-            networks: Ok(vec![network(0, "Home", NETWORK_FLAG_CURRENT)]),
-            list_calls: RefCell::new(0),
-            get_calls: RefCell::new(0),
-        };
-        let info = network_info_with_client("wlan0", &client)
-            .unwrap()
-            .expect("Some");
+        let essid = Essid::new("Home");
+        let info = assemble_network_info("wlan0", &essid, &ifaces).unwrap();
         assert_eq!(info.ip, IpAddr::V4(Ipv4Addr::new(192, 168, 1, 128)));
         assert_eq!(info.essid.as_str(), "Home");
-        assert_eq!(*client.list_calls.borrow(), 1);
-        assert_eq!(*client.get_calls.borrow(), 1);
     }
 
     #[test]
-    fn assembly_ok_none_when_no_current() {
-        let client = MockDhcpcd {
-            interfaces: Ok(InterfaceIpMap::new()),
-            networks: Ok(vec![network(0, "Guest", "[DISABLED]")]),
-            list_calls: RefCell::new(0),
-            get_calls: RefCell::new(0),
-        };
-        assert!(
-            network_info_with_client("wlan0", &client)
-                .unwrap()
-                .is_none()
-        );
-        assert_eq!(*client.get_calls.borrow(), 0);
-    }
-
-    #[test]
-    fn assembly_err_when_current_without_ip() {
-        let client = MockDhcpcd {
-            interfaces: Ok(InterfaceIpMap::new()),
-            networks: Ok(vec![network(0, "Home", NETWORK_FLAG_CURRENT)]),
-            list_calls: RefCell::new(0),
-            get_calls: RefCell::new(0),
-        };
+    fn assemble_err_when_ip_missing() {
+        let essid = Essid::new("Home");
         assert!(matches!(
-            network_info_with_client("wlan0", &client),
+            assemble_network_info("wlan0", &essid, &InterfaceIpMap::new()),
             Err(WifiError::Incomplete(_))
-        ));
-    }
-
-    #[test]
-    fn assembly_err_on_dbus_failure() {
-        let client = MockDhcpcd {
-            interfaces: Ok(InterfaceIpMap::new()),
-            networks: Err(WifiError::Dbus("boom".into())),
-            list_calls: RefCell::new(0),
-            get_calls: RefCell::new(0),
-        };
-        assert!(matches!(
-            network_info_with_client("wlan0", &client),
-            Err(WifiError::Dbus(_))
         ));
     }
 }

--- a/crates/core/src/device/kobo/wifi/dhcpcd.rs
+++ b/crates/core/src/device/kobo/wifi/dhcpcd.rs
@@ -1,0 +1,336 @@
+//! dhcpcd-dbus client for querying interface IP and current ESSID.
+
+use std::collections::HashMap;
+use std::net::{IpAddr, Ipv4Addr};
+
+use crate::device::wifi::{Essid, NetworkInfo, WifiError};
+
+const DHCPCCD_SERVICE: &str = "name.marples.roy.dhcpcd";
+const DHCPCCD_PATH: &str = "/name/marples/roy/dhcpcd";
+const DHCPCCD_INTERFACE: &str = "name.marples.roy.dhcpcd";
+
+/// dhcpcd-dbus method: returns interface status maps including `IPAddress`.
+const METHOD_GET_INTERFACES: &str = "GetInterfaces";
+
+/// dhcpcd-dbus method: lists configured WPA networks for an interface.
+///
+/// Each row is `(id, ssid, bssid, flags)`; the associated network’s flags
+/// contain [`NETWORK_FLAG_CURRENT`].
+const METHOD_LIST_NETWORKS: &str = "ListNetworks";
+
+/// Property key in a `GetInterfaces` status map for the leased IPv4 address
+/// (host-endian `u32`).
+const PROP_IP_ADDRESS: &str = "IPAddress";
+
+/// Flag substring in a `ListNetworks` flags field for the associated network.
+const NETWORK_FLAG_CURRENT: &str = "[CURRENT]";
+
+/// Interface name → host-endian [`PROP_IP_ADDRESS`] u32 from [`METHOD_GET_INTERFACES`].
+pub(crate) type InterfaceIpMap = HashMap<String, u32>;
+
+/// One row from dhcpcd-dbus [`METHOD_LIST_NETWORKS`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ListedNetwork {
+    pub id: i32,
+    pub ssid: String,
+    pub bssid: String,
+    pub flags: String,
+}
+
+pub(crate) trait DhcpcdClient {
+    fn get_interfaces(&self) -> Result<InterfaceIpMap, WifiError>;
+    fn list_networks(&self, interface: &str) -> Result<Vec<ListedNetwork>, WifiError>;
+}
+
+/// Converts a host-endian dhcpcd `IPAddress` u32 to [`Ipv4Addr`].
+///
+/// Device example: `2147592384` → `192.168.1.128`.
+#[cfg_attr(feature = "tracing", tracing::instrument(ret(level = tracing::Level::TRACE)))]
+pub(crate) fn ipv4_from_host_u32(host: u32) -> Ipv4Addr {
+    Ipv4Addr::from(host.to_ne_bytes())
+}
+
+/// Returns the ESSID of the first network whose flags contain [`NETWORK_FLAG_CURRENT`].
+#[cfg_attr(feature = "tracing", tracing::instrument(skip(networks), ret(level = tracing::Level::TRACE)))]
+pub(crate) fn current_essid(networks: &[ListedNetwork]) -> Option<Essid> {
+    networks
+        .iter()
+        .find(|n| n.flags.contains(NETWORK_FLAG_CURRENT))
+        .map(|n| Essid::new(n.ssid.clone()))
+}
+
+/// Assembles [`NetworkInfo`] from a mockable dhcpcd client.
+///
+/// The caller must ensure Wi-Fi is enabled before invoking this; disabled
+/// radio is [`WifiError::Disabled`] at the [`WifiManager`](crate::device::wifi::WifiManager)
+/// boundary, not here.
+#[cfg_attr(
+    feature = "tracing",
+    tracing::instrument(skip(client), fields(interface), ret)
+)]
+pub(crate) fn network_info_with_client(
+    interface: &str,
+    client: &dyn DhcpcdClient,
+) -> Result<Option<NetworkInfo>, WifiError> {
+    tracing::debug!(interface, "listing networks via dhcpcd-dbus");
+    let networks = client.list_networks(interface)?;
+    let Some(essid) = current_essid(&networks) else {
+        tracing::debug!(interface, "no current network");
+        return Ok(None);
+    };
+
+    tracing::debug!(interface, essid = %essid, "fetching interfaces via dhcpcd-dbus");
+    let ifaces = client.get_interfaces()?;
+    let Some(&host_ip) = ifaces.get(interface) else {
+        tracing::warn!(
+            interface,
+            essid = %essid,
+            "current network without IP address"
+        );
+        return Err(WifiError::Incomplete(format!(
+            "interface {interface} has {NETWORK_FLAG_CURRENT} network but no {PROP_IP_ADDRESS}"
+        )));
+    };
+
+    let ip = IpAddr::V4(ipv4_from_host_u32(host_ip));
+    tracing::debug!(interface, ip = %ip, essid = %essid, "assembled network info");
+    Ok(Some(NetworkInfo { ip, essid }))
+}
+
+#[derive(Debug)]
+pub(crate) struct ZbusDhcpcdClient;
+
+impl DhcpcdClient for ZbusDhcpcdClient {
+    #[cfg_attr(feature = "tracing", tracing::instrument(ret))]
+    fn get_interfaces(&self) -> Result<InterfaceIpMap, WifiError> {
+        crate::runtime::RUNTIME.block_on(get_interfaces_async())
+    }
+
+    #[cfg_attr(feature = "tracing", tracing::instrument(ret))]
+    fn list_networks(&self, interface: &str) -> Result<Vec<ListedNetwork>, WifiError> {
+        crate::runtime::RUNTIME.block_on(list_networks_async(interface))
+    }
+}
+
+#[cfg_attr(feature = "tracing", tracing::instrument(ret))]
+async fn get_interfaces_async() -> Result<InterfaceIpMap, WifiError> {
+    tracing::debug!(method = METHOD_GET_INTERFACES, "connecting to system bus");
+    let connection = zbus::Connection::system()
+        .await
+        .map_err(|e| WifiError::Dbus(format!("system bus connect: {e}")))?;
+    let proxy = zbus::Proxy::new(
+        &connection,
+        DHCPCCD_SERVICE,
+        DHCPCCD_PATH,
+        DHCPCCD_INTERFACE,
+    )
+    .await
+    .map_err(|e| WifiError::Dbus(format!("dhcpcd proxy: {e}")))?;
+
+    let raw: HashMap<String, HashMap<String, zbus::zvariant::OwnedValue>> = proxy
+        .call(METHOD_GET_INTERFACES, &())
+        .await
+        .map_err(|e| WifiError::Dbus(format!("{METHOD_GET_INTERFACES}: {e}")))?;
+
+    let mut map = InterfaceIpMap::new();
+    for (iface, props) in raw {
+        if let Some(value) = props.get(PROP_IP_ADDRESS)
+            && let Ok(host) = u32::try_from(value)
+        {
+            map.insert(iface, host);
+        }
+    }
+    tracing::debug!(
+        method = METHOD_GET_INTERFACES,
+        count = map.len(),
+        "parsed interface addresses"
+    );
+    Ok(map)
+}
+
+#[cfg_attr(feature = "tracing", tracing::instrument(ret))]
+async fn list_networks_async(interface: &str) -> Result<Vec<ListedNetwork>, WifiError> {
+    tracing::debug!(
+        method = METHOD_LIST_NETWORKS,
+        interface,
+        "connecting to system bus"
+    );
+    let connection = zbus::Connection::system()
+        .await
+        .map_err(|e| WifiError::Dbus(format!("system bus connect: {e}")))?;
+    let proxy = zbus::Proxy::new(
+        &connection,
+        DHCPCCD_SERVICE,
+        DHCPCCD_PATH,
+        DHCPCCD_INTERFACE,
+    )
+    .await
+    .map_err(|e| WifiError::Dbus(format!("dhcpcd proxy: {e}")))?;
+
+    let rows: Vec<(i32, String, String, String)> = proxy
+        .call(METHOD_LIST_NETWORKS, &(interface,))
+        .await
+        .map_err(|e| WifiError::Dbus(format!("{METHOD_LIST_NETWORKS}: {e}")))?;
+
+    let networks = rows
+        .into_iter()
+        .map(|(id, ssid, bssid, flags)| ListedNetwork {
+            id,
+            ssid,
+            bssid,
+            flags,
+        })
+        .collect();
+    tracing::debug!(method = METHOD_LIST_NETWORKS, interface, "succeeded");
+    Ok(networks)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::cell::RefCell;
+    use std::net::Ipv4Addr;
+
+    struct MockDhcpcd {
+        interfaces: Result<InterfaceIpMap, WifiError>,
+        networks: Result<Vec<ListedNetwork>, WifiError>,
+        list_calls: RefCell<u32>,
+        get_calls: RefCell<u32>,
+    }
+
+    impl DhcpcdClient for MockDhcpcd {
+        fn get_interfaces(&self) -> Result<InterfaceIpMap, WifiError> {
+            *self.get_calls.borrow_mut() += 1;
+            match &self.interfaces {
+                Ok(m) => Ok(m.clone()),
+                Err(e) => Err(clone_err(e)),
+            }
+        }
+
+        fn list_networks(&self, _interface: &str) -> Result<Vec<ListedNetwork>, WifiError> {
+            *self.list_calls.borrow_mut() += 1;
+            match &self.networks {
+                Ok(n) => Ok(n.clone()),
+                Err(e) => Err(clone_err(e)),
+            }
+        }
+    }
+
+    fn clone_err(e: &WifiError) -> WifiError {
+        match e {
+            WifiError::Disabled => WifiError::Disabled,
+            WifiError::Dbus(s) => WifiError::Dbus(s.clone()),
+            WifiError::Incomplete(s) => WifiError::Incomplete(s.clone()),
+            other => WifiError::Dbus(other.to_string()),
+        }
+    }
+
+    fn network(id: i32, ssid: &str, flags: &str) -> ListedNetwork {
+        ListedNetwork {
+            id,
+            ssid: ssid.to_string(),
+            bssid: "any".to_string(),
+            flags: flags.to_string(),
+        }
+    }
+
+    #[test]
+    fn ipv4_from_host_u32_decodes_device_sample() {
+        assert_eq!(
+            ipv4_from_host_u32(2147592384),
+            Ipv4Addr::new(192, 168, 1, 128)
+        );
+    }
+
+    #[test]
+    fn current_essid_finds_current_flag() {
+        let networks = vec![
+            network(0, "Guest", "[DISABLED]"),
+            network(1, "Home", NETWORK_FLAG_CURRENT),
+            network(2, "Other", ""),
+        ];
+        assert_eq!(
+            current_essid(&networks).as_ref().map(Essid::as_str),
+            Some("Home")
+        );
+    }
+
+    #[test]
+    fn current_essid_none_when_no_current() {
+        let networks = vec![network(0, "Guest", "[DISABLED]")];
+        assert!(current_essid(&networks).is_none());
+    }
+
+    #[test]
+    fn current_essid_none_on_empty_list() {
+        assert!(current_essid(&[]).is_none());
+    }
+
+    #[test]
+    fn essid_display() {
+        assert_eq!(Essid::new("Cafe").to_string(), "Cafe");
+    }
+
+    #[test]
+    fn assembly_ok_some_when_both_present() {
+        let mut ifaces = InterfaceIpMap::new();
+        ifaces.insert("wlan0".to_string(), 2147592384);
+        let client = MockDhcpcd {
+            interfaces: Ok(ifaces),
+            networks: Ok(vec![network(0, "Home", NETWORK_FLAG_CURRENT)]),
+            list_calls: RefCell::new(0),
+            get_calls: RefCell::new(0),
+        };
+        let info = network_info_with_client("wlan0", &client)
+            .unwrap()
+            .expect("Some");
+        assert_eq!(info.ip, IpAddr::V4(Ipv4Addr::new(192, 168, 1, 128)));
+        assert_eq!(info.essid.as_str(), "Home");
+        assert_eq!(*client.list_calls.borrow(), 1);
+        assert_eq!(*client.get_calls.borrow(), 1);
+    }
+
+    #[test]
+    fn assembly_ok_none_when_no_current() {
+        let client = MockDhcpcd {
+            interfaces: Ok(InterfaceIpMap::new()),
+            networks: Ok(vec![network(0, "Guest", "[DISABLED]")]),
+            list_calls: RefCell::new(0),
+            get_calls: RefCell::new(0),
+        };
+        assert!(
+            network_info_with_client("wlan0", &client)
+                .unwrap()
+                .is_none()
+        );
+        assert_eq!(*client.get_calls.borrow(), 0);
+    }
+
+    #[test]
+    fn assembly_err_when_current_without_ip() {
+        let client = MockDhcpcd {
+            interfaces: Ok(InterfaceIpMap::new()),
+            networks: Ok(vec![network(0, "Home", NETWORK_FLAG_CURRENT)]),
+            list_calls: RefCell::new(0),
+            get_calls: RefCell::new(0),
+        };
+        assert!(matches!(
+            network_info_with_client("wlan0", &client),
+            Err(WifiError::Incomplete(_))
+        ));
+    }
+
+    #[test]
+    fn assembly_err_on_dbus_failure() {
+        let client = MockDhcpcd {
+            interfaces: Ok(InterfaceIpMap::new()),
+            networks: Err(WifiError::Dbus("boom".into())),
+            list_calls: RefCell::new(0),
+            get_calls: RefCell::new(0),
+        };
+        assert!(matches!(
+            network_info_with_client("wlan0", &client),
+            Err(WifiError::Dbus(_))
+        ));
+    }
+}

--- a/crates/core/src/device/kobo/wifi/mod.rs
+++ b/crates/core/src/device/kobo/wifi/mod.rs
@@ -72,7 +72,7 @@ mod types;
 #[cfg(target_os = "linux")]
 use procfs;
 
-use crate::device::kobo::wifi::dhcpcd::{ZbusDhcpcdClient, network_info_with_client};
+use crate::device::kobo::wifi::dhcpcd::network_info_from_zbus;
 use crate::device::kobo::wifi::types::{PowerToggle, WifiModule, WifiModuleConfig};
 use crate::device::wifi::{NetworkInfo, WifiError, WifiManager};
 use nix::ioctl_write_int_bad;
@@ -767,7 +767,7 @@ impl WifiManager for KoboWifiManager {
             );
             return Err(WifiError::Disabled);
         }
-        network_info_with_client(&self.config.interface, &ZbusDhcpcdClient)
+        network_info_from_zbus(&self.config.interface)
     }
 }
 

--- a/crates/core/src/device/kobo/wifi/mod.rs
+++ b/crates/core/src/device/kobo/wifi/mod.rs
@@ -66,13 +66,15 @@
 //! - `mod_para=nxp/wifi_mod_para_sd8987.conf`
 //! - Loading `mlan.ko` dependency before the main module
 
+mod dhcpcd;
 mod types;
 
 #[cfg(target_os = "linux")]
 use procfs;
 
+use crate::device::kobo::wifi::dhcpcd::{ZbusDhcpcdClient, network_info_with_client};
 use crate::device::kobo::wifi::types::{PowerToggle, WifiModule, WifiModuleConfig};
-use crate::device::wifi::{WifiError, WifiManager};
+use crate::device::wifi::{NetworkInfo, WifiError, WifiManager};
 use nix::ioctl_write_int_bad;
 use std::fs;
 use std::os::fd::AsRawFd;
@@ -685,8 +687,7 @@ impl WifiManager for KoboWifiManager {
             .lock()
             .map_err(|e| WifiError::Lock(format!("Failed to acquire lock: {}", e)))?;
 
-        if is_module_loaded(self.config.module.as_ref()) && is_interface_up(&self.config.interface)
-        {
+        if self.is_enabled() {
             info!("WiFi already enabled, skipping");
             return Ok(());
         }
@@ -750,6 +751,23 @@ impl WifiManager for KoboWifiManager {
 
         info!("WiFi disabled successfully");
         Ok(())
+    }
+
+    #[cfg_attr(feature = "tracing", tracing::instrument(skip(self), fields(interface = %self.config.interface), ret))]
+    fn is_enabled(&self) -> bool {
+        is_module_loaded(self.config.module.as_ref()) && is_interface_up(&self.config.interface)
+    }
+
+    #[cfg_attr(feature = "tracing", tracing::instrument(skip(self), fields(interface = %self.config.interface), ret))]
+    fn network_info(&self) -> Result<Option<NetworkInfo>, WifiError> {
+        if !self.is_enabled() {
+            tracing::debug!(
+                interface = %self.config.interface,
+                "Wi-Fi disabled, refusing network_info"
+            );
+            return Err(WifiError::Disabled);
+        }
+        network_info_with_client(&self.config.interface, &ZbusDhcpcdClient)
     }
 }
 

--- a/crates/core/src/device/test_device.rs
+++ b/crates/core/src/device/test_device.rs
@@ -19,17 +19,31 @@ use std::path::PathBuf;
 use std::sync::mpsc::Receiver;
 use std::sync::{Arc, Mutex};
 
-#[derive(Debug, Default)]
+#[derive(Debug)]
 struct TestWifiState {
     enabled: Option<bool>,
     enable_calls: u32,
     disable_calls: u32,
+    network_info: Result<Option<crate::device::wifi::NetworkInfo>, crate::device::wifi::WifiError>,
+}
+
+impl Default for TestWifiState {
+    fn default() -> Self {
+        Self {
+            enabled: None,
+            enable_calls: 0,
+            disable_calls: 0,
+            network_info: Err(crate::device::wifi::WifiError::Disabled),
+        }
+    }
 }
 
 /// Assertable WiFi manager test double.
 ///
 /// Records enable/disable calls for lifecycle and settings tests. Default
 /// behavior is a cooperative no-op that returns `Ok(())`.
+/// [`network_info`](crate::device::wifi::WifiManager::network_info) defaults to
+/// [`WifiError::Disabled`](crate::device::wifi::WifiError::Disabled).
 #[derive(Clone)]
 pub struct TestWifiManager {
     state: Arc<Mutex<TestWifiState>>,
@@ -58,6 +72,25 @@ impl TestWifiManager {
     pub fn was_disable_called(&self) -> bool {
         self.disable_call_count() > 0
     }
+
+    /// Sets the value returned by subsequent [`network_info`](crate::device::wifi::WifiManager::network_info) calls.
+    ///
+    /// [`Ok`] results also mark the manager as enabled so [`is_enabled`](crate::device::wifi::WifiManager::is_enabled)
+    /// matches the stubbed connection state. [`WifiError::Disabled`](crate::device::wifi::WifiError::Disabled)
+    /// marks it disabled.
+    pub fn set_network_info(
+        &self,
+        info: Result<Option<crate::device::wifi::NetworkInfo>, crate::device::wifi::WifiError>,
+    ) {
+        if let Ok(mut state) = self.state.lock() {
+            match &info {
+                Ok(_) => state.enabled = Some(true),
+                Err(crate::device::wifi::WifiError::Disabled) => state.enabled = Some(false),
+                Err(_) => {}
+            }
+            state.network_info = info;
+        }
+    }
 }
 
 impl Default for TestWifiManager {
@@ -81,6 +114,38 @@ impl crate::device::wifi::WifiManager for TestWifiManager {
             state.disable_calls += 1;
         }
         Ok(())
+    }
+
+    fn is_enabled(&self) -> bool {
+        self.state
+            .lock()
+            .ok()
+            .and_then(|s| s.enabled)
+            .unwrap_or(false)
+    }
+
+    fn network_info(
+        &self,
+    ) -> Result<Option<crate::device::wifi::NetworkInfo>, crate::device::wifi::WifiError> {
+        if !self.is_enabled() {
+            return Err(crate::device::wifi::WifiError::Disabled);
+        }
+        let state = self.state.lock().map_err(|e| {
+            crate::device::wifi::WifiError::Lock(format!("Failed to acquire lock: {e}"))
+        })?;
+        match &state.network_info {
+            Ok(info) => Ok(info.clone()),
+            Err(crate::device::wifi::WifiError::Disabled) => {
+                Err(crate::device::wifi::WifiError::Disabled)
+            }
+            Err(crate::device::wifi::WifiError::Dbus(s)) => {
+                Err(crate::device::wifi::WifiError::Dbus(s.clone()))
+            }
+            Err(crate::device::wifi::WifiError::Incomplete(s)) => {
+                Err(crate::device::wifi::WifiError::Incomplete(s.clone()))
+            }
+            Err(other) => Err(crate::device::wifi::WifiError::Dbus(other.to_string())),
+        }
     }
 }
 

--- a/crates/core/src/device/test_device.rs
+++ b/crates/core/src/device/test_device.rs
@@ -135,16 +135,7 @@ impl crate::device::wifi::WifiManager for TestWifiManager {
         })?;
         match &state.network_info {
             Ok(info) => Ok(info.clone()),
-            Err(crate::device::wifi::WifiError::Disabled) => {
-                Err(crate::device::wifi::WifiError::Disabled)
-            }
-            Err(crate::device::wifi::WifiError::Dbus(s)) => {
-                Err(crate::device::wifi::WifiError::Dbus(s.clone()))
-            }
-            Err(crate::device::wifi::WifiError::Incomplete(s)) => {
-                Err(crate::device::wifi::WifiError::Incomplete(s.clone()))
-            }
-            Err(other) => Err(crate::device::wifi::WifiError::Dbus(other.to_string())),
+            Err(e) => Err(crate::device::wifi::clone_wifi_error(e)),
         }
     }
 }

--- a/crates/core/src/device/wifi/error.rs
+++ b/crates/core/src/device/wifi/error.rs
@@ -45,3 +45,30 @@ pub enum WifiError {
     #[error("Incomplete network state: {0}")]
     Incomplete(String),
 }
+
+/// Clones a [`WifiError`] for test doubles that store `Result`s by value.
+///
+/// `Io` is recreated from the display string because [`std::io::Error`] is not
+/// `Clone`.
+#[cfg(any(
+    test,
+    docsrs,
+    all(
+        feature = "deviceless",
+        not(any(feature = "kobo", feature = "emulator"))
+    )
+))]
+pub(crate) fn clone_wifi_error(error: &WifiError) -> WifiError {
+    match error {
+        WifiError::DeviceInfo(s) => WifiError::DeviceInfo(s.clone()),
+        WifiError::KernelModule(s) => WifiError::KernelModule(s.clone()),
+        WifiError::Interface(s) => WifiError::Interface(s.clone()),
+        WifiError::Ioctl(s) => WifiError::Ioctl(s.clone()),
+        WifiError::Config(s) => WifiError::Config(s.clone()),
+        WifiError::Io(e) => WifiError::Io(std::io::Error::other(e.to_string())),
+        WifiError::Lock(s) => WifiError::Lock(s.clone()),
+        WifiError::Disabled => WifiError::Disabled,
+        WifiError::Dbus(s) => WifiError::Dbus(s.clone()),
+        WifiError::Incomplete(s) => WifiError::Incomplete(s.clone()),
+    }
+}

--- a/crates/core/src/device/wifi/error.rs
+++ b/crates/core/src/device/wifi/error.rs
@@ -32,4 +32,16 @@ pub enum WifiError {
     /// Failed to acquire lock for WiFi operation.
     #[error("Failed to acquire WiFi lock: {0}")]
     Lock(String),
+
+    /// Wi-Fi is powered down / disabled.
+    #[error("Wi-Fi is disabled")]
+    Disabled,
+
+    /// D-Bus transport or deserialize failure.
+    #[error("D-Bus error: {0}")]
+    Dbus(String),
+
+    /// Associated network is missing IP or ESSID.
+    #[error("Incomplete network state: {0}")]
+    Incomplete(String),
 }

--- a/crates/core/src/device/wifi/manager.rs
+++ b/crates/core/src/device/wifi/manager.rs
@@ -1,6 +1,7 @@
 //! WiFi Manager trait definition.
 
 use crate::device::wifi::error::WifiError;
+use crate::device::wifi::network_info::NetworkInfo;
 
 /// Trait for WiFi management.
 ///
@@ -65,6 +66,23 @@ pub trait WifiManager: Send + Sync {
     /// # }
     /// ```
     fn disable(&self) -> Result<(), WifiError>;
+
+    /// Returns whether Wi-Fi is currently powered/enabled.
+    ///
+    /// Platform-specific: on Kobo this means the kernel module is loaded and
+    /// the network interface is up.
+    fn is_enabled(&self) -> bool;
+
+    /// Returns the active connection snapshot, if associated.
+    ///
+    /// - [`Ok`]`(None)` — Wi-Fi powered/enabled but not associated / no lease yet.
+    /// - [`Ok`]`(Some(_))` — connected; `ip` and `essid` are always present.
+    /// - [`Err`] — Wi-Fi is disabled, D-Bus/query failure, or connected but IP
+    ///   or ESSID missing (inconsistent state).
+    ///
+    /// Callers must not invoke this when [`is_enabled`](Self::is_enabled) is
+    /// false; implementations return [`WifiError::Disabled`] in that case.
+    fn network_info(&self) -> Result<Option<NetworkInfo>, WifiError>;
 }
 
 impl<T: WifiManager + ?Sized> WifiManager for Box<T> {
@@ -73,5 +91,11 @@ impl<T: WifiManager + ?Sized> WifiManager for Box<T> {
     }
     fn disable(&self) -> Result<(), WifiError> {
         (**self).disable()
+    }
+    fn is_enabled(&self) -> bool {
+        (**self).is_enabled()
+    }
+    fn network_info(&self) -> Result<Option<NetworkInfo>, WifiError> {
+        (**self).network_info()
     }
 }

--- a/crates/core/src/device/wifi/mod.rs
+++ b/crates/core/src/device/wifi/mod.rs
@@ -5,5 +5,14 @@ mod manager;
 mod network_info;
 
 pub use error::WifiError;
+#[cfg(any(
+    test,
+    docsrs,
+    all(
+        feature = "deviceless",
+        not(any(feature = "kobo", feature = "emulator"))
+    )
+))]
+pub(crate) use error::clone_wifi_error;
 pub use manager::WifiManager;
 pub use network_info::{Essid, NetworkInfo};

--- a/crates/core/src/device/wifi/mod.rs
+++ b/crates/core/src/device/wifi/mod.rs
@@ -2,6 +2,8 @@
 
 mod error;
 mod manager;
+mod network_info;
 
 pub use error::WifiError;
 pub use manager::WifiManager;
+pub use network_info::{Essid, NetworkInfo};

--- a/crates/core/src/device/wifi/network_info.rs
+++ b/crates/core/src/device/wifi/network_info.rs
@@ -1,0 +1,32 @@
+//! Connected Wi-Fi network snapshot.
+
+use std::fmt;
+use std::net::IpAddr;
+
+/// Connected Wi-Fi network name (ESSID / SSID).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Essid(String);
+
+impl Essid {
+    pub fn new(s: impl Into<String>) -> Self {
+        Self(s.into())
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Display for Essid {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+/// Snapshot of the active connection. Only constructed when the link is up
+/// and both address and ESSID were obtained.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NetworkInfo {
+    pub ip: IpAddr,
+    pub essid: Essid,
+}

--- a/crates/core/src/dictionary/db_index.rs
+++ b/crates/core/src/dictionary/db_index.rs
@@ -7,7 +7,7 @@ use levenshtein::levenshtein;
 use sqlx::SqlitePool;
 
 use crate::db::Database;
-use crate::db::runtime::RUNTIME;
+use crate::runtime::RUNTIME;
 
 use super::Metadata;
 use super::indexing::{Entry, IndexReader};
@@ -203,7 +203,7 @@ impl IndexReader for DbIndexReader {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::db::runtime::RUNTIME;
+    use crate::runtime::RUNTIME;
 
     fn setup_db() -> Database {
         let mut db = Database::new(":memory:").expect("in-memory db");

--- a/crates/core/src/dictionary/mod.rs
+++ b/crates/core/src/dictionary/mod.rs
@@ -126,7 +126,7 @@ pub fn resolve_dict_id(database: &Database, fingerprint: &Fp) -> Option<i64> {
     let fp_str = fingerprint.to_string();
     let pool = database.pool().clone();
 
-    crate::db::runtime::RUNTIME
+    crate::runtime::RUNTIME
         .block_on(async {
             sqlx::query_scalar!(
                 "SELECT dict_id FROM dictionary_index_meta WHERE fingerprint = ?",
@@ -195,7 +195,7 @@ pub fn load_dictionary(content: Box<dyn DictReader>, index: Box<dyn IndexReader>
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::db::runtime::RUNTIME;
+    use crate::runtime::RUNTIME;
 
     const PATH_CASE_SENSITIVE_DICT: &str = "src/dictionary/testdata/case_sensitive_dict.dict";
     const PATH_CASE_INSENSITIVE_DICT: &str = "src/dictionary/testdata/case_insensitive_dict.dict";

--- a/crates/core/src/dictionary/monolingual/db.rs
+++ b/crates/core/src/dictionary/monolingual/db.rs
@@ -9,8 +9,8 @@
 
 use super::metadata::DictionaryEntry;
 use crate::db::Database;
-use crate::db::runtime::RUNTIME;
 use crate::db::types::UnixTimestamp;
+use crate::runtime::RUNTIME;
 use anyhow::Error;
 use sqlx::SqlitePool;
 

--- a/crates/core/src/document/mod.rs
+++ b/crates/core/src/document/mod.rs
@@ -601,7 +601,11 @@ const HWINFO_KEYS: [&str; 19] = [
     "Wifi",
 ];
 
-pub fn sys_info_as_html(model: crate::device::Model, mark: u8) -> String {
+pub fn sys_info_as_html(
+    model: crate::device::Model,
+    mark: u8,
+    network: Option<&crate::device::wifi::NetworkInfo>,
+) -> String {
     let mut buf = "<html>\n\t<head>\n\t\t<title>System Info</title>\n\t\t\
                    <link rel=\"stylesheet\" type=\"text/css\" \
                    href=\"css/sysinfo.css\"/>\n\t</head>\n\t<body>\n"
@@ -639,19 +643,14 @@ pub fn sys_info_as_html(model: crate::device::Model, mark: u8) -> String {
 
     buf.push_str("\t\t\t<tr class=\"sep\"></tr>\n");
 
-    let output = Command::new("scripts/ip.sh")
-        .output()
-        .map_err(|e| error!("Can't execute command: {:#}.", e))
-        .ok();
-
-    if let Some(stdout) = output
-        .filter(|output| output.status.success())
-        .and_then(|output| String::from_utf8(output.stdout).ok())
-        .filter(|stdout| !stdout.is_empty())
-    {
+    if let Some(network) = network {
         buf.push_str("\t\t\t<tr>\n");
         buf.push_str("\t\t\t\t<td>IP Address</td>\n");
-        buf.push_str(&format!("\t\t\t\t<td>{}</td>\n", stdout));
+        buf.push_str(&format!("\t\t\t\t<td>{}</td>\n", network.ip));
+        buf.push_str("\t\t\t</tr>\n");
+        buf.push_str("\t\t\t<tr>\n");
+        buf.push_str("\t\t\t\t<td>Wi-Fi Network</td>\n");
+        buf.push_str(&format!("\t\t\t\t<td>{}</td>\n", network.essid));
         buf.push_str("\t\t\t</tr>\n");
     }
 
@@ -743,6 +742,7 @@ pub fn sys_info_as_html(model: crate::device::Model, mark: u8) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::net::{IpAddr, Ipv4Addr};
     use std::path::PathBuf;
 
     #[test]
@@ -765,5 +765,25 @@ mod tests {
         let path_mixed = PathBuf::from("test_file.HtM");
         assert_eq!(file_kind(&path_upper), Some(FileExtension::Html));
         assert_eq!(file_kind(&path_mixed), Some(FileExtension::Html));
+    }
+
+    #[test]
+    fn sys_info_as_html_includes_network_when_provided() {
+        let network = crate::device::wifi::NetworkInfo {
+            ip: IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2)),
+            essid: crate::device::wifi::Essid::new("Home"),
+        };
+        let html = sys_info_as_html(crate::device::Model::TestDevice, 7, Some(&network));
+        assert!(html.contains("IP Address"));
+        assert!(html.contains("10.0.0.2"));
+        assert!(html.contains("Wi-Fi Network"));
+        assert!(html.contains("Home"));
+    }
+
+    #[test]
+    fn sys_info_as_html_omits_network_rows_when_none() {
+        let html = sys_info_as_html(crate::device::Model::TestDevice, 7, None);
+        assert!(!html.contains("IP Address"));
+        assert!(!html.contains("Wi-Fi Network"));
     }
 }

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -40,6 +40,7 @@ pub mod logging;
 pub mod metadata;
 pub mod ota;
 pub use device::rtc::{AlarmManager, AlarmType};
+pub mod runtime;
 pub mod settings;
 pub mod task;
 #[cfg(any(feature = "profiling", feature = "tracing"))]

--- a/crates/core/src/library/db/mod.rs
+++ b/crates/core/src/library/db/mod.rs
@@ -2,7 +2,6 @@ pub mod conversion;
 pub mod models;
 
 use crate::db::Database;
-use crate::db::runtime::RUNTIME;
 use crate::db::types::{FileSize, OptionalUuid7, UnixTimestamp, Uuid7};
 use crate::document::SimpleTocEntry;
 use crate::geom::Point;
@@ -11,6 +10,7 @@ use crate::metadata::{
     CroppingMargins, FileInfo, Info, ReaderInfo, ScrollMode, SortMethod, TextAlign, ZoomMode,
     alphabetic_author, alphabetic_title, natural_cmp, sorter,
 };
+use crate::runtime::RUNTIME;
 use crate::settings::FileExtension;
 use anyhow::Error;
 use conversion::{

--- a/crates/core/src/library/migrations.rs
+++ b/crates/core/src/library/migrations.rs
@@ -1013,10 +1013,10 @@ mod tests {
     use super::*;
     use crate::db::Database;
     use crate::db::migrations::{MigrationContext, MigrationDevice};
-    use crate::db::runtime::RUNTIME;
     use crate::document::{SimpleTocEntry, TocLocation};
     use crate::library::db::Db;
     use crate::metadata::{FileInfo, ReaderInfo};
+    use crate::runtime::RUNTIME;
     use chrono::Local;
     use std::collections::BTreeSet;
     use std::path::PathBuf;

--- a/crates/core/src/runtime.rs
+++ b/crates/core/src/runtime.rs
@@ -1,0 +1,15 @@
+//! Process-wide Tokio runtime for sync→async bridges.
+//!
+//! Cadmus’s main event loop is synchronous. Async work (SQLx, zbus, …) is
+//! driven via [`RUNTIME::block_on`](RUNTIME) from call sites that must stay
+//! sync. Long-lived background tasks that own an event loop keep their own
+//! runtime so they do not monopolize this one with forever-running `block_on`.
+
+use once_cell::sync::Lazy;
+use tokio::runtime::Runtime;
+
+/// Global lazy-initialized Tokio runtime for process-wide sync→async bridges.
+pub static RUNTIME: Lazy<Runtime> = Lazy::new(|| {
+    tracing::info!("initializing process-wide Tokio runtime");
+    Runtime::new().expect("failed to create process-wide Tokio runtime")
+});

--- a/crates/core/src/settings/migrations.rs
+++ b/crates/core/src/settings/migrations.rs
@@ -193,7 +193,7 @@ mod tests {
             settings: &mut settings,
         };
 
-        crate::db::runtime::RUNTIME.block_on(async {
+        crate::runtime::RUNTIME.block_on(async {
             migrate_sketch_pen_speed_mm(&mut ctx)
                 .await
                 .expect("pen speed migration should succeed");

--- a/crates/core/src/task/dictionary_index.rs
+++ b/crates/core/src/task/dictionary_index.rs
@@ -12,10 +12,10 @@ use walkdir::WalkDir;
 
 use crate::context::DICTIONARIES_DIRNAME;
 use crate::db::Database;
-use crate::db::runtime::RUNTIME;
 use crate::dictionary::{Entry, Metadata, normalize};
 use crate::fl;
 use crate::helpers::{Fingerprint, IsHidden};
+use crate::runtime::RUNTIME;
 use crate::task::{BackgroundTask, ShutdownSignal, TaskId};
 use crate::view::notification::NotificationEvent;
 use crate::view::{Event, ID_FEEDER, ViewId};
@@ -713,7 +713,7 @@ impl BackgroundTask for DictionaryIndexTask {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::db::{Database, runtime::RUNTIME};
+    use crate::db::Database;
 
     fn setup_db() -> Database {
         let mut db = Database::new(":memory:").expect("failed to create in-memory database");

--- a/scripts/essid.sh
+++ b/scripts/essid.sh
@@ -1,3 +1,0 @@
-#! /bin/sh
-
-iwgetid -r

--- a/scripts/ip.sh
+++ b/scripts/ip.sh
@@ -1,3 +1,0 @@
-#! /bin/sh
-
-ip route get 1 | awk '{print $NF; exit}'

--- a/xtask/src/tasks/dist.rs
+++ b/xtask/src/tasks/dist.rs
@@ -1,8 +1,8 @@
 //! `cargo xtask dist` — assemble the Kobo distribution directory.
 //!
-//! Copies the compiled Cadmus binary, shared libraries, scripts, fonts,
-//! icons, and other assets into a `dist/` directory that mirrors the layout
-//! expected on the Kobo device.
+//! Copies the compiled Cadmus binary, shared libraries, fonts, icons, and
+//! other assets into a `dist/` directory that mirrors the layout expected on
+//! the Kobo device.
 //!
 //! ## Prerequisites
 //!
@@ -19,7 +19,6 @@
 //! ├── fonts/
 //! ├── icons/
 //! ├── css/
-//! ├── scripts/
 //! ├── keyboard-layouts/
 //! ├── hyphenation-patterns/
 //! ├── bin/
@@ -110,13 +109,12 @@ fn copy_libraries(root: &Path, dist_dir: &Path) -> Result<()> {
     Ok(())
 }
 
-/// Copies static assets (fonts, icons, scripts, etc.) into `dist/`.
+/// Copies static assets (fonts, icons, etc.) into `dist/`.
 fn copy_assets(root: &Path, dist_dir: &Path) -> Result<()> {
     let dirs = [
         "hyphenation-patterns",
         "keyboard-layouts",
         "bin",
-        "scripts",
         "icons",
         "resources",
         "fonts",
@@ -202,7 +200,6 @@ fn clean_user_files(dist_dir: &Path) -> Result<()> {
         ("css", "*-user.css"),
         ("keyboard-layouts", "*-user.json"),
         ("hyphenation-patterns", "*.bounds"),
-        ("scripts", "wifi-*-*.sh"),
     ];
 
     for (subdir, pattern) in patterns {


### PR DESCRIPTION
Replace ip.sh/essid.sh with WifiManager::network_info so NetUp and System Info use dhcpcd-dbus instead of shelling out. Lift the shared Tokio RUNTIME out of db for those sync bridges.

Closes: CAD-110

Ref: https://github.com/OGKevin/cadmus/issues/323
Ref: CAD-23

Change-Id: 9ac438460e33bef2506f92cc3cbb5e15
Change-Id-Short: qpnvwrvtzlww