### PR TITLE
feat(device): add DeviceLeds and Kobo LED control

### DIFF
--- a/crates/core/src/device/emulator/leds.rs
+++ b/crates/core/src/device/emulator/leds.rs
@@ -1,0 +1,13 @@
+use crate::device::leds::{DeviceLeds, LedsError};
+
+pub struct EmulatorLeds;
+
+impl DeviceLeds for EmulatorLeds {
+    fn on(&self) -> Result<(), LedsError> {
+        Ok(())
+    }
+
+    fn off(&self) -> Result<(), LedsError> {
+        Ok(())
+    }
+}

--- a/crates/core/src/device/emulator/mod.rs
+++ b/crates/core/src/device/emulator/mod.rs
@@ -4,6 +4,7 @@
 //! reports [`DEFAULT_ROTATION`] and rotation APIs are no-ops. This avoids
 //! inconsistent state until faithful framebuffer and input tracking exists.
 
+mod leds;
 mod power;
 mod rtc;
 mod usb;
@@ -399,6 +400,7 @@ pub struct EmulatorDevice {
     wifi_manager: Arc<crate::device::emulator::wifi::EmulatorWifiManager>,
     usb_manager: Arc<crate::device::emulator::usb::EmulatorUsbManager>,
     power_manager: Arc<crate::device::emulator::power::EmulatorPowerManager>,
+    leds: Arc<crate::device::emulator::leds::EmulatorLeds>,
     rtc: Arc<EmulatorRtc>,
     time_manager: crate::time_manager::TimeManager<EmulatorRtc>,
     input: EmulatorInputSource,
@@ -436,6 +438,7 @@ impl EmulatorDevice {
             wifi_manager: Arc::new(crate::device::emulator::wifi::EmulatorWifiManager),
             usb_manager: Arc::new(crate::device::emulator::usb::EmulatorUsbManager),
             power_manager: Arc::new(crate::device::emulator::power::EmulatorPowerManager),
+            leds: Arc::new(crate::device::emulator::leds::EmulatorLeds),
             rtc,
             time_manager,
             input: EmulatorInputSource::new(dpi),
@@ -508,6 +511,7 @@ crate::impl_device_hardware!(
     WifiManager = crate::device::emulator::wifi::EmulatorWifiManager,
     UsbManager = crate::device::emulator::usb::EmulatorUsbManager,
     PowerManager = crate::device::emulator::power::EmulatorPowerManager,
+    Leds = crate::device::emulator::leds::EmulatorLeds,
     Rtc = crate::device::emulator::rtc::EmulatorRtc,
 );
 

--- a/crates/core/src/device/forward.rs
+++ b/crates/core/src/device/forward.rs
@@ -120,6 +120,7 @@ macro_rules! forward_device_rotation {
 ///     WifiManager = TestWifiManager,
 ///     UsbManager = TestUsbManager,
 ///     PowerManager = TestPowerManager,
+///     Leds = TestLeds,
 ///     Rtc = TestRtc,
 ///     override metadata_from metadata,
 /// );
@@ -197,6 +198,12 @@ macro_rules! impl_device_hardware {
                 &self,
             ) -> Result<std::sync::Arc<Self::PowerManager>, $crate::device::power::PowerError> {
                 Ok(self.power_manager.clone())
+            }
+
+            fn leds(
+                &self,
+            ) -> Result<std::sync::Arc<Self::Leds>, $crate::device::leds::LedsError> {
+                Ok(self.leds.clone())
             }
 
             fn rtc(&self) -> Result<std::sync::Arc<Self::Rtc>, anyhow::Error> {

--- a/crates/core/src/device/kobo/device.rs
+++ b/crates/core/src/device/kobo/device.rs
@@ -36,6 +36,7 @@ pub struct Device {
     wifi_manager: std::sync::Arc<crate::device::kobo::wifi::KoboWifiManager>,
     usb_manager: std::sync::Arc<crate::device::kobo::usb::KoboUsbManager>,
     power_manager: std::sync::Arc<crate::device::kobo::power::KoboPowerManager>,
+    leds: std::sync::Arc<crate::device::kobo::leds::KoboLeds>,
     rtc: std::sync::Arc<LinuxRtc>,
     time_manager: crate::time_manager::TimeManager<LinuxRtc>,
     input: InputSource,
@@ -68,6 +69,7 @@ impl Device {
         wifi_manager: std::sync::Arc<crate::device::kobo::wifi::KoboWifiManager>,
         usb_manager: std::sync::Arc<crate::device::kobo::usb::KoboUsbManager>,
         power_manager: std::sync::Arc<crate::device::kobo::power::KoboPowerManager>,
+        leds: std::sync::Arc<crate::device::kobo::leds::KoboLeds>,
         rtc: std::sync::Arc<LinuxRtc>,
         time_manager: crate::time_manager::TimeManager<LinuxRtc>,
         boot_transformed_rotation: i8,
@@ -83,6 +85,7 @@ impl Device {
             wifi_manager,
             usb_manager,
             power_manager,
+            leds,
             rtc,
             time_manager,
             input,
@@ -162,6 +165,7 @@ crate::impl_device_hardware!(
     WifiManager = crate::device::kobo::wifi::KoboWifiManager,
     UsbManager = crate::device::kobo::usb::KoboUsbManager,
     PowerManager = crate::device::kobo::power::KoboPowerManager,
+    Leds = crate::device::kobo::leds::KoboLeds,
     Rtc = LinuxRtc;
     override
         metadata_from metadata,

--- a/crates/core/src/device/kobo/factory.rs
+++ b/crates/core/src/device/kobo/factory.rs
@@ -91,6 +91,7 @@ impl Model {
         );
         let power_manager =
             std::sync::Arc::new(crate::device::kobo::power::KoboPowerManager::new(self));
+        let leds = std::sync::Arc::new(crate::device::kobo::leds::KoboLeds::for_model(self));
         let rtc =
             std::sync::Arc::new(LinuxRtc::new(RTC_DEVICE).context("failed to initialize RTC")?);
         let time_manager = crate::time_manager::TimeManager::new(rtc.clone(), |tz| {
@@ -107,6 +108,7 @@ impl Model {
             wifi_manager,
             usb_manager,
             power_manager,
+            leds,
             rtc,
             time_manager,
             initial_rotation,

--- a/crates/core/src/device/kobo/leds.rs
+++ b/crates/core/src/device/kobo/leds.rs
@@ -1,0 +1,156 @@
+//! Kobo status LED via sysfs brightness.
+//!
+//! Turns the LED on or off by writing `"1"` or `"0"` to a model-resolved
+//! brightness path under `/sys/class/leds/`. [`KoboLeds::for_model`] asks
+//! [`super::Model::led_brightness_path`]: known models (for example Libra
+//! Colour) return a hardcoded path; others probe
+//! [`LED_BRIGHTNESS_CANDIDATES`] and info-log the hit so new hardcodes can be
+//! crowd-sourced from device logs. If no path is found, writes target the
+//! default `LED` node and are skipped when that path is missing.
+
+use crate::device::kobo::Model;
+use crate::device::leds::{DeviceLeds, LedsError};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+/// Default brightness path used when discovery finds nothing (graceful no-op).
+pub(super) const LED_BRIGHTNESS_PATH: &str = "/sys/class/leds/LED/brightness";
+
+/// Known standard-LED brightness nodes, same order as `contrib/cadmus.sh`.
+pub(super) const LED_BRIGHTNESS_CANDIDATES: &[&str] = &[
+    LED_BRIGHTNESS_PATH,
+    "/sys/class/leds/GLED/brightness",
+    "/sys/class/leds/bd71828-green-led/brightness",
+];
+
+/// Returns the first candidate path that exists on the filesystem.
+pub(super) fn discover_led_brightness_path(candidates: &[&str]) -> Option<PathBuf> {
+    candidates
+        .iter()
+        .map(Path::new)
+        .find(|path| path.exists())
+        .map(Path::to_path_buf)
+}
+
+/// Kobo status LED controller writing a resolved sysfs brightness path.
+pub struct KoboLeds {
+    brightness_path: PathBuf,
+}
+
+impl KoboLeds {
+    /// Creates a controller for `model` using [`Model::led_brightness_path`].
+    ///
+    /// Falls back to [`LED_BRIGHTNESS_PATH`] when no path is known or
+    /// discovered so missing-path writes stay graceful.
+    pub fn for_model(model: Model) -> Self {
+        let path = model
+            .led_brightness_path()
+            .unwrap_or_else(|| PathBuf::from(LED_BRIGHTNESS_PATH));
+        Self::with_path(path)
+    }
+
+    /// Creates a controller targeting the default Kobo LED brightness path.
+    pub fn new() -> Self {
+        Self {
+            brightness_path: PathBuf::from(LED_BRIGHTNESS_PATH),
+        }
+    }
+
+    /// Creates a controller targeting `brightness_path` (used by unit tests).
+    pub fn with_path(brightness_path: impl Into<PathBuf>) -> Self {
+        Self {
+            brightness_path: brightness_path.into(),
+        }
+    }
+
+    fn write_brightness(&self, value: &str) -> Result<(), LedsError> {
+        let path = self.brightness_path.as_path();
+        if !Path::new(path).exists() {
+            tracing::warn!(path = %path.display(), "LED brightness path missing");
+            return Ok(());
+        }
+
+        tracing::debug!(path = %path.display(), value, "Writing LED brightness");
+        fs::write(path, value).map_err(|e| {
+            tracing::error!(error = %e, path = %path.display(), "Failed to write LED brightness");
+            LedsError::Io(e)
+        })
+    }
+}
+
+impl Default for KoboLeds {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl DeviceLeds for KoboLeds {
+    fn on(&self) -> Result<(), LedsError> {
+        self.write_brightness("1")
+    }
+
+    fn off(&self) -> Result<(), LedsError> {
+        self.write_brightness("0")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn on_writes_one() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("brightness");
+        fs::write(&path, "0").expect("seed");
+        let leds = KoboLeds::with_path(&path);
+
+        leds.on().expect("on");
+
+        assert_eq!(fs::read_to_string(&path).expect("read").trim(), "1");
+    }
+
+    #[test]
+    fn off_writes_zero() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("brightness");
+        fs::write(&path, "1").expect("seed");
+        let leds = KoboLeds::with_path(&path);
+
+        leds.off().expect("off");
+
+        assert_eq!(fs::read_to_string(&path).expect("read").trim(), "0");
+    }
+
+    #[test]
+    fn missing_path_is_graceful() {
+        let leds = KoboLeds::with_path("/nonexistent/leds/LED/brightness");
+
+        assert!(leds.on().is_ok());
+        assert!(leds.off().is_ok());
+    }
+
+    #[test]
+    fn discover_returns_first_existing_candidate() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let gled = dir.path().join("GLED");
+        fs::create_dir_all(&gled).expect("mkdir");
+        let brightness = gled.join("brightness");
+        fs::write(&brightness, "0").expect("seed");
+
+        let missing = dir.path().join("LED/brightness");
+        let candidates = [missing.to_str().unwrap(), brightness.to_str().unwrap()];
+
+        assert_eq!(discover_led_brightness_path(&candidates), Some(brightness));
+    }
+
+    #[test]
+    fn discover_returns_none_when_empty() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let a = dir.path().join("LED/brightness");
+        let b = dir.path().join("GLED/brightness");
+        let candidates = [a.to_str().unwrap(), b.to_str().unwrap()];
+
+        assert_eq!(discover_led_brightness_path(&candidates), None);
+    }
+}

--- a/crates/core/src/device/kobo/mod.rs
+++ b/crates/core/src/device/kobo/mod.rs
@@ -1,6 +1,7 @@
 mod device;
 mod factory;
 mod input;
+mod leds;
 mod lifecycle;
 mod model;
 mod power;

--- a/crates/core/src/device/kobo/model.rs
+++ b/crates/core/src/device/kobo/model.rs
@@ -1,6 +1,8 @@
+use crate::device::kobo::leds::{LED_BRIGHTNESS_CANDIDATES, discover_led_brightness_path};
 use crate::device::{DeviceCapabilities, DeviceIdentity, DeviceRotation, FrontlightKind};
 use crate::input::TouchProto;
 use std::fmt;
+use std::path::PathBuf;
 
 /// Kobo device model identifiers.
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
@@ -136,6 +138,34 @@ impl Model {
             Model::Libra2 | Model::Sage | Model::Elipsa2E | Model::LibraColour => |n| (6 - n) % 4,
             Model::Elipsa => |n| (4 - n) % 4,
             _ => |n| n,
+        }
+    }
+
+    /// Returns the status LED brightness sysfs path for this model.
+    ///
+    /// Known models return a hardcoded path. Otherwise the known candidate
+    /// nodes are probed and the first existing path is returned (and logged)
+    /// so new hardcodes can be crowd-sourced from device logs.
+    pub fn led_brightness_path(self) -> Option<PathBuf> {
+        if let Some(path) = self.known_led_brightness_path() {
+            return Some(PathBuf::from(path));
+        }
+        let Some(path) = discover_led_brightness_path(LED_BRIGHTNESS_CANDIDATES) else {
+            tracing::warn!(model = %self, "no status LED brightness path found");
+            return None;
+        };
+        tracing::info!(
+            model = %self,
+            path = %path.display(),
+            "discovered status LED brightness path"
+        );
+        Some(path)
+    }
+
+    fn known_led_brightness_path(self) -> Option<&'static str> {
+        match self {
+            Model::LibraColour => Some("/sys/class/leds/LED/brightness"),
+            _ => None,
         }
     }
 }
@@ -424,6 +454,14 @@ mod tests {
             assert_eq!(
                 DeviceIdentity::proto(&Model::LibraColour),
                 TouchProto::MultiB
+            );
+        }
+
+        #[test]
+        fn libra_colour_led_brightness_path_is_hardcoded() {
+            assert_eq!(
+                Model::LibraColour.led_brightness_path().as_deref(),
+                Some(std::path::Path::new("/sys/class/leds/LED/brightness"))
             );
         }
 

--- a/crates/core/src/device/leds/error.rs
+++ b/crates/core/src/device/leds/error.rs
@@ -1,0 +1,11 @@
+//! LED control error types.
+
+use thiserror::Error;
+
+/// Errors that can occur while controlling device LEDs.
+#[derive(Error, Debug)]
+pub enum LedsError {
+    /// Standard I/O error.
+    #[error("I/O error: {0}")]
+    Io(#[from] std::io::Error),
+}

--- a/crates/core/src/device/leds/manager.rs
+++ b/crates/core/src/device/leds/manager.rs
@@ -1,0 +1,43 @@
+//! Device LEDs trait definition.
+
+use crate::device::leds::error::LedsError;
+
+/// Trait for turning the device status LED on or off.
+pub trait DeviceLeds: Send + Sync {
+    /// Turns the status LED on.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`LedsError`] when the LED brightness sysfs node cannot be written.
+    fn on(&self) -> Result<(), LedsError>;
+
+    /// Turns the status LED off.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`LedsError`] when the LED brightness sysfs node cannot be written.
+    fn off(&self) -> Result<(), LedsError>;
+
+    /// Sets the status LED to on (`true`) or off (`false`).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`LedsError`] when the LED brightness sysfs node cannot be written.
+    fn set_on(&self, on: bool) -> Result<(), LedsError> {
+        if on { self.on() } else { self.off() }
+    }
+}
+
+impl<T: DeviceLeds + ?Sized> DeviceLeds for Box<T> {
+    fn on(&self) -> Result<(), LedsError> {
+        (**self).on()
+    }
+
+    fn off(&self) -> Result<(), LedsError> {
+        (**self).off()
+    }
+
+    fn set_on(&self, on: bool) -> Result<(), LedsError> {
+        (**self).set_on(on)
+    }
+}

--- a/crates/core/src/device/leds/mod.rs
+++ b/crates/core/src/device/leds/mod.rs
@@ -1,0 +1,7 @@
+//! Device LED control.
+
+mod error;
+mod manager;
+
+pub use error::LedsError;
+pub use manager::DeviceLeds;

--- a/crates/core/src/device/mod.rs
+++ b/crates/core/src/device/mod.rs
@@ -8,6 +8,7 @@
 
 mod error;
 mod forward;
+pub mod leds;
 mod metadata;
 pub mod migration;
 mod model;
@@ -535,6 +536,7 @@ pub trait DeviceHardware: Send {
     type WifiManager: crate::device::wifi::WifiManager + Send + Sync + 'static;
     type UsbManager: crate::device::usb::UsbManager + Send + Sync;
     type PowerManager: crate::device::power::PowerManager + Send + Sync;
+    type Leds: crate::device::leds::DeviceLeds + Send + Sync;
     type Rtc: crate::device::rtc::Rtc + Send + Sync + 'static;
 
     /// Returns a shared reference to the display framebuffer.
@@ -579,6 +581,13 @@ pub trait DeviceHardware: Send {
     fn power_manager(
         &self,
     ) -> Result<std::sync::Arc<Self::PowerManager>, crate::device::power::PowerError>;
+
+    /// Returns a shared LED controller handle.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`crate::device::leds::LedsError`] when LEDs are unavailable.
+    fn leds(&self) -> Result<std::sync::Arc<Self::Leds>, crate::device::leds::LedsError>;
 
     /// Returns a shared RTC handle.
     ///

--- a/crates/core/src/device/test_device.rs
+++ b/crates/core/src/device/test_device.rs
@@ -255,6 +255,63 @@ impl crate::device::power::PowerManager for TestPowerManager {
     }
 }
 
+#[derive(Debug, Default)]
+struct TestLedsState {
+    on_calls: u32,
+    off_calls: u32,
+    is_on: bool,
+}
+
+/// Assertable LED controller test double.
+#[derive(Clone)]
+pub struct TestLeds {
+    state: Arc<Mutex<TestLedsState>>,
+}
+
+impl TestLeds {
+    pub fn new() -> Self {
+        Self {
+            state: Arc::new(Mutex::new(TestLedsState::default())),
+        }
+    }
+
+    pub fn on_call_count(&self) -> u32 {
+        self.state.lock().map(|s| s.on_calls).unwrap_or(0)
+    }
+
+    pub fn off_call_count(&self) -> u32 {
+        self.state.lock().map(|s| s.off_calls).unwrap_or(0)
+    }
+
+    pub fn is_on(&self) -> bool {
+        self.state.lock().map(|s| s.is_on).unwrap_or(false)
+    }
+}
+
+impl Default for TestLeds {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl crate::device::leds::DeviceLeds for TestLeds {
+    fn on(&self) -> Result<(), crate::device::leds::LedsError> {
+        if let Ok(mut state) = self.state.lock() {
+            state.on_calls += 1;
+            state.is_on = true;
+        }
+        Ok(())
+    }
+
+    fn off(&self) -> Result<(), crate::device::leds::LedsError> {
+        if let Ok(mut state) = self.state.lock() {
+            state.off_calls += 1;
+            state.is_on = false;
+        }
+        Ok(())
+    }
+}
+
 /// Stub input source for tests.
 pub struct TestInputSource;
 
@@ -281,6 +338,7 @@ pub struct TestDevice {
     wifi_manager: Arc<TestWifiManager>,
     usb_manager: Arc<TestUsbManager>,
     power_manager: Arc<TestPowerManager>,
+    leds: Arc<TestLeds>,
     rtc: Arc<TestRtc>,
     time_manager: crate::time_manager::TimeManager<TestRtc>,
     input: TestInputSource,
@@ -300,6 +358,7 @@ impl TestDevice {
             wifi_manager: Arc::new(TestWifiManager::new()),
             usb_manager: Arc::new(TestUsbManager::new()),
             power_manager: Arc::new(TestPowerManager::new()),
+            leds: Arc::new(TestLeds::new()),
             rtc,
             time_manager,
             input: TestInputSource,
@@ -319,6 +378,11 @@ impl TestDevice {
     /// Returns the power test double for lifecycle assertion helpers.
     pub fn power_manager_for_test(&self) -> &TestPowerManager {
         self.power_manager.as_ref()
+    }
+
+    /// Returns the LED test double for assertion helpers.
+    pub fn leds_for_test(&self) -> &TestLeds {
+        self.leds.as_ref()
     }
 }
 
@@ -416,6 +480,7 @@ crate::impl_device_hardware!(
     WifiManager = TestWifiManager,
     UsbManager = TestUsbManager,
     PowerManager = TestPowerManager,
+    Leds = TestLeds,
     Rtc = TestRtc,
 );
 


### PR DESCRIPTION
Expose status LED brightness via DeviceHardware so soft-suspend can signal awake time through /sys/class/leds/LED/brightness.

Change-Id: 5b9c0bd8a84216194dde455414198546
Change-Id-Short: uoqnzomrprvx
Ref: #361 
Ref: CAD-39

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Hardware sysfs writes are bounded and fail gracefully when paths are missing; trait wiring follows existing manager patterns with unit tests.
> 
> **Overview**
> Adds a **`DeviceLeds`** abstraction and wires it through **`DeviceHardware`** via a new **`leds()`** accessor (including **`impl_device_hardware!`**), so callers can drive the status LED without platform-specific code.
> 
> On **Kobo**, **`KoboLeds`** writes `1`/`0` to a model-resolved sysfs brightness node under `/sys/class/leds/`; **`Model::led_brightness_path`** hardcodes Libra Colour and otherwise probes known candidates (aligned with `contrib/cadmus.sh`), logging discoveries for future hardcodes. Missing nodes are warned and treated as a no-op so init does not fail.
> 
> **Emulator** and **test** builds get no-op **`EmulatorLeds`** and assertable **`TestLeds`** doubles respectively; Kobo factory construction now creates **`KoboLeds::for_model`** at device init.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 41eef0a5683e1ab05cd89974cbb3d0bc17f4c8cc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->