### PR TITLE
ci(renovate): keep mupdf pins in sync with submodule

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -67,11 +67,11 @@
     {
       "description": "Keep mupdf submodule and version pins in sync",
       "matchManagers": ["git-submodules", "custom.regex"],
-      "matchSourceUrls": ["https://github.com/ArtifexSoftware/mupdf"],
-      "matchDepNames": ["thirdparty/mupdf"],
+      "matchPackageNames": ["thirdparty/mupdf", "ArtifexSoftware/mupdf"],
       "groupName": "mupdf",
       "groupSlug": "mupdf",
-      "addLabels": ["thirdparty"]
+      "addLabels": ["thirdparty"],
+      "minimumReleaseAge": null
     },
     {
       "description": "Group bundled font release pins and font git submodules",
@@ -102,9 +102,7 @@
     },
     {
       "customType": "regex",
-      "managerFilePatterns": [
-        "/^\\.github\\/workflows\\/actions-lint\\.yml$/"
-      ],
+      "managerFilePatterns": ["/^\\.github\\/workflows\\/actions-lint\\.yml$/"],
       "matchStrings": [
         "ACTIONLINT_VERSION:\\s+\\\"(?<currentValue>[^\\\"]+)\\\""
       ],
@@ -116,9 +114,7 @@
     {
       "customType": "regex",
       "managerFilePatterns": ["/^\\.github\\/workflows\\/shell\\.yml$/"],
-      "matchStrings": [
-        "SHFMT_VERSION:\\s+\\\"(?<currentValue>[^\\\"]+)\\\""
-      ],
+      "matchStrings": ["SHFMT_VERSION:\\s+\\\"(?<currentValue>[^\\\"]+)\\\""],
       "datasourceTemplate": "github-releases",
       "depNameTemplate": "mvdan/sh",
       "extractVersionTemplate": "^v?(?<version>.+)$",


### PR DESCRIPTION
Use matchPackageNames like mdbook and clear minimumReleaseAge so regex version pins are not left behind when the submodule advances.

Change-Id: 40b68988becbf7cd0a77122ccae21a89
Change-Id-Short: vzotrqrrolno

Should make https://github.com/OGKevin/cadmus/pull/772 all green hopefully 🤞🏾 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Renovate-only configuration; no runtime or build logic changes.
> 
> **Overview**
> Updates the **mupdf** Renovate `packageRule` so the git submodule and regex-pinned MuPDF versions stay in one grouped PR.
> 
> **Matching** now uses `matchPackageNames` for `thirdparty/mupdf` and `ArtifexSoftware/mupdf` (same pattern as mdbook-i18n-helpers) instead of `matchSourceUrls` / `matchDepNames`, so both the submodule and the `MUPDF_VERSION` / `FZ_VERSION` custom-regex deps are grouped together.
> 
> **`minimumReleaseAge: null`** on that rule avoids the repo-wide 7-day delay blocking timely grouped bumps when the submodule moves ahead of the Rust version constants.
> 
> Minor **formatting** only in unrelated custom-manager regex blocks (single-line arrays).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e44e2a7a700e2205afa40638269b24b1177b7afa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->