### PR TITLE
ci(reviewdog): clear stale comments on clean runs

### DIFF
--- a/.github/actions/reviewdog-post/action.yml
+++ b/.github/actions/reviewdog-post/action.yml
@@ -1,7 +1,9 @@
 name: Post reviewdog diagnostics from artifact
 description: >
   Download a reviewdog-input artifact from a completed workflow run and post
-  inline PR review comments. Treats the artifact as untrusted text only.
+  inline PR review comments (including an empty file to clear stale comments).
+  Treats the artifact as untrusted text only. Skips when the artifact is missing
+  so path-filtered collect jobs do not wipe unrelated comments.
 
 inputs:
   pr_number:
@@ -94,9 +96,12 @@ runs:
         RD_FLAGS: ${{ inputs.reviewdog_flags }}
       run: |
         set -euo pipefail
-        if [ ! -s "$DIAGNOSTICS_PATH" ]; then
-          echo "No diagnostics at $DIAGNOSTICS_PATH — skipping"
-          exit 0
+        if [ ! -f "$DIAGNOSTICS_PATH" ]; then
+          mkdir -p "$(dirname "$DIAGNOSTICS_PATH")"
+          : > "$DIAGNOSTICS_PATH"
+        fi
+        if [ ! -s "$DIAGNOSTICS_PATH" ] && [ "$RD_FORMAT" = "sarif" ]; then
+          printf '%s\n' '{"version":"2.1.0","runs":[]}' > "$DIAGNOSTICS_PATH"
         fi
 
         args=(-name="$RD_NAME" -filter-mode="$RD_FILTER_MODE" -fail-on-error=false -reporter=github-pr-review)

--- a/.github/workflows/actions-lint.yml
+++ b/.github/workflows/actions-lint.yml
@@ -48,6 +48,7 @@ jobs:
           tag: v${{ env.ACTIONLINT_VERSION }}
 
       - name: Collect actionlint diagnostics
+        id: collect
         run: |
           set -euo pipefail
           mkdir -p actionlint-reviewdog-input
@@ -85,15 +86,20 @@ jobs:
             echo "${severity}:${line}" >> actionlint-reviewdog-input/diagnostics.txt
           done < actionlint-reviewdog-input/raw.txt
           if [ "$actionlint_exit" -ne 0 ]; then
+            if [ -s actionlint-reviewdog-input/diagnostics.txt ]; then
+              echo "upload=true" >> "$GITHUB_OUTPUT"
+            fi
             exit "$actionlint_exit"
           fi
+          echo "upload=true" >> "$GITHUB_OUTPUT"
 
       - name: Upload reviewdog input artifact
-        if: failure() && hashFiles('actionlint-reviewdog-input/diagnostics.txt') != ''
+        if: ${{ !cancelled() && steps.collect.outputs.upload == 'true' }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: actionlint-reviewdog-input
           path: actionlint-reviewdog-input/
+          if-no-files-found: error
           retention-days: 1
 
   prettier:
@@ -119,6 +125,7 @@ jobs:
         working-directory: .github/lint
 
       - name: Collect prettier diagnostics
+        id: collect
         run: |
           set -euo pipefail
           shopt -s globstar nullglob
@@ -126,21 +133,27 @@ jobs:
           files=(.github/workflows/**/*.yml .github/actions/**/*.yml)
           if [ "${#files[@]}" -eq 0 ]; then
             echo "No YAML files to format"
+            : > prettier-actions-reviewdog-input/diagnostics.diff
+            echo "upload=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
           npx --prefix .github/lint prettier --write "${files[@]}"
           if ! git diff --quiet; then
             git diff > prettier-actions-reviewdog-input/diagnostics.diff
+            echo "upload=true" >> "$GITHUB_OUTPUT"
             echo "::error::Prettier found formatting issues"
             exit 1
           fi
+          : > prettier-actions-reviewdog-input/diagnostics.diff
+          echo "upload=true" >> "$GITHUB_OUTPUT"
 
       - name: Upload reviewdog input artifact
-        if: failure() && hashFiles('prettier-actions-reviewdog-input/diagnostics.diff') != ''
+        if: ${{ !cancelled() && steps.collect.outputs.upload == 'true' }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: prettier-actions-reviewdog-input
           path: prettier-actions-reviewdog-input/
+          if-no-files-found: error
           retention-days: 1
 
   required-actions-lint:

--- a/.github/workflows/docs-lint.yml
+++ b/.github/workflows/docs-lint.yml
@@ -46,6 +46,7 @@ jobs:
           echo "list=${files[*]}" >> "$GITHUB_OUTPUT"
 
       - name: rumdl
+        id: rumdl
         if: steps.filter.outputs.docs == 'true'
         uses: ./.github/actions/rumdl-lint
         with:
@@ -53,12 +54,29 @@ jobs:
           rumdl_flags: ${{ steps.files.outputs.list }}
           output: rumdl-reviewdog-input/diagnostics.sarif
 
+      - name: Decide rumdl artifact upload
+        id: collect
+        if: ${{ !cancelled() && (steps.rumdl.outcome == 'success' || steps.rumdl.outcome == 'failure') }}
+        run: |
+          set -euo pipefail
+          sarif=rumdl-reviewdog-input/diagnostics.sarif
+          if [ "${{ steps.rumdl.outcome }}" = "success" ]; then
+            if [ ! -f "$sarif" ]; then
+              mkdir -p rumdl-reviewdog-input
+              printf '%s\n' '{"version":"2.1.0","runs":[]}' > "$sarif"
+            fi
+            echo "upload=true" >> "$GITHUB_OUTPUT"
+          elif [ -s "$sarif" ]; then
+            echo "upload=true" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Upload reviewdog input artifact
-        if: failure() && steps.filter.outputs.docs == 'true' && hashFiles('rumdl-reviewdog-input/diagnostics.sarif') != ''
+        if: ${{ !cancelled() && steps.collect.outputs.upload == 'true' }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: rumdl-reviewdog-input
           path: rumdl-reviewdog-input/
+          if-no-files-found: error
           retention-days: 1
 
       - name: No relevant changes

--- a/.github/workflows/shell.yml
+++ b/.github/workflows/shell.yml
@@ -43,12 +43,16 @@ jobs:
         run: shellcheck --version
 
       - name: Collect shellcheck diagnostics
+        id: collect
         run: |
           set -euo pipefail
           mkdir -p shellcheck-reviewdog-input
           mapfile -t files < <(find . -type f -name '*.sh' -not -path './.git/*')
           if [ "${#files[@]}" -eq 0 ]; then
             echo "No shell scripts found"
+            : > shellcheck-reviewdog-input/diagnostics.txt
+            : > shellcheck-reviewdog-input/suggestions.diff
+            echo "upload=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
@@ -63,15 +67,21 @@ jobs:
           set -e
 
           if [ "$json_exit" -ne 0 ] || [ "$diff_exit" -ne 0 ]; then
+            if [ -s shellcheck-reviewdog-input/diagnostics.txt ] || \
+              [ -s shellcheck-reviewdog-input/suggestions.diff ]; then
+              echo "upload=true" >> "$GITHUB_OUTPUT"
+            fi
             exit 1
           fi
+          echo "upload=true" >> "$GITHUB_OUTPUT"
 
       - name: Upload reviewdog input artifact
-        if: failure() && hashFiles('shellcheck-reviewdog-input/**') != ''
+        if: ${{ !cancelled() && steps.collect.outputs.upload == 'true' }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: shellcheck-reviewdog-input
           path: shellcheck-reviewdog-input/
+          if-no-files-found: error
           retention-days: 1
 
   shfmt:
@@ -96,6 +106,7 @@ jobs:
           chmod: "0755"
 
       - name: Collect shfmt diagnostics
+        id: collect
         run: |
           set -euo pipefail
           mkdir -p shfmt-reviewdog-input
@@ -103,16 +114,20 @@ jobs:
           shfmt -i 2 -ci -w .
           if ! git diff --quiet; then
             git diff > shfmt-reviewdog-input/diagnostics.diff
+            echo "upload=true" >> "$GITHUB_OUTPUT"
             echo "::error::shfmt found formatting issues"
             exit 1
           fi
+          : > shfmt-reviewdog-input/diagnostics.diff
+          echo "upload=true" >> "$GITHUB_OUTPUT"
 
       - name: Upload reviewdog input artifact
-        if: failure() && hashFiles('shfmt-reviewdog-input/diagnostics.diff') != ''
+        if: ${{ !cancelled() && steps.collect.outputs.upload == 'true' }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: shfmt-reviewdog-input
           path: shfmt-reviewdog-input/
+          if-no-files-found: error
           retention-days: 1
 
   required-shell:

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -38,6 +38,7 @@ jobs:
         working-directory: website
 
       - name: Collect prettier diagnostics
+        id: collect
         working-directory: website
         run: |
           set -euo pipefail
@@ -45,16 +46,20 @@ jobs:
           npx prettier --write .
           if ! git -C "$GITHUB_WORKSPACE" diff --quiet; then
             git -C "$GITHUB_WORKSPACE" diff > "$GITHUB_WORKSPACE/prettier-website-reviewdog-input/diagnostics.diff"
+            echo "upload=true" >> "$GITHUB_OUTPUT"
             echo "::error::Prettier found formatting issues"
             exit 1
           fi
+          : > "$GITHUB_WORKSPACE/prettier-website-reviewdog-input/diagnostics.diff"
+          echo "upload=true" >> "$GITHUB_OUTPUT"
 
       - name: Upload reviewdog input artifact
-        if: failure() && hashFiles('prettier-website-reviewdog-input/diagnostics.diff') != ''
+        if: ${{ !cancelled() && steps.collect.outputs.upload == 'true' }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: prettier-website-reviewdog-input
           path: prettier-website-reviewdog-input/
+          if-no-files-found: error
           retention-days: 1
 
   typecheck:
@@ -104,6 +109,7 @@ jobs:
         working-directory: website
 
       - name: Collect eslint diagnostics
+        id: collect
         working-directory: website
         run: |
           set -euo pipefail
@@ -115,15 +121,20 @@ jobs:
           eslint_exit=$?
           set -e
           if [ "$eslint_exit" -ne 0 ]; then
+            if [ -s "$GITHUB_WORKSPACE/eslint-reviewdog-input/diagnostics.txt" ]; then
+              echo "upload=true" >> "$GITHUB_OUTPUT"
+            fi
             exit "$eslint_exit"
           fi
+          echo "upload=true" >> "$GITHUB_OUTPUT"
 
       - name: Upload reviewdog input artifact
-        if: failure() && hashFiles('eslint-reviewdog-input/diagnostics.txt') != ''
+        if: ${{ !cancelled() && steps.collect.outputs.upload == 'true' }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: eslint-reviewdog-input
           path: eslint-reviewdog-input/
+          if-no-files-found: error
           retention-days: 1
 
   stylelint:
@@ -147,6 +158,7 @@ jobs:
         working-directory: website
 
       - name: Collect stylelint diagnostics
+        id: collect
         working-directory: website
         run: |
           set -euo pipefail
@@ -159,18 +171,26 @@ jobs:
           set -e
           # stylelint: 0 = OK, 2 = lint issues; other codes are hard failures.
           if [ "$stylelint_exit" -ne 0 ] && [ "$stylelint_exit" -ne 2 ]; then
+            if [ -s "$GITHUB_WORKSPACE/stylelint-reviewdog-input/diagnostics.txt" ]; then
+              echo "upload=true" >> "$GITHUB_OUTPUT"
+            fi
             exit "$stylelint_exit"
           fi
           if [ "$stylelint_exit" -eq 2 ]; then
+            if [ -s "$GITHUB_WORKSPACE/stylelint-reviewdog-input/diagnostics.txt" ]; then
+              echo "upload=true" >> "$GITHUB_OUTPUT"
+            fi
             exit 1
           fi
+          echo "upload=true" >> "$GITHUB_OUTPUT"
 
       - name: Upload reviewdog input artifact
-        if: failure() && hashFiles('stylelint-reviewdog-input/diagnostics.txt') != ''
+        if: ${{ !cancelled() && steps.collect.outputs.upload == 'true' }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: stylelint-reviewdog-input
           path: stylelint-reviewdog-input/
+          if-no-files-found: error
           retention-days: 1
 
   build:


### PR DESCRIPTION
Always upload empty diagnostics so report jobs can reconcile and delete addressed PR review comments.

Change-Id: 612f4ba9f7a85a7206a59b3c447f786d
Change-Id-Short: tyxkvopqkspr

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only changes to artifact upload and reviewdog posting behavior; no application runtime impact, with guards to avoid clearing unrelated linter comments when artifacts are missing.
> 
> **Overview**
> **Reviewdog PR comments now reconcile on clean lint runs** instead of leaving outdated inline comments after issues are fixed.
> 
> Collect jobs in actions-lint, docs-lint, shell, and website workflows **upload reviewdog input artifacts on success** as well as failure, writing **empty** diagnostics (or minimal empty SARIF for rumdl) when there are no findings. Upload is gated by a `collect` step `upload=true` output and `if-no-files-found: error`, replacing the old **failure-only + `hashFiles`** checks.
> 
> The **`reviewdog-post`** composite action **no longer exits early** when the diagnostics file is empty; it ensures the file exists and posts through reviewdog so stale comments clear. **Missing artifacts still skip posting** (documented) so path-filtered collect jobs do not wipe comments from other linters.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b4028fe3118dba414414d650e9aad2a31ca5fab9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->