### PR TITLE
ci(renovate): give mupdf pins distinct depName

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -270,7 +270,7 @@
         "MUPDF_VERSION: &str = \\\"(?<currentValue>[^\\\"]+)\\\""
       ],
       "datasourceTemplate": "github-tags",
-      "depNameTemplate": "thirdparty/mupdf",
+      "depNameTemplate": "ArtifexSoftware/mupdf",
       "packageNameTemplate": "ArtifexSoftware/mupdf",
       "versioningTemplate": "semver"
     },
@@ -283,7 +283,7 @@
         "pub const FZ_VERSION: &str = \\\"(?<currentValue>[^\\\"]+)\\\""
       ],
       "datasourceTemplate": "github-tags",
-      "depNameTemplate": "thirdparty/mupdf",
+      "depNameTemplate": "ArtifexSoftware/mupdf",
       "packageNameTemplate": "ArtifexSoftware/mupdf",
       "versioningTemplate": "semver"
     }


### PR DESCRIPTION
Match mdbook: regex pins use ArtifexSoftware/mupdf so they are not collapsed with the thirdparty/mupdf submodule into one update.

Change-Id: 01fc98b0172b6a5e798ae0cd6361c8d4
Change-Id-Short: zyknqrozysxo