### PR TITLE
fix(wifi): retry idle disable after transient radio failure

### DIFF
--- a/crates/core/src/device/kobo/lifecycle/wifi.rs
+++ b/crates/core/src/device/kobo/lifecycle/wifi.rs
@@ -220,7 +220,7 @@ fn handle_might_disable_wifi(context: &mut AppContext) -> EventOutcome {
         "Disabling WiFi after idle timeout"
     );
 
-    context.wifi_session.notify_offline();
+    context.wifi_session.mark_offline_pending();
     context.online = false;
 
     let session = context.wifi_session.clone();

--- a/crates/core/src/device/wifi/session.rs
+++ b/crates/core/src/device/wifi/session.rs
@@ -201,6 +201,24 @@ impl WifiSession {
         self.online_cv.notify_all();
     }
 
+    /// Marks the session offline without clearing the idle timer (pending disable).
+    #[cfg_attr(
+        feature = "tracing",
+        tracing::instrument(skip(self), level = tracing::Level::TRACE)
+    )]
+    pub fn mark_offline_pending(&self) {
+        {
+            let mut state = self.state.lock().unwrap_or_else(|e| e.into_inner());
+            state.online = false;
+            tracing::info!(
+                mode = %state.mode,
+                holders = self.tracker.len(),
+                "wifi session marked offline pending disable"
+            );
+        }
+        self.online_cv.notify_all();
+    }
+
     /// Marks the session offline (after disable / suspend).
     #[cfg_attr(
         feature = "tracing",
@@ -438,9 +456,9 @@ impl WifiSession {
             tracing::error!(error = %error, "failed to disable wifi radio");
         } else {
             tracing::debug!("wifi radio disabled");
+            self.notify_offline();
+            self.clear_idle();
         }
-        self.notify_offline();
-        self.clear_idle();
         result
     }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Reopens the changes from #799 (auto-closed when #784 merged).

When idle timeout triggers WiFi disable, preserve the idle timer until `disable_radio()` succeeds. On transient radio failure, subsequent `MightDisableWifi` polls can retry instead of losing the idle deadline.

### Changes

- Add `WifiSession::mark_offline_pending()` — marks offline without clearing `idle_since`
- Idle shutdown path calls `mark_offline_pending()` instead of `notify_offline()`
- `disable_radio()` only calls `notify_offline()` and `clear_idle()` on success

### Context

PR #799 targeted a feature branch that was merged separately; merging that branch closed #799 without landing this follow-up fix on `master`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f30d6c33-7c53-450b-a740-97eae134e785?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f30d6c33-7c53-450b-a740-97eae134e785&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

