### PR TITLE
fix(wifi): reconcile radio at startup

### DIFF
--- a/crates/cadmus/src/app.rs
+++ b/crates/cadmus/src/app.rs
@@ -357,6 +357,8 @@ pub fn run() -> Result<(), Error> {
         );
     }
 
+    context.wifi_session.set_hub(tx.clone());
+
     AppDevice::on_startup(
         &mut context,
         &tx,

--- a/crates/core/src/device/kobo/lifecycle/mod.rs
+++ b/crates/core/src/device/kobo/lifecycle/mod.rs
@@ -27,7 +27,7 @@ use crate::framebuffer::Framebuffer as _;
 use crate::framebuffer::UpdateMode;
 use crate::frontlight::Frontlight as _;
 use crate::gesture::GestureEvent;
-use crate::input::ButtonCode;
+use crate::input::{ButtonCode, DeviceEvent};
 use crate::view::common::locate;
 use crate::view::intermission::Intermission;
 use crate::view::{EntryId, Event, RenderData, View, wait_for_all};
@@ -83,8 +83,13 @@ fn cancel_suspend(
         context.set_frontlight(context.settings.frontlight);
         if context.settings.wifi.wants_radio_at_rest() {
             let session = context.wifi_session.clone();
-            thread::spawn(move || {
-                if let Err(error) = session.enable_radio() {
+            let hub = hub.clone();
+            thread::spawn(move || match session.enable_radio() {
+                Ok(true) => {
+                    hub.send(Event::Device(DeviceEvent::NetUp)).ok();
+                }
+                Ok(false) => {}
+                Err(error) => {
                     tracing::error!(error = %error, "Failed to enable WiFi on resume");
                 }
             });
@@ -219,14 +224,36 @@ impl DeviceLifecycle for Device {
             context.online = false;
         }
         let wifi_session = context.wifi_session.clone();
+        let hub_wifi = hub.clone();
         thread::spawn(move || {
-            let result = if wants_on {
-                wifi_session.enable_radio()
+            if wants_on {
+                match wifi_session.enable_radio() {
+                    Ok(connected) => {
+                        let enabled = wifi_session.wifi_manager().is_enabled();
+                        tracing::info!(wants_on, enabled, connected, "wifi startup reconcile");
+                        if connected {
+                            hub_wifi.send(Event::Device(DeviceEvent::NetUp)).ok();
+                        }
+                    }
+                    Err(error) => {
+                        tracing::error!(
+                            error = %error,
+                            wants_on,
+                            "Failed to configure WiFi on startup"
+                        );
+                    }
+                }
             } else {
-                wifi_session.disable_radio()
-            };
-            if let Err(error) = result {
-                tracing::error!(error = %error, wants_on, "Failed to configure WiFi on startup");
+                let result = wifi_session.disable_radio();
+                let enabled = wifi_session.wifi_manager().is_enabled();
+                tracing::info!(wants_on, enabled, "wifi startup reconcile");
+                if let Err(error) = result {
+                    tracing::error!(
+                        error = %error,
+                        wants_on,
+                        "Failed to configure WiFi on startup"
+                    );
+                }
             }
         });
 
@@ -324,7 +351,7 @@ impl DeviceLifecycle for Device {
             Event::Device(_) => device_events::handle_event(event, hub, bus, rq, context, runtime),
             Event::SetWifiMode(_)
             | Event::Select(EntryId::SetWifiMode(_))
-            | Event::MightDisableWifi => wifi::handle_event(event, context),
+            | Event::MightDisableWifi => wifi::handle_event(event, hub, context),
             Event::PrepareSuspend | Event::Suspend | Event::MightSuspend => {
                 suspend::handle_event(event, hub, bus, rq, context, runtime)
             }
@@ -355,7 +382,82 @@ impl DeviceLifecycle for Device {
 mod tests {
     use super::*;
     use crate::device::kobo::lifecycle::test_helpers::LifecycleHarness;
+    use crate::device::wifi::{Essid, NetworkInfo};
     use crate::input::{ButtonCode, ButtonStatus, DeviceEvent};
+    use crate::settings::WifiMode;
+    use std::time::Duration;
+
+    fn wait_for_wifi_thread() {
+        std::thread::sleep(Duration::from_millis(50));
+    }
+
+    #[test]
+    fn on_startup_auto_disables_without_netup() {
+        let mut harness = LifecycleHarness::new();
+        harness.context.settings.wifi = WifiMode::Auto;
+        harness.context.online = true;
+        harness
+            .context
+            .device
+            .wifi_manager_for_test()
+            .set_network_info(Ok(Some(NetworkInfo {
+                ip: "192.168.1.1".parse().unwrap(),
+                essid: Essid::new("test"),
+            })));
+        harness.with_parts(|hub, _bus, _rq, context, runtime| {
+            Device::on_startup(context, hub, runtime).unwrap();
+        });
+        wait_for_wifi_thread();
+        assert!(!harness.context.online);
+        assert_eq!(
+            harness
+                .context
+                .device
+                .wifi_manager_for_test()
+                .disable_call_count(),
+            1
+        );
+        let events = harness.drain_hub();
+        assert!(
+            !events
+                .iter()
+                .any(|e| matches!(e, Event::Device(DeviceEvent::NetUp))),
+            "Auto startup must not emit NetUp, got {events:?}"
+        );
+    }
+
+    #[test]
+    fn on_startup_always_on_sends_netup_when_connected() {
+        let mut harness = LifecycleHarness::new();
+        harness.context.settings.wifi = WifiMode::AlwaysOn;
+        harness
+            .context
+            .device
+            .wifi_manager_for_test()
+            .set_network_info(Ok(Some(NetworkInfo {
+                ip: "192.168.1.1".parse().unwrap(),
+                essid: Essid::new("test"),
+            })));
+        harness.with_parts(|hub, _bus, _rq, context, runtime| {
+            Device::on_startup(context, hub, runtime).unwrap();
+        });
+        wait_for_wifi_thread();
+        assert_eq!(
+            harness
+                .context
+                .device
+                .wifi_manager_for_test()
+                .enable_call_count(),
+            1
+        );
+        let events = harness.drain_hub();
+        assert!(
+            events
+                .iter()
+                .any(|e| matches!(e, Event::Device(DeviceEvent::NetUp))),
+            "expected NetUp when AlwaysOn and associated, got {events:?}"
+        );
+    }
 
     #[test]
     fn handle_event_device_delegates() {

--- a/crates/core/src/device/kobo/lifecycle/wifi.rs
+++ b/crates/core/src/device/kobo/lifecycle/wifi.rs
@@ -1,6 +1,7 @@
 //! WiFi mode and idle-disable event handling.
 
 use crate::device::{AppContext, EventOutcome};
+use crate::input::DeviceEvent;
 use crate::settings::{WIFI_IDLE_TIMEOUT_MIN_MINUTES, WifiMode};
 use crate::view::{EntryId, Event, Hub};
 use std::sync::mpsc;
@@ -71,16 +72,16 @@ pub(super) fn spawn_wifi_idle_poller(
 #[cfg_attr(
     feature = "tracing",
     tracing::instrument(
-        skip(event, context),
+        skip(event, hub, context),
         fields(event = ?event),
         ret(level = tracing::Level::TRACE),
         level = tracing::Level::TRACE,
     )
 )]
-pub(super) fn handle_event(event: &Event, context: &mut AppContext) -> EventOutcome {
+pub(super) fn handle_event(event: &Event, hub: &Hub, context: &mut AppContext) -> EventOutcome {
     match event {
-        Event::SetWifiMode(mode) => handle_set_wifi_mode(*mode, context),
-        Event::Select(EntryId::SetWifiMode(mode)) => handle_set_wifi_mode(*mode, context),
+        Event::SetWifiMode(mode) => handle_set_wifi_mode(*mode, hub, context),
+        Event::Select(EntryId::SetWifiMode(mode)) => handle_set_wifi_mode(*mode, hub, context),
         Event::MightDisableWifi => handle_might_disable_wifi(context),
         _ => EventOutcome::Unhandled,
     }
@@ -89,13 +90,13 @@ pub(super) fn handle_event(event: &Event, context: &mut AppContext) -> EventOutc
 #[cfg_attr(
     feature = "tracing",
     tracing::instrument(
-        skip(context),
+        skip(hub, context),
         fields(mode = %mode, previous = tracing::field::Empty),
         ret(level = tracing::Level::TRACE),
         level = tracing::Level::TRACE,
     )
 )]
-fn handle_set_wifi_mode(mode: WifiMode, context: &mut AppContext) -> EventOutcome {
+fn handle_set_wifi_mode(mode: WifiMode, hub: &Hub, context: &mut AppContext) -> EventOutcome {
     if context.settings.wifi == mode {
         tracing::trace!(mode = %mode, "wifi mode unchanged");
         return EventOutcome::Handled;
@@ -112,8 +113,13 @@ fn handle_set_wifi_mode(mode: WifiMode, context: &mut AppContext) -> EventOutcom
     match mode {
         WifiMode::AlwaysOn => {
             let session = context.wifi_session.clone();
-            thread::spawn(move || {
-                if let Err(error) = session.enable_radio() {
+            let hub = hub.clone();
+            thread::spawn(move || match session.enable_radio() {
+                Ok(true) => {
+                    hub.send(Event::Device(DeviceEvent::NetUp)).ok();
+                }
+                Ok(false) => {}
+                Err(error) => {
                     tracing::error!(error = %error, "Failed to enable WiFi");
                 }
             });
@@ -244,6 +250,7 @@ mod tests {
         harness.context.wifi_session.set_mode(WifiMode::AlwaysOn);
         let outcome = handle_event(
             &Event::SetWifiMode(WifiMode::AlwaysOn),
+            &harness.hub_tx,
             &mut harness.context,
         );
         assert_eq!(outcome, EventOutcome::Handled);
@@ -264,6 +271,7 @@ mod tests {
         harness.context.settings.wifi = WifiMode::Off;
         let outcome = handle_event(
             &Event::SetWifiMode(WifiMode::AlwaysOn),
+            &harness.hub_tx,
             &mut harness.context,
         );
         assert_eq!(outcome, EventOutcome::Handled);
@@ -279,13 +287,48 @@ mod tests {
         let mut harness = LifecycleHarness::new();
         harness.context.settings.wifi = WifiMode::AlwaysOn;
         harness.context.online = true;
-        let outcome = handle_event(&Event::SetWifiMode(WifiMode::Off), &mut harness.context);
+        let outcome = handle_event(
+            &Event::SetWifiMode(WifiMode::Off),
+            &harness.hub_tx,
+            &mut harness.context,
+        );
         assert_eq!(outcome, EventOutcome::Handled);
         assert_eq!(harness.context.settings.wifi, WifiMode::Off);
         assert!(!harness.context.online);
         wait_for_wifi_thread();
         let wifi = harness.context.device.wifi_manager_for_test();
         assert_eq!(wifi.disable_call_count(), 1);
+    }
+
+    #[test]
+    fn handle_set_wifi_mode_always_on_sends_netup_when_connected() {
+        use crate::device::wifi::{Essid, NetworkInfo};
+        use crate::input::DeviceEvent;
+
+        let mut harness = LifecycleHarness::new();
+        harness.context.settings.wifi = WifiMode::Off;
+        harness
+            .context
+            .device
+            .wifi_manager_for_test()
+            .set_network_info(Ok(Some(NetworkInfo {
+                ip: "192.168.1.1".parse().unwrap(),
+                essid: Essid::new("test"),
+            })));
+        let outcome = handle_event(
+            &Event::SetWifiMode(WifiMode::AlwaysOn),
+            &harness.hub_tx,
+            &mut harness.context,
+        );
+        assert_eq!(outcome, EventOutcome::Handled);
+        wait_for_wifi_thread();
+        let events = harness.drain_hub();
+        assert!(
+            events
+                .iter()
+                .any(|e| matches!(e, Event::Device(DeviceEvent::NetUp))),
+            "expected NetUp when already associated, got {events:?}"
+        );
     }
 
     #[test]
@@ -300,7 +343,11 @@ mod tests {
         drop(lease);
         assert!(harness.context.wifi_session.idle_since().is_some());
 
-        let outcome = handle_event(&Event::MightDisableWifi, &mut harness.context);
+        let outcome = handle_event(
+            &Event::MightDisableWifi,
+            &harness.hub_tx,
+            &mut harness.context,
+        );
         assert_eq!(outcome, EventOutcome::Handled);
         wait_for_wifi_thread();
         assert!(!harness.context.online);

--- a/crates/core/src/device/wifi/session.rs
+++ b/crates/core/src/device/wifi/session.rs
@@ -1,8 +1,10 @@
 //! WiFi session: named leases over [`LeaseTracker`] plus radio bring-up.
 
 use crate::device::wifi::{WifiError, WifiManager};
+use crate::input::DeviceEvent;
 use crate::lease::{Lease, LeaseName, LeaseObserver, LeaseTracker};
 use crate::settings::WifiMode;
+use crate::view::{Event, Hub};
 use std::sync::mpsc::Sender;
 use std::sync::{Arc, Condvar, Mutex};
 use std::time::{Duration, Instant};
@@ -36,6 +38,7 @@ struct SessionState {
     online: bool,
     idle_since: Option<Instant>,
     idle_wake: Option<Sender<()>>,
+    hub: Option<Hub>,
 }
 
 struct IdleArmer {
@@ -115,6 +118,7 @@ impl WifiSession {
             online: false,
             idle_since: None,
             idle_wake: None,
+            hub: None,
         }));
         let observer = Arc::new(IdleArmer {
             state: Arc::clone(&state),
@@ -133,6 +137,11 @@ impl WifiSession {
             .lock()
             .unwrap_or_else(|e| e.into_inner())
             .idle_wake = Some(sender);
+    }
+
+    /// Stores the app event hub for emitting device events from lease paths.
+    pub fn set_hub(&self, hub: Hub) {
+        self.state.lock().unwrap_or_else(|e| e.into_inner()).hub = Some(hub);
     }
 
     /// Updates the configured WiFi mode (from settings).
@@ -315,6 +324,21 @@ impl WifiSession {
             }
         }
 
+        if matches!(self.wifi.network_info(), Ok(Some(_))) {
+            tracing::debug!(name = %name, "wifi lease acquired; already associated");
+            self.notify_online();
+            if let Some(hub) = self
+                .state
+                .lock()
+                .unwrap_or_else(|e| e.into_inner())
+                .hub
+                .as_ref()
+            {
+                hub.send(Event::Device(DeviceEvent::NetUp)).ok();
+            }
+            return Ok(WifiLease { inner: Some(inner) });
+        }
+
         let deadline = Instant::now() + timeout;
         let mut state = self.state.lock().map_err(|_| WifiSessionError::Lock)?;
         while !state.online {
@@ -374,16 +398,26 @@ impl WifiSession {
     }
 
     /// Enables the radio without taking a lease (AlwaysOn / resume).
+    ///
+    /// Returns `Ok(true)` when the radio is enabled and
+    /// [`WifiManager::network_info`] already reports an association (so the
+    /// caller can emit [`crate::input::DeviceEvent::NetUp`] without waiting for
+    /// a dhcpcd signal).
     #[cfg_attr(
         feature = "tracing",
         tracing::instrument(skip(self), err, level = tracing::Level::TRACE)
     )]
-    pub fn enable_radio(&self) -> Result<(), WifiError> {
+    pub fn enable_radio(&self) -> Result<bool, WifiError> {
         tracing::info!("enabling wifi radio");
         match self.wifi.enable() {
             Ok(()) => {
-                tracing::debug!("wifi radio enabled");
-                Ok(())
+                let connected =
+                    self.wifi.is_enabled() && matches!(self.wifi.network_info(), Ok(Some(_)));
+                tracing::debug!(connected, "wifi radio enabled");
+                if connected {
+                    self.notify_online();
+                }
+                Ok(connected)
             }
             Err(error) => {
                 tracing::error!(error = %error, "failed to enable wifi radio");
@@ -516,5 +550,30 @@ mod tests {
         assert!(matches!(err, WifiSessionError::Timeout));
         assert!(!session.has_holders());
         assert!(session.idle_since().is_some());
+    }
+
+    #[test]
+    fn enable_radio_reports_connected_when_associated() {
+        let (session, wifi) = session(WifiMode::AlwaysOn);
+        wifi.set_network_info(Ok(Some(crate::device::wifi::NetworkInfo {
+            ip: "192.168.1.1".parse().unwrap(),
+            essid: crate::device::wifi::Essid::new("test"),
+        })));
+        assert!(session.enable_radio().unwrap());
+        assert!(session.is_online());
+    }
+
+    #[test]
+    fn acquire_skips_wait_when_already_associated() {
+        let (session, wifi) = session(WifiMode::Auto);
+        wifi.set_network_info(Ok(Some(crate::device::wifi::NetworkInfo {
+            ip: "192.168.1.1".parse().unwrap(),
+            essid: crate::device::wifi::Essid::new("test"),
+        })));
+        let lease = session
+            .acquire_with_timeout("fast", Duration::from_millis(50))
+            .unwrap();
+        assert!(session.is_online());
+        drop(lease);
     }
 }

--- a/crates/core/src/task/wifi_status_monitor.rs
+++ b/crates/core/src/task/wifi_status_monitor.rs
@@ -1,8 +1,9 @@
 //! WiFi status monitor using dhcpcd-dbus.
 //!
 //! Subscribes to the `WpaStatus` signal from `name.marples.roy.dhcpcd` on the
-//! system bus. When the status changes to `COMPLETED`, sends a `NetUp` event
-//! to indicate the network is available.
+//! system bus. When the status changes to `COMPLETED` with an IP, sends a
+//! `NetUp` event. Startup connectivity is reconciled by the device lifecycle
+//! (enable/disable + `network_info`), not by probing dhcpcd here.
 
 use std::collections::HashMap;
 use std::sync::mpsc::Sender;
@@ -19,9 +20,7 @@ use crate::input::DeviceEvent;
 use crate::task::{BackgroundTask, ShutdownSignal, TaskId};
 use crate::view::Event;
 
-const DHCPCCD_SERVICE: &str = "name.marples.roy.dhcpcd";
 const DHCPCCD_PATH: &str = "/name/marples/roy/dhcpcd";
-const DHCPCCD_INTERFACE: &str = "name.marples.roy.dhcpcd";
 const SHUTDOWN_POLL_INTERVAL: Duration = Duration::from_millis(200);
 
 /// WiFi status monitor that listens for dhcpcd-dbus WpaStatus signals.
@@ -49,36 +48,12 @@ impl BackgroundTask for WifiStatusMonitorTask {
     }
 }
 
-#[cfg_attr(feature = "tracing", tracing::instrument(skip(connection, hub), ret(level=tracing::Level::TRACE)))]
-async fn check_initial_status(
-    connection: &zbus::Connection,
-    hub: &Sender<Event>,
-) -> Result<(), Box<dyn std::error::Error>> {
-    let proxy =
-        zbus::Proxy::new(connection, DHCPCCD_SERVICE, DHCPCCD_PATH, DHCPCCD_INTERFACE).await?;
-
-    let status: String = proxy.call("GetStatus", &()).await?;
-
-    tracing::debug!(status = %status, "initial dhcpcd status");
-
-    if status == "connected" {
-        tracing::info!("network already up at startup, sending NetUp event");
-        hub.send(Event::Device(DeviceEvent::NetUp)).ok();
-    }
-
-    Ok(())
-}
-
 async fn monitor(
     hub: &Sender<Event>,
     shutdown: &ShutdownSignal,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let connection = zbus::Connection::system().await?;
     tracing::info!("connected to system bus");
-
-    if let Err(e) = check_initial_status(&connection, hub).await {
-        tracing::warn!(error = %e, "failed to check initial dhcpcd status, will rely on signals");
-    }
 
     let rule = zbus::MatchRule::builder()
         .msg_type(zbus::message::Type::Signal)


### PR DESCRIPTION
Stale dhcpcd GetStatus NetUp at monitor start marked Auto sessions online before leases ran. Lifecycle owns startup enable/disable; NetUp only when AlwaysOn is already associated.

Change-Id: d2b9cbaba74a48967da9a3a52064bbc6
Change-Id-Short: mxoqnopopsvp

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when `context.online` is set and who emits NetUp, which affects sync/fetch behavior; scope is WiFi lifecycle with new tests but timing remains partly async on background threads.
> 
> **Overview**
> Fixes **Auto** WiFi falsely showing as online when dhcpcd’s startup **GetStatus** fired **NetUp** before lifecycle had disabled the radio or granted a lease.
> 
> **Startup and monitor:** Kobo lifecycle now enables or disables the radio from `wants_radio_at_rest()`, clears `context.online` when the radio should stay off, and only posts **`DeviceEvent::NetUp`** when **AlwaysOn** (or resume) enables the radio and **`network_info`** already shows an association. The wifi status monitor no longer probes dhcpcd at start; it still emits **NetUp** on later **WpaStatus** signals with an IP.
> 
> **Session and app:** `WifiSession::enable_radio` returns whether the link is already up; lease **acquire** can skip the online wait and emit **NetUp** via a hub set in the app before **`on_startup`**. Switching to **AlwaysOn** and cancel-suspend resume use the same connected check.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 509720818070f2d97df96748bc6b6185c65216d0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->