### PR TITLE
agents(cursor): use dockerfile to build could env

### DIFF
--- a/.cursor/CLOUD.md
+++ b/.cursor/CLOUD.md
@@ -3,30 +3,53 @@
 Applies only to Cursor Cloud agents. Coding conventions and testing policy:
 [AGENTS.md](../AGENTS.md). Command how-tos: [.agents/skills/](../.agents/skills/).
 
-## Environment overview
+## Layout
 
-- No Nix/devenv; toolchain is pre-baked in the snapshot (Rust, native libs,
-  mdbook stack, cargo-nextest, Linaro ARM cross toolchain).
-- VM boot runs the `install` script in [.cursor/environment.json](environment.json):
-  `git submodule update --init --recursive`.
+| File | Role |
+| ---- | ---- |
+| [.cursor/Dockerfile](Dockerfile) | Baked Ubuntu image: apt (incl. clang/gettext), rustup, Linaro, mdbook/mdbook-epub/mdbook-mermaid, cargo-nextest, Node. `ENV` pins match CI (`MDBOOK_*`, `NEXTEST_VERSION`, `NODE_VERSION`). No project `COPY`. |
+| [.cursor/cloud-install.sh](cloud-install.sh) | Idempotent install on each agent boot: submodules, `cargo xtask ci install-doc-tools`, `cargo xtask setup --host`, `npm ci`, EPUB if missing, `cargo fetch`, `~/.bashrc` exports. |
+| [.cursor/environment.json](environment.json) | Wires Dockerfile build (`context: ..`) and `install`; `agentCanUpdateSnapshot` lets setup agents promote snapshots. |
+| [.cursor/verify-cloud-install.sh](verify-cloud-install.sh) | Post-install assertions (used by CI). |
+| [.github/workflows/cursor-cloud.yml](../.github/workflows/cursor-cloud.yml) | Path-filtered CI: `check-jsonschema`, `docker build`, `container-structure-test`, `cloud-install` + verify. |
+
+## Boot sequence
+
+1. Cursor builds or restores from a snapshot/checkpoint based on [environment.json](environment.json).
+2. The Dockerfile layer provides `/home/ubuntu` toolchain paths and global `ENV` pins.
+3. [cloud-install.sh](cloud-install.sh) runs from the repo root (`install` in environment.json).
+4. `~/.bashrc` gains a managed block with SQLite, `PKG_CONFIG`, `SQLX_OFFLINE`, `LIBCLANG_PATH`, `DISPLAY`, and `PATH`.
+
+Use `CADMUS_HOME=/home/ubuntu` in the image so root-driven snapshot builds find Dockerfile-installed tools under `/home/ubuntu/.local/bin`.
 
 ## Build environment variables
 
-Exported in `~/.bashrc` — re-source in non-login shells:
+Exported in `~/.bashrc` (managed by cloud-install) — re-source in non-login shells:
 
-- `SQLITE3_STATIC=1`, `SQLITE3_LIB_DIR`, `SQLITE3_INCLUDE_DIR`
-- `PKG_CONFIG_PATH_x86_64_unknown_linux_gnu`, `SQLX_OFFLINE=true`
-- Kobo cross: `~/linaro-toolchain/bin` on `PATH`, `PKG_CONFIG_ALLOW_CROSS=1`,
-  `PKG_CONFIG_PATH_arm_unknown_linux_gnueabihf`
+- `CADMUS_ROOT`, `SQLITE3_STATIC=1`, `SQLITE3_LIB_DIR`, `SQLITE3_INCLUDE_DIR`
+- `PKG_CONFIG_PATH_x86_64_unknown_linux_gnu`, `PKG_CONFIG_PATH_arm_unknown_linux_gnueabihf`
+- `SQLX_OFFLINE=true`, `PKG_CONFIG_ALLOW_CROSS=1`, `LIBCLANG_PATH=/usr/lib/llvm-18/lib`
+- `DISPLAY=:1`
+- `PATH` includes `/home/ubuntu/.local/bin`, `/home/ubuntu/linaro-toolchain/bin`, `/usr/local/cargo/bin`
+
+## Renovate pins
+
+| Tool | Where pinned | Renovate |
+| ---- | ------------ | -------- |
+| mdbook / mdbook-epub / mdbook-mermaid | `.cursor/Dockerfile`, CI action, `cloud-install.sh` fallbacks | `custom.regex` + `mdbook` group |
+| mdbook-i18n-helpers | `thirdparty/mdbook-i18n-helpers` git submodule (+ `devenv.nix` rev) | `git-submodules` + `mdbook-i18n-helpers` group; [cloud-install.sh](cloud-install.sh) and CI read `git rev-parse HEAD:thirdparty/mdbook-i18n-helpers` after submodules init |
+| nextest / Node | Dockerfile + `cargo.yml` | `custom.regex` groups |
+| container-structure-test | `cursor-cloud.yml` | `custom.regex` |
+
+Do not Renovate-track: apt lists, floating rustup stable, Linaro 4.9.4 tarball URL.
 
 ## First-build recovery
 
 If a fresh snapshot fails to compile, see the relevant skill:
 
-- Custom SQLite: `cargo xtask setup --host` (before any `cargo build`)
-- EPUB: `build-cadmus-native` skill
-- Kobo assets: `cargo xtask download-assets` if `bin/`, `resources/`,
-  `hyphenation-patterns/` are missing
+- Custom SQLite: `cargo xtask setup --host` (cloud-install runs this; rerun manually if needed)
+- EPUB: `build-cadmus-native` skill (`cargo xtask docs --mdbook-only`)
+- Kobo assets: `cargo xtask download-assets` if `bin/`, `resources/`, `hyphenation-patterns/` are missing (not part of cloud-install)
 
 ## Emulator
 

--- a/.cursor/Dockerfile
+++ b/.cursor/Dockerfile
@@ -33,17 +33,28 @@ RUN apt-get update \
         git \
         gperf \
         jq \
+        libasound2 \
+        libatk-bridge2.0-0 \
+        libatk1.0-0 \
         libbz2-dev \
         libclang-dev \
         libdjvulibre-dev \
         libfreetype6-dev \
+        libgbm1 \
         libgumbo-dev \
         libharfbuzz-dev \
         libjbig2dec0-dev \
         libjpeg-dev \
+        libnspr4 \
+        libnss3 \
         libopenjp2-7-dev \
         libpng-dev \
         libtool \
+        libxcomposite1 \
+        libxdamage1 \
+        libxfixes3 \
+        libxkbcommon0 \
+        libxrandr2 \
         libsdl2-dev \
         llvm-dev \
         meson \

--- a/.cursor/Dockerfile
+++ b/.cursor/Dockerfile
@@ -1,0 +1,109 @@
+# Cadmus Cursor Cloud base image — toolchain only (no project COPY).
+# Checkout-dependent setup runs via .cursor/cloud-install.sh on each agent boot.
+
+FROM ubuntu:24.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Renovate-tracked version pins (same names as CI).
+ENV MDBOOK_VERSION=0.5.4
+ENV MDBOOK_EPUB_REV=21a1c8134134201a2d555313447c96e56e2a8996
+ENV MDBOOK_MERMAID_VERSION=0.17.0
+ENV NEXTEST_VERSION=0.9.140
+ENV NODE_VERSION=24
+
+ENV CARGO_HOME=/usr/local/cargo
+ENV RUSTUP_HOME=/usr/local/rustup
+ENV SQLX_OFFLINE=true
+ENV PKG_CONFIG_ALLOW_CROSS=1
+ENV DISPLAY=:1
+ENV NVM_DIR=/home/ubuntu/.nvm
+ENV PATH="/home/ubuntu/.local/bin:/home/ubuntu/linaro-toolchain/bin:/usr/local/cargo/bin:${PATH}"
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        autoconf \
+        automake \
+        build-essential \
+        ca-certificates \
+        clang \
+        cmake \
+        curl \
+        gettext \
+        git \
+        gperf \
+        jq \
+        libbz2-dev \
+        libclang-dev \
+        libdjvulibre-dev \
+        libfreetype6-dev \
+        libgumbo-dev \
+        libharfbuzz-dev \
+        libjbig2dec0-dev \
+        libjpeg-dev \
+        libopenjp2-7-dev \
+        libpng-dev \
+        libtool \
+        libsdl2-dev \
+        llvm-dev \
+        meson \
+        ninja-build \
+        patchelf \
+        pkg-config \
+        python3 \
+        tcl \
+        unzip \
+        wget \
+        zlib1g-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+ENV LIBCLANG_PATH=/usr/lib/llvm-18/lib
+
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
+        | sh -s -- -y --no-modify-path --default-toolchain stable \
+    && rustup target add arm-unknown-linux-gnueabihf \
+    && rustup component add rustfmt clippy llvm-tools-preview
+
+RUN mkdir -p /home/ubuntu/linaro-toolchain \
+    && cd /home/ubuntu/linaro-toolchain \
+    && wget -q https://developer.arm.com/-/cdn-downloads/permalink/legacy-linaro-gnu-toolchains/4.9-2017.01/gcc-linaro-4.9.4-2017.01-x86_64_arm-linux-gnueabihf.tar.xz \
+    && tar xf gcc-linaro-4.9.4-2017.01-x86_64_arm-linux-gnueabihf.tar.xz --strip-components=1 \
+    && rm gcc-linaro-4.9.4-2017.01-x86_64_arm-linux-gnueabihf.tar.xz
+
+RUN mkdir -p /home/ubuntu/.cache/mdbook /home/ubuntu/.local/bin \
+    && curl -fsSL "https://github.com/rust-lang/mdBook/releases/download/v${MDBOOK_VERSION}/mdbook-v${MDBOOK_VERSION}-x86_64-unknown-linux-gnu.tar.gz" \
+        | tar xz -C /home/ubuntu/.cache/mdbook \
+    && ln -sf /home/ubuntu/.cache/mdbook/mdbook /home/ubuntu/.local/bin/mdbook
+
+RUN mkdir -p /home/ubuntu/.cache/mdbook-epub /home/ubuntu/.local/bin \
+    && tmp="$(mktemp -d)" \
+    && curl -fsSL "https://github.com/Michael-F-Bryan/mdbook-epub/archive/${MDBOOK_EPUB_REV}.tar.gz" \
+        | tar xz -C "$tmp" \
+    && cargo install --path "$tmp/mdbook-epub-${MDBOOK_EPUB_REV}" --locked \
+        --root /home/ubuntu/.cache/mdbook-epub \
+    && echo "${MDBOOK_EPUB_REV}" > /home/ubuntu/.cache/mdbook-epub/.rev \
+    && ln -sf /home/ubuntu/.cache/mdbook-epub/bin/mdbook-epub /home/ubuntu/.local/bin/mdbook-epub \
+    && rm -rf "$tmp"
+
+RUN mkdir -p /home/ubuntu/.cache/mdbook-mermaid /home/ubuntu/.local/bin \
+    && cargo install mdbook-mermaid --version "${MDBOOK_MERMAID_VERSION}" \
+        --root /home/ubuntu/.cache/mdbook-mermaid \
+    && echo "${MDBOOK_MERMAID_VERSION}" > /home/ubuntu/.cache/mdbook-mermaid/.version \
+    && ln -sf /home/ubuntu/.cache/mdbook-mermaid/bin/mdbook-mermaid /home/ubuntu/.local/bin/mdbook-mermaid
+
+RUN cargo install cargo-nextest --version "${NEXTEST_VERSION}" --locked \
+    && ln -sf /usr/local/cargo/bin/cargo-nextest /home/ubuntu/.local/bin/cargo-nextest
+
+RUN export HOME=/home/ubuntu NVM_DIR=/home/ubuntu/.nvm \
+    && curl -fsSL https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.2/install.sh | bash \
+    && . /home/ubuntu/.nvm/nvm.sh \
+    && nvm install "${NODE_VERSION}" \
+    && nvm alias default "${NODE_VERSION}" \
+    && node_path="$(nvm which default)" \
+    && ln -sf "$node_path" /home/ubuntu/.local/bin/node \
+    && ln -sf "$(dirname "$node_path")/npm" /home/ubuntu/.local/bin/npm \
+    && ln -sf "$(dirname "$node_path")/npx" /home/ubuntu/.local/bin/npx
+
+RUN chown -R ubuntu:ubuntu /home/ubuntu
+
+WORKDIR /workspace

--- a/.cursor/Dockerfile
+++ b/.cursor/Dockerfile
@@ -33,9 +33,9 @@ RUN apt-get update \
         git \
         gperf \
         jq \
-        libasound2 \
-        libatk-bridge2.0-0 \
-        libatk1.0-0 \
+        libasound2t64 \
+        libatk-bridge2.0-0t64 \
+        libatk1.0-0t64 \
         libbz2-dev \
         libclang-dev \
         libdjvulibre-dev \

--- a/.cursor/cloud-install.sh
+++ b/.cursor/cloud-install.sh
@@ -21,6 +21,7 @@ fi
 
 EPUB_PATH="${ROOT}/docs/book/epub/Cadmus Documentation.epub"
 if [[ ! -f "$EPUB_PATH" ]]; then
+    export PUPPETEER_ARGS='--no-sandbox --disable-setuid-sandbox'
     cargo xtask docs --mdbook-only
 fi
 

--- a/.cursor/cloud-install.sh
+++ b/.cursor/cloud-install.sh
@@ -4,14 +4,15 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT"
 
-export PATH="$HOME/.local/bin:$HOME/linaro-toolchain/bin:/usr/local/cargo/bin:$PATH"
+CADMUS_HOME="${CADMUS_HOME:-/home/ubuntu}"
+export PATH="${CADMUS_HOME}/.local/bin:${CADMUS_HOME}/linaro-toolchain/bin:/usr/local/cargo/bin:${HOME}/.local/bin:$PATH"
 export SQLX_OFFLINE=true
 export PKG_CONFIG_ALLOW_CROSS=1
 
 git submodule update --init --recursive
 
 MDBOOK_I18N_HELPERS_REV="$(git rev-parse HEAD:thirdparty/mdbook-i18n-helpers)"
-cargo xtask ci install-doc-tools \
+HOME="${CADMUS_HOME}" cargo xtask ci install-doc-tools \
     --mdbook-version "${MDBOOK_VERSION:-0.5.4}" \
     --mdbook-epub-rev "${MDBOOK_EPUB_REV:-21a1c8134134201a2d555313447c96e56e2a8996}" \
     --mdbook-mermaid-version "${MDBOOK_MERMAID_VERSION:-0.17.0}" \
@@ -56,8 +57,9 @@ export SQLX_OFFLINE=true
 export PKG_CONFIG_ALLOW_CROSS=1
 export LIBCLANG_PATH=/usr/lib/llvm-18/lib
 export DISPLAY=:1
-export PATH="$HOME/linaro-toolchain/bin:$HOME/.local/bin:/usr/local/cargo/bin:$PATH"
-export NVM_DIR="$HOME/.nvm"
+export CADMUS_HOME="/home/ubuntu"
+export PATH="$CADMUS_HOME/.local/bin:$CADMUS_HOME/linaro-toolchain/bin:/usr/local/cargo/bin:$HOME/.local/bin:$PATH"
+export NVM_DIR="$CADMUS_HOME/.nvm"
 [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"
 {end}
 """

--- a/.cursor/cloud-install.sh
+++ b/.cursor/cloud-install.sh
@@ -4,6 +4,10 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT"
 
+export PATH="$HOME/.local/bin:$HOME/linaro-toolchain/bin:/usr/local/cargo/bin:$PATH"
+export SQLX_OFFLINE=true
+export PKG_CONFIG_ALLOW_CROSS=1
+
 git submodule update --init --recursive
 
 cargo xtask setup --host

--- a/.cursor/cloud-install.sh
+++ b/.cursor/cloud-install.sh
@@ -13,24 +13,23 @@ git submodule update --init --recursive
 
 MDBOOK_I18N_HELPERS_REV="$(git rev-parse HEAD:thirdparty/mdbook-i18n-helpers)"
 HOME="${CADMUS_HOME}" cargo xtask ci install-doc-tools \
-    --mdbook-version "${MDBOOK_VERSION:-0.5.4}" \
-    --mdbook-epub-rev "${MDBOOK_EPUB_REV:-21a1c8134134201a2d555313447c96e56e2a8996}" \
-    --mdbook-mermaid-version "${MDBOOK_MERMAID_VERSION:-0.17.0}" \
-    --mdbook-i18n-helpers-rev "${MDBOOK_I18N_HELPERS_REV}"
+  --mdbook-version "${MDBOOK_VERSION:-0.5.4}" \
+  --mdbook-epub-rev "${MDBOOK_EPUB_REV:-21a1c8134134201a2d555313447c96e56e2a8996}" \
+  --mdbook-mermaid-version "${MDBOOK_MERMAID_VERSION:-0.17.0}" \
+  --mdbook-i18n-helpers-rev "${MDBOOK_I18N_HELPERS_REV}"
 
 cargo xtask setup --host
 
 HOST_TRIPLE="$(rustc -vV | sed -n 's/^host: //p')"
-SQLITE_BASE="${ROOT}/target/cadmus-build-deps/${HOST_TRIPLE}/sqlite"
 
 if [[ -f package-lock.json ]]; then
-    npm ci
+  npm ci
 fi
 
 EPUB_PATH="${ROOT}/docs/book/epub/Cadmus Documentation.epub"
 if [[ ! -f "$EPUB_PATH" ]]; then
-    export PUPPETEER_ARGS='--no-sandbox --disable-setuid-sandbox'
-    cargo xtask docs --mdbook-only
+  export PUPPETEER_ARGS='--no-sandbox --disable-setuid-sandbox'
+  cargo xtask docs --mdbook-only
 fi
 
 cargo fetch

--- a/.cursor/cloud-install.sh
+++ b/.cursor/cloud-install.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+git submodule update --init --recursive
+
+cargo xtask setup --host
+
+HOST_TRIPLE="$(rustc -vV | sed -n 's/^host: //p')"
+SQLITE_BASE="${ROOT}/target/cadmus-build-deps/${HOST_TRIPLE}/sqlite"
+
+if [[ -f package-lock.json ]]; then
+    npm ci
+fi
+
+EPUB_PATH="${ROOT}/docs/book/epub/Cadmus Documentation.epub"
+if [[ ! -f "$EPUB_PATH" ]]; then
+    cargo xtask docs --mdbook-only
+fi
+
+cargo fetch
+
+BASHRC="${HOME}/.bashrc"
+MARKER_START="# >>> cadmus-cloud-env >>>"
+MARKER_END="# <<< cadmus-cloud-env <<<"
+
+python3 - "$BASHRC" "$MARKER_START" "$MARKER_END" "$ROOT" "$HOST_TRIPLE" <<'PY'
+import pathlib
+import sys
+
+bashrc, start, end, root, host_triple = sys.argv[1:6]
+path = pathlib.Path(bashrc)
+block = f"""{start}
+# Managed by .cursor/cloud-install.sh — do not edit manually.
+export CADMUS_ROOT="{root}"
+export SQLITE3_STATIC=1
+export SQLITE3_LIB_DIR="{root}/target/cadmus-build-deps/{host_triple}/sqlite/lib"
+export SQLITE3_INCLUDE_DIR="{root}/target/cadmus-build-deps/{host_triple}/sqlite/include"
+export PKG_CONFIG_PATH_x86_64_unknown_linux_gnu="{root}/target/cadmus-build-deps/x86_64-unknown-linux-gnu/sqlite/lib/pkgconfig"
+export PKG_CONFIG_PATH_arm_unknown_linux_gnueabihf="{root}/target/cadmus-build-deps/arm-unknown-linux-gnueabihf/sqlite/lib/pkgconfig"
+export SQLX_OFFLINE=true
+export PKG_CONFIG_ALLOW_CROSS=1
+export LIBCLANG_PATH=/usr/lib/llvm-18/lib
+export DISPLAY=:1
+export PATH="$HOME/linaro-toolchain/bin:$HOME/.local/bin:/usr/local/cargo/bin:$PATH"
+export NVM_DIR="$HOME/.nvm"
+[ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"
+{end}
+"""
+
+text = path.read_text() if path.exists() else ""
+if start in text and end in text:
+    before, rest = text.split(start, 1)
+    _, after = rest.split(end, 1)
+    text = before + block + after
+else:
+    text = text.rstrip() + "\n\n" + block + "\n"
+
+path.write_text(text)
+PY

--- a/.cursor/cloud-install.sh
+++ b/.cursor/cloud-install.sh
@@ -56,6 +56,7 @@ export SQLX_OFFLINE=true
 export PKG_CONFIG_ALLOW_CROSS=1
 export LIBCLANG_PATH=/usr/lib/llvm-18/lib
 export DISPLAY=:1
+export PUPPETEER_ARGS="--no-sandbox --disable-setuid-sandbox"
 export CADMUS_HOME="/home/ubuntu"
 export PATH="$CADMUS_HOME/.local/bin:$CADMUS_HOME/linaro-toolchain/bin:/usr/local/cargo/bin:$HOME/.local/bin:$PATH"
 export NVM_DIR="$CADMUS_HOME/.nvm"

--- a/.cursor/cloud-install.sh
+++ b/.cursor/cloud-install.sh
@@ -10,6 +10,13 @@ export PKG_CONFIG_ALLOW_CROSS=1
 
 git submodule update --init --recursive
 
+MDBOOK_I18N_HELPERS_REV="$(git rev-parse HEAD:thirdparty/mdbook-i18n-helpers)"
+cargo xtask ci install-doc-tools \
+    --mdbook-version "${MDBOOK_VERSION:-0.5.4}" \
+    --mdbook-epub-rev "${MDBOOK_EPUB_REV:-21a1c8134134201a2d555313447c96e56e2a8996}" \
+    --mdbook-mermaid-version "${MDBOOK_MERMAID_VERSION:-0.17.0}" \
+    --mdbook-i18n-helpers-rev "${MDBOOK_I18N_HELPERS_REV}"
+
 cargo xtask setup --host
 
 HOST_TRIPLE="$(rustc -vV | sed -n 's/^host: //p')"

--- a/.cursor/cloud-install.sh
+++ b/.cursor/cloud-install.sh
@@ -5,14 +5,16 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT"
 
 CADMUS_HOME="${CADMUS_HOME:-/home/ubuntu}"
-export PATH="${CADMUS_HOME}/.local/bin:${CADMUS_HOME}/linaro-toolchain/bin:/usr/local/cargo/bin:${HOME}/.local/bin:$PATH"
+export HOME="${CADMUS_HOME}"
+export PATH="${CADMUS_HOME}/.local/bin:${CADMUS_HOME}/linaro-toolchain/bin:/usr/local/cargo/bin:${PATH}"
 export SQLX_OFFLINE=true
 export PKG_CONFIG_ALLOW_CROSS=1
+export PUPPETEER_ARGS="${PUPPETEER_ARGS:---no-sandbox --disable-setuid-sandbox}"
 
 git submodule update --init --recursive
 
 MDBOOK_I18N_HELPERS_REV="$(git rev-parse HEAD:thirdparty/mdbook-i18n-helpers)"
-HOME="${CADMUS_HOME}" cargo xtask ci install-doc-tools \
+cargo xtask ci install-doc-tools \
   --mdbook-version "${MDBOOK_VERSION:-0.5.4}" \
   --mdbook-epub-rev "${MDBOOK_EPUB_REV:-21a1c8134134201a2d555313447c96e56e2a8996}" \
   --mdbook-mermaid-version "${MDBOOK_MERMAID_VERSION:-0.17.0}" \
@@ -28,7 +30,6 @@ fi
 
 EPUB_PATH="${ROOT}/docs/book/epub/Cadmus Documentation.epub"
 if [[ ! -f "$EPUB_PATH" ]]; then
-  export PUPPETEER_ARGS='--no-sandbox --disable-setuid-sandbox'
   cargo xtask docs --mdbook-only
 fi
 

--- a/.cursor/container-structure-test.yaml
+++ b/.cursor/container-structure-test.yaml
@@ -1,7 +1,7 @@
 schemaVersion: "2.0.0"
 
 metadataTest:
-  env:
+  envVars:
     - key: SQLX_OFFLINE
       value: "true"
     - key: PKG_CONFIG_ALLOW_CROSS

--- a/.cursor/container-structure-test.yaml
+++ b/.cursor/container-structure-test.yaml
@@ -27,7 +27,7 @@ commandTests:
   - name: mdbook-epub
     command: mdbook-epub
     args: ["--version"]
-    expectedOutput: ["mdbook-epub"]
+    expectedOutput: ["MDBook epub"]
   - name: mdbook-mermaid
     command: mdbook-mermaid
     args: ["--version"]

--- a/.cursor/container-structure-test.yaml
+++ b/.cursor/container-structure-test.yaml
@@ -13,7 +13,7 @@ fileExistenceTests:
   - name: linaro-arm-gcc
     path: /home/ubuntu/linaro-toolchain/bin/arm-linux-gnueabihf-gcc
     shouldExist: true
-    permissions: "-rwx"
+    permissions: "-rwxr-xr-x"
 
 commandTests:
   - name: rustc

--- a/.cursor/container-structure-test.yaml
+++ b/.cursor/container-structure-test.yaml
@@ -1,0 +1,42 @@
+schemaVersion: "2.0.0"
+
+metadataTest:
+  env:
+    - key: SQLX_OFFLINE
+      value: "true"
+    - key: PKG_CONFIG_ALLOW_CROSS
+      value: "1"
+    - key: LIBCLANG_PATH
+      value: "/usr/lib/llvm-18/lib"
+
+fileExistenceTests:
+  - name: linaro-arm-gcc
+    path: /home/ubuntu/linaro-toolchain/bin/arm-linux-gnueabihf-gcc
+    shouldExist: true
+    permissions: "-rwx"
+
+commandTests:
+  - name: rustc
+    command: rustc
+    args: ["--version"]
+    expectedOutput: ["rustc"]
+  - name: mdbook
+    command: mdbook
+    args: ["--version"]
+    expectedOutput: ["mdbook"]
+  - name: mdbook-epub
+    command: mdbook-epub
+    args: ["--version"]
+    expectedOutput: ["mdbook-epub"]
+  - name: mdbook-mermaid
+    command: mdbook-mermaid
+    args: ["--version"]
+    expectedOutput: ["mdbook-mermaid"]
+  - name: cargo-nextest
+    command: cargo-nextest
+    args: ["--version"]
+    expectedOutput: ["cargo-nextest"]
+  - name: node
+    command: node
+    args: ["--version"]
+    expectedOutput: ["v24"]

--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,3 +1,8 @@
 {
-  "install": "git submodule update --init --recursive"
+  "build": {
+    "dockerfile": "Dockerfile",
+    "context": ".."
+  },
+  "agentCanUpdateSnapshot": true,
+  "install": "bash .cursor/cloud-install.sh"
 }

--- a/.cursor/verify-cloud-install.sh
+++ b/.cursor/verify-cloud-install.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+CADMUS_HOME="${CADMUS_HOME:-/home/ubuntu}"
+export PATH="${CADMUS_HOME}/.local/bin:${CADMUS_HOME}/linaro-toolchain/bin:/usr/local/cargo/bin:${PATH}"
+
+HOST_TRIPLE="$(rustc -vV | sed -n 's/^host: //p')"
+SQLITE_LIB="${ROOT}/target/cadmus-build-deps/${HOST_TRIPLE}/sqlite/lib/libsqlite3.a"
+EPUB_PATH="${ROOT}/docs/book/epub/Cadmus Documentation.epub"
+
+for cmd in rustc cargo mdbook mdbook-epub mdbook-mermaid mdbook-gettext cargo-nextest node npm; do
+    if ! command -v "$cmd" >/dev/null 2>&1; then
+        echo "missing command: $cmd" >&2
+        exit 1
+    fi
+done
+
+if [[ ! -f "$SQLITE_LIB" ]]; then
+    echo "missing custom SQLite static library: $SQLITE_LIB" >&2
+    exit 1
+fi
+
+if [[ ! -f "$EPUB_PATH" ]]; then
+    echo "missing documentation EPUB: $EPUB_PATH" >&2
+    exit 1
+fi
+
+if [[ ! -x "${CADMUS_HOME}/linaro-toolchain/bin/arm-linux-gnueabihf-gcc" ]]; then
+    echo "missing Linaro ARM GCC" >&2
+    exit 1
+fi
+
+echo "Cursor Cloud install verification passed."

--- a/.cursor/verify-cloud-install.sh
+++ b/.cursor/verify-cloud-install.sh
@@ -33,4 +33,15 @@ if [[ ! -x "${CADMUS_HOME}/linaro-toolchain/bin/arm-linux-gnueabihf-gcc" ]]; the
   exit 1
 fi
 
+MERMAID_DIR="${ROOT}/docs/src/mermaid-images"
+expected_mermaid="$(grep -r '```mermaid' "${ROOT}/docs/src" --include='*.md' 2>/dev/null | wc -l)"
+actual_mermaid="$(find "$MERMAID_DIR" -name '*.png' 2>/dev/null | wc -l)"
+if [[ "$expected_mermaid" -gt 0 ]]; then
+  if [[ "$actual_mermaid" -lt "$expected_mermaid" ]]; then
+    echo "missing mermaid PNG renders for EPUB: expected ${expected_mermaid}, got ${actual_mermaid}" >&2
+    echo "ensure Chrome headless deps are installed and PUPPETEER_ARGS is set for containers" >&2
+    exit 1
+  fi
+fi
+
 echo "Cursor Cloud install verification passed."

--- a/.cursor/verify-cloud-install.sh
+++ b/.cursor/verify-cloud-install.sh
@@ -12,25 +12,25 @@ SQLITE_LIB="${ROOT}/target/cadmus-build-deps/${HOST_TRIPLE}/sqlite/lib/libsqlite
 EPUB_PATH="${ROOT}/docs/book/epub/Cadmus Documentation.epub"
 
 for cmd in rustc cargo mdbook mdbook-epub mdbook-mermaid mdbook-gettext cargo-nextest node npm; do
-    if ! command -v "$cmd" >/dev/null 2>&1; then
-        echo "missing command: $cmd" >&2
-        exit 1
-    fi
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    echo "missing command: $cmd" >&2
+    exit 1
+  fi
 done
 
 if [[ ! -f "$SQLITE_LIB" ]]; then
-    echo "missing custom SQLite static library: $SQLITE_LIB" >&2
-    exit 1
+  echo "missing custom SQLite static library: $SQLITE_LIB" >&2
+  exit 1
 fi
 
 if [[ ! -f "$EPUB_PATH" ]]; then
-    echo "missing documentation EPUB: $EPUB_PATH" >&2
-    exit 1
+  echo "missing documentation EPUB: $EPUB_PATH" >&2
+  exit 1
 fi
 
 if [[ ! -x "${CADMUS_HOME}/linaro-toolchain/bin/arm-linux-gnueabihf-gcc" ]]; then
-    echo "missing Linaro ARM GCC" >&2
-    exit 1
+  echo "missing Linaro ARM GCC" >&2
+  exit 1
 fi
 
 echo "Cursor Cloud install verification passed."

--- a/.github/workflows/cursor-cloud.yml
+++ b/.github/workflows/cursor-cloud.yml
@@ -77,7 +77,9 @@ jobs:
           docker run --rm \
             -v "${GITHUB_WORKSPACE}:/workspace" \
             -w /workspace \
+            -e HOME=/home/ubuntu \
             -e CADMUS_HOME=/home/ubuntu \
+            -e PUPPETEER_ARGS='--no-sandbox --disable-setuid-sandbox' \
             "$CURSOR_CLOUD_IMAGE" \
             bash -c '
               set -euo pipefail

--- a/.github/workflows/cursor-cloud.yml
+++ b/.github/workflows/cursor-cloud.yml
@@ -1,0 +1,101 @@
+name: Cursor Cloud environment
+
+on:
+  pull_request:
+  push:
+    branches: [main, master]
+    paths:
+      - ".cursor/**"
+      - ".github/workflows/cursor-cloud.yml"
+
+permissions:
+  contents: read
+
+env:
+  CURSOR_CLOUD_IMAGE: cadmus-cursor-cloud:ci
+  CONTAINER_STRUCTURE_TEST_VERSION: v1.19.3
+
+jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      cursor: ${{ steps.filter.outputs.cursor }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
+        id: filter
+        with:
+          filters: |
+            cursor:
+              - '.cursor/**'
+              - '.github/workflows/cursor-cloud.yml'
+
+  validate:
+    needs: changes
+    if: github.event_name != 'pull_request' || needs.changes.outputs.cursor == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Setup Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
+        with:
+          python-version: "3.x"
+
+      - name: Install JSON schema validator
+        run: pip install check-jsonschema
+
+      - name: Validate environment.json
+        run: >-
+          check-jsonschema
+          --schemafile https://www.cursor.com/schemas/environment.schema.json
+          .cursor/environment.json
+
+      - name: Build Cursor Cloud image
+        run: docker build -f .cursor/Dockerfile -t "$CURSOR_CLOUD_IMAGE" .
+
+      - name: Install container-structure-test
+        run: |
+          curl -fsSL \
+            "https://github.com/GoogleContainerTools/container-structure-test/releases/download/${CONTAINER_STRUCTURE_TEST_VERSION}/container-structure-test-linux-amd64" \
+            -o /usr/local/bin/container-structure-test
+          chmod +x /usr/local/bin/container-structure-test
+
+      - name: Assert baked toolchain in image
+        run: >-
+          container-structure-test test
+          --image "$CURSOR_CLOUD_IMAGE"
+          --config .cursor/container-structure-test.yaml
+
+      - name: Run cloud-install in image
+        run: |
+          docker run --rm \
+            -v "${GITHUB_WORKSPACE}:/workspace" \
+            -w /workspace \
+            -e CADMUS_HOME=/home/ubuntu \
+            "$CURSOR_CLOUD_IMAGE" \
+            bash -c '
+              set -euo pipefail
+              git config --global --add safe.directory /workspace
+              bash .cursor/cloud-install.sh
+              bash .cursor/verify-cloud-install.sh
+            '
+
+  required-cursor-cloud:
+    name: required-cursor-cloud
+    permissions: {}
+    needs: [changes, validate]
+    if: >-
+      always() &&
+      github.event_name == 'pull_request' &&
+      (cancelled() || contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled'))
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          echo "::error::One or more required jobs failed or were cancelled"
+          exit 1

--- a/docs/mdbook-mermaid-preprocessor.py
+++ b/docs/mdbook-mermaid-preprocessor.py
@@ -17,10 +17,21 @@ Source files remain untouched - all processing happens in memory.
 import json
 import os
 import re
+import shlex
 import subprocess
 import sys
 import tempfile
 from pathlib import Path
+
+
+def puppeteer_launch_args() -> list[str]:
+    """Chrome flags for mmdc/Puppeteer (e.g. --no-sandbox in containers)."""
+    raw = os.environ.get("PUPPETEER_ARGS", "").strip()
+    if raw:
+        return shlex.split(raw)
+    if os.environ.get("CI") or os.environ.get("GITHUB_ACTIONS"):
+        return ["--no-sandbox"]
+    return []
 
 
 def render_mermaid_to_png(mermaid_code: str, output_path: Path) -> bool:
@@ -74,18 +85,17 @@ def render_mermaid_to_png(mermaid_code: str, output_path: Path) -> bool:
             "transparent",
         ]
 
-        is_ci = os.environ.get("CI") or os.environ.get("GITHUB_ACTIONS")
+        launch_args = puppeteer_launch_args()
         temp_puppeteer_config = None
-        if is_ci:
+        if launch_args:
             with tempfile.NamedTemporaryFile(
                 mode="w", suffix=".json", delete=False
             ) as config_file:
-                json.dump({"args": ["--no-sandbox"]}, config_file)
+                json.dump({"args": launch_args}, config_file)
                 temp_puppeteer_config = config_file.name
             cmd.extend(["--puppeteerConfigFile", temp_puppeteer_config])
 
         subprocess.run(cmd, capture_output=True, text=True, check=True, env=env)
-        
         if temp_puppeteer_config:
             Path(temp_puppeteer_config).unlink()
 

--- a/docs/mdbook-mermaid-preprocessor.py
+++ b/docs/mdbook-mermaid-preprocessor.py
@@ -34,6 +34,35 @@ def puppeteer_launch_args() -> list[str]:
     return []
 
 
+def find_chrome_headless_executable() -> str | None:
+    """Locate puppeteer's chrome-headless-shell binary under the browser cache."""
+    cache_dirs: list[Path] = []
+    if os.environ.get("PUPPETEER_CACHE_DIR"):
+        cache_dirs.append(Path(os.environ["PUPPETEER_CACHE_DIR"]))
+    home = Path(os.environ.get("CADMUS_HOME", Path.home()))
+    cache_dirs.append(home / ".cache" / "puppeteer")
+
+    platform_dir_names = [
+        "chrome-headless-shell-linux64",
+        "chrome-headless-shell-linux-x64",
+        "chrome-headless-shell-mac-arm64",
+        "chrome-headless-shell",
+    ]
+
+    for cache_dir in cache_dirs:
+        shell_root = cache_dir / "chrome-headless-shell"
+        if not shell_root.is_dir():
+            continue
+        for version_dir in sorted(shell_root.iterdir(), reverse=True):
+            if not version_dir.is_dir():
+                continue
+            for platform_name in platform_dir_names:
+                chrome_exe = version_dir / platform_name / "chrome-headless-shell"
+                if chrome_exe.is_file():
+                    return str(chrome_exe)
+    return None
+
+
 def render_mermaid_to_png(mermaid_code: str, output_path: Path) -> bool:
     """
     Render a mermaid diagram to PNG using mermaid-cli (mmdc).
@@ -53,24 +82,7 @@ def render_mermaid_to_png(mermaid_code: str, output_path: Path) -> bool:
             temp_mmd_path = temp_mmd.name
 
         mmdc_cmd = "../node_modules/.bin/mmdc"
-        home = Path.home()
-        puppeteer_cache = home / ".cache" / "puppeteer" / "chrome-headless-shell"
-
-        chrome_path = None
-        if puppeteer_cache.exists():
-            for version_dir in puppeteer_cache.iterdir():
-                if version_dir.is_dir():
-                    for platform in [
-                        "chrome-headless-shell-mac-arm64",
-                        "chrome-headless-shell-linux-x64",
-                        "chrome-headless-shell",
-                    ]:
-                        chrome_exe = version_dir / platform / "chrome-headless-shell"
-                        if chrome_exe.exists():
-                            chrome_path = str(chrome_exe)
-                            break
-                    if chrome_path:
-                        break
+        chrome_path = find_chrome_headless_executable()
 
         env = os.environ.copy()
         if chrome_path:

--- a/renovate.json
+++ b/renovate.json
@@ -55,7 +55,7 @@
       "addLabels": ["thirdparty"]
     },
     {
-      "description": "Keep mdbook-i18n-helpers submodule and devenv.nix fetchFromGitHub pin in sync",
+      "description": "Keep mdbook-i18n-helpers submodule, devenv.nix pin, and install-doc-tools/cloud-install gitlink in sync",
       "matchManagers": ["git-submodules", "custom.regex"],
       "matchPackageNames": [
         "thirdparty/mdbook-i18n-helpers",
@@ -160,9 +160,13 @@
       "customType": "regex",
       "managerFilePatterns": [
         "/^\\.github\\/actions\\/install-doc-tools\\/action\\.yml$/",
-        "/^\\.cursor\\/Dockerfile$/"
+        "/^\\.cursor\\/Dockerfile$/",
+        "/^\\.cursor\\/cloud-install\\.sh$/"
       ],
-      "matchStrings": ["MDBOOK_VERSION=(?<currentValue>[^\"]+)"],
+      "matchStrings": [
+        "MDBOOK_VERSION=(?<currentValue>[^\"]+)",
+        "MDBOOK_VERSION:-(?<currentValue>[0-9.]+)"
+      ],
       "datasourceTemplate": "github-releases",
       "depNameTemplate": "rust-lang/mdBook",
       "versioningTemplate": "semver"
@@ -171,9 +175,13 @@
       "customType": "regex",
       "managerFilePatterns": [
         "/^\\.github\\/actions\\/install-doc-tools\\/action\\.yml$/",
-        "/^\\.cursor\\/Dockerfile$/"
+        "/^\\.cursor\\/Dockerfile$/",
+        "/^\\.cursor\\/cloud-install\\.sh$/"
       ],
-      "matchStrings": ["MDBOOK_EPUB_REV=(?<currentValue>[a-f0-9]{40})"],
+      "matchStrings": [
+        "MDBOOK_EPUB_REV=(?<currentValue>[a-f0-9]{40})",
+        "MDBOOK_EPUB_REV:-(?<currentValue>[a-f0-9]{40})"
+      ],
       "datasourceTemplate": "git-refs",
       "depNameTemplate": "Michael-F-Bryan/mdbook-epub",
       "packageNameTemplate": "https://github.com/Michael-F-Bryan/mdbook-epub",
@@ -183,9 +191,13 @@
       "customType": "regex",
       "managerFilePatterns": [
         "/^\\.github\\/actions\\/install-doc-tools\\/action\\.yml$/",
-        "/^\\.cursor\\/Dockerfile$/"
+        "/^\\.cursor\\/Dockerfile$/",
+        "/^\\.cursor\\/cloud-install\\.sh$/"
       ],
-      "matchStrings": ["MDBOOK_MERMAID_VERSION=(?<currentValue>[^\"]+)"],
+      "matchStrings": [
+        "MDBOOK_MERMAID_VERSION=(?<currentValue>[^\"]+)",
+        "MDBOOK_MERMAID_VERSION:-(?<currentValue>[0-9.]+)"
+      ],
       "datasourceTemplate": "github-releases",
       "depNameTemplate": "badboy/mdbook-mermaid",
       "versioningTemplate": "semver"

--- a/renovate.json
+++ b/renovate.json
@@ -147,6 +147,17 @@
     },
     {
       "customType": "regex",
+      "managerFilePatterns": ["/^\\.github\\/workflows\\/cursor-cloud\\.yml$/"],
+      "matchStrings": [
+        "CONTAINER_STRUCTURE_TEST_VERSION:\\s+(?<currentValue>v[^\\s]+)"
+      ],
+      "datasourceTemplate": "github-releases",
+      "depNameTemplate": "GoogleContainerTools/container-structure-test",
+      "extractVersionTemplate": "^v?(?<version>.+)$",
+      "versioningTemplate": "semver"
+    },
+    {
+      "customType": "regex",
       "managerFilePatterns": [
         "/^\\.github\\/actions\\/install-doc-tools\\/action\\.yml$/",
         "/^\\.cursor\\/Dockerfile$/"

--- a/renovate.json
+++ b/renovate.json
@@ -65,6 +65,31 @@
       "groupSlug": "mdbook-i18n-helpers"
     },
     {
+      "description": "Keep mdbook tool pins in sync across CI action and Dockerfile",
+      "matchManagers": ["custom.regex"],
+      "matchDepNames": [
+        "rust-lang/mdBook",
+        "Michael-F-Bryan/mdbook-epub",
+        "badboy/mdbook-mermaid"
+      ],
+      "groupName": "mdbook",
+      "groupSlug": "mdbook"
+    },
+    {
+      "description": "Keep cargo-nextest pins in sync across CI workflow and Dockerfile",
+      "matchManagers": ["custom.regex"],
+      "matchDepNames": ["nextest-rs/nextest"],
+      "groupName": "cargo-nextest",
+      "groupSlug": "cargo-nextest"
+    },
+    {
+      "description": "Keep Node.js version pins in sync across workflows and Dockerfile",
+      "matchManagers": ["custom.regex"],
+      "matchDepNames": ["node"],
+      "groupName": "node",
+      "groupSlug": "node"
+    },
+    {
       "description": "Keep mupdf submodule and version pins in sync",
       "matchManagers": ["git-submodules", "custom.regex"],
       "matchDepNames": ["thirdparty/mupdf", "ArtifexSoftware/mupdf"],
@@ -123,7 +148,8 @@
     {
       "customType": "regex",
       "managerFilePatterns": [
-        "/^\\.github\\/actions\\/install-doc-tools\\/action\\.yml$/"
+        "/^\\.github\\/actions\\/install-doc-tools\\/action\\.yml$/",
+        "/^\\.cursor\\/Dockerfile$/"
       ],
       "matchStrings": ["MDBOOK_VERSION=(?<currentValue>[^\"]+)"],
       "datasourceTemplate": "github-releases",
@@ -133,7 +159,8 @@
     {
       "customType": "regex",
       "managerFilePatterns": [
-        "/^\\.github\\/actions\\/install-doc-tools\\/action\\.yml$/"
+        "/^\\.github\\/actions\\/install-doc-tools\\/action\\.yml$/",
+        "/^\\.cursor\\/Dockerfile$/"
       ],
       "matchStrings": ["MDBOOK_EPUB_REV=(?<currentValue>[a-f0-9]{40})"],
       "datasourceTemplate": "git-refs",
@@ -144,7 +171,8 @@
     {
       "customType": "regex",
       "managerFilePatterns": [
-        "/^\\.github\\/actions\\/install-doc-tools\\/action\\.yml$/"
+        "/^\\.github\\/actions\\/install-doc-tools\\/action\\.yml$/",
+        "/^\\.cursor\\/Dockerfile$/"
       ],
       "matchStrings": ["MDBOOK_MERMAID_VERSION=(?<currentValue>[^\"]+)"],
       "datasourceTemplate": "github-releases",
@@ -191,17 +219,27 @@
         "/^\\.github\\/workflows\\/release\\.yml$/",
         "/^\\.github\\/workflows\\/build-release-candidate\\.yml$/",
         "/^\\.github\\/workflows\\/actions-lint\\.yml$/",
-        "/^\\.github\\/workflows\\/website\\.yml$/"
+        "/^\\.github\\/workflows\\/website\\.yml$/",
+        "/^\\.cursor\\/Dockerfile$/"
       ],
-      "matchStrings": ["NODE_VERSION:\\s+\\\"(?<currentValue>[^\\\"]+)\\\""],
+      "matchStrings": [
+        "NODE_VERSION:\\s+\\\"(?<currentValue>[^\\\"]+)\\\"",
+        "ENV NODE_VERSION=(?<currentValue>[^\"\\s]+)"
+      ],
       "datasourceTemplate": "node-version",
       "depNameTemplate": "node",
       "versioningTemplate": "node"
     },
     {
       "customType": "regex",
-      "managerFilePatterns": ["/^\\.github\\/workflows\\/cargo\\.yml$/"],
-      "matchStrings": ["NEXTEST_VERSION:\\s+\\\"(?<currentValue>[^\\\"]+)\\\""],
+      "managerFilePatterns": [
+        "/^\\.github\\/workflows\\/cargo\\.yml$/",
+        "/^\\.cursor\\/Dockerfile$/"
+      ],
+      "matchStrings": [
+        "NEXTEST_VERSION:\\s+\\\"(?<currentValue>[^\\\"]+)\\\"",
+        "ENV NEXTEST_VERSION=(?<currentValue>[^\"\\s]+)"
+      ],
       "datasourceTemplate": "github-releases",
       "depNameTemplate": "nextest-rs/nextest",
       "extractVersionTemplate": "^cargo-nextest-(?<version>.+)$",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a repo-managed Cursor Cloud environment split between a baked Dockerfile toolchain and a checkout-dependent install script, plus CI to verify it.

- **`.cursor/Dockerfile`** — Ubuntu base with apt (clang/gettext), rustup, Linaro, mdbook stack, nextest, Node; `ENV` pins match CI.
- **`.cursor/cloud-install.sh`** — Submodules, `install-doc-tools`, `setup --host`, `npm ci`, EPUB if missing, `cargo fetch`, `~/.bashrc` exports; uses `/home/ubuntu` paths for root snapshot builds.
- **`.cursor/environment.json`** — Dockerfile build + `cloud-install.sh`; `agentCanUpdateSnapshot`.
- **`renovate.json`** — Dockerfile pins tracked alongside CI.
- **`.github/workflows/cursor-cloud.yml`** — On `.cursor/**` changes: `check-jsonschema` for `environment.json`, `docker build`, `container-structure-test`, `cloud-install` + `verify-cloud-install.sh` in the image.

## Test plan

- [x] Draft Cursor Cloud environment build **SUCCEEDED** (`bld-20260804-61b8aadd-6967-4cde-b7dd-a549f396093c`)
- [x] `check-jsonschema` validates `environment.json` locally
- [ ] `cursor-cloud` GitHub Actions workflow on this PR
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-05b824fa-09a6-497a-88cc-e8c44b9a85c2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-05b824fa-09a6-497a-88cc-e8c44b9a85c2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

