### PR TITLE
docs(investigations): document autosleep

### DIFF
--- a/docs/po/messages.pot
+++ b/docs/po/messages.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Cadmus Documentation\n"
-"POT-Creation-Date: 2026-08-10T15:23:10+02:00\n"
+"POT-Creation-Date: 2026-08-10T20:37:37+02:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -200,6 +200,10 @@ msgstr ""
 
 #: src/SUMMARY.md:59
 msgid "Reading IP and ESSID via dhcpcd-dbus"
+msgstr ""
+
+#: src/SUMMARY.md:60
+msgid "Soft suspend via autosleep and wake_lock"
 msgstr ""
 
 #: src/index.md:3

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -57,3 +57,4 @@
 - [Intro](investigations/index.md)
   - [DHCP IP Address Changes on WiFi Toggle](investigations/kobo/issue-51-dhcp-investigation.md)
   - [Reading IP and ESSID via dhcpcd-dbus](investigations/kobo/issue-261-dhcpcd-dbus-network-info.md)
+  - [Soft suspend via autosleep and wake_lock](investigations/kobo/issue-361-autosleep-wake-lock.md)

--- a/docs/src/investigations/index.md
+++ b/docs/src/investigations/index.md
@@ -10,5 +10,6 @@ referred to in the future if needed.
 | ---------- | -------- | ------------------------------------------------------------------------------------ |
 | 2026-03-24 | Kobo     | [DHCP IP Address Changes on WiFi Toggle](./kobo/issue-51-dhcp-investigation.md)      |
 | 2026-07-29 | Kobo     | [Reading IP and ESSID via dhcpcd-dbus](./kobo/issue-261-dhcpcd-dbus-network-info.md) |
+| 2026-08-04 | Kobo     | [Soft suspend via autosleep and wake_lock](./kobo/issue-361-autosleep-wake-lock.md)  |
 
 <!-- i18n:skip-end -->

--- a/docs/src/investigations/kobo/issue-361-autosleep-wake-lock.md
+++ b/docs/src/investigations/kobo/issue-361-autosleep-wake-lock.md
@@ -1,0 +1,79 @@
+<!-- i18n:skip-start -->
+
+# Soft suspend via autosleep and wake_lock
+
+Research for [#361](https://github.com/OGKevin/cadmus/issues/361): can Kobo’s
+kernel drive opportunistic soft suspend without a Cadmus-owned sleep loop?
+
+How Cadmus wires this up lives in
+[Soft Suspend (contributor)](../../contributing/soft-suspend.md).
+
+---
+
+## Summary
+
+On KLC, `/sys/power/autosleep` and `/sys/power/wake_lock` /
+`wake_unlock` are present. Writing `freeze` or `mem` to autosleep arms the
+kernel’s opportunistic suspend workqueue; userspace stays awake by holding
+wake locks. That is enough for soft suspend — Cadmus does not need to poll
+and write `/sys/power/state` itself for this path.
+
+Hard suspend (power button / cover / Auto Suspend) remains a separate,
+explicit `state-extended` + `mem` path.
+
+## Device probes
+
+```sh
+$ cat /sys/power/state
+freeze mem
+
+$ ls /sys/power/
+… autosleep … state state-extended wake_lock wake_unlock …
+```
+
+Smoke test that worked on device:
+
+```sh
+$ echo test > /sys/power/wake_lock
+$ echo freeze > /sys/power/autosleep
+# stays awake
+
+$ echo test > /sys/power/wake_unlock
+# enters freeze when nothing else holds a wakeup source
+
+$ echo off > /sys/power/autosleep
+```
+
+### freeze vs mem
+
+With `freeze`, Wi‑Fi could stay associated across soft sleep. With `mem`,
+the link dropped and needed reconnect — consistent with deeper device
+suspend. Issue notes also observed charging LED / radio side effects under
+soft sleep.
+
+### Status LED
+
+```sh
+$ echo 1 > /sys/class/leds/LED/brightness
+$ echo 0 > /sys/class/leds/LED/brightness
+```
+
+Useful as an awake indicator while soft suspend is armed: the kernel clears
+the LED on sleep, and on wake it is turned back on automatically.
+
+## Design takeaway from the research
+
+Do **not** enable/disable autosleep as a stand-in for “busy”. Leave
+autosleep armed at the chosen target and use wake locks (refcount in
+userspace → one kernel lock) so the wake→handle→sleep race stays
+kernel-correct. Missing autosleep / wake_lock nodes → no-op.
+
+## Upstream references
+
+- [sysfs-power ABI](https://www.kernel.org/doc/Documentation/ABI/testing/sysfs-power)
+  — `/sys/power/autosleep`, `wake_lock`, `wake_unlock`, `state`
+- [Autosleep and wake locks (LWN)](https://lwn.net/Articles/479841/) —
+  opportunistic suspend + userspace wakeup sources
+- [`kernel/power/autosleep.c`](https://github.com/torvalds/linux/blob/master/kernel/power/autosleep.c)
+
+<!-- i18n:skip-end -->


### PR DESCRIPTION
Capture freeze/mem, wake_lock, LED, and main-loop TRACE strategy before implementing SoftSuspendSession.

Change-Id: a70ef950c0ac3ee2782c0a76dcbe0137
Change-Id-Short: pszlkquznzpn

Ref: https://github.com/OGKevin/cadmus/issues/361
Closes: CAD-39

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime, auth, or data-handling impact.
> 
> **Overview**
> Documents **issue #361** research on Kobo soft suspend using `/sys/power/autosleep` and `wake_lock` / `wake_unlock`, ahead of implementation work.
> 
> A new investigation page records on-device probes, a working smoke-test sequence, **`freeze` vs `mem`** tradeoffs (Wi‑Fi association, charging LED / radio behavior), status LED behavior as an awake indicator, and the design takeaway: keep autosleep armed and use refcounted wake locks instead of toggling autosleep for “busy” or polling `/sys/power/state`. Hard suspend stays on the separate `state-extended` + `mem` path. The doc points to the contributor **Soft Suspend** guide for how Cadmus will wire this up.
> 
> **Navigation / i18n:** the page is listed in `docs/src/SUMMARY.md`, the investigations index table, and `docs/po/messages.pot` is refreshed for the new sidebar title.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dafc76c7ce60d23eaa6eeb08b17acd9ec6fe7c36. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->