### PR TITLE
docs(investigations): document dhcpcd-dbus IP/ESSID probe

### DIFF
--- a/docs/po/messages.pot
+++ b/docs/po/messages.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Cadmus Documentation\n"
-"POT-Creation-Date: 2026-07-14T20:06:37+02:00\n"
+"POT-Creation-Date: 2026-08-01T16:14:55+02:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -176,6 +176,10 @@ msgstr ""
 
 #: src/SUMMARY.md:53
 msgid "DHCP IP Address Changes on WiFi Toggle"
+msgstr ""
+
+#: src/SUMMARY.md:54
+msgid "Reading IP and ESSID via dhcpcd-dbus"
 msgstr ""
 
 #: src/index.md:3

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -51,3 +51,4 @@
 
 - [Intro](investigations/index.md)
   - [DHCP IP Address Changes on WiFi Toggle](investigations/kobo/issue-51-dhcp-investigation.md)
+  - [Reading IP and ESSID via dhcpcd-dbus](investigations/kobo/issue-261-dhcpcd-dbus-network-info.md)

--- a/docs/src/investigations/index.md
+++ b/docs/src/investigations/index.md
@@ -6,8 +6,9 @@ When something needs investigating, the investigation and its results are
 documented here. This is to ensure that the investigation is not lost and can be
 referred to in the future if needed.
 
-| Date       | Platform | Title                                                                           |
-| ---------- | -------- | ------------------------------------------------------------------------------- |
-| 2026-03-24 | Kobo     | [DHCP IP Address Changes on WiFi Toggle](./kobo/issue-51-dhcp-investigation.md) |
+| Date       | Platform | Title                                                                                |
+| ---------- | -------- | ------------------------------------------------------------------------------------ |
+| 2026-03-24 | Kobo     | [DHCP IP Address Changes on WiFi Toggle](./kobo/issue-51-dhcp-investigation.md)      |
+| 2026-07-29 | Kobo     | [Reading IP and ESSID via dhcpcd-dbus](./kobo/issue-261-dhcpcd-dbus-network-info.md) |
 
 <!-- i18n:skip-end -->

--- a/docs/src/investigations/kobo/issue-261-dhcpcd-dbus-network-info.md
+++ b/docs/src/investigations/kobo/issue-261-dhcpcd-dbus-network-info.md
@@ -1,0 +1,165 @@
+<!-- i18n:skip-start -->
+
+# Reading IP and ESSID via dhcpcd-dbus
+
+As part of [#261](https://github.com/OGKevin/cadmus/issues/261) the scripts `scripts/ip.sh` and
+`scripts/essid.sh`, used only to fill the NetUp notification and the System Info
+page, needed to migrated to pure rust. Cadmus already talks to Nickel’s **dhcpcd-dbus** for Wi-Fi status
+(`WpaStatus` → `DeviceEvent::NetUp`), so I SSH’d into a device to see whether
+the same bus already exposes the connected IP and ESSID without shelling out to
+`ip` / `iwgetid`.
+
+Examples below use documentation-range addresses and fake SSIDs; real device
+values are omitted.
+
+---
+
+## Summary
+
+On current Kobo firmware, `name.marples.roy.dhcpcd` (dhcpcd-dbus **0.6.0**) is
+the only network-related D-Bus service. There is no
+`fi.w1.wpa_supplicant1`. Pollable answers:
+
+| Need  | Method          | How                                       |
+| ----- | --------------- | ----------------------------------------- |
+| IP    | `GetInterfaces` | `IPAddress` property as host-endian `u32` |
+| ESSID | `ListNetworks`  | row whose flags contain `[CURRENT]`       |
+
+There is **no** dedicated “get current SSID” method. Signals such as
+`WpaStatus` / `SignalStrength` can carry `ssid`, but they are not queryable.
+
+Outcome in tree: `WifiManager::network_info()` assembles both fields in
+[`crates/core/src/device/kobo/wifi/dhcpcd.rs`](https://github.com/OGKevin/cadmus/blob/master/crates/core/src/device/kobo/wifi/dhcpcd.rs).
+
+## Device environment
+
+Tools on device:
+
+- `dbus-send` present
+- `busctl` / `gdbus` **not** present
+
+Ground truth from the old scripts / wpa:
+
+```sh
+# was scripts/ip.sh
+$ ip route get 1
+1.0.0.0 via 203.0.113.1 dev wlan0  src 203.0.113.10
+
+# was scripts/essid.sh
+$ iwgetid -r
+ExampleNet
+```
+
+```sh
+$ wpa_cli -i wlan0 status
+bssid=aa:bb:cc:dd:ee:ff
+ssid=ExampleNet
+wpa_state=COMPLETED
+ip_address=203.0.113.10
+…
+```
+
+System bus names (trimmed): only `org.freedesktop.DBus` and
+`name.marples.roy.dhcpcd` matter for networking.
+
+`GetVersion` → `0.6.0`, `GetDhcpcdVersion` → firmware’s `dhcpcd` version string.
+
+## Introspection (what exists)
+
+Object path: `/name/marples/roy/dhcpcd`, interface `name.marples.roy.dhcpcd`.
+
+Notable **methods**: `GetStatus`, `ListInterfaces`, `GetInterfaces`,
+`ListNetworks`, `GetNetwork`, `Scan` / `ScanResults`, config helpers, …
+
+Notable **signals**: `Event`, `StatusChanged`, `WpaStatus`, `WpaFailureEvent`,
+`SignalStrength`, `ScanResults`, …
+
+**Not** present: `org.freedesktop.DBus.Properties`, `GetCurrentNetwork`,
+`GetWpaStatus` (as a method).
+
+Full Introspect XML is long; probe with:
+
+```sh
+dbus-send --system --print-reply \
+  --dest=name.marples.roy.dhcpcd \
+  /name/marples/roy/dhcpcd \
+  org.freedesktop.DBus.Introspectable.Introspect
+```
+
+## IP address: `GetInterfaces`
+
+```sh
+$ dbus-send --system --print-reply \
+    --dest=name.marples.roy.dhcpcd \
+    /name/marples/roy/dhcpcd \
+    name.marples.roy.dhcpcd.GetStatus
+method return …
+   string "connected"
+```
+
+```sh
+$ dbus-send --system --print-reply \
+    --dest=name.marples.roy.dhcpcd \
+    /name/marples/roy/dhcpcd \
+    name.marples.roy.dhcpcd.GetInterfaces
+method return …
+   array [
+      dict entry(
+         string "wlan0"
+         array [
+            dict entry( string "Interface"  variant string "wlan0" )
+            dict entry( string "Reason"     variant string "BOUND" )
+            dict entry( string "Wireless"   variant boolean true )
+            dict entry( string "Up"         variant boolean true )
+            # 203.0.113.10 as host-endian u32 on little-endian ARM ≈ 175177931
+            dict entry( string "IPAddress"  variant uint32 175177931 )
+            dict entry( string "SubnetCIDR" variant byte 24 )
+            # further lease / DNS / router fields omitted
+            dict entry( string "Type"       variant string "ipv4" )
+         ]
+      )
+   ]
+```
+
+Decode in Rust with the same layout Cadmus uses:
+`Ipv4Addr::from(host_u32.to_ne_bytes())`.
+
+`GetStatus` alone is only a coarse string (`"connected"`); it does not carry
+the address.
+
+## ESSID: `ListNetworks` + `[CURRENT]`
+
+`GetInterfaces` has **no** SSID field.
+
+```sh
+$ dbus-send --system --print-reply \
+    --dest=name.marples.roy.dhcpcd \
+    /name/marples/roy/dhcpcd \
+    name.marples.roy.dhcpcd.ListNetworks \
+    string:wlan0
+method return …
+   array [
+      struct { int32 0  string "ExampleNet"  string "any"  string "[CURRENT]" }
+      struct { int32 1  string "GuestNet"    string "any"  string "[DISABLED]" }
+      struct { int32 2  string "OtherNet"    string "any"  string "[DISABLED]" }
+   ]
+```
+
+Take the first row whose flags contain `[CURRENT]`.
+
+Once the id is known, `GetNetwork` can fetch the `ssid` parameter (wpa may
+return extra quotes):
+
+```sh
+$ dbus-send --system --print-reply \
+    --dest=name.marples.roy.dhcpcd \
+    /name/marples/roy/dhcpcd \
+    name.marples.roy.dhcpcd.GetNetwork \
+    string:wlan0 int32:0 string:ssid
+method return …
+   string "\"ExampleNet\""
+```
+
+Prefer the SSID from `ListNetworks` for display.
+
+<!-- i18n:skip-end -->


### PR DESCRIPTION
Capture device SSH findings that justify network_info() over ip.sh/essid.sh.

Closes: CAD-110 

Change-Id: cf7cf591c2c30272d54797bfcce36d90
Change-Id-Short: nksnkuqynxnw

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime, auth, or data-handling impact.
> 
> **Overview**
> Adds a **Kobo investigation** write-up for issue #261 that records why NetUp notifications and System Info can drop `scripts/ip.sh` and `scripts/essid.sh` in favor of pure Rust.
> 
> The new page documents on-device **dhcpcd-dbus** (`name.marples.roy.dhcpcd`) probes: **IP** from `GetInterfaces` (`IPAddress` as host-endian `u32`) and **ESSID** from `ListNetworks` rows flagged `[CURRENT]`, with example `dbus-send` output and a pointer to `WifiManager::network_info()` / `dhcpcd.rs`.
> 
> **Investigations** navigation is updated in `SUMMARY.md`, the investigations index table, and the docs i18n `messages.pot` entry for the new title.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bb208541bd9489eff986997ac5898c21e3956384. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->