### PR TITLE
test(kobo): isolate peer_installs from shared /tmp

### DIFF
--- a/crates/core/src/device/kobo/device.rs
+++ b/crates/core/src/device/kobo/device.rs
@@ -5,7 +5,26 @@ use crate::device::linux::LinuxRtc;
 use crate::device::metadata::DeviceMetadata;
 use std::env;
 use std::fmt::Debug;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
+
+fn discover_peer_installs(root: &Path, current: &Path) -> Vec<crate::device::PeerInstall> {
+    [
+        (".adds/cadmus", crate::version::BuildKind::Standard),
+        (".adds/cadmus-tst", crate::version::BuildKind::Test),
+    ]
+    .into_iter()
+    .filter_map(|(subdir, kind)| {
+        let dir = root.join(subdir);
+        if dir == current {
+            return None;
+        }
+        let launcher = dir.join("cadmus.sh");
+        launcher
+            .is_file()
+            .then_some(crate::device::PeerInstall { kind, launcher })
+    })
+    .collect()
+}
 
 pub struct Device {
     model: Model,
@@ -130,23 +149,7 @@ impl crate::device::DevicePaths for Device {
             test => { std::env::temp_dir().join("test-kobo-installation") }
             _ => { PathBuf::from(crate::settings::INTERNAL_CARD_ROOT) }
         };
-        let current = self.install_dir();
-        [
-            (".adds/cadmus", crate::version::BuildKind::Standard),
-            (".adds/cadmus-tst", crate::version::BuildKind::Test),
-        ]
-        .into_iter()
-        .filter_map(|(subdir, kind)| {
-            let dir = root.join(subdir);
-            if dir == current {
-                return None;
-            }
-            let launcher = dir.join("cadmus.sh");
-            launcher
-                .is_file()
-                .then_some(crate::device::PeerInstall { kind, launcher })
-        })
-        .collect()
+        discover_peer_installs(&root, &self.install_dir())
     }
 }
 
@@ -264,36 +267,24 @@ mod tests {
 
         #[test]
         fn peer_installs_empty_without_peer_launcher() {
-            let d = Model::Sage.device().unwrap();
-            assert!(d.peer_installs().is_empty());
+            let root = tempfile::tempdir().unwrap();
+            let current = root.path().join(".adds/cadmus");
+            assert!(discover_peer_installs(root.path(), &current).is_empty());
         }
 
         #[test]
         fn peer_installs_finds_peer_cadmus_sh() {
-            let d = Model::Sage.device().unwrap();
-            let root = std::env::temp_dir().join("test-kobo-installation");
-            let peer_subdir = if d.install_subdir() == ".adds/cadmus" {
-                ".adds/cadmus-tst"
-            } else {
-                ".adds/cadmus"
-            };
-            let peer_dir = root.join(peer_subdir);
+            let root = tempfile::tempdir().unwrap();
+            let current = root.path().join(".adds/cadmus");
+            let peer_dir = root.path().join(".adds/cadmus-tst");
             let launcher = peer_dir.join("cadmus.sh");
             std::fs::create_dir_all(&peer_dir).unwrap();
             std::fs::write(&launcher, "#!/bin/sh\n").unwrap();
 
-            let peers = d.peer_installs();
+            let peers = discover_peer_installs(root.path(), &current);
             assert_eq!(peers.len(), 1);
             assert_eq!(peers[0].launcher, launcher);
-            let expected_kind = if peer_subdir == ".adds/cadmus-tst" {
-                crate::version::BuildKind::Test
-            } else {
-                crate::version::BuildKind::Standard
-            };
-            assert_eq!(peers[0].kind, expected_kind);
-
-            std::fs::remove_file(&launcher).ok();
-            std::fs::remove_dir_all(&peer_dir).ok();
+            assert_eq!(peers[0].kind, crate::version::BuildKind::Test);
         }
     }
 

--- a/crates/core/src/device/kobo/lifecycle/power.rs
+++ b/crates/core/src/device/kobo/lifecycle/power.rs
@@ -78,6 +78,14 @@ mod tests {
         assert_eq!(outcome, EventOutcome::Exit(ExitStatus::PowerOff));
     }
 
+    struct RemovePeerLauncherOnDrop(std::path::PathBuf);
+
+    impl Drop for RemovePeerLauncherOnDrop {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_file(&self.0);
+        }
+    }
+
     #[test]
     fn handle_event_switch_install_exits_run_command() {
         let mut harness = LifecycleHarness::new();
@@ -87,6 +95,7 @@ mod tests {
         let launcher = peer_dir.join("cadmus.sh");
         std::fs::create_dir_all(&peer_dir).unwrap();
         std::fs::write(&launcher, "#!/bin/sh\n").unwrap();
+        let _cleanup = RemovePeerLauncherOnDrop(launcher.clone());
 
         let outcome = harness.with_parts(|hub, bus, rq, context, runtime| {
             handle_event(
@@ -102,9 +111,6 @@ mod tests {
             outcome,
             EventOutcome::Exit(ExitStatus::RunCommand(launcher.clone()))
         );
-
-        std::fs::remove_file(&launcher).ok();
-        std::fs::remove_dir_all(&peer_dir).ok();
     }
 
     #[test]


### PR DESCRIPTION
Parallel nextest raced writers vs empty assert on
/tmp/test-kobo-installation; exercise discovery via TempDir.

Change-Id: 445d6652c97e567c10026a7202cda0e2
Change-Id-Short: vvumttuxnqsl

---

Shall fix the flaky test failure 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only refactors and a small production helper extraction; runtime behavior of `peer_installs()` is unchanged.
> 
> **Overview**
> Fixes flaky **parallel nextest** failures where Kobo `peer_installs` tests fought over the shared `test-kobo-installation` directory under `/tmp`.
> 
> Peer discovery logic is pulled into a **`discover_peer_installs(root, current)`** helper used by `Device::peer_installs()`, and the unit tests now drive that helper with **`tempfile::TempDir`** instead of calling `peer_installs()` on a real device (which still resolves the global test install root). The lifecycle **SwitchInstall** test drops manual FS teardown in favor of a small **`RemovePeerLauncherOnDrop`** guard on the fake `cadmus.sh` peer launcher.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9c3b9c0c80a7ac74ebdac35487d411c78243026f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->