### PR TITLE
feat(kobo): switch between main and test installs

### DIFF
--- a/contrib/cadmus.sh
+++ b/contrib/cadmus.sh
@@ -87,6 +87,10 @@ exit_cadmus() {
     reboot
   elif [ -e /tmp/power_off ]; then
     poweroff -f
+  elif [ -e /tmp/run_command ]; then
+    CMD=$(cat /tmp/run_command)
+    rm -f /tmp/run_command
+    exec "$CMD"
   else
     ./nickel.sh &
   fi

--- a/crates/cadmus/src/app.rs
+++ b/crates/cadmus/src/app.rs
@@ -844,6 +844,11 @@ pub fn run() -> Result<(), Error> {
 
     background_tasks.stop_all();
 
+    let save_settings = match &exit_status {
+        ExitStatus::Restart | ExitStatus::Reboot => !context.shared,
+        _ => true,
+    };
+
     if let Err(e) = AppDevice::on_shutdown(
         &mut context,
         exit_status,
@@ -860,11 +865,6 @@ pub fn run() -> Result<(), Error> {
     ) {
         tracing::error!(error = %e, "Failed to run on_shutdown");
     }
-
-    let save_settings = match exit_status {
-        ExitStatus::Restart | ExitStatus::Reboot => !context.shared,
-        _ => true,
-    };
 
     if save_settings {
         if let Err(e) = manager.save(&context.settings) {

--- a/crates/core/i18n/AGENTS.md
+++ b/crates/core/i18n/AGENTS.md
@@ -1,0 +1,16 @@
+# UI string translations (`i18n/`)
+
+## Source of truth
+
+- Edit **only** [`en-GB/cadmus_core.ftl`](en-GB/cadmus_core.ftl) when adding or
+  changing user-visible strings.
+- Keep message IDs sorted within each comment section.
+
+## Other locales
+
+- **Never** translate or invent copy in locale files under this tree (for
+  example `fr/`). Crowdin owns those translations.
+- Do not auto-translate, machine-translate, or hand-port English strings into
+  other `.ftl` files.
+- Missing keys in a locale fall back to `en-GB` at runtime until Crowdin
+  syncs them.

--- a/crates/core/i18n/en-GB/cadmus_core.ftl
+++ b/crates/core/i18n/en-GB/cadmus_core.ftl
@@ -6,6 +6,8 @@ build-attributes =
     Built { $timestamp }
     By { $user }@{ $host }
 build-features = Features: { $features }
+build-kind-main = Main
+build-kind-test = Test
 
 english = English
 
@@ -36,6 +38,7 @@ top-menu-restart-app = Restart {-app-name}
 top-menu-suspend = Suspend
 top-menu-quit = Quit
 top-menu-power-off = Power Off
+top-menu-switch-to = Switch to { $build }
 top-menu-sync-time = Sync Time
 
 # Settings - Button Scheme

--- a/crates/core/src/device/emulator/mod.rs
+++ b/crates/core/src/device/emulator/mod.rs
@@ -628,6 +628,9 @@ impl DeviceLifecycle for EmulatorDevice {
                 EventOutcome::Handled
             }
             Event::Select(EntryId::Quit) => EventOutcome::Exit(crate::device::ExitStatus::Quit),
+            Event::Select(EntryId::SwitchInstall) => {
+                EventOutcome::Exit(crate::device::ExitStatus::Quit)
+            }
             _ => EventOutcome::Unhandled,
         }
     }

--- a/crates/core/src/device/kobo/device.rs
+++ b/crates/core/src/device/kobo/device.rs
@@ -124,6 +124,30 @@ impl crate::device::DevicePaths for Device {
             }
         }
     }
+
+    fn peer_installs(&self) -> Vec<crate::device::PeerInstall> {
+        let root = cfg_select! {
+            test => { std::env::temp_dir().join("test-kobo-installation") }
+            _ => { PathBuf::from(crate::settings::INTERNAL_CARD_ROOT) }
+        };
+        let current = self.install_dir();
+        [
+            (".adds/cadmus", crate::version::BuildKind::Standard),
+            (".adds/cadmus-tst", crate::version::BuildKind::Test),
+        ]
+        .into_iter()
+        .filter_map(|(subdir, kind)| {
+            let dir = root.join(subdir);
+            if dir == current {
+                return None;
+            }
+            let launcher = dir.join("cadmus.sh");
+            launcher
+                .is_file()
+                .then_some(crate::device::PeerInstall { kind, launcher })
+        })
+        .collect()
+    }
 }
 
 crate::impl_device_hardware!(
@@ -239,16 +263,37 @@ mod tests {
         }
 
         #[test]
-        fn resolve_db_path_prefers_data_dir() {
+        fn peer_installs_empty_without_peer_launcher() {
             let d = Model::Sage.device().unwrap();
-            let db_path = d.resolve_db_path();
-            let expected = d.data_path(crate::db::DB_FILENAME);
-            let install_expected = d.install_path(crate::db::DB_FILENAME);
-            assert!(
-                db_path == expected || db_path == install_expected,
-                "resolve_db_path {:?} should be either data_dir or install_dir location",
-                db_path
-            );
+            assert!(d.peer_installs().is_empty());
+        }
+
+        #[test]
+        fn peer_installs_finds_peer_cadmus_sh() {
+            let d = Model::Sage.device().unwrap();
+            let root = std::env::temp_dir().join("test-kobo-installation");
+            let peer_subdir = if d.install_subdir() == ".adds/cadmus" {
+                ".adds/cadmus-tst"
+            } else {
+                ".adds/cadmus"
+            };
+            let peer_dir = root.join(peer_subdir);
+            let launcher = peer_dir.join("cadmus.sh");
+            std::fs::create_dir_all(&peer_dir).unwrap();
+            std::fs::write(&launcher, "#!/bin/sh\n").unwrap();
+
+            let peers = d.peer_installs();
+            assert_eq!(peers.len(), 1);
+            assert_eq!(peers[0].launcher, launcher);
+            let expected_kind = if peer_subdir == ".adds/cadmus-tst" {
+                crate::version::BuildKind::Test
+            } else {
+                crate::version::BuildKind::Standard
+            };
+            assert_eq!(peers[0].kind, expected_kind);
+
+            std::fs::remove_file(&launcher).ok();
+            std::fs::remove_dir_all(&peer_dir).ok();
         }
     }
 

--- a/crates/core/src/device/kobo/lifecycle/mod.rs
+++ b/crates/core/src/device/kobo/lifecycle/mod.rs
@@ -286,6 +286,17 @@ impl DeviceLifecycle for Device {
             ExitStatus::PowerOff => {
                 File::create("/tmp/power_off").ok();
             }
+            ExitStatus::RunCommand(command) => {
+                if let Err(error) =
+                    std::fs::write("/tmp/run_command", command.to_string_lossy().as_bytes())
+                {
+                    tracing::error!(
+                        error = %error,
+                        command = %command.display(),
+                        "Failed to write run_command marker"
+                    );
+                }
+            }
             ExitStatus::Quit => {
                 if let Ok(wifi) = context.device.wifi_manager()
                     && let Err(error) = wifi.disable()
@@ -329,7 +340,8 @@ impl DeviceLifecycle for Device {
             | Event::Select(EntryId::Restart)
             | Event::Select(EntryId::Reboot)
             | Event::Select(EntryId::Quit)
-            | Event::Select(EntryId::Suspend) => {
+            | Event::Select(EntryId::Suspend)
+            | Event::Select(EntryId::SwitchInstall) => {
                 power::handle_event(event, hub, bus, rq, context, runtime)
             }
             _ => EventOutcome::Unhandled,

--- a/crates/core/src/device/kobo/lifecycle/power.rs
+++ b/crates/core/src/device/kobo/lifecycle/power.rs
@@ -1,6 +1,7 @@
 //! Power-off and application exit event handling.
 
 use super::{begin_suspend, show_power_off_intermission};
+use crate::device::DevicePaths as _;
 use crate::device::{AppContext, DeviceRuntime, EventOutcome, ExitStatus};
 use crate::gesture::GestureEvent;
 use crate::input::ButtonCode;
@@ -37,6 +38,15 @@ pub(super) fn handle_event(
         Event::Select(EntryId::Restart) => EventOutcome::Exit(ExitStatus::Restart),
         Event::Select(EntryId::Reboot) => EventOutcome::Exit(ExitStatus::Reboot),
         Event::Select(EntryId::Quit) => EventOutcome::Exit(ExitStatus::Quit),
+        Event::Select(EntryId::SwitchInstall) => {
+            match context.device.peer_installs().into_iter().next() {
+                Some(peer) => EventOutcome::Exit(ExitStatus::RunCommand(peer.launcher)),
+                None => {
+                    tracing::error!("SwitchInstall selected but no peer install found");
+                    EventOutcome::Handled
+                }
+            }
+        }
         Event::Select(EntryId::Suspend) => {
             begin_suspend(context, runtime.view.as_mut(), hub, bus, rq, runtime.tasks);
             EventOutcome::Handled
@@ -66,6 +76,35 @@ mod tests {
             )
         });
         assert_eq!(outcome, EventOutcome::Exit(ExitStatus::PowerOff));
+    }
+
+    #[test]
+    fn handle_event_switch_install_exits_run_command() {
+        let mut harness = LifecycleHarness::new();
+        let peer_dir = std::env::temp_dir()
+            .join("test-kobo-installation")
+            .join(".adds/cadmus");
+        let launcher = peer_dir.join("cadmus.sh");
+        std::fs::create_dir_all(&peer_dir).unwrap();
+        std::fs::write(&launcher, "#!/bin/sh\n").unwrap();
+
+        let outcome = harness.with_parts(|hub, bus, rq, context, runtime| {
+            handle_event(
+                &Event::Select(EntryId::SwitchInstall),
+                hub,
+                bus,
+                rq,
+                context,
+                runtime,
+            )
+        });
+        assert_eq!(
+            outcome,
+            EventOutcome::Exit(ExitStatus::RunCommand(launcher.clone()))
+        );
+
+        std::fs::remove_file(&launcher).ok();
+        std::fs::remove_dir_all(&peer_dir).ok();
     }
 
     #[test]

--- a/crates/core/src/device/mod.rs
+++ b/crates/core/src/device/mod.rs
@@ -123,7 +123,7 @@ pub struct DeviceRuntime<'a> {
 }
 
 /// Outcome of [`DeviceLifecycle::handle_event`].
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum EventOutcome {
     /// The lifecycle consumed the event; the main loop should skip view dispatch.
     Handled,
@@ -139,12 +139,23 @@ pub enum EventOutcome {
 }
 
 /// How the application should terminate.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ExitStatus {
     Quit,
     Restart,
     Reboot,
     PowerOff,
+    /// Run `command` on exit instead of returning to Nickel (Kobo: `/tmp/run_command`).
+    RunCommand(PathBuf),
+}
+
+/// A peer Cadmus install that can be launched from the current one.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PeerInstall {
+    /// Build flavor of the peer install.
+    pub kind: crate::version::BuildKind,
+    /// Absolute path to the peer's `cadmus.sh` launcher.
+    pub launcher: PathBuf,
 }
 
 /// Trait for device input sources.
@@ -505,6 +516,13 @@ pub trait DevicePaths: Send {
             tracing::warn!(path = ?dir, error = %e, "Failed to create tmp dir");
         }
     }
+
+    /// Other Cadmus installs on this device that can be switched to.
+    ///
+    /// Default: none (emulator and platforms without side-by-side installs).
+    fn peer_installs(&self) -> Vec<PeerInstall> {
+        Vec::new()
+    }
 }
 
 /// Hardware subsystem accessors with associated types.
@@ -663,8 +681,8 @@ pub trait DeviceLifecycle:
     /// Runs once when the main event loop exits, before settings are persisted.
     ///
     /// `status` reflects how the application is terminating (quit, restart,
-    /// reboot, or power off). Platform implementations tear down hardware and
-    /// may write marker files consumed by the device init system.
+    /// reboot, power off, or run a command). Platform implementations tear down
+    /// hardware and may write marker files consumed by the device init system.
     ///
     /// Default: no-op success.
     fn on_shutdown(

--- a/crates/core/src/device/test_device.rs
+++ b/crates/core/src/device/test_device.rs
@@ -384,6 +384,27 @@ impl DevicePaths for TestDevice {
     fn data_dir(&self) -> PathBuf {
         self.install_dir()
     }
+
+    fn peer_installs(&self) -> Vec<crate::device::PeerInstall> {
+        let root = std::env::temp_dir().join("test-kobo-installation");
+        let current = self.install_dir();
+        [
+            (".adds/cadmus", crate::version::BuildKind::Standard),
+            (".adds/cadmus-tst", crate::version::BuildKind::Test),
+        ]
+        .into_iter()
+        .filter_map(|(subdir, kind)| {
+            let dir = root.join(subdir);
+            if dir == current {
+                return None;
+            }
+            let launcher = dir.join("cadmus.sh");
+            launcher
+                .is_file()
+                .then_some(crate::device::PeerInstall { kind, launcher })
+        })
+        .collect()
+    }
 }
 
 crate::impl_device_hardware!(

--- a/crates/core/src/view/common.rs
+++ b/crates/core/src/view/common.rs
@@ -4,7 +4,7 @@ use super::{AppCmd, EntryId, EntryKind, RenderData, RenderQueue, View, ViewId};
 use crate::battery::Battery as _;
 use crate::device::AppContext;
 use crate::device::DeviceHardware as _;
-use crate::device::{DeviceCapabilities as _, DeviceRotation as _};
+use crate::device::{DeviceCapabilities as _, DevicePaths as _, DeviceRotation as _};
 use crate::fl;
 use crate::framebuffer::Framebuffer as _;
 use crate::framebuffer::UpdateMode;
@@ -231,16 +231,28 @@ pub fn toggle_main_menu(
             EntryKind::Separator,
             EntryKind::SubMenu("Applications".to_string(), apps),
             EntryKind::Separator,
-            EntryKind::SubMenu(
-                fl!("top-menu-exit").to_string(),
-                vec![
+            EntryKind::SubMenu(fl!("top-menu-exit").to_string(), {
+                let mut exit_entries = Vec::new();
+                if let Some(peer) = context.device.peer_installs().first() {
+                    let build = match peer.kind {
+                        crate::version::BuildKind::Standard => fl!("build-kind-main"),
+                        crate::version::BuildKind::Test => fl!("build-kind-test"),
+                    };
+                    exit_entries.push(EntryKind::Command(
+                        fl!("top-menu-switch-to", build = build.as_str()).to_string(),
+                        EntryId::SwitchInstall,
+                    ));
+                    exit_entries.push(EntryKind::Separator);
+                }
+                exit_entries.extend([
                     EntryKind::Command(fl!("top-menu-suspend").to_string(), EntryId::Suspend),
                     EntryKind::Command(fl!("top-menu-restart-app").to_string(), EntryId::Restart),
                     EntryKind::Command(fl!("top-menu-reboot-device").to_string(), EntryId::Reboot),
                     EntryKind::Command(fl!("top-menu-power-off").to_string(), EntryId::PowerOff),
                     EntryKind::Command(fl!("top-menu-quit").to_string(), EntryId::Quit),
-                ],
-            ),
+                ]);
+                exit_entries
+            }),
         ]);
 
         let main_menu = Menu::new(rect, ViewId::MainMenu, MenuKind::DropDown, entries, context);

--- a/crates/core/src/view/mod.rs
+++ b/crates/core/src/view/mod.rs
@@ -863,6 +863,8 @@ pub enum EntryId {
     Quit,
     Suspend,
     PowerOff,
+    /// Switch to the peer Cadmus install (main ↔ test).
+    SwitchInstall,
     CheckForUpdates,
     FileEntry(PathBuf),
     Ota(OtaEntryId),

--- a/crates/core/src/view/reader/mod.rs
+++ b/crates/core/src/view/reader/mod.rs
@@ -5305,6 +5305,7 @@ impl View for Reader {
             Event::Select(EntryId::Quit)
             | Event::Select(EntryId::Reboot)
             | Event::Select(EntryId::Restart)
+            | Event::Select(EntryId::SwitchInstall)
             | Event::Back
             | Event::Suspend => {
                 self.quit(context);

--- a/docs/po/messages.pot
+++ b/docs/po/messages.pot
@@ -457,6 +457,18 @@ msgid ""
 "device. This lets you test changes without connecting to a computer."
 msgstr ""
 
+#: src/installation/test-builds.md:24
+msgid "Switching builds"
+msgstr ""
+
+#: src/installation/test-builds.md:26
+msgid ""
+"When both the main and test builds are installed, open the Exit menu and "
+"choose **Switch to Test** or **Switch to Main**. Cadmus hands off to the "
+"other install without going through Nickel. Quit still returns you to Nickel "
+"as usual."
+msgstr ""
+
 #: src/installation/ota.md:3
 msgid ""
 "Once Cadmus is installed, you can update it wirelessly without connecting to "

--- a/docs/src/installation/test-builds.md
+++ b/docs/src/installation/test-builds.md
@@ -20,3 +20,9 @@
 
 Use the OTA feature to download updates from a PR number directly on your
 device. This lets you test changes without connecting to a computer.
+
+## Switching builds
+
+When both the main and test builds are installed, open the Exit menu and choose
+**Switch to Test** or **Switch to Main**. Cadmus hands off to the other install
+without going through Nickel. Quit still returns you to Nickel as usual.

--- a/renovate.json
+++ b/renovate.json
@@ -102,9 +102,7 @@
     },
     {
       "customType": "regex",
-      "managerFilePatterns": [
-        "/^\\.github\\/workflows\\/actions-lint\\.yml$/"
-      ],
+      "managerFilePatterns": ["/^\\.github\\/workflows\\/actions-lint\\.yml$/"],
       "matchStrings": [
         "ACTIONLINT_VERSION:\\s+\\\"(?<currentValue>[^\\\"]+)\\\""
       ],
@@ -116,9 +114,7 @@
     {
       "customType": "regex",
       "managerFilePatterns": ["/^\\.github\\/workflows\\/shell\\.yml$/"],
-      "matchStrings": [
-        "SHFMT_VERSION:\\s+\\\"(?<currentValue>[^\\\"]+)\\\""
-      ],
+      "matchStrings": ["SHFMT_VERSION:\\s+\\\"(?<currentValue>[^\\\"]+)\\\""],
       "datasourceTemplate": "github-releases",
       "depNameTemplate": "mvdan/sh",
       "extractVersionTemplate": "^v?(?<version>.+)$",


### PR DESCRIPTION
Side-by-side installs required quitting through Nickel.

- Add Exit menu Switch to Main/Test when peer exists
- Hand off via /tmp/run_command consumed by cadmus.sh
- Document switching in test-builds docs

Change-Id: 50b8e783ec43b5e8d2af0307258e41da
Change-Id-Short: uzorlsrwlnvw

Closes: CAD-20
Closes: #304

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new process-exit path that execs an external launcher script; behavior is scoped to Kobo side-by-side installs and covered by unit tests, but mistakes could affect boot handoff.
> 
> **Overview**
> **Switching main ↔ test builds** when both `.adds/cadmus` and `.adds/cadmus-tst` are present: the Exit submenu gains **Switch to Main/Test** (from `peer_installs()` and new Fluent strings), routed through `EntryId::SwitchInstall` like other power/exit actions.
> 
> Choosing switch exits with new **`ExitStatus::RunCommand`** carrying the peer’s `cadmus.sh` path. Kobo shutdown writes that path to **`/tmp/run_command`**; **`contrib/cadmus.sh`** reads it on exit and **`exec`s** the launcher instead of starting Nickel. **Quit** still returns to Nickel.
> 
> Supporting changes: **`PeerInstall`** / **`DevicePaths::peer_installs()`** on Kobo (and test doubles), reader treats switch like quit, emulator maps switch to quit, docs in **test-builds.md**, and **`save_settings`** is decided before **`on_shutdown`** using a borrowed **`exit_status`**. Minor **renovate.json** formatting and new **i18n/AGENTS.md**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 32276b3498361ab4887364e219c57fe18353fca5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->