### PR TITLE
refactor(settings): pass AppContext to SettingKind::handle

### DIFF
--- a/crates/core/src/view/settings_editor/kinds/dictionary.rs
+++ b/crates/core/src/view/settings_editor/kinds/dictionary.rs
@@ -1,6 +1,7 @@
 //! Setting kinds for the Dictionaries category.
 
 use super::{SettingData, SettingIdentity, SettingKind, SettingsFetchData, WidgetKind};
+use crate::device::AppContext;
 use crate::fl;
 use crate::settings::Settings;
 use crate::view::{EntryId, EntryKind, Event};
@@ -36,7 +37,7 @@ impl SettingKind for DictionaryInfo {
     fn handle(
         &self,
         evt: &Event,
-        _settings: &mut Settings,
+        _context: &mut AppContext,
         _bus: &mut crate::view::Bus,
     ) -> (Option<String>, bool) {
         match evt {
@@ -102,6 +103,7 @@ impl SettingKind for DictionaryInfo {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::context::test_helpers::create_test_context;
     use crate::settings::Settings;
     use crate::view::Bus;
     use std::collections::VecDeque;
@@ -233,11 +235,12 @@ mod tests {
                 update_available: false,
                 is_installing: false,
             };
-            let mut settings = make_settings();
+            let mut context = create_test_context();
+            context.settings = make_settings();
             let mut bus: Bus = VecDeque::new();
             let event = Event::Select(EntryId::DownloadDictionary("en".to_string()));
 
-            let (display, consumed) = info.handle(&event, &mut settings, &mut bus);
+            let (display, consumed) = info.handle(&event, &mut context, &mut bus);
 
             assert!(display.is_some());
             assert!(!consumed);
@@ -251,11 +254,12 @@ mod tests {
                 update_available: false,
                 is_installing: false,
             };
-            let mut settings = make_settings();
+            let mut context = create_test_context();
+            context.settings = make_settings();
             let mut bus: Bus = VecDeque::new();
             let event = Event::Select(EntryId::RequestDictionaryDownload("en".to_string()));
 
-            let (display, consumed) = info.handle(&event, &mut settings, &mut bus);
+            let (display, consumed) = info.handle(&event, &mut context, &mut bus);
 
             assert!(display.is_none());
             assert!(!consumed);
@@ -269,11 +273,12 @@ mod tests {
                 update_available: false,
                 is_installing: false,
             };
-            let mut settings = make_settings();
+            let mut context = create_test_context();
+            context.settings = make_settings();
             let mut bus: Bus = VecDeque::new();
             let event = Event::Select(EntryId::DownloadDictionary("fr".to_string()));
 
-            let (display, _) = info.handle(&event, &mut settings, &mut bus);
+            let (display, _) = info.handle(&event, &mut context, &mut bus);
 
             assert!(display.is_none());
         }
@@ -286,10 +291,11 @@ mod tests {
                 update_available: false,
                 is_installing: false,
             };
-            let mut settings = make_settings();
+            let mut context = create_test_context();
+            context.settings = make_settings();
             let mut bus: Bus = VecDeque::new();
 
-            let (display, _) = info.handle(&Event::Select(EntryId::About), &mut settings, &mut bus);
+            let (display, _) = info.handle(&Event::Select(EntryId::About), &mut context, &mut bus);
 
             assert!(display.is_none());
         }

--- a/crates/core/src/view/settings_editor/kinds/general.rs
+++ b/crates/core/src/view/settings_editor/kinds/general.rs
@@ -4,6 +4,7 @@ use super::{
     InputSettingKind, SettingData, SettingIdentity, SettingKind, SettingsFetchData, ToggleSettings,
     WidgetKind,
 };
+use crate::device::AppContext;
 use crate::fl;
 use crate::frontlight::LightLevel;
 use crate::geolocation::Coordinates;
@@ -54,11 +55,11 @@ impl SettingKind for Locale {
     fn handle(
         &self,
         evt: &Event,
-        settings: &mut Settings,
+        context: &mut AppContext,
         _bus: &mut Bus,
     ) -> (Option<String>, bool) {
         if let Event::Select(EntryId::SetLocale(locale)) = evt {
-            settings.locale = locale.clone();
+            context.settings.locale = locale.clone();
             crate::i18n::init(locale.as_ref());
             let display = locale
                 .as_ref()
@@ -110,11 +111,11 @@ impl SettingKind for KeyboardLayout {
     fn handle(
         &self,
         evt: &Event,
-        settings: &mut Settings,
+        context: &mut AppContext,
         _bus: &mut Bus,
     ) -> (Option<String>, bool) {
         if let Event::Select(EntryId::SetKeyboardLayout(layout)) = evt {
-            settings.keyboard_layout = layout.clone();
+            context.settings.keyboard_layout = layout.clone();
             return (Some(layout.clone()), true);
         }
         (None, false)
@@ -350,12 +351,12 @@ impl SettingKind for SleepCover {
     fn handle(
         &self,
         evt: &Event,
-        settings: &mut Settings,
+        context: &mut AppContext,
         _bus: &mut Bus,
     ) -> (Option<String>, bool) {
         if let Event::Toggle(ToggleEvent::Setting(ToggleSettings::SleepCover)) = evt {
-            settings.sleep_cover = !settings.sleep_cover;
-            return (Some(settings.sleep_cover.to_string()), true);
+            context.settings.sleep_cover = !context.settings.sleep_cover;
+            return (Some(context.settings.sleep_cover.to_string()), true);
         }
         (None, false)
     }
@@ -388,12 +389,12 @@ impl SettingKind for AutoShare {
     fn handle(
         &self,
         evt: &Event,
-        settings: &mut Settings,
+        context: &mut AppContext,
         _bus: &mut Bus,
     ) -> (Option<String>, bool) {
         if let Event::Toggle(ToggleEvent::Setting(ToggleSettings::AutoShare)) = evt {
-            settings.auto_share = !settings.auto_share;
-            return (Some(settings.auto_share.to_string()), true);
+            context.settings.auto_share = !context.settings.auto_share;
+            return (Some(context.settings.auto_share.to_string()), true);
         }
         (None, false)
     }
@@ -426,12 +427,12 @@ impl SettingKind for AutoTime {
     fn handle(
         &self,
         evt: &Event,
-        settings: &mut Settings,
+        context: &mut AppContext,
         _bus: &mut Bus,
     ) -> (Option<String>, bool) {
         if let Event::Toggle(ToggleEvent::Setting(ToggleSettings::AutoTime)) = evt {
-            settings.auto_time = !settings.auto_time;
-            return (Some(settings.auto_time.to_string()), true);
+            context.settings.auto_time = !context.settings.auto_time;
+            return (Some(context.settings.auto_time.to_string()), true);
         }
         (None, false)
     }
@@ -521,12 +522,12 @@ impl SettingKind for ButtonScheme {
     fn handle(
         &self,
         evt: &Event,
-        settings: &mut Settings,
+        context: &mut AppContext,
         bus: &mut Bus,
     ) -> (Option<String>, bool) {
         let new_scheme = match evt {
             Event::Toggle(ToggleEvent::Setting(ToggleSettings::ButtonScheme)) => {
-                match settings.button_scheme {
+                match context.settings.button_scheme {
                     crate::settings::ButtonScheme::Natural => {
                         Some(crate::settings::ButtonScheme::Inverted)
                     }
@@ -540,9 +541,9 @@ impl SettingKind for ButtonScheme {
         };
 
         if let Some(scheme) = new_scheme {
-            settings.button_scheme = scheme;
+            context.settings.button_scheme = scheme;
             bus.push_back(Event::Select(EntryId::SetButtonScheme(scheme)));
-            return (Some(settings.button_scheme.to_i18n_string()), true);
+            return (Some(context.settings.button_scheme.to_i18n_string()), true);
         }
         (None, false)
     }
@@ -578,13 +579,13 @@ impl SettingKind for AutoFrontlight {
     fn handle(
         &self,
         evt: &Event,
-        settings: &mut Settings,
+        context: &mut AppContext,
         bus: &mut Bus,
     ) -> (Option<String>, bool) {
         if let Event::Toggle(ToggleEvent::Setting(ToggleSettings::AutoFrontlight)) = evt {
-            settings.auto_frontlight = !settings.auto_frontlight;
+            context.settings.auto_frontlight = !context.settings.auto_frontlight;
             bus.push_back(Event::AutoFrontlightConfigChanged);
-            return (Some(settings.auto_frontlight.to_string()), true);
+            return (Some(context.settings.auto_frontlight.to_string()), true);
         }
         (None, false)
     }
@@ -615,11 +616,11 @@ impl SettingKind for AutoFrontlightBrightness {
     fn handle(
         &self,
         evt: &Event,
-        settings: &mut Settings,
+        context: &mut AppContext,
         bus: &mut Bus,
     ) -> (Option<String>, bool) {
         if let Event::Submit(ViewId::AutoFrontlightBrightnessInput, text) = evt {
-            let display = self.apply_text(text, settings);
+            let display = self.apply_text(text, &mut context.settings);
             bus.push_back(Event::AutoFrontlightConfigChanged);
             return (Some(display), true);
         }
@@ -700,11 +701,11 @@ impl SettingKind for AutoFrontlightManualCoordinates {
     fn handle(
         &self,
         evt: &Event,
-        settings: &mut Settings,
+        context: &mut AppContext,
         bus: &mut Bus,
     ) -> (Option<String>, bool) {
         if let Event::Submit(ViewId::AutoFrontlightManualCoordinatesInput, text) = evt {
-            let display = self.apply_text(text, settings);
+            let display = self.apply_text(text, &mut context.settings);
             bus.push_back(Event::AutoFrontlightConfigChanged);
             return (Some(display), true);
         }
@@ -924,11 +925,11 @@ impl SettingKind for StartupModeSetting {
     fn handle(
         &self,
         evt: &Event,
-        settings: &mut Settings,
+        context: &mut AppContext,
         _bus: &mut Bus,
     ) -> (Option<String>, bool) {
         if let Event::Select(EntryId::SetStartupMode(mode)) = evt {
-            settings.startup_mode = *mode;
+            context.settings.startup_mode = *mode;
             return (Some(mode.to_i18n_string()), true);
         }
         (None, false)
@@ -970,6 +971,7 @@ fn get_available_layouts(layouts_dir: &Path) -> Result<Vec<String>, Error> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::context::test_helpers::create_test_context;
     use crate::settings::Settings;
     use crate::view::settings_editor::kinds::{InputSettingKind, ToggleSettings};
     use crate::view::{Bus, EntryId, Event, ToggleEvent};
@@ -981,25 +983,27 @@ mod tests {
         #[test]
         fn handle_set_locale_updates_settings() {
             let setting = Locale;
-            let mut settings = Settings::default();
+            let mut context = create_test_context();
+            context.settings = Settings::default();
             let mut bus: Bus = VecDeque::new();
             let locale: Option<unic_langid::LanguageIdentifier> = Some("de-DE".parse().unwrap());
             let event = Event::Select(EntryId::SetLocale(locale.clone()));
 
-            let result = setting.handle(&event, &mut settings, &mut bus);
+            let result = setting.handle(&event, &mut context, &mut bus);
 
             assert!(result.0.is_some());
             assert_eq!(result.0.unwrap(), "de-DE");
-            assert_eq!(settings.locale, locale);
+            assert_eq!(context.settings.locale, locale);
         }
 
         #[test]
         fn handle_returns_none_for_wrong_event() {
             let setting = Locale;
-            let mut settings = Settings::default();
+            let mut context = create_test_context();
+            context.settings = Settings::default();
             let mut bus: Bus = VecDeque::new();
 
-            let result = setting.handle(&Event::Select(EntryId::About), &mut settings, &mut bus);
+            let result = setting.handle(&Event::Select(EntryId::About), &mut context, &mut bus);
 
             assert!(result.0.is_none());
         }
@@ -1011,24 +1015,26 @@ mod tests {
         #[test]
         fn handle_set_layout_updates_settings() {
             let setting = KeyboardLayout;
-            let mut settings = Settings::default();
+            let mut context = create_test_context();
+            context.settings = Settings::default();
             let mut bus: Bus = VecDeque::new();
             let event = Event::Select(EntryId::SetKeyboardLayout("German".to_string()));
 
-            let result = setting.handle(&event, &mut settings, &mut bus);
+            let result = setting.handle(&event, &mut context, &mut bus);
 
             assert!(result.0.is_some());
             assert_eq!(result.0.unwrap(), "German");
-            assert_eq!(settings.keyboard_layout, "German");
+            assert_eq!(context.settings.keyboard_layout, "German");
         }
 
         #[test]
         fn handle_returns_none_for_wrong_event() {
             let setting = KeyboardLayout;
-            let mut settings = Settings::default();
+            let mut context = create_test_context();
+            context.settings = Settings::default();
             let mut bus: Bus = VecDeque::new();
 
-            let result = setting.handle(&Event::Select(EntryId::About), &mut settings, &mut bus);
+            let result = setting.handle(&Event::Select(EntryId::About), &mut context, &mut bus);
 
             assert!(result.0.is_none());
         }
@@ -1147,27 +1153,29 @@ mod tests {
         #[test]
         fn handle_toggle_event_toggles_value() {
             let setting = SleepCover;
-            let mut settings = Settings {
+            let mut context = create_test_context();
+            context.settings = Settings {
                 sleep_cover: true,
                 ..Default::default()
             };
             let mut bus: Bus = VecDeque::new();
             let event = Event::Toggle(ToggleEvent::Setting(ToggleSettings::SleepCover));
 
-            let result = setting.handle(&event, &mut settings, &mut bus);
+            let result = setting.handle(&event, &mut context, &mut bus);
 
             assert!(result.0.is_some());
             assert_eq!(result.0.unwrap(), "false");
-            assert!(!settings.sleep_cover);
+            assert!(!context.settings.sleep_cover);
         }
 
         #[test]
         fn handle_returns_none_for_wrong_event() {
             let setting = SleepCover;
-            let mut settings = Settings::default();
+            let mut context = create_test_context();
+            context.settings = Settings::default();
             let mut bus: Bus = VecDeque::new();
 
-            let result = setting.handle(&Event::Select(EntryId::About), &mut settings, &mut bus);
+            let result = setting.handle(&Event::Select(EntryId::About), &mut context, &mut bus);
 
             assert!(result.0.is_none());
         }
@@ -1179,27 +1187,29 @@ mod tests {
         #[test]
         fn handle_toggle_event_toggles_value() {
             let setting = AutoShare;
-            let mut settings = Settings {
+            let mut context = create_test_context();
+            context.settings = Settings {
                 auto_share: false,
                 ..Default::default()
             };
             let mut bus: Bus = VecDeque::new();
             let event = Event::Toggle(ToggleEvent::Setting(ToggleSettings::AutoShare));
 
-            let result = setting.handle(&event, &mut settings, &mut bus);
+            let result = setting.handle(&event, &mut context, &mut bus);
 
             assert!(result.0.is_some());
             assert_eq!(result.0.unwrap(), "true");
-            assert!(settings.auto_share);
+            assert!(context.settings.auto_share);
         }
 
         #[test]
         fn handle_returns_none_for_wrong_event() {
             let setting = AutoShare;
-            let mut settings = Settings::default();
+            let mut context = create_test_context();
+            context.settings = Settings::default();
             let mut bus: Bus = VecDeque::new();
 
-            let result = setting.handle(&Event::Select(EntryId::About), &mut settings, &mut bus);
+            let result = setting.handle(&Event::Select(EntryId::About), &mut context, &mut bus);
 
             assert!(result.0.is_none());
         }
@@ -1211,18 +1221,22 @@ mod tests {
         #[test]
         fn brightness_apply_text_parses_and_updates() {
             let setting = AutoFrontlightBrightness;
-            let mut settings = Settings::default();
+            let mut context = create_test_context();
+            context.settings = Settings::default();
             let mut bus: Bus = VecDeque::new();
 
-            let display = setting.apply_text("25", &mut settings);
+            let display = setting.apply_text("25", &mut context.settings);
             let result = setting.handle(
                 &Event::Submit(ViewId::AutoFrontlightBrightnessInput, "25".to_string()),
-                &mut settings,
+                &mut context,
                 &mut bus,
             );
 
             assert_eq!(display, "25%");
-            assert_eq!(settings.auto_frontlight_night_brightness, Some(25.0.into()));
+            assert_eq!(
+                context.settings.auto_frontlight_night_brightness,
+                Some(25.0.into())
+            );
             assert_eq!(result, (Some("25%".to_string()), true));
             assert!(matches!(
                 bus.pop_front(),
@@ -1233,21 +1247,25 @@ mod tests {
         #[test]
         fn brightness_apply_text_ignores_invalid_input() {
             let setting = AutoFrontlightBrightness;
-            let mut settings = Settings {
+            let mut context = create_test_context();
+            context.settings = Settings {
                 auto_frontlight_night_brightness: Some(10.0.into()),
                 ..Default::default()
             };
             let mut bus: Bus = VecDeque::new();
 
-            let display = setting.apply_text("invalid", &mut settings);
+            let display = setting.apply_text("invalid", &mut context.settings);
             let result = setting.handle(
                 &Event::Submit(ViewId::AutoFrontlightBrightnessInput, "invalid".to_string()),
-                &mut settings,
+                &mut context,
                 &mut bus,
             );
 
             assert_eq!(display, "10%");
-            assert_eq!(settings.auto_frontlight_night_brightness, Some(10.0.into()));
+            assert_eq!(
+                context.settings.auto_frontlight_night_brightness,
+                Some(10.0.into())
+            );
             assert_eq!(result, (Some("10%".to_string()), true));
             assert!(matches!(
                 bus.pop_front(),
@@ -1258,22 +1276,23 @@ mod tests {
         #[test]
         fn manual_coordinates_apply_text_parses_and_updates() {
             let setting = AutoFrontlightManualCoordinates;
-            let mut settings = Settings::default();
+            let mut context = create_test_context();
+            context.settings = Settings::default();
             let mut bus: Bus = VecDeque::new();
 
-            let display = setting.apply_text("51.5074, -0.1278", &mut settings);
+            let display = setting.apply_text("51.5074, -0.1278", &mut context.settings);
             let result = setting.handle(
                 &Event::Submit(
                     ViewId::AutoFrontlightManualCoordinatesInput,
                     "51.5074, -0.1278".to_string(),
                 ),
-                &mut settings,
+                &mut context,
                 &mut bus,
             );
 
             assert_eq!(display, "51.5074, -0.1278");
             assert_eq!(
-                settings.auto_frontlight_manual_coordinates,
+                context.settings.auto_frontlight_manual_coordinates,
                 Some(Coordinates::new(51.5074, -0.1278).unwrap())
             );
             assert_eq!(result, (Some("51.5074, -0.1278".to_string()), true));
@@ -1286,7 +1305,8 @@ mod tests {
         #[test]
         fn manual_coordinates_apply_text_clears_on_empty_input() {
             let setting = AutoFrontlightManualCoordinates;
-            let mut settings = Settings {
+            let mut context = create_test_context();
+            context.settings = Settings {
                 auto_frontlight_manual_coordinates: Some(
                     Coordinates::new(51.5074, -0.1278).unwrap(),
                 ),
@@ -1294,15 +1314,15 @@ mod tests {
             };
             let mut bus: Bus = VecDeque::new();
 
-            let display = setting.apply_text("", &mut settings);
+            let display = setting.apply_text("", &mut context.settings);
             let result = setting.handle(
                 &Event::Submit(ViewId::AutoFrontlightManualCoordinatesInput, "".to_string()),
-                &mut settings,
+                &mut context,
                 &mut bus,
             );
 
             assert_eq!(display, "Not set");
-            assert_eq!(settings.auto_frontlight_manual_coordinates, None);
+            assert_eq!(context.settings.auto_frontlight_manual_coordinates, None);
             assert_eq!(result, (Some("Not set".to_string()), true));
             assert!(matches!(
                 bus.pop_front(),
@@ -1313,7 +1333,8 @@ mod tests {
         #[test]
         fn manual_coordinates_apply_text_ignores_invalid_input() {
             let setting = AutoFrontlightManualCoordinates;
-            let mut settings = Settings {
+            let mut context = create_test_context();
+            context.settings = Settings {
                 auto_frontlight_manual_coordinates: Some(
                     Coordinates::new(51.5074, -0.1278).unwrap(),
                 ),
@@ -1321,19 +1342,19 @@ mod tests {
             };
             let mut bus: Bus = VecDeque::new();
 
-            let display = setting.apply_text("invalid", &mut settings);
+            let display = setting.apply_text("invalid", &mut context.settings);
             let result = setting.handle(
                 &Event::Submit(
                     ViewId::AutoFrontlightManualCoordinatesInput,
                     "invalid".to_string(),
                 ),
-                &mut settings,
+                &mut context,
                 &mut bus,
             );
 
             assert_eq!(display, "51.5074, -0.1278");
             assert_eq!(
-                settings.auto_frontlight_manual_coordinates,
+                context.settings.auto_frontlight_manual_coordinates,
                 Some(Coordinates::new(51.5074, -0.1278).unwrap())
             );
             assert_eq!(result, (Some("51.5074, -0.1278".to_string()), true));
@@ -1407,16 +1428,17 @@ mod tests {
         #[test]
         fn handle_toggle_event_switches_natural_to_inverted() {
             let setting = ButtonScheme;
-            let mut settings = Settings {
+            let mut context = create_test_context();
+            context.settings = Settings {
                 button_scheme: ButtonScheme::Natural,
                 ..Default::default()
             };
             let mut bus: Bus = VecDeque::new();
             let event = Event::Toggle(ToggleEvent::Setting(ToggleSettings::ButtonScheme));
 
-            let result = setting.handle(&event, &mut settings, &mut bus);
+            let result = setting.handle(&event, &mut context, &mut bus);
 
-            assert_eq!(settings.button_scheme, ButtonScheme::Inverted);
+            assert_eq!(context.settings.button_scheme, ButtonScheme::Inverted);
             assert_eq!(bus.len(), 1);
             assert!(result.0.is_some());
         }
@@ -1424,16 +1446,17 @@ mod tests {
         #[test]
         fn handle_toggle_event_switches_inverted_to_natural() {
             let setting = ButtonScheme;
-            let mut settings = Settings {
+            let mut context = create_test_context();
+            context.settings = Settings {
                 button_scheme: ButtonScheme::Inverted,
                 ..Default::default()
             };
             let mut bus: Bus = VecDeque::new();
             let event = Event::Toggle(ToggleEvent::Setting(ToggleSettings::ButtonScheme));
 
-            let result = setting.handle(&event, &mut settings, &mut bus);
+            let result = setting.handle(&event, &mut context, &mut bus);
 
-            assert_eq!(settings.button_scheme, ButtonScheme::Natural);
+            assert_eq!(context.settings.button_scheme, ButtonScheme::Natural);
             assert_eq!(bus.len(), 1);
             assert!(result.0.is_some());
         }
@@ -1441,26 +1464,28 @@ mod tests {
         #[test]
         fn handle_set_scheme_event_applies_directly() {
             let setting = ButtonScheme;
-            let mut settings = Settings {
+            let mut context = create_test_context();
+            context.settings = Settings {
                 button_scheme: ButtonScheme::Natural,
                 ..Default::default()
             };
             let mut bus: Bus = VecDeque::new();
             let event = Event::Select(EntryId::SetButtonScheme(ButtonScheme::Inverted));
 
-            let result = setting.handle(&event, &mut settings, &mut bus);
+            let result = setting.handle(&event, &mut context, &mut bus);
 
-            assert_eq!(settings.button_scheme, ButtonScheme::Inverted);
+            assert_eq!(context.settings.button_scheme, ButtonScheme::Inverted);
             assert!(result.0.is_some());
         }
 
         #[test]
         fn handle_returns_none_for_wrong_event() {
             let setting = ButtonScheme;
-            let mut settings = Settings::default();
+            let mut context = create_test_context();
+            context.settings = Settings::default();
             let mut bus: Bus = VecDeque::new();
 
-            let result = setting.handle(&Event::Select(EntryId::About), &mut settings, &mut bus);
+            let result = setting.handle(&Event::Select(EntryId::About), &mut context, &mut bus);
 
             assert!(result.0.is_none());
         }

--- a/crates/core/src/view/settings_editor/kinds/import.rs
+++ b/crates/core/src/view/settings_editor/kinds/import.rs
@@ -3,6 +3,7 @@
 use super::{
     SettingData, SettingIdentity, SettingKind, SettingsFetchData, ToggleSettings, WidgetKind,
 };
+use crate::device::AppContext;
 use crate::fl;
 use crate::settings::{FileExtension, Settings};
 use crate::view::{Bus, EntryId, EntryKind, Event, ToggleEvent};
@@ -29,7 +30,7 @@ impl SettingKind for ForceFullImport {
     fn handle(
         &self,
         _evt: &Event,
-        _settings: &mut Settings,
+        _context: &mut AppContext,
         _bus: &mut Bus,
     ) -> (Option<String>, bool) {
         (None, false)
@@ -63,12 +64,15 @@ impl SettingKind for ImportSyncMetadata {
     fn handle(
         &self,
         evt: &Event,
-        settings: &mut Settings,
+        context: &mut AppContext,
         _bus: &mut Bus,
     ) -> (Option<String>, bool) {
         if let Event::Toggle(ToggleEvent::Setting(ToggleSettings::ImportSyncMetadata)) = evt {
-            settings.import.sync_metadata = !settings.import.sync_metadata;
-            return (Some(settings.import.sync_metadata.to_string()), true);
+            context.settings.import.sync_metadata = !context.settings.import.sync_metadata;
+            return (
+                Some(context.settings.import.sync_metadata.to_string()),
+                true,
+            );
         }
         (None, false)
     }
@@ -108,16 +112,16 @@ impl SettingKind for AllowedKindsSetting {
     fn handle(
         &self,
         evt: &Event,
-        settings: &mut Settings,
+        context: &mut AppContext,
         _bus: &mut Bus,
     ) -> (Option<String>, bool) {
         if let Event::Select(EntryId::ToggleAllowedKind(kind)) = evt {
-            if !settings.import.allowed_kinds.remove(kind) {
-                settings.import.allowed_kinds.insert(*kind);
+            if !context.settings.import.allowed_kinds.remove(kind) {
+                context.settings.import.allowed_kinds.insert(*kind);
             }
 
             return (
-                Some(kinds_summary(settings.import.allowed_kinds.len())),
+                Some(kinds_summary(context.settings.import.allowed_kinds.len())),
                 true,
             );
         }
@@ -137,6 +141,7 @@ fn kinds_summary(selected: usize) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::context::test_helpers::create_test_context;
     use crate::settings::{FileExtension, Settings};
     use crate::view::{Bus, EntryKind, Event};
     use std::collections::VecDeque;
@@ -168,10 +173,11 @@ mod tests {
         #[test]
         fn handle_ignores_events() {
             let setting = ForceFullImport;
-            let mut settings = Settings::default();
+            let mut context = create_test_context();
+            context.settings = Settings::default();
             let mut bus: Bus = VecDeque::new();
 
-            let result = setting.handle(&Event::Select(EntryId::About), &mut settings, &mut bus);
+            let result = setting.handle(&Event::Select(EntryId::About), &mut context, &mut bus);
 
             assert!(result.0.is_none());
             assert!(!result.1);
@@ -184,39 +190,42 @@ mod tests {
         #[test]
         fn handle_toggle_disables_when_enabled() {
             let setting = ImportSyncMetadata;
-            let mut settings = Settings::default();
-            settings.import.sync_metadata = true;
+            let mut context = create_test_context();
+            context.settings = Settings::default();
+            context.settings.import.sync_metadata = true;
             let mut bus: Bus = VecDeque::new();
             let event = Event::Toggle(ToggleEvent::Setting(ToggleSettings::ImportSyncMetadata));
 
-            let result = setting.handle(&event, &mut settings, &mut bus);
+            let result = setting.handle(&event, &mut context, &mut bus);
 
             assert!(result.0.is_some());
-            assert!(!settings.import.sync_metadata);
+            assert!(!context.settings.import.sync_metadata);
         }
 
         #[test]
         fn handle_toggle_enables_when_disabled() {
             let setting = ImportSyncMetadata;
-            let mut settings = Settings::default();
-            settings.import.sync_metadata = false;
+            let mut context = create_test_context();
+            context.settings = Settings::default();
+            context.settings.import.sync_metadata = false;
             let mut bus: Bus = VecDeque::new();
             let event = Event::Toggle(ToggleEvent::Setting(ToggleSettings::ImportSyncMetadata));
 
-            let result = setting.handle(&event, &mut settings, &mut bus);
+            let result = setting.handle(&event, &mut context, &mut bus);
 
             assert!(result.0.is_some());
-            assert!(settings.import.sync_metadata);
+            assert!(context.settings.import.sync_metadata);
         }
 
         #[test]
         fn handle_returns_none_for_wrong_event() {
             let setting = ImportSyncMetadata;
-            let mut settings = Settings::default();
+            let mut context = create_test_context();
+            context.settings = Settings::default();
             let mut bus: Bus = VecDeque::new();
             use crate::view::EntryId;
 
-            let result = setting.handle(&Event::Select(EntryId::About), &mut settings, &mut bus);
+            let result = setting.handle(&Event::Select(EntryId::About), &mut context, &mut bus);
 
             assert!(result.0.is_none());
         }
@@ -224,12 +233,13 @@ mod tests {
         #[test]
         fn handle_returns_none_for_wrong_toggle() {
             let setting = ImportSyncMetadata;
-            let mut settings = Settings::default();
+            let mut context = create_test_context();
+            context.settings = Settings::default();
             let mut bus: Bus = VecDeque::new();
 
             let result = setting.handle(
                 &Event::Toggle(ToggleEvent::Setting(ToggleSettings::SleepCover)),
-                &mut settings,
+                &mut context,
                 &mut bus,
             );
 
@@ -267,31 +277,48 @@ mod tests {
         #[test]
         fn handle_toggle_adds_and_removes_extensions() {
             let setting = AllowedKindsSetting;
-            let mut settings = Settings::default();
-            settings.import.allowed_kinds.remove(&FileExtension::Cbr);
+            let mut context = create_test_context();
+            context.settings = Settings::default();
+            context
+                .settings
+                .import
+                .allowed_kinds
+                .remove(&FileExtension::Cbr);
             let mut bus: Bus = VecDeque::new();
 
             let add = setting.handle(
                 &Event::Select(EntryId::ToggleAllowedKind(FileExtension::Cbr)),
-                &mut settings,
+                &mut context,
                 &mut bus,
             );
             assert_eq!(
                 add.0,
-                Some(kinds_summary(settings.import.allowed_kinds.len()))
+                Some(kinds_summary(context.settings.import.allowed_kinds.len()))
             );
-            assert!(settings.import.allowed_kinds.contains(&FileExtension::Cbr));
+            assert!(
+                context
+                    .settings
+                    .import
+                    .allowed_kinds
+                    .contains(&FileExtension::Cbr)
+            );
 
             let remove = setting.handle(
                 &Event::Select(EntryId::ToggleAllowedKind(FileExtension::Cbr)),
-                &mut settings,
+                &mut context,
                 &mut bus,
             );
             assert_eq!(
                 remove.0,
-                Some(kinds_summary(settings.import.allowed_kinds.len()))
+                Some(kinds_summary(context.settings.import.allowed_kinds.len()))
             );
-            assert!(!settings.import.allowed_kinds.contains(&FileExtension::Cbr));
+            assert!(
+                !context
+                    .settings
+                    .import
+                    .allowed_kinds
+                    .contains(&FileExtension::Cbr)
+            );
         }
     }
 }

--- a/crates/core/src/view/settings_editor/kinds/intermission.rs
+++ b/crates/core/src/view/settings_editor/kinds/intermission.rs
@@ -1,6 +1,7 @@
 //! Setting kinds for the Intermissions category.
 
 use super::{SettingData, SettingIdentity, SettingKind, SettingsFetchData, WidgetKind};
+use crate::device::AppContext;
 use crate::fl;
 use crate::i18n::I18nDisplay;
 use crate::settings::{IntermKind, IntermissionDisplay, Settings};
@@ -104,11 +105,12 @@ impl SettingKind for IntermissionSuspend {
     fn handle(
         &self,
         evt: &Event,
-        settings: &mut Settings,
+        context: &mut AppContext,
         _bus: &mut Bus,
     ) -> (Option<String>, bool) {
         if let Event::Select(EntryId::SetIntermission(IntermKind::Suspend, display)) = evt {
-            if !settings
+            if !context
+                .settings
                 .intermissions
                 .set_display(IntermKind::Suspend, display.clone())
             {
@@ -120,7 +122,7 @@ impl SettingKind for IntermissionSuspend {
 
         if let Event::FileChooserClosed(Some(path)) = evt {
             let display = IntermissionDisplay::Image(path.clone());
-            settings.intermissions[IntermKind::Suspend] = display.clone();
+            context.settings.intermissions[IntermKind::Suspend] = display.clone();
             return (Some(intermission_display_name(&display)), true);
         }
 
@@ -151,11 +153,12 @@ impl SettingKind for IntermissionPowerOff {
     fn handle(
         &self,
         evt: &Event,
-        settings: &mut Settings,
+        context: &mut AppContext,
         _bus: &mut Bus,
     ) -> (Option<String>, bool) {
         if let Event::Select(EntryId::SetIntermission(IntermKind::PowerOff, display)) = evt {
-            if !settings
+            if !context
+                .settings
                 .intermissions
                 .set_display(IntermKind::PowerOff, display.clone())
             {
@@ -167,7 +170,7 @@ impl SettingKind for IntermissionPowerOff {
 
         if let Event::FileChooserClosed(Some(path)) = evt {
             let display = IntermissionDisplay::Image(path.clone());
-            settings.intermissions[IntermKind::PowerOff] = display.clone();
+            context.settings.intermissions[IntermKind::PowerOff] = display.clone();
             return (Some(intermission_display_name(&display)), true);
         }
 
@@ -198,11 +201,12 @@ impl SettingKind for IntermissionShare {
     fn handle(
         &self,
         evt: &Event,
-        settings: &mut Settings,
+        context: &mut AppContext,
         _bus: &mut Bus,
     ) -> (Option<String>, bool) {
         if let Event::Select(EntryId::SetIntermission(IntermKind::Share, display)) = evt {
-            if !settings
+            if !context
+                .settings
                 .intermissions
                 .set_display(IntermKind::Share, display.clone())
             {
@@ -214,7 +218,7 @@ impl SettingKind for IntermissionShare {
 
         if let Event::FileChooserClosed(Some(path)) = evt {
             let display = IntermissionDisplay::Image(path.clone());
-            settings.intermissions[IntermKind::Share] = display.clone();
+            context.settings.intermissions[IntermKind::Share] = display.clone();
             return (Some(intermission_display_name(&display)), true);
         }
 
@@ -229,6 +233,7 @@ impl SettingKind for IntermissionShare {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::context::test_helpers::create_test_context;
     use crate::settings::{IntermissionDisplay, Settings};
     use crate::view::{Bus, EntryId, Event};
     use std::collections::VecDeque;
@@ -241,18 +246,19 @@ mod tests {
         #[test]
         fn handle_set_intermission_updates_settings() {
             let setting = IntermissionSuspend;
-            let mut settings = Settings::default();
+            let mut context = create_test_context();
+            context.settings = Settings::default();
             let mut bus: Bus = VecDeque::new();
             let event = Event::Select(EntryId::SetIntermission(
                 IntermKind::Suspend,
                 IntermissionDisplay::Cover,
             ));
 
-            let result = setting.handle(&event, &mut settings, &mut bus);
+            let result = setting.handle(&event, &mut context, &mut bus);
 
             assert!(result.0.is_some());
             assert_eq!(
-                settings.intermissions[IntermKind::Suspend],
+                context.settings.intermissions[IntermKind::Suspend],
                 IntermissionDisplay::Cover
             );
         }
@@ -260,16 +266,17 @@ mod tests {
         #[test]
         fn handle_file_chooser_closed_updates_settings() {
             let setting = IntermissionSuspend;
-            let mut settings = Settings::default();
+            let mut context = create_test_context();
+            context.settings = Settings::default();
             let mut bus: Bus = VecDeque::new();
             let path = PathBuf::from("/selected/image.jpg");
             let event = Event::FileChooserClosed(Some(path));
 
-            let result = setting.handle(&event, &mut settings, &mut bus);
+            let result = setting.handle(&event, &mut context, &mut bus);
 
             assert!(result.0.is_some());
             assert_eq!(
-                settings.intermissions[IntermKind::Suspend],
+                context.settings.intermissions[IntermKind::Suspend],
                 IntermissionDisplay::Image(PathBuf::from("/selected/image.jpg"))
             );
         }
@@ -277,14 +284,15 @@ mod tests {
         #[test]
         fn handle_returns_none_for_wrong_kind() {
             let setting = IntermissionSuspend;
-            let mut settings = Settings::default();
+            let mut context = create_test_context();
+            context.settings = Settings::default();
             let mut bus: Bus = VecDeque::new();
             let event = Event::Select(EntryId::SetIntermission(
                 IntermKind::PowerOff,
                 IntermissionDisplay::Cover,
             ));
 
-            let result = setting.handle(&event, &mut settings, &mut bus);
+            let result = setting.handle(&event, &mut context, &mut bus);
 
             assert!(result.0.is_none());
         }
@@ -292,10 +300,11 @@ mod tests {
         #[test]
         fn handle_returns_none_for_cancelled_file_chooser() {
             let setting = IntermissionSuspend;
-            let mut settings = Settings::default();
+            let mut context = create_test_context();
+            context.settings = Settings::default();
             let mut bus: Bus = VecDeque::new();
 
-            let result = setting.handle(&Event::FileChooserClosed(None), &mut settings, &mut bus);
+            let result = setting.handle(&Event::FileChooserClosed(None), &mut context, &mut bus);
 
             assert!(result.0.is_none());
         }
@@ -375,18 +384,19 @@ mod tests {
         #[test]
         fn handle_set_intermission_updates_settings() {
             let setting = IntermissionPowerOff;
-            let mut settings = Settings::default();
+            let mut context = create_test_context();
+            context.settings = Settings::default();
             let mut bus: Bus = VecDeque::new();
             let event = Event::Select(EntryId::SetIntermission(
                 IntermKind::PowerOff,
                 IntermissionDisplay::Cover,
             ));
 
-            let result = setting.handle(&event, &mut settings, &mut bus);
+            let result = setting.handle(&event, &mut context, &mut bus);
 
             assert!(result.0.is_some());
             assert_eq!(
-                settings.intermissions[IntermKind::PowerOff],
+                context.settings.intermissions[IntermKind::PowerOff],
                 IntermissionDisplay::Cover
             );
         }
@@ -394,16 +404,17 @@ mod tests {
         #[test]
         fn handle_file_chooser_closed_updates_settings() {
             let setting = IntermissionPowerOff;
-            let mut settings = Settings::default();
+            let mut context = create_test_context();
+            context.settings = Settings::default();
             let mut bus: Bus = VecDeque::new();
             let path = PathBuf::from("/selected/poweroff.png");
             let event = Event::FileChooserClosed(Some(path));
 
-            let result = setting.handle(&event, &mut settings, &mut bus);
+            let result = setting.handle(&event, &mut context, &mut bus);
 
             assert!(result.0.is_some());
             assert_eq!(
-                settings.intermissions[IntermKind::PowerOff],
+                context.settings.intermissions[IntermKind::PowerOff],
                 IntermissionDisplay::Image(PathBuf::from("/selected/poweroff.png"))
             );
         }
@@ -411,14 +422,15 @@ mod tests {
         #[test]
         fn handle_returns_none_for_wrong_kind() {
             let setting = IntermissionPowerOff;
-            let mut settings = Settings::default();
+            let mut context = create_test_context();
+            context.settings = Settings::default();
             let mut bus: Bus = VecDeque::new();
             let event = Event::Select(EntryId::SetIntermission(
                 IntermKind::Suspend,
                 IntermissionDisplay::Logo,
             ));
 
-            let result = setting.handle(&event, &mut settings, &mut bus);
+            let result = setting.handle(&event, &mut context, &mut bus);
 
             assert!(result.0.is_none());
         }
@@ -426,10 +438,11 @@ mod tests {
         #[test]
         fn handle_returns_none_for_cancelled_file_chooser() {
             let setting = IntermissionPowerOff;
-            let mut settings = Settings::default();
+            let mut context = create_test_context();
+            context.settings = Settings::default();
             let mut bus: Bus = VecDeque::new();
 
-            let result = setting.handle(&Event::FileChooserClosed(None), &mut settings, &mut bus);
+            let result = setting.handle(&Event::FileChooserClosed(None), &mut context, &mut bus);
 
             assert!(result.0.is_none());
         }
@@ -437,18 +450,19 @@ mod tests {
         #[test]
         fn handle_rejects_calendar_selection() {
             let setting = IntermissionPowerOff;
-            let mut settings = Settings::default();
+            let mut context = create_test_context();
+            context.settings = Settings::default();
             let mut bus: Bus = VecDeque::new();
             let event = Event::Select(EntryId::SetIntermission(
                 IntermKind::PowerOff,
                 IntermissionDisplay::Calendar,
             ));
 
-            let result = setting.handle(&event, &mut settings, &mut bus);
+            let result = setting.handle(&event, &mut context, &mut bus);
 
             assert_eq!(result, (None, true));
             assert_eq!(
-                settings.intermissions[IntermKind::PowerOff],
+                context.settings.intermissions[IntermKind::PowerOff],
                 IntermissionDisplay::Logo
             );
         }
@@ -456,18 +470,19 @@ mod tests {
         #[test]
         fn handle_accepts_blank_selection() {
             let setting = IntermissionPowerOff;
-            let mut settings = Settings::default();
+            let mut context = create_test_context();
+            context.settings = Settings::default();
             let mut bus: Bus = VecDeque::new();
             let event = Event::Select(EntryId::SetIntermission(
                 IntermKind::PowerOff,
                 IntermissionDisplay::Blank,
             ));
 
-            let result = setting.handle(&event, &mut settings, &mut bus);
+            let result = setting.handle(&event, &mut context, &mut bus);
 
             assert_eq!(result, (Some(fl!("settings-intermission-blank")), true));
             assert_eq!(
-                settings.intermissions[IntermKind::PowerOff],
+                context.settings.intermissions[IntermKind::PowerOff],
                 IntermissionDisplay::Blank
             );
         }
@@ -508,18 +523,19 @@ mod tests {
         #[test]
         fn handle_set_intermission_updates_settings() {
             let setting = IntermissionShare;
-            let mut settings = Settings::default();
+            let mut context = create_test_context();
+            context.settings = Settings::default();
             let mut bus: Bus = VecDeque::new();
             let event = Event::Select(EntryId::SetIntermission(
                 IntermKind::Share,
                 IntermissionDisplay::Cover,
             ));
 
-            let result = setting.handle(&event, &mut settings, &mut bus);
+            let result = setting.handle(&event, &mut context, &mut bus);
 
             assert!(result.0.is_some());
             assert_eq!(
-                settings.intermissions[IntermKind::Share],
+                context.settings.intermissions[IntermKind::Share],
                 IntermissionDisplay::Cover
             );
         }
@@ -527,16 +543,17 @@ mod tests {
         #[test]
         fn handle_file_chooser_closed_updates_settings() {
             let setting = IntermissionShare;
-            let mut settings = Settings::default();
+            let mut context = create_test_context();
+            context.settings = Settings::default();
             let mut bus: Bus = VecDeque::new();
             let path = PathBuf::from("/selected/share.jpg");
             let event = Event::FileChooserClosed(Some(path));
 
-            let result = setting.handle(&event, &mut settings, &mut bus);
+            let result = setting.handle(&event, &mut context, &mut bus);
 
             assert!(result.0.is_some());
             assert_eq!(
-                settings.intermissions[IntermKind::Share],
+                context.settings.intermissions[IntermKind::Share],
                 IntermissionDisplay::Image(PathBuf::from("/selected/share.jpg"))
             );
         }
@@ -544,14 +561,15 @@ mod tests {
         #[test]
         fn handle_returns_none_for_wrong_kind() {
             let setting = IntermissionShare;
-            let mut settings = Settings::default();
+            let mut context = create_test_context();
+            context.settings = Settings::default();
             let mut bus: Bus = VecDeque::new();
             let event = Event::Select(EntryId::SetIntermission(
                 IntermKind::PowerOff,
                 IntermissionDisplay::Cover,
             ));
 
-            let result = setting.handle(&event, &mut settings, &mut bus);
+            let result = setting.handle(&event, &mut context, &mut bus);
 
             assert!(result.0.is_none());
         }
@@ -559,10 +577,11 @@ mod tests {
         #[test]
         fn handle_returns_none_for_cancelled_file_chooser() {
             let setting = IntermissionShare;
-            let mut settings = Settings::default();
+            let mut context = create_test_context();
+            context.settings = Settings::default();
             let mut bus: Bus = VecDeque::new();
 
-            let result = setting.handle(&Event::FileChooserClosed(None), &mut settings, &mut bus);
+            let result = setting.handle(&Event::FileChooserClosed(None), &mut context, &mut bus);
 
             assert!(result.0.is_none());
         }
@@ -570,18 +589,19 @@ mod tests {
         #[test]
         fn handle_rejects_calendar_selection() {
             let setting = IntermissionShare;
-            let mut settings = Settings::default();
+            let mut context = create_test_context();
+            context.settings = Settings::default();
             let mut bus: Bus = VecDeque::new();
             let event = Event::Select(EntryId::SetIntermission(
                 IntermKind::Share,
                 IntermissionDisplay::Calendar,
             ));
 
-            let result = setting.handle(&event, &mut settings, &mut bus);
+            let result = setting.handle(&event, &mut context, &mut bus);
 
             assert_eq!(result, (None, true));
             assert_eq!(
-                settings.intermissions[IntermKind::Share],
+                context.settings.intermissions[IntermKind::Share],
                 IntermissionDisplay::Logo
             );
         }
@@ -589,21 +609,22 @@ mod tests {
         #[test]
         fn handle_accepts_blank_inverted_selection() {
             let setting = IntermissionShare;
-            let mut settings = Settings::default();
+            let mut context = create_test_context();
+            context.settings = Settings::default();
             let mut bus: Bus = VecDeque::new();
             let event = Event::Select(EntryId::SetIntermission(
                 IntermKind::Share,
                 IntermissionDisplay::BlankInverted,
             ));
 
-            let result = setting.handle(&event, &mut settings, &mut bus);
+            let result = setting.handle(&event, &mut context, &mut bus);
 
             assert_eq!(
                 result,
                 (Some(fl!("settings-intermission-blank-inverted")), true)
             );
             assert_eq!(
-                settings.intermissions[IntermKind::Share],
+                context.settings.intermissions[IntermKind::Share],
                 IntermissionDisplay::BlankInverted
             );
         }

--- a/crates/core/src/view/settings_editor/kinds/mod.rs
+++ b/crates/core/src/view/settings_editor/kinds/mod.rs
@@ -20,6 +20,7 @@ pub mod telemetry;
 
 pub use identity::SettingIdentity;
 
+use crate::device::AppContext;
 use crate::geom::Rectangle;
 use crate::settings::Settings;
 use crate::view::{Bus, EntryId, EntryKind, Event, ViewId};
@@ -115,7 +116,7 @@ pub trait SettingKind {
 
     /// Handle an incoming event that may apply a change to this setting.
     ///
-    /// Mutates `settings` if the event is relevant and returns:
+    /// Mutates `context.settings` (and may use other context state) if the event is relevant and returns:
     /// - `Some(display_string)` as the first element when the event changes this
     ///   setting's display value, or `None` if the event does not apply.
     /// - `true` as the second element when the event has been fully consumed and
@@ -125,7 +126,7 @@ pub trait SettingKind {
     fn handle(
         &self,
         _evt: &Event,
-        _settings: &mut Settings,
+        _context: &mut AppContext,
         _bus: &mut Bus,
     ) -> (Option<String>, bool) {
         (None, false)
@@ -174,10 +175,10 @@ impl<T: SettingKind + ?Sized> SettingKind for &T {
     fn handle(
         &self,
         evt: &Event,
-        settings: &mut Settings,
+        context: &mut AppContext,
         bus: &mut Bus,
     ) -> (Option<String>, bool) {
-        (**self).handle(evt, settings, bus)
+        (**self).handle(evt, context, bus)
     }
 
     fn as_input_kind(&self) -> Option<&dyn InputSettingKind> {
@@ -213,10 +214,10 @@ impl<T: SettingKind + ?Sized> SettingKind for Box<T> {
     fn handle(
         &self,
         evt: &Event,
-        settings: &mut Settings,
+        context: &mut AppContext,
         bus: &mut Bus,
     ) -> (Option<String>, bool) {
-        (**self).handle(evt, settings, bus)
+        (**self).handle(evt, context, bus)
     }
 
     fn as_input_kind(&self) -> Option<&dyn InputSettingKind> {

--- a/crates/core/src/view/settings_editor/kinds/reader.rs
+++ b/crates/core/src/view/settings_editor/kinds/reader.rs
@@ -1,6 +1,7 @@
 //! Setting kinds for the Reader category.
 
 use super::{SettingData, SettingIdentity, SettingKind, SettingsFetchData, WidgetKind};
+use crate::device::AppContext;
 use crate::fl;
 use crate::geom::Rectangle;
 use crate::i18n::I18nDisplay;
@@ -44,16 +45,16 @@ impl SettingKind for DitheredKindsSetting {
     fn handle(
         &self,
         evt: &Event,
-        settings: &mut Settings,
+        context: &mut AppContext,
         _bus: &mut Bus,
     ) -> (Option<String>, bool) {
         if let Event::Select(EntryId::ToggleDitheredKind(kind)) = evt {
-            if !settings.reader.dithered_kinds.remove(kind) {
-                settings.reader.dithered_kinds.insert(*kind);
+            if !context.settings.reader.dithered_kinds.remove(kind) {
+                context.settings.reader.dithered_kinds.insert(*kind);
             }
 
             return (
-                Some(kinds_summary(settings.reader.dithered_kinds.len())),
+                Some(kinds_summary(context.settings.reader.dithered_kinds.len())),
                 true,
             );
         }
@@ -109,11 +110,11 @@ impl SettingKind for FinishedActionSetting {
     fn handle(
         &self,
         evt: &Event,
-        settings: &mut Settings,
+        context: &mut AppContext,
         _bus: &mut Bus,
     ) -> (Option<String>, bool) {
         if let Event::Select(EntryId::SetFinishedAction(action)) = evt {
-            settings.reader.finished = *action;
+            context.settings.reader.finished = *action;
             return (Some(action.to_i18n_string()), true);
         }
         (None, false)
@@ -150,10 +151,10 @@ impl SettingKind for RefreshRateInfo {
     fn handle(
         &self,
         evt: &Event,
-        settings: &mut Settings,
+        context: &mut AppContext,
         _bus: &mut Bus,
     ) -> (Option<String>, bool) {
-        let global = &settings.reader.refresh_rate.global;
+        let global = &context.settings.reader.refresh_rate.global;
         match evt {
             Event::Submit(ViewId::RefreshRateRegularInput, text) => {
                 let regular = text.parse::<u8>().unwrap_or(global.regular);
@@ -254,13 +255,13 @@ impl SettingKind for RefreshRateRegularSetting {
     fn handle(
         &self,
         evt: &Event,
-        settings: &mut Settings,
+        context: &mut AppContext,
         _bus: &mut Bus,
     ) -> (Option<String>, bool) {
         if let Event::Submit(crate::view::ViewId::RefreshRateRegularInput, text) = evt
             && let Ok(v) = text.parse::<u8>()
         {
-            settings.reader.refresh_rate.global.regular = v;
+            context.settings.reader.refresh_rate.global.regular = v;
             return (Some(v.to_string()), true);
         }
 
@@ -309,13 +310,13 @@ impl SettingKind for RefreshRateInvertedSetting {
     fn handle(
         &self,
         evt: &Event,
-        settings: &mut Settings,
+        context: &mut AppContext,
         _bus: &mut Bus,
     ) -> (Option<String>, bool) {
         if let Event::Submit(crate::view::ViewId::RefreshRateInvertedInput, text) = evt
             && let Ok(v) = text.parse::<u8>()
         {
-            settings.reader.refresh_rate.global.inverted = v;
+            context.settings.reader.refresh_rate.global.inverted = v;
             return (Some(v.to_string()), true);
         }
 
@@ -362,13 +363,14 @@ impl SettingKind for RefreshRateByKindRegular {
     fn handle(
         &self,
         evt: &Event,
-        settings: &mut Settings,
+        context: &mut AppContext,
         _bus: &mut Bus,
     ) -> (Option<String>, bool) {
         if let Event::Submit(crate::view::ViewId::RefreshRateByKindRegularInput, text) = evt
             && let Ok(v) = text.parse::<u8>()
         {
-            let pair = settings
+            let pair = context
+                .settings
                 .reader
                 .refresh_rate
                 .by_kind
@@ -424,13 +426,14 @@ impl SettingKind for RefreshRateByKindInverted {
     fn handle(
         &self,
         evt: &Event,
-        settings: &mut Settings,
+        context: &mut AppContext,
         _bus: &mut Bus,
     ) -> (Option<String>, bool) {
         if let Event::Submit(crate::view::ViewId::RefreshRateByKindInvertedInput, text) = evt
             && let Ok(v) = text.parse::<u8>()
         {
-            let pair = settings
+            let pair = context
+                .settings
                 .reader
                 .refresh_rate
                 .by_kind
@@ -450,6 +453,7 @@ impl SettingKind for RefreshRateByKindInverted {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::context::test_helpers::create_test_context;
     use crate::settings::{FileExtension, FinishedAction, Settings};
     use crate::view::{Bus, EntryId, Event};
     use std::collections::VecDeque;
@@ -460,21 +464,23 @@ mod tests {
         #[test]
         fn handle_set_action_updates_settings() {
             let setting = FinishedActionSetting;
-            let mut settings = Settings::default();
-            settings.reader.finished = FinishedAction::Close;
+            let mut context = create_test_context();
+            context.settings = Settings::default();
+            context.settings.reader.finished = FinishedAction::Close;
             let mut bus: Bus = VecDeque::new();
             let event = Event::Select(EntryId::SetFinishedAction(FinishedAction::GoToNext));
 
-            let result = setting.handle(&event, &mut settings, &mut bus);
+            let result = setting.handle(&event, &mut context, &mut bus);
 
             assert!(result.0.is_some());
-            assert_eq!(settings.reader.finished, FinishedAction::GoToNext);
+            assert_eq!(context.settings.reader.finished, FinishedAction::GoToNext);
         }
 
         #[test]
         fn handle_can_set_all_actions() {
             let setting = FinishedActionSetting;
-            let mut settings = Settings::default();
+            let mut context = create_test_context();
+            context.settings = Settings::default();
             let mut bus: Bus = VecDeque::new();
 
             for action in [
@@ -483,8 +489,8 @@ mod tests {
                 FinishedAction::GoToNext,
             ] {
                 let event = Event::Select(EntryId::SetFinishedAction(action));
-                setting.handle(&event, &mut settings, &mut bus);
-                assert_eq!(settings.reader.finished, action);
+                setting.handle(&event, &mut context, &mut bus);
+                assert_eq!(context.settings.reader.finished, action);
             }
         }
 
@@ -521,41 +527,59 @@ mod tests {
             #[test]
             fn handle_toggle_adds_and_removes_extensions() {
                 let setting = DitheredKindsSetting;
-                let mut settings = Settings::default();
-                settings.reader.dithered_kinds.remove(&FileExtension::Pdf);
+                let mut context = create_test_context();
+                context.settings = Settings::default();
+                context
+                    .settings
+                    .reader
+                    .dithered_kinds
+                    .remove(&FileExtension::Pdf);
                 let mut bus: Bus = VecDeque::new();
 
                 let add = setting.handle(
                     &Event::Select(EntryId::ToggleDitheredKind(FileExtension::Pdf)),
-                    &mut settings,
+                    &mut context,
                     &mut bus,
                 );
                 assert_eq!(
                     add.0,
-                    Some(kinds_summary(settings.reader.dithered_kinds.len()))
+                    Some(kinds_summary(context.settings.reader.dithered_kinds.len()))
                 );
-                assert!(settings.reader.dithered_kinds.contains(&FileExtension::Pdf));
+                assert!(
+                    context
+                        .settings
+                        .reader
+                        .dithered_kinds
+                        .contains(&FileExtension::Pdf)
+                );
 
                 let remove = setting.handle(
                     &Event::Select(EntryId::ToggleDitheredKind(FileExtension::Pdf)),
-                    &mut settings,
+                    &mut context,
                     &mut bus,
                 );
                 assert_eq!(
                     remove.0,
-                    Some(kinds_summary(settings.reader.dithered_kinds.len()))
+                    Some(kinds_summary(context.settings.reader.dithered_kinds.len()))
                 );
-                assert!(!settings.reader.dithered_kinds.contains(&FileExtension::Pdf));
+                assert!(
+                    !context
+                        .settings
+                        .reader
+                        .dithered_kinds
+                        .contains(&FileExtension::Pdf)
+                );
             }
         }
 
         #[test]
         fn handle_returns_none_for_wrong_event() {
             let setting = FinishedActionSetting;
-            let mut settings = Settings::default();
+            let mut context = create_test_context();
+            context.settings = Settings::default();
             let mut bus: Bus = VecDeque::new();
 
-            let result = setting.handle(&Event::Select(EntryId::About), &mut settings, &mut bus);
+            let result = setting.handle(&Event::Select(EntryId::About), &mut context, &mut bus);
 
             assert!(result.0.is_none());
         }
@@ -563,11 +587,12 @@ mod tests {
         #[test]
         fn handle_returns_none_for_per_library_entry_id() {
             let setting = FinishedActionSetting;
-            let mut settings = Settings::default();
+            let mut context = create_test_context();
+            context.settings = Settings::default();
             let mut bus: Bus = VecDeque::new();
             let event = Event::Select(EntryId::SetLibraryFinishedAction(0, FinishedAction::Notify));
 
-            let result = setting.handle(&event, &mut settings, &mut bus);
+            let result = setting.handle(&event, &mut context, &mut bus);
 
             assert!(result.0.is_none());
         }
@@ -579,13 +604,14 @@ mod tests {
         #[test]
         fn handle_regular_submit_updates_display_without_writing_settings() {
             let setting = RefreshRateInfo;
-            let mut settings = Settings::default();
-            settings.reader.refresh_rate.global.regular = 5;
-            settings.reader.refresh_rate.global.inverted = 10;
+            let mut context = create_test_context();
+            context.settings = Settings::default();
+            context.settings.reader.refresh_rate.global.regular = 5;
+            context.settings.reader.refresh_rate.global.inverted = 10;
             let mut bus: Bus = VecDeque::new();
 
             let event = Event::Submit(ViewId::RefreshRateRegularInput, "3".to_string());
-            let (display, handled) = setting.handle(&event, &mut settings, &mut bus);
+            let (display, handled) = setting.handle(&event, &mut context, &mut bus);
 
             assert_eq!(
                 display.as_deref(),
@@ -599,19 +625,20 @@ mod tests {
                 )
             );
             assert!(!handled);
-            assert_eq!(settings.reader.refresh_rate.global.regular, 5);
+            assert_eq!(context.settings.reader.refresh_rate.global.regular, 5);
         }
 
         #[test]
         fn handle_inverted_submit_updates_display_without_writing_settings() {
             let setting = RefreshRateInfo;
-            let mut settings = Settings::default();
-            settings.reader.refresh_rate.global.regular = 5;
-            settings.reader.refresh_rate.global.inverted = 10;
+            let mut context = create_test_context();
+            context.settings = Settings::default();
+            context.settings.reader.refresh_rate.global.regular = 5;
+            context.settings.reader.refresh_rate.global.inverted = 10;
             let mut bus: Bus = VecDeque::new();
 
             let event = Event::Submit(ViewId::RefreshRateInvertedInput, "7".to_string());
-            let (display, handled) = setting.handle(&event, &mut settings, &mut bus);
+            let (display, handled) = setting.handle(&event, &mut context, &mut bus);
 
             assert_eq!(
                 display.as_deref(),
@@ -625,19 +652,20 @@ mod tests {
                 )
             );
             assert!(!handled);
-            assert_eq!(settings.reader.refresh_rate.global.inverted, 10);
+            assert_eq!(context.settings.reader.refresh_rate.global.inverted, 10);
         }
 
         #[test]
         fn handle_invalid_text_falls_back_to_current_value() {
             let setting = RefreshRateInfo;
-            let mut settings = Settings::default();
-            settings.reader.refresh_rate.global.regular = 5;
-            settings.reader.refresh_rate.global.inverted = 10;
+            let mut context = create_test_context();
+            context.settings = Settings::default();
+            context.settings.reader.refresh_rate.global.regular = 5;
+            context.settings.reader.refresh_rate.global.inverted = 10;
             let mut bus: Bus = VecDeque::new();
 
             let event = Event::Submit(ViewId::RefreshRateRegularInput, "bad".to_string());
-            let (display, _) = setting.handle(&event, &mut settings, &mut bus);
+            let (display, _) = setting.handle(&event, &mut context, &mut bus);
 
             assert_eq!(
                 display.as_deref(),
@@ -655,11 +683,12 @@ mod tests {
         #[test]
         fn handle_unrelated_event_returns_none() {
             let setting = RefreshRateInfo;
-            let mut settings = Settings::default();
+            let mut context = create_test_context();
+            context.settings = Settings::default();
             let mut bus: Bus = VecDeque::new();
 
             let (display, handled) =
-                setting.handle(&Event::Select(EntryId::About), &mut settings, &mut bus);
+                setting.handle(&Event::Select(EntryId::About), &mut context, &mut bus);
 
             assert!(display.is_none());
             assert!(!handled);

--- a/crates/core/src/view/settings_editor/kinds/telemetry.rs
+++ b/crates/core/src/view/settings_editor/kinds/telemetry.rs
@@ -3,6 +3,7 @@
 use super::{
     SettingData, SettingIdentity, SettingKind, SettingsFetchData, ToggleSettings, WidgetKind,
 };
+use crate::device::AppContext;
 use crate::fl;
 use crate::settings::Settings;
 use crate::view::{Bus, EntryId, EntryKind, Event, ToggleEvent};
@@ -40,12 +41,12 @@ impl SettingKind for LoggingEnabled {
     fn handle(
         &self,
         evt: &Event,
-        settings: &mut Settings,
+        context: &mut AppContext,
         _bus: &mut Bus,
     ) -> (Option<String>, bool) {
         if let Event::Toggle(ToggleEvent::Setting(ToggleSettings::LoggingEnabled)) = evt {
-            settings.logging.enabled = !settings.logging.enabled;
-            return (Some(settings.logging.enabled.to_string()), true);
+            context.settings.logging.enabled = !context.settings.logging.enabled;
+            return (Some(context.settings.logging.enabled.to_string()), true);
         }
         (None, false)
     }
@@ -116,11 +117,11 @@ impl SettingKind for LogLevel {
     fn handle(
         &self,
         evt: &Event,
-        settings: &mut Settings,
+        context: &mut AppContext,
         _bus: &mut Bus,
     ) -> (Option<String>, bool) {
         if let Event::Select(EntryId::SetLogLevel(level)) = evt {
-            settings.logging.level = level.to_string();
+            context.settings.logging.level = level.to_string();
             return (Some(Self::level_to_i18n(level)), true);
         }
         (None, false)
@@ -300,12 +301,15 @@ impl SettingKind for EnableKernLog {
     fn handle(
         &self,
         evt: &Event,
-        settings: &mut Settings,
+        context: &mut AppContext,
         _bus: &mut Bus,
     ) -> (Option<String>, bool) {
         if let Event::Toggle(ToggleEvent::Setting(ToggleSettings::EnableKernLog)) = evt {
-            settings.logging.enable_kern_log = !settings.logging.enable_kern_log;
-            return (Some(settings.logging.enable_kern_log.to_string()), true);
+            context.settings.logging.enable_kern_log = !context.settings.logging.enable_kern_log;
+            return (
+                Some(context.settings.logging.enable_kern_log.to_string()),
+                true,
+            );
         }
         (None, false)
     }
@@ -340,12 +344,15 @@ impl SettingKind for EnableDbusLog {
     fn handle(
         &self,
         evt: &Event,
-        settings: &mut Settings,
+        context: &mut AppContext,
         _bus: &mut Bus,
     ) -> (Option<String>, bool) {
         if let Event::Toggle(ToggleEvent::Setting(ToggleSettings::EnableDbusLog)) = evt {
-            settings.logging.enable_dbus_log = !settings.logging.enable_dbus_log;
-            return (Some(settings.logging.enable_dbus_log.to_string()), true);
+            context.settings.logging.enable_dbus_log = !context.settings.logging.enable_dbus_log;
+            return (
+                Some(context.settings.logging.enable_dbus_log.to_string()),
+                true,
+            );
         }
         (None, false)
     }
@@ -354,6 +361,7 @@ impl SettingKind for EnableDbusLog {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::context::test_helpers::create_test_context;
     use crate::settings::Settings;
     use crate::view::settings_editor::kinds::ToggleSettings;
     use crate::view::{Bus, EntryId, Event, ToggleEvent};
@@ -365,38 +373,41 @@ mod tests {
         #[test]
         fn handle_toggle_disables_when_enabled() {
             let setting = LoggingEnabled;
-            let mut settings = Settings::default();
-            settings.logging.enabled = true;
+            let mut context = create_test_context();
+            context.settings = Settings::default();
+            context.settings.logging.enabled = true;
             let mut bus: Bus = VecDeque::new();
             let event = Event::Toggle(ToggleEvent::Setting(ToggleSettings::LoggingEnabled));
 
-            let result = setting.handle(&event, &mut settings, &mut bus);
+            let result = setting.handle(&event, &mut context, &mut bus);
 
             assert!(result.0.is_some());
-            assert!(!settings.logging.enabled);
+            assert!(!context.settings.logging.enabled);
         }
 
         #[test]
         fn handle_toggle_enables_when_disabled() {
             let setting = LoggingEnabled;
-            let mut settings = Settings::default();
-            settings.logging.enabled = false;
+            let mut context = create_test_context();
+            context.settings = Settings::default();
+            context.settings.logging.enabled = false;
             let mut bus: Bus = VecDeque::new();
             let event = Event::Toggle(ToggleEvent::Setting(ToggleSettings::LoggingEnabled));
 
-            let result = setting.handle(&event, &mut settings, &mut bus);
+            let result = setting.handle(&event, &mut context, &mut bus);
 
             assert!(result.0.is_some());
-            assert!(settings.logging.enabled);
+            assert!(context.settings.logging.enabled);
         }
 
         #[test]
         fn handle_returns_none_for_wrong_event() {
             let setting = LoggingEnabled;
-            let mut settings = Settings::default();
+            let mut context = create_test_context();
+            context.settings = Settings::default();
             let mut bus: Bus = VecDeque::new();
 
-            let result = setting.handle(&Event::Select(EntryId::About), &mut settings, &mut bus);
+            let result = setting.handle(&Event::Select(EntryId::About), &mut context, &mut bus);
 
             assert!(result.0.is_none());
         }
@@ -404,12 +415,13 @@ mod tests {
         #[test]
         fn handle_returns_none_for_wrong_toggle() {
             let setting = LoggingEnabled;
-            let mut settings = Settings::default();
+            let mut context = create_test_context();
+            context.settings = Settings::default();
             let mut bus: Bus = VecDeque::new();
 
             let result = setting.handle(
                 &Event::Toggle(ToggleEvent::Setting(ToggleSettings::SleepCover)),
-                &mut settings,
+                &mut context,
                 &mut bus,
             );
 
@@ -423,21 +435,23 @@ mod tests {
         #[test]
         fn handle_set_level_updates_settings() {
             let setting = LogLevel;
-            let mut settings = Settings::default();
-            settings.logging.level = "INFO".to_string();
+            let mut context = create_test_context();
+            context.settings = Settings::default();
+            context.settings.logging.level = "INFO".to_string();
             let mut bus: Bus = VecDeque::new();
             let event = Event::Select(EntryId::SetLogLevel(tracing::Level::WARN));
 
-            let result = setting.handle(&event, &mut settings, &mut bus);
+            let result = setting.handle(&event, &mut context, &mut bus);
 
             assert!(result.0.is_some());
-            assert_eq!(settings.logging.level, "WARN");
+            assert_eq!(context.settings.logging.level, "WARN");
         }
 
         #[test]
         fn handle_can_set_all_levels() {
             let setting = LogLevel;
-            let mut settings = Settings::default();
+            let mut context = create_test_context();
+            context.settings = Settings::default();
             let mut bus: Bus = VecDeque::new();
 
             for level in [
@@ -448,18 +462,19 @@ mod tests {
                 tracing::Level::ERROR,
             ] {
                 let event = Event::Select(EntryId::SetLogLevel(level));
-                setting.handle(&event, &mut settings, &mut bus);
-                assert_eq!(settings.logging.level, level.to_string());
+                setting.handle(&event, &mut context, &mut bus);
+                assert_eq!(context.settings.logging.level, level.to_string());
             }
         }
 
         #[test]
         fn handle_returns_none_for_wrong_event() {
             let setting = LogLevel;
-            let mut settings = Settings::default();
+            let mut context = create_test_context();
+            context.settings = Settings::default();
             let mut bus: Bus = VecDeque::new();
 
-            let result = setting.handle(&Event::Select(EntryId::About), &mut settings, &mut bus);
+            let result = setting.handle(&Event::Select(EntryId::About), &mut context, &mut bus);
 
             assert!(result.0.is_none());
         }
@@ -530,38 +545,41 @@ mod tests {
         #[test]
         fn handle_toggle_enables_when_disabled() {
             let setting = EnableKernLog;
-            let mut settings = Settings::default();
-            settings.logging.enable_kern_log = false;
+            let mut context = create_test_context();
+            context.settings = Settings::default();
+            context.settings.logging.enable_kern_log = false;
             let mut bus: Bus = VecDeque::new();
             let event = Event::Toggle(ToggleEvent::Setting(ToggleSettings::EnableKernLog));
 
-            let result = setting.handle(&event, &mut settings, &mut bus);
+            let result = setting.handle(&event, &mut context, &mut bus);
 
             assert!(result.0.is_some());
-            assert!(settings.logging.enable_kern_log);
+            assert!(context.settings.logging.enable_kern_log);
         }
 
         #[test]
         fn handle_toggle_disables_when_enabled() {
             let setting = EnableKernLog;
-            let mut settings = Settings::default();
-            settings.logging.enable_kern_log = true;
+            let mut context = create_test_context();
+            context.settings = Settings::default();
+            context.settings.logging.enable_kern_log = true;
             let mut bus: Bus = VecDeque::new();
             let event = Event::Toggle(ToggleEvent::Setting(ToggleSettings::EnableKernLog));
 
-            let result = setting.handle(&event, &mut settings, &mut bus);
+            let result = setting.handle(&event, &mut context, &mut bus);
 
             assert!(result.0.is_some());
-            assert!(!settings.logging.enable_kern_log);
+            assert!(!context.settings.logging.enable_kern_log);
         }
 
         #[test]
         fn handle_returns_none_for_wrong_event() {
             let setting = EnableKernLog;
-            let mut settings = Settings::default();
+            let mut context = create_test_context();
+            context.settings = Settings::default();
             let mut bus: Bus = VecDeque::new();
 
-            let result = setting.handle(&Event::Select(EntryId::About), &mut settings, &mut bus);
+            let result = setting.handle(&Event::Select(EntryId::About), &mut context, &mut bus);
 
             assert!(result.0.is_none());
         }
@@ -569,12 +587,13 @@ mod tests {
         #[test]
         fn handle_returns_none_for_wrong_toggle() {
             let setting = EnableKernLog;
-            let mut settings = Settings::default();
+            let mut context = create_test_context();
+            context.settings = Settings::default();
             let mut bus: Bus = VecDeque::new();
 
             let result = setting.handle(
                 &Event::Toggle(ToggleEvent::Setting(ToggleSettings::LoggingEnabled)),
-                &mut settings,
+                &mut context,
                 &mut bus,
             );
 
@@ -589,38 +608,41 @@ mod tests {
         #[test]
         fn handle_toggle_enables_when_disabled() {
             let setting = EnableDbusLog;
-            let mut settings = Settings::default();
-            settings.logging.enable_dbus_log = false;
+            let mut context = create_test_context();
+            context.settings = Settings::default();
+            context.settings.logging.enable_dbus_log = false;
             let mut bus: Bus = VecDeque::new();
             let event = Event::Toggle(ToggleEvent::Setting(ToggleSettings::EnableDbusLog));
 
-            let result = setting.handle(&event, &mut settings, &mut bus);
+            let result = setting.handle(&event, &mut context, &mut bus);
 
             assert!(result.0.is_some());
-            assert!(settings.logging.enable_dbus_log);
+            assert!(context.settings.logging.enable_dbus_log);
         }
 
         #[test]
         fn handle_toggle_disables_when_enabled() {
             let setting = EnableDbusLog;
-            let mut settings = Settings::default();
-            settings.logging.enable_dbus_log = true;
+            let mut context = create_test_context();
+            context.settings = Settings::default();
+            context.settings.logging.enable_dbus_log = true;
             let mut bus: Bus = VecDeque::new();
             let event = Event::Toggle(ToggleEvent::Setting(ToggleSettings::EnableDbusLog));
 
-            let result = setting.handle(&event, &mut settings, &mut bus);
+            let result = setting.handle(&event, &mut context, &mut bus);
 
             assert!(result.0.is_some());
-            assert!(!settings.logging.enable_dbus_log);
+            assert!(!context.settings.logging.enable_dbus_log);
         }
 
         #[test]
         fn handle_returns_none_for_wrong_event() {
             let setting = EnableDbusLog;
-            let mut settings = Settings::default();
+            let mut context = create_test_context();
+            context.settings = Settings::default();
             let mut bus: Bus = VecDeque::new();
 
-            let result = setting.handle(&Event::Select(EntryId::About), &mut settings, &mut bus);
+            let result = setting.handle(&Event::Select(EntryId::About), &mut context, &mut bus);
 
             assert!(result.0.is_none());
         }
@@ -628,12 +650,13 @@ mod tests {
         #[test]
         fn handle_returns_none_for_wrong_toggle() {
             let setting = EnableDbusLog;
-            let mut settings = Settings::default();
+            let mut context = create_test_context();
+            context.settings = Settings::default();
             let mut bus: Bus = VecDeque::new();
 
             let result = setting.handle(
                 &Event::Toggle(ToggleEvent::Setting(ToggleSettings::LoggingEnabled)),
-                &mut settings,
+                &mut context,
                 &mut bus,
             );
 

--- a/crates/core/src/view/settings_editor/setting_value.rs
+++ b/crates/core/src/view/settings_editor/setting_value.rs
@@ -249,7 +249,7 @@ impl View for SettingValue {
 
         if let Event::FileChooserClosed(_) = evt {
             if self.active_file_chooser {
-                if let (Some(display), _) = self.kind.handle(evt, &mut context.settings, bus) {
+                if let (Some(display), _) = self.kind.handle(evt, context, bus) {
                     self.update(display, &context.settings, rq);
                 }
                 return false;
@@ -272,7 +272,7 @@ impl View for SettingValue {
             }
         }
 
-        if let (Some(display), handled) = self.kind.handle(evt, &mut context.settings, bus) {
+        if let (Some(display), handled) = self.kind.handle(evt, context, bus) {
             self.update(display, &context.settings, rq);
             if !self.kind.keep_menu_open() {
                 bus.push_back(Event::Close(ViewId::SettingsValueMenu));


### PR DESCRIPTION
Handlers need runtime state (e.g. soft-suspend session) without a deferred bus event. apply_text still takes &mut Settings.

Change-Id: 0234c50822cd9f108c32b8b31f18525a
Change-Id-Short: zxwvnuzrxxnm

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Wide mechanical API change across the settings editor dispatch path; behavior should be equivalent for settings-only handlers, but any missed call site or future context use increases regression risk.
> 
> **Overview**
> **`SettingKind::handle`** now takes **`&mut AppContext`** instead of **`&mut Settings`**, so handlers can read or update runtime state beyond persisted settings (e.g. soft-suspend session) without routing everything through deferred bus events. Implementations that only touch configuration now mutate **`context.settings`**; **`InputSettingKind::apply_text`** is unchanged and still uses **`&mut Settings`**.
> 
> The trait default and **`&T` / `Box<T>`** forwards are updated, **`SettingValue`** passes the full context into **`handle`**, and unit tests build state via **`create_test_context()`** with settings assigned on **`context.settings`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f02afb15f1503abdca13a876716856060f7fb9e0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->