### PR TITLE
feat(wifi): migrate network consumers onto leases

### DIFF
--- a/crates/core/src/device/kobo/lifecycle/usb_share.rs
+++ b/crates/core/src/device/kobo/lifecycle/usb_share.rs
@@ -3,8 +3,6 @@
 use super::{KOBO_UPDATE_BUNDLE, schedule_device_task};
 use crate::device::DeviceHardware as _;
 use crate::device::usb::UsbManager;
-#[cfg(not(feature = "test"))]
-use crate::device::wifi::WifiManager;
 use crate::device::{
     AppContext, DeviceRuntime, DeviceTask, DeviceTaskId, EventOutcome, HistoryItem,
 };

--- a/crates/core/src/dictionary/monolingual/service.rs
+++ b/crates/core/src/dictionary/monolingual/service.rs
@@ -174,7 +174,7 @@ impl MonolingualDictionaryService {
     }
 
     #[cfg_attr(feature = "tracing", tracing::instrument(skip(self)))]
-    fn finish_install(&self, lang: &str) {
+    pub(crate) fn finish_install(&self, lang: &str) {
         #[cfg(feature = "tracing")]
         let _span = tracing::info_span!("lock").entered();
         self.pending_installs().remove(lang);

--- a/crates/core/src/lease.rs
+++ b/crates/core/src/lease.rs
@@ -576,6 +576,74 @@ mod tests {
         assert!(host.tracker.is_empty());
     }
 
+    struct FallibleTracker {
+        inner: LeaseTracker,
+        fail: bool,
+    }
+
+    impl FallibleTracker {
+        fn acquire(&self, name: impl Into<LeaseName>) -> Result<Lease, &'static str> {
+            if self.fail {
+                Err("denied")
+            } else {
+                Ok(self.inner.acquire(name))
+            }
+        }
+    }
+
+    #[test]
+    fn lease_attribute_or_return_holds_on_ok() {
+        struct Host {
+            tracker: FallibleTracker,
+        }
+
+        impl Host {
+            #[lease(self.tracker, "or-return", or_return)]
+            fn work(&self) {
+                assert_eq!(self.tracker.inner.len(), 1);
+            }
+        }
+
+        let host = Host {
+            tracker: FallibleTracker {
+                inner: LeaseTracker::new(),
+                fail: false,
+            },
+        };
+        host.work();
+        assert!(host.tracker.inner.is_empty());
+    }
+
+    #[test]
+    fn lease_attribute_or_return_exits_on_err() {
+        struct Host {
+            tracker: FallibleTracker,
+            ran: std::cell::Cell<bool>,
+        }
+
+        impl Host {
+            #[lease(
+                self.tracker,
+                "or-return",
+                or_return("failed to acquire WiFi lease for time sync")
+            )]
+            fn work(&self) {
+                self.ran.set(true);
+            }
+        }
+
+        let host = Host {
+            tracker: FallibleTracker {
+                inner: LeaseTracker::new(),
+                fail: true,
+            },
+            ran: std::cell::Cell::new(false),
+        };
+        host.work();
+        assert!(!host.ran.get());
+        assert!(host.tracker.inner.is_empty());
+    }
+
     #[test]
     fn concurrent_acquire_release() {
         let tracker = LeaseTracker::new();

--- a/crates/core/src/task/mod.rs
+++ b/crates/core/src/task/mod.rs
@@ -475,7 +475,7 @@ impl TaskManager {
             Event::Select(EntryId::SyncTime) => {
                 #[cfg(feature = "kobo")]
                 {
-                    if !context.online {
+                    if !context.online && !context.settings.wifi.allows_on_demand() {
                         hub.send(Event::Notification(NotificationEvent::Show(fl!(
                             "notification-not-online"
                         ))))
@@ -606,6 +606,7 @@ impl TaskManager {
                     time_manager.clone(),
                     context.settings.ntp_server.clone(),
                     manual,
+                    context.wifi_session.clone(),
                 ));
                 if let Err(e) = self.start(task, hub.clone()) {
                     tracing::warn!(error = %e, "failed to start time sync task");

--- a/crates/core/src/task/time_sync.rs
+++ b/crates/core/src/task/time_sync.rs
@@ -1,6 +1,8 @@
+use std::sync::Arc;
 use std::sync::mpsc::Sender;
 
 use crate::device::rtc::Rtc;
+use crate::device::wifi::WifiSession;
 use crate::geolocation::fetch_geolocation;
 use crate::http::Client;
 use crate::network_address::NetworkAddress;
@@ -12,14 +14,21 @@ pub struct TimeSyncTask<R: Rtc> {
     time_manager: TimeManager<R>,
     ntp_server: NetworkAddress,
     manual: bool,
+    wifi_session: Arc<WifiSession>,
 }
 
 impl<R: Rtc> TimeSyncTask<R> {
-    pub fn new(time_manager: TimeManager<R>, ntp_server: NetworkAddress, manual: bool) -> Self {
+    pub fn new(
+        time_manager: TimeManager<R>,
+        ntp_server: NetworkAddress,
+        manual: bool,
+        wifi_session: Arc<WifiSession>,
+    ) -> Self {
         TimeSyncTask {
             time_manager,
             ntp_server,
             manual,
+            wifi_session,
         }
     }
 }
@@ -30,6 +39,20 @@ impl<R: Rtc + Send + 'static> BackgroundTask for TimeSyncTask<R> {
     }
 
     fn run(&mut self, hub: &Sender<Event>, _shutdown: &ShutdownSignal) {
+        let _wifi = match self.wifi_session.acquire("time-sync") {
+            Ok(lease) => lease,
+            Err(e) => {
+                tracing::error!(error = %e, "failed to acquire WiFi lease for time sync");
+                if self.manual {
+                    hub.send(Event::Notification(crate::view::NotificationEvent::Show(
+                        crate::fl!("notification-time-sync-failed"),
+                    )))
+                    .ok();
+                }
+                return;
+            }
+        };
+
         let geo = match Client::new() {
             Ok(client) => match fetch_geolocation(&client) {
                 Ok(geo) => Some(geo),

--- a/crates/core/src/view/ota.rs
+++ b/crates/core/src/view/ota.rs
@@ -76,7 +76,7 @@ pub fn show_ota_view(
     #[cfg(feature = "tracing")]
     tracing::trace!("showing ota view");
 
-    if !context.online {
+    if !context.online && !context.settings.wifi.allows_on_demand() {
         let notif = Notification::new(
             None,
             fl!("notification-not-online"),
@@ -436,10 +436,23 @@ impl OtaView {
         let ota_view_id = self.view_id;
         let tmp_dir = context.device.tmp_dir();
         let install_dir = context.device.install_dir();
+        let wifi_session = context.wifi_session.clone();
 
         thread::spawn(move || {
             let _span =
                 tracing::info_span!(parent: &parent_span, "pr_download_async", pr_number).entered();
+            let _wifi = match wifi_session.acquire("ota-download") {
+                Ok(lease) => lease,
+                Err(e) => {
+                    error!(error = %e, "Failed to acquire WiFi lease for OTA download");
+                    hub2.send(Event::Close(ota_view_id)).ok();
+                    hub2.send(Event::Notification(NotificationEvent::Show(fl!(
+                        "notification-not-online"
+                    ))))
+                    .ok();
+                    return;
+                }
+            };
             let github = match GithubClient::new(Some(github_token)) {
                 Ok(c) => c,
                 Err(e) => {
@@ -536,10 +549,23 @@ impl OtaView {
         let ota_view_id = self.view_id;
         let tmp_dir = context.device.tmp_dir();
         let install_dir = context.device.install_dir();
+        let wifi_session = context.wifi_session.clone();
 
         thread::spawn(move || {
             let _span = tracing::info_span!(parent: &parent_span, "default_branch_download_async")
                 .entered();
+            let _wifi = match wifi_session.acquire("ota-download") {
+                Ok(lease) => lease,
+                Err(e) => {
+                    error!(error = %e, "Failed to acquire WiFi lease for OTA download");
+                    hub2.send(Event::Close(ota_view_id)).ok();
+                    hub2.send(Event::Notification(NotificationEvent::Show(fl!(
+                        "notification-not-online"
+                    ))))
+                    .ok();
+                    return;
+                }
+            };
             let github = match GithubClient::new(Some(github_token)) {
                 Ok(c) => c,
                 Err(e) => {
@@ -636,10 +662,23 @@ impl OtaView {
         let ota_view_id = self.view_id;
         let tmp_dir = context.device.tmp_dir();
         let install_dir = context.device.install_dir();
+        let wifi_session = context.wifi_session.clone();
 
         thread::spawn(move || {
             let _span = tracing::info_span!(parent: &parent_span, "stable_release_download_async")
                 .entered();
+            let _wifi = match wifi_session.acquire("ota-download") {
+                Ok(lease) => lease,
+                Err(e) => {
+                    error!(error = %e, "Failed to acquire WiFi lease for OTA download");
+                    hub2.send(Event::Close(ota_view_id)).ok();
+                    hub2.send(Event::Notification(NotificationEvent::Show(fl!(
+                        "notification-not-online"
+                    ))))
+                    .ok();
+                    return;
+                }
+            };
             let github = match GithubClient::new(github_token) {
                 Ok(c) => c,
                 Err(e) => {

--- a/crates/core/src/view/settings_editor/category_editor.rs
+++ b/crates/core/src/view/settings_editor/category_editor.rs
@@ -579,6 +579,7 @@ impl CategoryEditor {
         let lang_owned = lang.to_string();
         let hub2 = hub.clone();
         let parent_span = tracing::Span::current();
+        let wifi_session = context.wifi_session.clone();
 
         let download_id = ViewId::MessageNotif(ID_FEEDER.next());
         hub.send(Event::Notification(NotificationEvent::ShowPinned(
@@ -590,6 +591,21 @@ impl CategoryEditor {
         thread::spawn(move || {
             let _span =
                 tracing::info_span!(parent: &parent_span, "dictionary_install_async").entered();
+
+            let _wifi = match wifi_session.acquire("dictionary-download") {
+                Ok(lease) => lease,
+                Err(e) => {
+                    tracing::error!(error = %e, "Failed to acquire WiFi lease for dictionary download");
+                    service.finish_install(&lang_owned);
+                    hub2.send(Event::Close(download_id)).ok();
+                    hub2.send(crate::view::Event::DictionaryInstallComplete {
+                        lang: lang_owned,
+                        result: Err(e.to_string()),
+                    })
+                    .ok();
+                    return;
+                }
+            };
 
             let result = service
                 .install_reserved_dictionary(
@@ -641,7 +657,7 @@ impl CategoryEditor {
         rq: &mut RenderQueue,
         context: &mut AppContext,
     ) -> bool {
-        if !context.online {
+        if !context.online && !context.settings.wifi.allows_on_demand() {
             hub.send(Event::Notification(NotificationEvent::Show(fl!(
                 "notification-not-online"
             ))))
@@ -742,7 +758,7 @@ impl CategoryEditor {
     ) -> bool {
         self.remove_dictionary_download_confirm(rq);
 
-        if !context.online {
+        if !context.online && !context.settings.wifi.allows_on_demand() {
             hub.send(Event::Notification(NotificationEvent::Show(fl!(
                 "notification-not-online"
             ))))

--- a/crates/macros/src/lib.rs
+++ b/crates/macros/src/lib.rs
@@ -5,10 +5,19 @@ use quote::quote;
 use syn::parse::{Parse, ParseStream};
 use syn::{Expr, ItemFn, LitStr, Token, parse_macro_input};
 
+enum AcquireMode {
+    /// `acquire` returns the lease value directly.
+    Direct,
+    /// `acquire` returns `Result`; propagate with `?` (function must return `Result`).
+    Try,
+    /// `acquire` returns `Result`; log and `return` on `Err` (function must return `()`).
+    OrReturn { message: Option<LitStr> },
+}
+
 struct LeaseArgs {
     target: Expr,
     name: LitStr,
-    try_acquire: bool,
+    mode: AcquireMode,
 }
 
 impl Parse for LeaseArgs {
@@ -16,24 +25,30 @@ impl Parse for LeaseArgs {
         let target: Expr = input.parse()?;
         input.parse::<Token![,]>()?;
         let name: LitStr = input.parse()?;
-        let try_acquire = if input.peek(Token![,]) {
+        let mode = if input.peek(Token![,]) {
             input.parse::<Token![,]>()?;
             let ident: syn::Ident = input.parse()?;
-            if ident != "try" {
+            if ident == "try" {
+                AcquireMode::Try
+            } else if ident == "or_return" {
+                let message = if input.peek(syn::token::Paren) {
+                    let content;
+                    syn::parenthesized!(content in input);
+                    Some(content.parse::<LitStr>()?)
+                } else {
+                    None
+                };
+                AcquireMode::OrReturn { message }
+            } else {
                 return Err(syn::Error::new(
                     ident.span(),
-                    "expected `try` after lease name",
+                    "expected `try` or `or_return` after lease name",
                 ));
             }
-            true
         } else {
-            false
+            AcquireMode::Direct
         };
-        Ok(Self {
-            target,
-            name,
-            try_acquire,
-        })
+        Ok(Self { target, name, mode })
     }
 }
 
@@ -49,11 +64,26 @@ impl Parse for LeaseArgs {
 /// fn download(&self) -> Result<(), Error> {
 ///     // `self.wifi_session.acquire("ota-download")?` held until return
 /// }
+///
+/// #[lease(self.wifi_session, "time-sync", or_return)]
+/// fn run(&mut self) {
+///     // on `Err`: log and return early
+/// }
+///
+/// #[lease(self.wifi_session, "time-sync", or_return("failed to acquire WiFi lease for time sync"))]
+/// fn run(&mut self) {
+///     // custom error message
+/// }
 /// ```
 ///
-/// The first argument is any expression with an `acquire` method. Pass `try` as
-/// a third argument when `acquire` returns [`Result`] and the function returns
-/// `Result` so the expansion can use `?`.
+/// The first argument is any expression with an `acquire` method.
+///
+/// - No third argument — `acquire` returns the lease directly.
+/// - `try` — `acquire` returns [`Result`] and the function returns [`Result`];
+///   uses `?`.
+/// - `or_return` — `acquire` returns [`Result`] and the function returns `()`;
+///   logs with `tracing::error!` and returns on `Err`. Pass an optional string
+///   for a custom message (default: `"failed to acquire lease"`).
 #[proc_macro_attribute]
 pub fn lease(attr: TokenStream, item: TokenStream) -> TokenStream {
     let args = parse_macro_input!(attr as LeaseArgs);
@@ -61,14 +91,28 @@ pub fn lease(attr: TokenStream, item: TokenStream) -> TokenStream {
 
     let target = &args.target;
     let name = &args.name;
-    let acquire = if args.try_acquire {
-        quote! {
+    let acquire = match &args.mode {
+        AcquireMode::Try => quote! {
             let _lease = (#target).acquire(#name)?;
+        },
+        AcquireMode::OrReturn { message } => {
+            let message = message
+                .as_ref()
+                .map(|m| m.value())
+                .unwrap_or_else(|| "failed to acquire lease".to_string());
+            quote! {
+                let _lease = match (#target).acquire(#name) {
+                    ::core::result::Result::Ok(lease) => lease,
+                    ::core::result::Result::Err(error) => {
+                        ::tracing::error!(error = %error, name = #name, #message);
+                        return;
+                    }
+                };
+            }
         }
-    } else {
-        quote! {
+        AcquireMode::Direct => quote! {
             let _lease = (#target).acquire(#name);
-        }
+        },
     };
 
     let original_block = *input_fn.block;


### PR DESCRIPTION
Time sync, OTA downloads, and dictionary installs acquire named WiFi leases so Auto mode can bring the radio up on demand.

Change-Id: bf68c871b69940e5421ec892498ec890
Change-Id-Short: oktrnrsyotqq
Closes: CAD-37
Ref: https://github.com/OGKevin/cadmus/issues/352

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes WiFi power/connectivity timing for OTA, NTP, and dictionary downloads across background threads; mis-handled leases could leave radio on/off incorrectly or confuse offline UX.
> 
> **Overview**
> **WiFi Auto / on-demand:** Time sync, OTA downloads (PR, main branch, stable), and dictionary installs now **`acquire` a `WifiSession` lease** (`time-sync`, `ota-download`, `dictionary-download`) for the duration of the work so the radio can come up under lease tracking. Failed acquires surface **not-online** or install-failure events and clean up UI state (e.g. `finish_install` on dictionary lease failure).
> 
> **Gating:** Manual sync, OTA entry, and dictionary download confirmation no longer require `context.online` alone—they block only when offline **and** `wifi.allows_on_demand()` is false (WiFi Off), so **Auto** can start work that brings WiFi up via a lease.
> 
> **`#[lease]` macro:** Adds **`or_return`** (optional custom log message) for fallible `acquire` in `()` functions, with unit tests in `lease.rs`.
> 
> Minor: `MonolingualDictionaryService::finish_install` is **`pub(crate)`** for background cleanup; unused `WifiManager` import removed from USB share prep.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 72fcbd9b7ddbc843a12783b0d50a8dfa46e37137. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->