### PR TITLE
refactor(power): schedule Auto Suspend via RTC

### DIFF
--- a/crates/cadmus/src/app.rs
+++ b/crates/cadmus/src/app.rs
@@ -224,7 +224,6 @@ fn build_context(
 pub fn run() -> Result<(), Error> {
     let start_time = Instant::now();
 
-    let mut inactive_since = Instant::now();
     let mut exit_status = ExitStatus::Quit;
 
     let mut device = AppDevice::default();
@@ -367,7 +366,6 @@ pub fn run() -> Result<(), Error> {
             history: &mut history,
             tasks: &mut tasks,
             updating: &mut updating,
-            inactive_since: &mut inactive_since,
             settings_manager: Some(&manager),
             startup_cwd: Some(&startup_cwd),
             background_tasks: Some(&mut background_tasks),
@@ -394,7 +392,6 @@ pub fn run() -> Result<(), Error> {
             history: &mut history,
             tasks: &mut tasks,
             updating: &mut updating,
-            inactive_since: &mut inactive_since,
             settings_manager: Some(&manager),
             startup_cwd: Some(&startup_cwd),
             background_tasks: Some(&mut background_tasks),
@@ -859,7 +856,6 @@ pub fn run() -> Result<(), Error> {
             history: &mut history,
             tasks: &mut tasks,
             updating: &mut updating,
-            inactive_since: &mut inactive_since,
             settings_manager: Some(&manager),
             startup_cwd: Some(&startup_cwd),
             background_tasks: Some(&mut background_tasks),

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -33,7 +33,7 @@ byteorder = "1.5.0"
 cadmus-macros = { path = "../macros" }
 flate2 = "1.1.5"
 levenshtein = "1.0.5"
-nix = { version = "0.31.0", features = ["fs", "ioctl", "mount"] }
+nix = { version = "0.31.0", features = ["fs", "ioctl", "mount", "poll"] }
 indexmap = { version = "2.13.0", features = ["serde"] }
 arc-swap = "1"
 anyhow = "1.0.100"

--- a/crates/core/src/context.rs
+++ b/crates/core/src/context.rs
@@ -2,7 +2,7 @@ use crate::db::Database;
 use crate::device::Device;
 #[cfg(test)]
 use crate::device::DeviceHardware as _;
-use crate::device::rtc::AlarmManager;
+use crate::device::rtc::{AlarmManager, AlarmType};
 use crate::device::wifi::WifiSession;
 use crate::dictionary::{Dictionary, load_dictionary_from_db};
 use crate::font::Fonts;
@@ -28,13 +28,27 @@ use tracing::error;
 
 use walkdir::WalkDir;
 
+/// Converts Auto Suspend minutes to a chrono duration of at least one second.
+///
+/// Sub-minute settings must not truncate to zero via `as i64` on whole seconds.
+fn auto_suspend_chrono_duration(minutes: f32) -> chrono::Duration {
+    let secs = (minutes * 60.0).max(0.0);
+    let duration = chrono::Duration::from_std(std::time::Duration::from_secs_f32(secs))
+        .unwrap_or_else(|_| chrono::Duration::milliseconds(((secs * 1000.0) as i64).max(1)));
+    if duration.num_seconds() < 1 {
+        chrono::Duration::seconds(1)
+    } else {
+        duration
+    }
+}
+
 const KEYBOARD_LAYOUTS_DIRNAME: &str = "keyboard-layouts";
 pub(crate) const DICTIONARIES_DIRNAME: &str = "dictionaries";
 const INPUT_HISTORY_SIZE: usize = 32;
 
 pub struct Context<D: Device> {
     pub device: D,
-    pub alarm_manager: Option<AlarmManager<D::Rtc>>,
+    pub alarm_manager: Option<std::sync::Arc<std::sync::Mutex<AlarmManager<D::Rtc>>>>,
     pub display: Display,
     pub settings: Settings,
     pub library: Library,
@@ -50,6 +64,7 @@ pub struct Context<D: Device> {
     pub covered: bool,
     pub shared: bool,
     pub online: bool,
+    pub suspend_cycle_active: bool,
     pub wifi_session: std::sync::Arc<crate::device::wifi::WifiSession>,
 }
 
@@ -75,7 +90,9 @@ impl<D: Device> Context<D> {
         );
         let rng = Xoroshiro128Plus::seed_from_u64(Local::now().timestamp_subsec_nanos() as u64);
         let alarm_manager = match device.rtc() {
-            Ok(rtc) => Some(AlarmManager::new(rtc)),
+            Ok(rtc) => Some(std::sync::Arc::new(std::sync::Mutex::new(
+                AlarmManager::new(rtc),
+            ))),
             Err(e) => {
                 tracing::warn!(error = %e, "RTC init failed, alarm manager unavailable");
                 None
@@ -107,6 +124,7 @@ impl<D: Device> Context<D> {
             covered: false,
             shared: false,
             online: false,
+            suspend_cycle_active: false,
             wifi_session,
         }
     }
@@ -219,6 +237,30 @@ impl<D: Device> Context<D> {
 
         if history.len() > INPUT_HISTORY_SIZE {
             history.pop_back();
+        }
+    }
+
+    /// Schedules or cancels [`AlarmType::AutoSuspend`] from the Auto Suspend setting.
+    ///
+    /// When `auto_suspend` is `0`, cancels any pending alarm. Otherwise replaces the
+    /// alarm with a wake time of *now + timeout* (setting is minutes).
+    pub(crate) fn reschedule_auto_suspend_alarm(&mut self) {
+        let Some(alarm_manager) = self.alarm_manager.as_ref() else {
+            return;
+        };
+        let mut alarm_manager = alarm_manager.lock().unwrap_or_else(|e| e.into_inner());
+
+        let minutes = self.settings.auto_suspend;
+        if minutes <= 0.0 {
+            if let Err(error) = alarm_manager.cancel_alarm(AlarmType::AutoSuspend) {
+                tracing::error!(error = %error, "failed to cancel AutoSuspend alarm");
+            }
+            return;
+        }
+
+        let duration = auto_suspend_chrono_duration(minutes);
+        if let Err(error) = alarm_manager.schedule_alarm(AlarmType::AutoSuspend, duration) {
+            tracing::error!(error = %error, "failed to schedule AutoSuspend alarm");
         }
     }
 
@@ -360,6 +402,7 @@ pub mod test_helpers {
         assert!(!context.covered);
         assert!(!context.shared);
         assert!(!context.online);
+        assert!(!context.suspend_cycle_active);
         assert_eq!(context.notification_index, 0);
         assert!(context.dictionaries.is_empty());
         assert!(context.keyboard_layouts.is_empty());

--- a/crates/core/src/device/emulator/mod.rs
+++ b/crates/core/src/device/emulator/mod.rs
@@ -12,7 +12,7 @@ mod wifi;
 use crate::battery::FakeBattery;
 use crate::color::Color;
 use crate::device::DeviceHardware as _;
-use crate::device::emulator::rtc::NoopRtc;
+use crate::device::emulator::rtc::EmulatorRtc;
 use crate::device::types::FrontlightKind;
 use crate::device::{AppContext, Model};
 use crate::device::{
@@ -399,8 +399,8 @@ pub struct EmulatorDevice {
     wifi_manager: Arc<crate::device::emulator::wifi::EmulatorWifiManager>,
     usb_manager: Arc<crate::device::emulator::usb::EmulatorUsbManager>,
     power_manager: Arc<crate::device::emulator::power::EmulatorPowerManager>,
-    rtc: Arc<NoopRtc>,
-    time_manager: crate::time_manager::TimeManager<NoopRtc>,
+    rtc: Arc<EmulatorRtc>,
+    time_manager: crate::time_manager::TimeManager<EmulatorRtc>,
     input: EmulatorInputSource,
 }
 
@@ -424,7 +424,7 @@ impl EmulatorDevice {
     pub fn new(framebuffer: Box<dyn Framebuffer + Send>) -> Self {
         let dims = framebuffer.dims();
         let dpi = 167;
-        let rtc = Arc::new(NoopRtc);
+        let rtc = Arc::new(EmulatorRtc::new());
         let time_manager = crate::time_manager::TimeManager::new(rtc.clone(), |_| Ok(()));
         Self {
             dims,
@@ -508,7 +508,7 @@ crate::impl_device_hardware!(
     WifiManager = crate::device::emulator::wifi::EmulatorWifiManager,
     UsbManager = crate::device::emulator::usb::EmulatorUsbManager,
     PowerManager = crate::device::emulator::power::EmulatorPowerManager,
-    Rtc = crate::device::emulator::rtc::NoopRtc,
+    Rtc = crate::device::emulator::rtc::EmulatorRtc,
 );
 
 impl DeviceInput for EmulatorDevice {
@@ -587,6 +587,24 @@ fn show_suspend_intermission(
 }
 
 impl DeviceLifecycle for EmulatorDevice {
+    fn on_startup(
+        context: &mut AppContext,
+        hub: &Hub,
+        _runtime: &mut DeviceRuntime<'_>,
+    ) -> Result<(), anyhow::Error> {
+        if let Some(alarm_manager) = context.alarm_manager.clone() {
+            context.reschedule_auto_suspend_alarm();
+            let hub = hub.clone();
+            crate::device::rtc::AlarmManager::start_irq_listener(
+                &alarm_manager,
+                move |alarm_type| {
+                    hub.send(Event::RtcAlarmFired(alarm_type)).ok();
+                },
+            );
+        }
+        Ok(())
+    }
+
     fn handle_event(
         event: &Event,
         hub: &Hub,
@@ -629,6 +647,13 @@ impl DeviceLifecycle for EmulatorDevice {
             Event::Select(EntryId::PowerOff) => EventOutcome::Exit(ExitStatus::PowerOff),
             Event::Select(EntryId::Suspend) => {
                 show_suspend_intermission(hub, bus, rq, context, runtime);
+                EventOutcome::Handled
+            }
+            Event::RtcAlarmFired(crate::AlarmType::AutoSuspend) => {
+                show_suspend_intermission(hub, bus, rq, context, runtime);
+                EventOutcome::Handled
+            }
+            Event::RtcAlarmFired(crate::AlarmType::Suspend | crate::AlarmType::WakeDebounce) => {
                 EventOutcome::Handled
             }
             Event::Select(EntryId::Reboot) => {
@@ -766,7 +791,6 @@ mod lifecycle {
     use crate::view::filler::Filler;
     use crate::view::{Bus, EntryId, Event, RenderQueue, View};
     use std::sync::mpsc;
-    use std::time::Instant;
 
     fn with_runtime<R>(
         f: impl FnOnce(
@@ -786,13 +810,11 @@ mod lifecycle {
         let mut tasks = Vec::new();
         let mut history = Vec::<HistoryItem>::new();
         let mut updating = Vec::new();
-        let mut inactive_since = Instant::now();
         let mut runtime = DeviceRuntime {
             view: &mut view,
             history: &mut history,
             tasks: &mut tasks,
             updating: &mut updating,
-            inactive_since: &mut inactive_since,
             settings_manager: None,
             startup_cwd: None,
             background_tasks: None,

--- a/crates/core/src/device/emulator/rtc.rs
+++ b/crates/core/src/device/emulator/rtc.rs
@@ -1,22 +1,75 @@
+//! In-memory emulator RTC with Condvar-backed alarm IRQ waits.
+
 use anyhow::Error;
 use chrono::{DateTime, Utc};
+use std::sync::{Arc, Condvar, Mutex};
+use std::time::Duration;
 
 use crate::device::rtc::{Rtc, RtcWkalrm};
 
-/// Emulator RTC that performs no hardware operations.
-#[derive(Clone, Copy, Default)]
-pub struct NoopRtc;
+const RTC_AF: u32 = 0x20;
 
-impl Rtc for NoopRtc {
+#[derive(Debug)]
+struct EmulatorRtcState {
+    alarm_enabled: bool,
+    alarm_wake_time: Option<DateTime<Utc>>,
+    irq_pending: bool,
+}
+
+/// Emulator RTC that schedules in-memory wake alarms and wakes IRQ waiters.
+#[derive(Clone)]
+pub struct EmulatorRtc {
+    state: Arc<Mutex<EmulatorRtcState>>,
+    cond: Arc<Condvar>,
+}
+
+impl EmulatorRtc {
+    pub fn new() -> Self {
+        Self {
+            state: Arc::new(Mutex::new(EmulatorRtcState {
+                alarm_enabled: false,
+                alarm_wake_time: None,
+                irq_pending: false,
+            })),
+            cond: Arc::new(Condvar::new()),
+        }
+    }
+}
+
+impl Default for EmulatorRtc {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Rtc for EmulatorRtc {
     fn alarm(&self) -> Result<RtcWkalrm, Error> {
-        Ok(RtcWkalrm::default())
+        let state = self
+            .state
+            .lock()
+            .map_err(|e| anyhow::anyhow!("lock poisoned: {}", e))?;
+        let wake_time = state.alarm_wake_time.unwrap_or_else(Utc::now);
+        Ok(RtcWkalrm::from_parts(state.alarm_enabled, wake_time))
     }
 
-    fn set_alarm(&self, _wake_time: DateTime<Utc>) -> Result<i32, Error> {
+    fn set_alarm(&self, wake_time: DateTime<Utc>) -> Result<i32, Error> {
+        let mut state = self
+            .state
+            .lock()
+            .map_err(|e| anyhow::anyhow!("lock poisoned: {}", e))?;
+        state.alarm_enabled = true;
+        state.alarm_wake_time = Some(wake_time);
+        self.cond.notify_all();
         Ok(0)
     }
 
     fn disable_alarm(&self) -> Result<i32, Error> {
+        let mut state = self
+            .state
+            .lock()
+            .map_err(|e| anyhow::anyhow!("lock poisoned: {}", e))?;
+        state.alarm_enabled = false;
+        self.cond.notify_all();
         Ok(0)
     }
 
@@ -26,5 +79,75 @@ impl Rtc for NoopRtc {
 
     fn set_time(&self, _time: DateTime<Utc>) -> Result<(), Error> {
         Ok(())
+    }
+
+    fn wait_for_alarm_irq(&self, timeout: Option<Duration>) -> Result<Option<u32>, Error> {
+        let mut state = self
+            .state
+            .lock()
+            .map_err(|e| anyhow::anyhow!("lock poisoned: {}", e))?;
+        let deadline = timeout.map(|duration| std::time::Instant::now() + duration);
+
+        loop {
+            if state.irq_pending {
+                state.irq_pending = false;
+                return Ok(Some(RTC_AF));
+            }
+
+            let now = Utc::now();
+            if state.alarm_enabled
+                && let Some(wake_time) = state.alarm_wake_time
+                && wake_time <= now
+            {
+                state.alarm_enabled = false;
+                return Ok(Some(RTC_AF));
+            }
+
+            let remaining_timeout =
+                deadline.map(|end| end.saturating_duration_since(std::time::Instant::now()));
+            if let Some(remaining) = remaining_timeout
+                && remaining.is_zero()
+            {
+                return Ok(None);
+            }
+
+            let until_wake = if state.alarm_enabled {
+                state.alarm_wake_time.and_then(|wake_time| {
+                    wake_time
+                        .signed_duration_since(now)
+                        .to_std()
+                        .ok()
+                        .filter(|d| !d.is_zero())
+                })
+            } else {
+                None
+            };
+
+            let wait_duration = match (remaining_timeout, until_wake) {
+                (Some(timeout), Some(until_wake)) => Some(timeout.min(until_wake)),
+                (Some(timeout), None) => Some(timeout),
+                (None, Some(until_wake)) => Some(until_wake),
+                (None, None) => None,
+            };
+
+            match wait_duration {
+                Some(duration) => {
+                    let (guard, wait_result) = self
+                        .cond
+                        .wait_timeout(state, duration)
+                        .map_err(|e| anyhow::anyhow!("condvar wait poisoned: {}", e))?;
+                    state = guard;
+                    if wait_result.timed_out() {
+                        continue;
+                    }
+                }
+                None => {
+                    state = self
+                        .cond
+                        .wait(state)
+                        .map_err(|e| anyhow::anyhow!("condvar wait poisoned: {}", e))?;
+                }
+            }
+        }
     }
 }

--- a/crates/core/src/device/kobo/lifecycle/battery.rs
+++ b/crates/core/src/device/kobo/lifecycle/battery.rs
@@ -51,7 +51,7 @@ pub(super) fn handle_event(
         runtime.tasks,
     );
 
-    if is_suspend_active(runtime.tasks) {
+    if is_suspend_active(context, runtime.tasks) {
         return EventOutcome::Handled;
     }
 

--- a/crates/core/src/device/kobo/lifecycle/device_events.rs
+++ b/crates/core/src/device/kobo/lifecycle/device_events.rs
@@ -1,7 +1,8 @@
 //! Device input event handling for suspend, power, cover, and USB plug events.
 
 use super::super::input::BATTERY_REFRESH_INTERVAL;
-use super::helpers::{cancel_suspend_if_pending, has_task, is_suspend_active};
+use super::helpers::{cancel_suspend_if_pending, is_suspend_active};
+use super::suspend::is_suspend_rtc_pending;
 use super::usb_share::disable_usb_share;
 use super::{begin_suspend, schedule_device_task};
 use crate::device::DeviceHardware as _;
@@ -13,7 +14,6 @@ use crate::framebuffer::UpdateMode;
 use crate::input::{ButtonCode, ButtonStatus, DeviceEvent, PowerSource};
 use crate::view::dialog::Dialog;
 use crate::view::{EntryId, Event, Hub, NotificationEvent, RenderData, RenderQueue, View, ViewId};
-use std::time::Instant;
 
 /// Dispatches a lifecycle [`Event`] to the appropriate device-input handler.
 pub(super) fn handle_event(
@@ -64,9 +64,7 @@ fn handle_power_button_released(
         return EventOutcome::Handled;
     }
 
-    if has_task(runtime.tasks, DeviceTaskId::PrepareSuspend)
-        || has_task(runtime.tasks, DeviceTaskId::Suspend)
-    {
+    if is_suspend_active(context, runtime.tasks) {
         cancel_suspend_if_pending(context, runtime.tasks, runtime.view.as_mut(), hub, rq);
     } else {
         begin_suspend(context, runtime.view.as_mut(), hub, bus, rq, runtime.tasks);
@@ -93,7 +91,7 @@ fn handle_rotate_screen(
 ) -> EventOutcome {
     tracing::debug!(rotation = n, "Gyro rotation");
 
-    if context.shared || is_suspend_active(runtime.tasks) {
+    if context.shared || is_suspend_active(context, runtime.tasks) {
         return EventOutcome::Handled;
     }
 
@@ -123,7 +121,7 @@ fn handle_net_up(
     context: &mut AppContext,
     runtime: &mut DeviceRuntime<'_>,
 ) -> EventOutcome {
-    if is_suspend_active(runtime.tasks) || context.online {
+    if is_suspend_active(context, runtime.tasks) || context.online {
         return EventOutcome::Handled;
     }
 
@@ -170,7 +168,8 @@ fn handle_cover_on(
     }
 
     context.covered = true;
-    if !context.settings.sleep_cover || context.shared || is_suspend_active(runtime.tasks) {
+    if !context.settings.sleep_cover || context.shared || is_suspend_active(context, runtime.tasks)
+    {
         return EventOutcome::Handled;
     }
 
@@ -203,10 +202,11 @@ fn handle_cover_off(
     EventOutcome::Handled
 }
 
-/// Resets inactivity tracking when auto-suspend is enabled.
-fn handle_user_activity(context: &AppContext, runtime: &mut DeviceRuntime<'_>) -> EventOutcome {
+/// Reschedules the Auto Suspend RTC deadline when auto-suspend is enabled.
+fn handle_user_activity(context: &mut AppContext, runtime: &mut DeviceRuntime<'_>) -> EventOutcome {
+    let _ = runtime;
     if context.settings.auto_suspend > 0.0 {
-        *runtime.inactive_since = Instant::now();
+        super::suspend::reschedule_auto_suspend_alarm(context);
     }
     EventOutcome::Handled
 }
@@ -234,7 +234,7 @@ fn handle_plug(
 
     match power_source {
         PowerSource::Wall => {
-            if has_task(runtime.tasks, DeviceTaskId::Suspend) {
+            if is_suspend_rtc_pending(context) {
                 return EventOutcome::Handled;
             }
         }
@@ -270,7 +270,9 @@ fn handle_plug_host(
         runtime.view.children_mut().push(Box::new(dialog));
     }
 
-    *runtime.inactive_since = Instant::now();
+    if context.settings.auto_suspend > 0.0 {
+        super::suspend::reschedule_auto_suspend_alarm(context);
+    }
 }
 
 /// Handles charger or USB-host unplug.
@@ -303,7 +305,7 @@ fn handle_unplug(
             hub,
             runtime.tasks,
         );
-        if has_task(runtime.tasks, DeviceTaskId::Suspend) {
+        if is_suspend_rtc_pending(context) {
             if !context.covered {
                 super::helpers::cancel_suspend_if_pending(
                     context,
@@ -324,6 +326,7 @@ fn handle_unplug(
 #[cfg(all(test, feature = "kobo"))]
 mod tests {
     use super::*;
+    use crate::device::kobo::lifecycle::helpers::has_task;
     use crate::device::kobo::lifecycle::test_helpers::LifecycleHarness;
     use crate::input::PowerSource;
     use crate::view::EntryId;
@@ -376,7 +379,21 @@ mod tests {
     #[test]
     fn handle_rotate_screen_blocked_during_suspend() {
         let mut harness = LifecycleHarness::new();
-        harness.push_task(DeviceTaskId::Suspend);
+        {
+            let mut alarms = harness
+                .context
+                .alarm_manager
+                .as_ref()
+                .unwrap()
+                .lock()
+                .unwrap();
+            alarms
+                .schedule_alarm(
+                    crate::AlarmType::Suspend,
+                    crate::chrono::Duration::seconds(15),
+                )
+                .unwrap();
+        }
         let hub = harness.hub_tx.clone();
         let outcome = harness
             .with_runtime_only(|context, runtime| handle_rotate_screen(1, &hub, context, runtime));
@@ -515,15 +532,32 @@ mod tests {
     }
 
     #[test]
-    fn handle_user_activity_resets_inactive_since() {
+    fn handle_user_activity_reschedules_auto_suspend() {
         let mut harness = LifecycleHarness::new();
-        harness.context.settings.auto_suspend = 300.0;
-        let before = harness.inactive_since;
-        std::thread::sleep(std::time::Duration::from_millis(5));
-        let outcome =
-            harness.with_runtime_only(|context, runtime| handle_user_activity(context, runtime));
+        harness.context.settings.auto_suspend = 30.0;
+        harness.with_runtime_only(handle_user_activity);
+        let first = harness
+            .context
+            .alarm_manager
+            .as_ref()
+            .unwrap()
+            .lock()
+            .unwrap()
+            .time_until_alarm(crate::AlarmType::AutoSuspend)
+            .unwrap();
+        std::thread::sleep(std::time::Duration::from_millis(20));
+        let outcome = harness.with_runtime_only(handle_user_activity);
         assert_eq!(outcome, EventOutcome::Handled);
-        assert!(harness.inactive_since > before);
+        let second = harness
+            .context
+            .alarm_manager
+            .as_ref()
+            .unwrap()
+            .lock()
+            .unwrap()
+            .time_until_alarm(crate::AlarmType::AutoSuspend)
+            .unwrap();
+        assert!(second >= first);
     }
 
     #[test]

--- a/crates/core/src/device/kobo/lifecycle/frontlight.rs
+++ b/crates/core/src/device/kobo/lifecycle/frontlight.rs
@@ -149,7 +149,6 @@ mod tests {
                 history: &mut harness.history,
                 tasks: &mut harness.tasks,
                 updating: &mut harness.updating,
-                inactive_since: &mut harness.inactive_since,
                 settings_manager: None,
                 startup_cwd: None,
                 background_tasks: Some(&mut background_tasks),

--- a/crates/core/src/device/kobo/lifecycle/helpers.rs
+++ b/crates/core/src/device/kobo/lifecycle/helpers.rs
@@ -1,6 +1,8 @@
 //! Shared suspend-task predicates for lifecycle handlers.
 
 use super::cancel_suspend;
+use super::finish_suspend_cycle;
+use super::suspend::{cancel_suspend_rtcs, is_suspend_rtc_pending};
 use crate::device::AppContext;
 use crate::device::{DeviceTask, DeviceTaskId};
 use crate::view::{RenderQueue, View};
@@ -11,15 +13,20 @@ pub(super) fn has_task(tasks: &[DeviceTask], id: DeviceTaskId) -> bool {
     tasks.iter().any(|task| task.id == id)
 }
 
-/// Returns whether a suspend flow is in progress (`PrepareSuspend` or `Suspend`).
-pub(super) fn is_suspend_active(tasks: &[DeviceTask]) -> bool {
-    has_task(tasks, DeviceTaskId::PrepareSuspend) || has_task(tasks, DeviceTaskId::Suspend)
+/// Returns whether a suspend flow is in progress.
+///
+/// True when PrepareSuspend is pending, a Suspend / WakeDebounce RTC is armed in
+/// the map (including past-due), or [`AppContext::suspend_cycle_active`] is set.
+pub(super) fn is_suspend_active(context: &AppContext, tasks: &[DeviceTask]) -> bool {
+    has_task(tasks, DeviceTaskId::PrepareSuspend)
+        || is_suspend_rtc_pending(context)
+        || context.suspend_cycle_active
 }
 
-/// Cancels an in-progress suspend when `PrepareSuspend` or `Suspend` is pending.
+/// Cancels an in-progress suspend when PrepareSuspend or a suspend RTC is pending.
 ///
 /// Prefer [`super::begin_suspend`] to start suspend and [`cancel_suspend`] when the
-/// caller already knows which task id to cancel.
+/// caller already knows PrepareSuspend is pending.
 pub(super) fn cancel_suspend_if_pending(
     context: &mut AppContext,
     tasks: &mut Vec<DeviceTask>,
@@ -27,22 +34,27 @@ pub(super) fn cancel_suspend_if_pending(
     hub: &Sender<crate::view::Event>,
     rq: &mut RenderQueue,
 ) {
+    let should_finish = is_suspend_rtc_pending(context) || context.suspend_cycle_active;
+    cancel_suspend_rtcs(context);
     if has_task(tasks, DeviceTaskId::PrepareSuspend) {
         cancel_suspend(context, DeviceTaskId::PrepareSuspend, tasks, view, hub, rq);
-    } else if has_task(tasks, DeviceTaskId::Suspend) {
-        cancel_suspend(context, DeviceTaskId::Suspend, tasks, view, hub, rq);
+    } else if should_finish {
+        finish_suspend_cycle(context, tasks, view, hub, rq);
     }
 }
 
 #[cfg(all(test, feature = "kobo"))]
 mod tests {
     use super::*;
+    use crate::AlarmType;
+    use crate::chrono::Duration as ChronoDuration;
+    use crate::device::kobo::lifecycle::suspend::is_suspend_alarm_scheduled;
     use crate::device::kobo::lifecycle::test_helpers::LifecycleHarness;
 
     #[test]
     fn has_task_empty() {
         let harness = LifecycleHarness::new();
-        assert!(!has_task(&harness.tasks, DeviceTaskId::Suspend));
+        assert!(!has_task(&harness.tasks, DeviceTaskId::PrepareSuspend));
     }
 
     #[test]
@@ -50,27 +62,64 @@ mod tests {
         let mut harness = LifecycleHarness::new();
         harness.push_task(DeviceTaskId::PrepareSuspend);
         assert!(has_task(&harness.tasks, DeviceTaskId::PrepareSuspend));
-        assert!(!has_task(&harness.tasks, DeviceTaskId::Suspend));
     }
 
     #[test]
     fn is_suspend_active_prepare() {
         let mut harness = LifecycleHarness::new();
         harness.push_task(DeviceTaskId::PrepareSuspend);
-        assert!(is_suspend_active(&harness.tasks));
+        assert!(is_suspend_active(&harness.context, &harness.tasks));
     }
 
     #[test]
-    fn is_suspend_active_suspend() {
-        let mut harness = LifecycleHarness::new();
-        harness.push_task(DeviceTaskId::Suspend);
-        assert!(is_suspend_active(&harness.tasks));
+    fn is_suspend_active_suspend_rtc() {
+        let harness = LifecycleHarness::new();
+        {
+            let mut alarms = harness
+                .context
+                .alarm_manager
+                .as_ref()
+                .unwrap()
+                .lock()
+                .unwrap();
+            alarms
+                .schedule_alarm(AlarmType::Suspend, ChronoDuration::seconds(15))
+                .unwrap();
+        }
+        assert!(is_suspend_active(&harness.context, &harness.tasks));
     }
 
     #[test]
     fn is_suspend_active_false() {
         let harness = LifecycleHarness::new();
-        assert!(!is_suspend_active(&harness.tasks));
+        assert!(!is_suspend_active(&harness.context, &harness.tasks));
+    }
+
+    #[test]
+    fn is_suspend_active_past_due_suspend_rtc() {
+        let harness = LifecycleHarness::new();
+        {
+            let mut alarms = harness
+                .context
+                .alarm_manager
+                .as_ref()
+                .unwrap()
+                .lock()
+                .unwrap();
+            alarms
+                .schedule_alarm(AlarmType::Suspend, ChronoDuration::seconds(-1))
+                .unwrap();
+            assert!(alarms.has_alarm(AlarmType::Suspend));
+            assert!(!alarms.is_alarm_scheduled(AlarmType::Suspend));
+        }
+        assert!(is_suspend_active(&harness.context, &harness.tasks));
+    }
+
+    #[test]
+    fn is_suspend_active_cycle_flag_without_rtc() {
+        let mut harness = LifecycleHarness::new();
+        harness.context.suspend_cycle_active = true;
+        assert!(is_suspend_active(&harness.context, &harness.tasks));
     }
 
     #[test]
@@ -88,9 +137,20 @@ mod tests {
     }
 
     #[test]
-    fn cancel_suspend_if_pending_suspend() {
+    fn cancel_suspend_if_pending_suspend_rtc() {
         let mut harness = LifecycleHarness::new();
-        harness.push_task(DeviceTaskId::Suspend);
+        {
+            let mut alarms = harness
+                .context
+                .alarm_manager
+                .as_ref()
+                .unwrap()
+                .lock()
+                .unwrap();
+            alarms
+                .schedule_alarm(AlarmType::Suspend, ChronoDuration::seconds(15))
+                .unwrap();
+        }
         cancel_suspend_if_pending(
             &mut harness.context,
             &mut harness.tasks,
@@ -98,7 +158,41 @@ mod tests {
             &harness.hub_tx,
             &mut harness.rq,
         );
-        assert!(!has_task(&harness.tasks, DeviceTaskId::Suspend));
+        assert!(!is_suspend_alarm_scheduled(&harness.context));
+    }
+
+    #[test]
+    fn cancel_suspend_if_pending_wake_debounce() {
+        let mut harness = LifecycleHarness::new();
+        harness.context.settings.auto_suspend = 30.0;
+        {
+            let mut alarms = harness
+                .context
+                .alarm_manager
+                .as_ref()
+                .unwrap()
+                .lock()
+                .unwrap();
+            alarms
+                .schedule_alarm(AlarmType::WakeDebounce, ChronoDuration::seconds(15))
+                .unwrap();
+        }
+        cancel_suspend_if_pending(
+            &mut harness.context,
+            &mut harness.tasks,
+            harness.view.as_mut(),
+            &harness.hub_tx,
+            &mut harness.rq,
+        );
+        let alarms = harness
+            .context
+            .alarm_manager
+            .as_ref()
+            .unwrap()
+            .lock()
+            .unwrap();
+        assert!(!alarms.has_alarm(AlarmType::WakeDebounce));
+        assert!(alarms.is_alarm_scheduled(AlarmType::AutoSuspend));
     }
 
     #[test]
@@ -112,5 +206,65 @@ mod tests {
             &mut harness.rq,
         );
         assert!(harness.tasks.is_empty());
+    }
+
+    #[test]
+    fn cancel_suspend_if_pending_past_due_suspend_rtc() {
+        let mut harness = LifecycleHarness::new();
+        harness.context.settings.auto_suspend = 30.0;
+        harness.context.suspend_cycle_active = true;
+        {
+            let mut alarms = harness
+                .context
+                .alarm_manager
+                .as_ref()
+                .unwrap()
+                .lock()
+                .unwrap();
+            alarms
+                .schedule_alarm(AlarmType::Suspend, ChronoDuration::seconds(-1))
+                .unwrap();
+        }
+        cancel_suspend_if_pending(
+            &mut harness.context,
+            &mut harness.tasks,
+            harness.view.as_mut(),
+            &harness.hub_tx,
+            &mut harness.rq,
+        );
+        assert!(!is_suspend_alarm_scheduled(&harness.context));
+        assert!(!harness.context.suspend_cycle_active);
+        let alarms = harness
+            .context
+            .alarm_manager
+            .as_ref()
+            .unwrap()
+            .lock()
+            .unwrap();
+        assert!(alarms.is_alarm_scheduled(AlarmType::AutoSuspend));
+    }
+
+    #[test]
+    fn cancel_suspend_if_pending_after_claim_uses_cycle_flag() {
+        let mut harness = LifecycleHarness::new();
+        harness.context.settings.auto_suspend = 30.0;
+        harness.context.suspend_cycle_active = true;
+        assert!(!is_suspend_rtc_pending(&harness.context));
+        cancel_suspend_if_pending(
+            &mut harness.context,
+            &mut harness.tasks,
+            harness.view.as_mut(),
+            &harness.hub_tx,
+            &mut harness.rq,
+        );
+        assert!(!harness.context.suspend_cycle_active);
+        let alarms = harness
+            .context
+            .alarm_manager
+            .as_ref()
+            .unwrap()
+            .lock()
+            .unwrap();
+        assert!(alarms.is_alarm_scheduled(AlarmType::AutoSuspend));
     }
 }

--- a/crates/core/src/device/kobo/lifecycle/mod.rs
+++ b/crates/core/src/device/kobo/lifecycle/mod.rs
@@ -64,12 +64,59 @@ fn schedule_device_task(
     });
 }
 
-/// Aborts an in-progress suspend and restores UI and hardware state.
+/// Ends an in-progress suspend cycle and returns to interactive use.
 ///
-/// When cancelling [`DeviceTaskId::Suspend`], re-enables frontlight and
-/// WiFi and clears alarms that should not fire after a manual wake. For
-/// either suspend task, removes the intermission overlay and refreshes clock
-/// and battery widgets.
+/// Drops PrepareSuspend task channels, restores frontlight and wifi-at-rest,
+/// cancels post-resume alarms, re-arms AutoSuspend, and removes the suspend
+/// intermission.
+pub(super) fn finish_suspend_cycle(
+    context: &mut AppContext,
+    tasks: &mut Vec<DeviceTask>,
+    view: &mut dyn View,
+    hub: &Sender<Event>,
+    rq: &mut crate::view::RenderQueue,
+) {
+    tasks.retain(|task| task.id != DeviceTaskId::PrepareSuspend);
+    context.set_frontlight(context.settings.frontlight);
+    if context.settings.wifi.wants_radio_at_rest() {
+        let session = context.wifi_session.clone();
+        let hub = hub.clone();
+        thread::spawn(move || match session.enable_radio() {
+            Ok(true) => {
+                hub.send(Event::Device(DeviceEvent::NetUp)).ok();
+            }
+            Ok(false) => {}
+            Err(error) => {
+                tracing::error!(error = %error, "Failed to enable WiFi on resume");
+            }
+        });
+    }
+    if let Some(alarm_manager) = context.alarm_manager.as_ref() {
+        let mut alarm_manager = alarm_manager.lock().unwrap_or_else(|e| e.into_inner());
+        for alarm in AlarmType::alarms_to_cancel_after_resume() {
+            if let Err(error) = alarm_manager.cancel_alarm(alarm) {
+                tracing::error!(error = ?error, alarm = ?alarm, "failed to cancel alarm after resume");
+            }
+        }
+    }
+    suspend::reschedule_auto_suspend_alarm(context);
+    if let Some(index) = locate::<Intermission>(view) {
+        let rect = *view.child(index).rect();
+        view.children_mut().remove(index);
+        rq.add(RenderData::expose(rect, UpdateMode::Full));
+    } else {
+        tracing::warn!("resume called but no intermission view found to remove");
+    }
+    hub.send(Event::ClockTick).ok();
+    hub.send(Event::BatteryTick).ok();
+    context.suspend_cycle_active = false;
+}
+
+/// Aborts an in-progress PrepareSuspend and restores UI without full resume.
+///
+/// Drops the prepare task and clears the intermission, then re-arms AutoSuspend
+/// so aborting during prepare does not leave idle tracking disabled. Full cycle
+/// cancels after Suspend RTC arming use [`finish_suspend_cycle`].
 fn cancel_suspend(
     context: &mut AppContext,
     id: DeviceTaskId,
@@ -78,43 +125,22 @@ fn cancel_suspend(
     hub: &Sender<Event>,
     rq: &mut crate::view::RenderQueue,
 ) {
-    if id == DeviceTaskId::Suspend {
-        tasks.retain(|task| task.id != DeviceTaskId::Suspend);
-        context.set_frontlight(context.settings.frontlight);
-        if context.settings.wifi.wants_radio_at_rest() {
-            let session = context.wifi_session.clone();
-            let hub = hub.clone();
-            thread::spawn(move || match session.enable_radio() {
-                Ok(true) => {
-                    hub.send(Event::Device(DeviceEvent::NetUp)).ok();
-                }
-                Ok(false) => {}
-                Err(error) => {
-                    tracing::error!(error = %error, "Failed to enable WiFi on resume");
-                }
-            });
-        }
-        if let Some(alarm_manager) = context.alarm_manager.as_mut() {
-            for alarm in AlarmType::alarms_to_cancel_after_resume() {
-                if let Err(error) = alarm_manager.cancel_alarm(alarm) {
-                    tracing::error!(error = ?error, alarm = ?alarm, "failed to cancel alarm after resume");
-                }
-            }
-        }
+    if id != DeviceTaskId::PrepareSuspend {
+        return;
     }
 
-    if id == DeviceTaskId::Suspend || id == DeviceTaskId::PrepareSuspend {
-        tasks.retain(|task| task.id != DeviceTaskId::PrepareSuspend);
-        if let Some(index) = locate::<Intermission>(view) {
-            let rect = *view.child(index).rect();
-            view.children_mut().remove(index);
-            rq.add(RenderData::expose(rect, UpdateMode::Full));
-        } else {
-            tracing::warn!("resume called but no intermission view found to remove");
-        }
-        hub.send(Event::ClockTick).ok();
-        hub.send(Event::BatteryTick).ok();
+    tasks.retain(|task| task.id != DeviceTaskId::PrepareSuspend);
+    if let Some(index) = locate::<Intermission>(view) {
+        let rect = *view.child(index).rect();
+        view.children_mut().remove(index);
+        rq.add(RenderData::expose(rect, UpdateMode::Full));
+    } else {
+        tracing::warn!("resume called but no intermission view found to remove");
     }
+    hub.send(Event::ClockTick).ok();
+    hub.send(Event::BatteryTick).ok();
+    suspend::reschedule_auto_suspend_alarm(context);
+    context.suspend_cycle_active = false;
 }
 
 /// Restores the display rotation observed at device init for non-gyro devices.
@@ -131,10 +157,13 @@ pub(super) fn restore_boot_rotation_if_needed(context: &mut AppContext) {
 
 /// Begins the suspend flow.
 ///
-/// Suspends the current view and shows the suspend intermission immediately,
-/// so the device already appears asleep to the user. A
-/// [`DeviceTaskId::PrepareSuspend`] task is scheduled to send
-/// [`Event::PrepareSuspend`] after [`PREPARE_SUSPEND_WAIT_DELAY`].
+/// Cancels [`crate::AlarmType::AutoSuspend`], [`crate::AlarmType::Suspend`], and
+/// [`crate::AlarmType::WakeDebounce`] so idle / arming / wake-debounce RTCs do
+/// not compete with AutoPowerOff / Calendar during the suspend cycle. Suspends
+/// the current view and shows the suspend intermission immediately, so the
+/// device already appears asleep to the user. A [`DeviceTaskId::PrepareSuspend`]
+/// task is scheduled to send [`Event::PrepareSuspend`] after
+/// [`PREPARE_SUSPEND_WAIT_DELAY`].
 fn begin_suspend(
     context: &mut AppContext,
     view: &mut dyn View,
@@ -143,6 +172,9 @@ fn begin_suspend(
     rq: &mut crate::view::RenderQueue,
     tasks: &mut Vec<DeviceTask>,
 ) {
+    suspend::cancel_auto_suspend_alarm(context);
+    suspend::cancel_suspend_rtcs(context);
+    context.suspend_cycle_active = true;
     view.handle_event(&Event::Suspend, hub, bus, rq, context);
     let interm = Intermission::new(
         context.device.framebuffer().rect(),
@@ -275,7 +307,16 @@ impl DeviceLifecycle for Device {
             runtime.tasks,
         );
         hub.send(Event::WakeUp).ok();
-        suspend::spawn_auto_suspend_poller(hub, context.settings.auto_suspend);
+        suspend::reschedule_auto_suspend_alarm(context);
+        if let Some(alarm_manager) = context.alarm_manager.clone() {
+            let hub = hub.clone();
+            crate::device::rtc::AlarmManager::start_irq_listener(
+                &alarm_manager,
+                move |alarm_type| {
+                    hub.send(Event::RtcAlarmFired(alarm_type)).ok();
+                },
+            );
+        }
         let (idle_wake_tx, idle_wake_rx) = mpsc::channel();
         context.wifi_session.set_idle_wake_sender(idle_wake_tx);
         wifi::spawn_wifi_idle_poller(hub, context.settings.wifi_idle_timeout, idle_wake_rx);
@@ -292,10 +333,11 @@ impl DeviceLifecycle for Device {
             restore_boot_rotation_if_needed(context);
         }
 
-        if runtime
-            .tasks
-            .iter()
-            .all(|task| task.id != DeviceTaskId::Suspend)
+        if !suspend::is_suspend_rtc_pending(context)
+            && runtime
+                .tasks
+                .iter()
+                .all(|task| task.id != DeviceTaskId::PrepareSuspend)
             && context.settings.frontlight
         {
             context.settings.frontlight_levels = context.device.frontlight().levels();
@@ -352,7 +394,7 @@ impl DeviceLifecycle for Device {
             Event::SetWifiMode(_)
             | Event::Select(EntryId::SetWifiMode(_))
             | Event::MightDisableWifi => wifi::handle_event(event, hub, context),
-            Event::PrepareSuspend | Event::Suspend | Event::MightSuspend => {
+            Event::PrepareSuspend | Event::Suspend | Event::RtcAlarmFired(_) => {
                 suspend::handle_event(event, hub, bus, rq, context, runtime)
             }
             Event::PrepareShare | Event::Share => {

--- a/crates/core/src/device/kobo/lifecycle/power.rs
+++ b/crates/core/src/device/kobo/lifecycle/power.rs
@@ -1,5 +1,6 @@
 //! Power-off and application exit event handling.
 
+use super::helpers::{cancel_suspend_if_pending, is_suspend_active};
 use super::{begin_suspend, show_power_off_intermission};
 use crate::device::DevicePaths as _;
 use crate::device::{AppContext, DeviceRuntime, EventOutcome, ExitStatus};
@@ -18,6 +19,10 @@ pub(super) fn handle_event(
 ) -> EventOutcome {
     match event {
         Event::Gesture(GestureEvent::HoldButtonLong(ButtonCode::Power)) => {
+            if is_suspend_active(context, runtime.tasks) {
+                cancel_suspend_if_pending(context, runtime.tasks, runtime.view.as_mut(), hub, rq);
+                return EventOutcome::Handled;
+            }
             show_power_off_intermission(
                 context,
                 runtime.view.as_mut(),

--- a/crates/core/src/device/kobo/lifecycle/suspend.rs
+++ b/crates/core/src/device/kobo/lifecycle/suspend.rs
@@ -1,7 +1,16 @@
 //! Suspend preparation, sleep/wake, post-wake alarm handling, and auto-suspend.
+//!
+//! # Auto Suspend via RTC
+//!
+//! Auto Suspend is scheduled as [`AlarmType::AutoSuspend`] on the device RTC
+//! through [`AlarmManager`]. Activity calls [`reschedule_auto_suspend_alarm`];
+//! when the IRQ listener claims the alarm it emits [`Event::RtcAlarmFired`],
+//! which starts [`begin_suspend`]. Monotonic idle (`Instant::elapsed`) is not
+//! authoritative: soft sleep does not advance it, so the wall-clock RTC
+//! deadline is the idle source of truth.
 
 use super::helpers::is_suspend_active;
-use super::{SUSPEND_WAIT_DELAY, begin_suspend, schedule_device_task, show_power_off_intermission};
+use super::{SUSPEND_WAIT_DELAY, begin_suspend, show_power_off_intermission};
 use crate::AlarmType;
 use crate::chrono::{Duration as ChronoDuration, Local, Timelike};
 use crate::device::DeviceHardware as _;
@@ -14,24 +23,118 @@ use crate::settings::IntermKind;
 use crate::view::common::locate;
 use crate::view::intermission::Intermission;
 use crate::view::{Event, Hub, RenderData, RenderQueue, View, wait_for_all};
-use std::thread;
-use std::time::{Duration, Instant};
 
-pub(super) const AUTO_SUSPEND_REFRESH_INTERVAL: Duration = Duration::from_secs(60);
-
-/// Spawns a background thread that periodically sends [`Event::MightSuspend`].
-pub(super) fn spawn_auto_suspend_poller(hub: &Hub, auto_suspend: f32) {
-    if auto_suspend <= 0.0 {
-        return;
+/// Converts Auto Power Off days to a chrono duration of at least one second.
+fn auto_power_off_chrono_duration(days: f32) -> ChronoDuration {
+    let secs = (days * 86_400.0).max(0.0);
+    let duration = ChronoDuration::from_std(std::time::Duration::from_secs_f32(secs))
+        .unwrap_or_else(|_| ChronoDuration::milliseconds(((secs * 1000.0) as i64).max(1)));
+    if duration.num_seconds() < 1 {
+        ChronoDuration::seconds(1)
+    } else {
+        duration
     }
+}
 
-    let hub = hub.clone();
-    thread::spawn(move || {
-        loop {
-            thread::sleep(AUTO_SUSPEND_REFRESH_INTERVAL);
-            hub.send(Event::MightSuspend).ok();
-        }
-    });
+/// Schedules or cancels [`AlarmType::AutoSuspend`] from the Auto Suspend setting.
+///
+/// When `auto_suspend` is `0`, cancels any pending alarm. Otherwise replaces the
+/// alarm with a wake time of *now + timeout* (setting is minutes). Call on
+/// startup, user activity, settings Submit, and when returning to interactive use
+/// after suspend cancel so the idle window restarts from the current moment.
+pub(super) fn reschedule_auto_suspend_alarm(context: &mut AppContext) {
+    context.reschedule_auto_suspend_alarm();
+}
+
+/// Cancels [`AlarmType::AutoSuspend`] when entering an explicit suspend cycle.
+pub(super) fn cancel_auto_suspend_alarm(context: &mut AppContext) {
+    let Some(alarm_manager) = context.alarm_manager.as_ref() else {
+        return;
+    };
+    let mut alarm_manager = alarm_manager.lock().unwrap_or_else(|e| e.into_inner());
+    if let Err(error) = alarm_manager.cancel_alarm(AlarmType::AutoSuspend) {
+        tracing::error!(error = %error, "failed to cancel AutoSuspend alarm");
+    }
+}
+
+/// Schedules [`AlarmType::WakeDebounce`] for [`super::SUSPEND_WAIT_DELAY`] after leave sleep.
+pub(super) fn schedule_wake_debounce_alarm(context: &mut AppContext) {
+    let Some(alarm_manager) = context.alarm_manager.as_ref() else {
+        return;
+    };
+    let mut alarm_manager = alarm_manager.lock().unwrap_or_else(|e| e.into_inner());
+    let duration = ChronoDuration::from_std(super::SUSPEND_WAIT_DELAY)
+        .unwrap_or_else(|_| ChronoDuration::seconds(15));
+    if let Err(error) = alarm_manager.schedule_alarm(AlarmType::WakeDebounce, duration) {
+        tracing::error!(error = %error, "failed to schedule WakeDebounce alarm");
+    }
+}
+
+/// Cancels [`AlarmType::WakeDebounce`] when staying interactive or entering suspend.
+pub(super) fn cancel_wake_debounce_alarm(context: &mut AppContext) {
+    let Some(alarm_manager) = context.alarm_manager.as_ref() else {
+        return;
+    };
+    let mut alarm_manager = alarm_manager.lock().unwrap_or_else(|e| e.into_inner());
+    if let Err(error) = alarm_manager.cancel_alarm(AlarmType::WakeDebounce) {
+        tracing::error!(error = %error, "failed to cancel WakeDebounce alarm");
+    }
+}
+
+/// Returns whether [`AlarmType::WakeDebounce`] is armed in the alarm map.
+///
+/// True for future and past-due entries until the alarm is cancelled or claimed.
+pub(super) fn is_wake_debounce_scheduled(context: &AppContext) -> bool {
+    let Some(alarm_manager) = context.alarm_manager.as_ref() else {
+        return false;
+    };
+    let alarm_manager = alarm_manager.lock().unwrap_or_else(|e| e.into_inner());
+    alarm_manager.has_alarm(AlarmType::WakeDebounce)
+}
+
+/// Schedules [`AlarmType::Suspend`] after PrepareSuspend (classic enter-sleep delay).
+pub(super) fn schedule_suspend_alarm(context: &mut AppContext, delay: std::time::Duration) {
+    let Some(alarm_manager) = context.alarm_manager.as_ref() else {
+        return;
+    };
+    let mut alarm_manager = alarm_manager.lock().unwrap_or_else(|e| e.into_inner());
+    let duration = ChronoDuration::from_std(delay).unwrap_or_else(|_| ChronoDuration::seconds(15));
+    if let Err(error) = alarm_manager.schedule_alarm(AlarmType::Suspend, duration) {
+        tracing::error!(error = %error, "failed to schedule Suspend alarm");
+    }
+}
+
+/// Cancels [`AlarmType::Suspend`] when aborting prepare→sleep or entering a new cycle.
+pub(super) fn cancel_suspend_alarm(context: &mut AppContext) {
+    let Some(alarm_manager) = context.alarm_manager.as_ref() else {
+        return;
+    };
+    let mut alarm_manager = alarm_manager.lock().unwrap_or_else(|e| e.into_inner());
+    if let Err(error) = alarm_manager.cancel_alarm(AlarmType::Suspend) {
+        tracing::error!(error = %error, "failed to cancel Suspend alarm");
+    }
+}
+
+/// Returns whether [`AlarmType::Suspend`] is armed in the alarm map.
+///
+/// True for future and past-due entries until the alarm is cancelled or claimed.
+pub(super) fn is_suspend_alarm_scheduled(context: &AppContext) -> bool {
+    let Some(alarm_manager) = context.alarm_manager.as_ref() else {
+        return false;
+    };
+    let alarm_manager = alarm_manager.lock().unwrap_or_else(|e| e.into_inner());
+    alarm_manager.has_alarm(AlarmType::Suspend)
+}
+
+/// Returns whether Suspend or WakeDebounce RTC is armed in the alarm map.
+pub(super) fn is_suspend_rtc_pending(context: &AppContext) -> bool {
+    is_suspend_alarm_scheduled(context) || is_wake_debounce_scheduled(context)
+}
+
+/// Cancels both Suspend and WakeDebounce RTCs.
+pub(super) fn cancel_suspend_rtcs(context: &mut AppContext) {
+    cancel_suspend_alarm(context);
+    cancel_wake_debounce_alarm(context);
 }
 
 /// Dispatches suspend-related lifecycle events.
@@ -45,13 +148,48 @@ pub(super) fn handle_event(
 ) -> EventOutcome {
     match event {
         Event::PrepareSuspend => handle_prepare_suspend(hub, rq, context, runtime),
-        Event::Suspend => handle_suspend(hub, rq, context, runtime),
-        Event::MightSuspend => handle_might_suspend(hub, bus, rq, context, runtime),
+        Event::Suspend => handle_suspend(hub, bus, rq, context, runtime),
+        Event::RtcAlarmFired(alarm_type) => {
+            handle_rtc_alarm_fired(*alarm_type, hub, bus, rq, context, runtime)
+        }
         _ => EventOutcome::Unhandled,
     }
 }
 
-fn handle_might_suspend(
+/// Handles a claimed RTC logical alarm delivered by the IRQ listener.
+fn handle_rtc_alarm_fired(
+    alarm_type: AlarmType,
+    hub: &Hub,
+    bus: &mut crate::view::Bus,
+    rq: &mut RenderQueue,
+    context: &mut AppContext,
+    runtime: &mut DeviceRuntime<'_>,
+) -> EventOutcome {
+    match alarm_type {
+        AlarmType::AutoSuspend => handle_auto_suspend_fired(hub, bus, rq, context, runtime),
+        AlarmType::Suspend => handle_suspend(hub, bus, rq, context, runtime),
+        AlarmType::WakeDebounce => handle_wake_debounce_fired(hub, bus, rq, context, runtime),
+        AlarmType::AutoPowerOff => {
+            show_power_off_intermission(
+                context,
+                runtime.view.as_mut(),
+                runtime.history,
+                runtime.updating,
+            );
+            EventOutcome::Exit(ExitStatus::PowerOff)
+        }
+        AlarmType::CalendarUpdate => {
+            refresh_calendar_intermission(rq, context, runtime);
+            EventOutcome::Handled
+        }
+    }
+}
+
+/// Starts suspend when [`AlarmType::AutoSuspend`] fires while interactive.
+///
+/// When USB share is active or a suspend cycle is already pending, pushes the
+/// deadline forward instead of suspending.
+fn handle_auto_suspend_fired(
     hub: &Hub,
     bus: &mut crate::view::Bus,
     rq: &mut RenderQueue,
@@ -59,20 +197,63 @@ fn handle_might_suspend(
     runtime: &mut DeviceRuntime<'_>,
 ) -> EventOutcome {
     if context.settings.auto_suspend <= 0.0 {
-        return EventOutcome::Unhandled;
-    }
-
-    if context.shared || is_suspend_active(runtime.tasks) {
-        *runtime.inactive_since = Instant::now();
         return EventOutcome::Handled;
     }
 
-    let seconds = 60.0 * context.settings.auto_suspend;
-    if runtime.inactive_since.elapsed() > Duration::from_secs_f32(seconds) {
-        begin_suspend(context, runtime.view.as_mut(), hub, bus, rq, runtime.tasks);
+    if context.shared || is_suspend_active(context, runtime.tasks) {
+        reschedule_auto_suspend_alarm(context);
+        return EventOutcome::Handled;
     }
 
+    begin_suspend(context, runtime.view.as_mut(), hub, bus, rq, runtime.tasks);
     EventOutcome::Handled
+}
+
+/// Re-enters sleep when [`AlarmType::WakeDebounce`] fires after a brief wake.
+///
+/// Clears the fired alarm first (IRQ claim already removed it in production;
+/// synthetic test events may not). Reuses the existing intermission via
+/// [`handle_suspend`] instead of stacking another [`begin_suspend`].
+fn handle_wake_debounce_fired(
+    hub: &Hub,
+    bus: &mut crate::view::Bus,
+    rq: &mut RenderQueue,
+    context: &mut AppContext,
+    runtime: &mut DeviceRuntime<'_>,
+) -> EventOutcome {
+    cancel_wake_debounce_alarm(context);
+    if context.shared {
+        return EventOutcome::Handled;
+    }
+    handle_suspend(hub, bus, rq, context, runtime)
+}
+
+fn refresh_calendar_intermission(
+    rq: &mut RenderQueue,
+    context: &mut AppContext,
+    runtime: &mut DeviceRuntime<'_>,
+) {
+    if context.settings.intermissions[IntermKind::Suspend]
+        != crate::settings::IntermissionDisplay::Calendar
+    {
+        return;
+    }
+    tracing::debug!("CalendarUpdate alarm fired; refreshing calendar intermission");
+    if let Some(index) = locate::<Intermission>(runtime.view.as_mut()) {
+        runtime.view.children_mut().remove(index);
+        tracing::debug!("old calendar intermission removed");
+    }
+    let interm = Intermission::new(
+        context.device.framebuffer().rect(),
+        IntermKind::Suspend,
+        context,
+    );
+    rq.add(RenderData::new(
+        interm.id(),
+        *interm.rect(),
+        crate::framebuffer::UpdateMode::Full,
+    ));
+    runtime.view.children_mut().push(Box::new(interm));
 }
 
 /// Handles [`Event::PrepareSuspend`]: persists state and schedules full suspend.
@@ -80,7 +261,7 @@ fn handle_might_suspend(
 /// Clears the prepare task, saves settings, turns off frontlight and WiFi,
 /// then schedules [`Event::Suspend`] after [`super::SUSPEND_WAIT_DELAY`].
 fn handle_prepare_suspend(
-    hub: &Hub,
+    _hub: &Hub,
     _rq: &mut RenderQueue,
     context: &mut AppContext,
     runtime: &mut DeviceRuntime<'_>,
@@ -108,30 +289,33 @@ fn handle_prepare_suspend(
         }
         context.online = false;
     }
-    schedule_device_task(
-        DeviceTaskId::Suspend,
-        Event::Suspend,
-        SUSPEND_WAIT_DELAY,
-        hub,
-        runtime.tasks,
-    );
+    schedule_suspend_alarm(context, SUSPEND_WAIT_DELAY);
 
     EventOutcome::Handled
 }
 
 /// Handles [`Event::Suspend`]: schedules alarms, sleeps, and processes wake events.
+///
+/// A late [`AlarmType::Suspend`] after user cancel has no intermission; treat that
+/// as stale and skip hardware sleep.
 fn handle_suspend(
     hub: &Hub,
+    bus: &mut crate::view::Bus,
     rq: &mut RenderQueue,
     context: &mut AppContext,
     runtime: &mut DeviceRuntime<'_>,
 ) -> EventOutcome {
+    cancel_suspend_alarm(context);
+    if locate::<Intermission>(runtime.view.as_ref()).is_none() {
+        return EventOutcome::Handled;
+    }
+
     if let Some(outcome) = schedule_alarms_before_sleep(context, runtime) {
         return outcome;
     }
 
     let (before, after) = perform_suspend_resume(hub, context, runtime);
-    handle_post_wake(before, after, hub, rq, context, runtime)
+    handle_post_wake(before, after, hub, bus, rq, context, runtime)
 }
 
 /// Schedules auto-power-off and calendar-update alarms before sleep.
@@ -142,10 +326,11 @@ fn schedule_alarms_before_sleep(
     context: &mut AppContext,
     runtime: &mut DeviceRuntime<'_>,
 ) -> Option<EventOutcome> {
-    let alarm_manager = context.alarm_manager.as_mut()?;
+    let alarm_manager = context.alarm_manager.as_ref()?;
+    let mut alarm_manager = alarm_manager.lock().unwrap_or_else(|e| e.into_inner());
 
     if context.settings.auto_power_off > 0.0 {
-        let duration = ChronoDuration::seconds((context.settings.auto_power_off * 86_400.0) as i64);
+        let duration = auto_power_off_chrono_duration(context.settings.auto_power_off);
         match alarm_manager.ensure_scheduled(
             AlarmType::AutoPowerOff,
             duration,
@@ -153,6 +338,7 @@ fn schedule_alarms_before_sleep(
         ) {
             Ok(EnsureAlarmOutcome::PastDue) => {
                 tracing::info!("AutoPowerOff alarm is past due, powering off");
+                drop(alarm_manager);
                 show_power_off_intermission(
                     context,
                     runtime.view.as_mut(),
@@ -189,7 +375,7 @@ fn schedule_alarms_before_sleep(
     None
 }
 
-/// Suspends and resumes the device, then reschedules the suspend task.
+/// Suspends and resumes the device, then schedules wake-debounce RTC.
 fn perform_suspend_resume(
     hub: &Hub,
     context: &mut AppContext,
@@ -222,16 +408,10 @@ fn perform_suspend_resume(
             tracing::error!(error = %error, "power_manager() initialization failed for resume");
         }
     }
-    *runtime.inactive_since = Instant::now();
     let pending_task_ids: Vec<_> = runtime.tasks.iter().map(|t| t.id).collect();
     tracing::debug!(pending_tasks = ?pending_task_ids, "task state after wake");
-    schedule_device_task(
-        DeviceTaskId::Suspend,
-        Event::Suspend,
-        SUSPEND_WAIT_DELAY,
-        hub,
-        runtime.tasks,
-    );
+    let _ = hub;
+    schedule_wake_debounce_alarm(context);
     (before, after)
 }
 
@@ -240,49 +420,39 @@ fn handle_post_wake(
     before: chrono::DateTime<Local>,
     after: chrono::DateTime<Local>,
     hub: &Hub,
+    bus: &mut crate::view::Bus,
     rq: &mut RenderQueue,
     context: &mut AppContext,
     runtime: &mut DeviceRuntime<'_>,
 ) -> EventOutcome {
-    let _ = hub;
-    if let Some(alarm_manager) = context.alarm_manager.as_mut() {
-        match alarm_manager.check_fired_alarms(before.to_utc(), after.to_utc()) {
-            Ok(fired_alarms) => {
-                tracing::info!(alarms = ?fired_alarms, "Checked fired alarms after wake");
-                if fired_alarms.contains(&AlarmType::AutoPowerOff) {
-                    show_power_off_intermission(
-                        context,
-                        runtime.view.as_mut(),
-                        runtime.history,
-                        runtime.updating,
-                    );
-                    return EventOutcome::Exit(ExitStatus::PowerOff);
+    if let Some(alarm_manager) = context.alarm_manager.as_ref() {
+        let fired_alarms = {
+            let mut alarm_manager = alarm_manager.lock().unwrap_or_else(|e| e.into_inner());
+            match alarm_manager.check_fired_alarms(before.to_utc(), after.to_utc()) {
+                Ok(fired) => {
+                    tracing::info!(alarms = ?fired, "Checked fired alarms after wake");
+                    fired
                 }
-                if fired_alarms.contains(&AlarmType::CalendarUpdate)
-                    && context.settings.intermissions[IntermKind::Suspend]
-                        == crate::settings::IntermissionDisplay::Calendar
-                {
-                    tracing::debug!("CalendarUpdate alarm fired; refreshing calendar intermission");
-                    if let Some(index) = locate::<Intermission>(runtime.view.as_mut()) {
-                        runtime.view.children_mut().remove(index);
-                        tracing::debug!("old calendar intermission removed");
-                    }
-                    let interm = Intermission::new(
-                        context.device.framebuffer().rect(),
-                        IntermKind::Suspend,
-                        context,
-                    );
-                    rq.add(RenderData::new(
-                        interm.id(),
-                        *interm.rect(),
-                        crate::framebuffer::UpdateMode::Full,
-                    ));
-                    runtime.view.children_mut().push(Box::new(interm));
+                Err(error) => {
+                    tracing::error!(error = %error, "Error checking fired alarms");
+                    Vec::new()
                 }
             }
-            Err(error) => {
-                tracing::error!(error = %error, "Error checking fired alarms");
-            }
+        };
+        if fired_alarms.contains(&AlarmType::AutoPowerOff) {
+            show_power_off_intermission(
+                context,
+                runtime.view.as_mut(),
+                runtime.history,
+                runtime.updating,
+            );
+            return EventOutcome::Exit(ExitStatus::PowerOff);
+        }
+        if fired_alarms.contains(&AlarmType::WakeDebounce) {
+            return handle_wake_debounce_fired(hub, bus, rq, context, runtime);
+        }
+        if fired_alarms.contains(&AlarmType::CalendarUpdate) {
+            refresh_calendar_intermission(rq, context, runtime);
         }
     }
 
@@ -292,13 +462,27 @@ fn handle_post_wake(
 #[cfg(all(test, feature = "kobo"))]
 mod tests {
     use super::*;
-    use crate::device::kobo::lifecycle::helpers::has_task;
+    use crate::device::kobo::lifecycle::helpers::{cancel_suspend_if_pending, has_task};
     use crate::device::kobo::lifecycle::test_helpers::LifecycleHarness;
+    use crate::device::rtc::AlarmManager;
     use crate::frontlight::{Frontlight, LightLevel};
     use crate::settings::IntermissionDisplay;
+    use std::time::Duration;
+
+    fn lock_alarms(
+        harness: &mut LifecycleHarness,
+    ) -> std::sync::MutexGuard<'_, AlarmManager<crate::device::rtc::TestRtc>> {
+        harness
+            .context
+            .alarm_manager
+            .as_ref()
+            .unwrap()
+            .lock()
+            .unwrap()
+    }
 
     #[test]
-    fn handle_prepare_suspend_schedules_suspend_task() {
+    fn handle_prepare_suspend_schedules_suspend_rtc() {
         let mut harness = LifecycleHarness::new();
         harness.push_task(DeviceTaskId::PrepareSuspend);
         harness.context.settings.wifi = crate::settings::WifiMode::AlwaysOn;
@@ -308,7 +492,7 @@ mod tests {
         });
         assert_eq!(outcome, EventOutcome::Handled);
         assert!(!has_task(&harness.tasks, DeviceTaskId::PrepareSuspend));
-        assert!(has_task(&harness.tasks, DeviceTaskId::Suspend));
+        assert!(lock_alarms(&mut harness).is_alarm_scheduled(AlarmType::Suspend));
         assert!(!harness.context.online);
         assert!(
             harness
@@ -348,11 +532,9 @@ mod tests {
     fn schedule_alarms_past_due_auto_power_off_exits() {
         let mut harness = LifecycleHarness::new();
         harness.context.settings.auto_power_off = 1.0;
-        if let Some(alarm_manager) = harness.context.alarm_manager.as_mut() {
-            alarm_manager
-                .schedule_alarm(AlarmType::AutoPowerOff, ChronoDuration::seconds(-10))
-                .unwrap();
-        }
+        lock_alarms(&mut harness)
+            .schedule_alarm(AlarmType::AutoPowerOff, ChronoDuration::seconds(-10))
+            .unwrap();
         let outcome = harness.with_runtime_only(schedule_alarms_before_sleep);
         assert_eq!(outcome, Some(EventOutcome::Exit(ExitStatus::PowerOff)));
     }
@@ -363,42 +545,35 @@ mod tests {
         harness.context.settings.intermissions[IntermKind::Suspend] = IntermissionDisplay::Calendar;
         let outcome = harness.with_runtime_only(schedule_alarms_before_sleep);
         assert!(outcome.is_none());
-        assert!(
-            harness
-                .context
-                .alarm_manager
-                .as_ref()
-                .unwrap()
-                .has_alarm(AlarmType::CalendarUpdate)
-        );
+        assert!(lock_alarms(&mut harness).has_alarm(AlarmType::CalendarUpdate));
     }
 
     #[test]
     fn handle_post_wake_auto_power_off_exit() {
         let mut harness = LifecycleHarness::new();
         let before = Local::now();
-        if let Some(alarm_manager) = harness.context.alarm_manager.as_mut() {
-            alarm_manager
+        {
+            lock_alarms(&mut harness)
                 .schedule_alarm(AlarmType::AutoPowerOff, ChronoDuration::minutes(5))
                 .unwrap();
             if let Ok(rtc) = harness.context.device.rtc() {
                 rtc.simulate_alarm_fired();
             }
         }
-        let after = before + ChronoDuration::minutes(5);
-        let outcome = harness.with_parts(|hub, _bus, rq, context, runtime| {
-            handle_post_wake(before, after, hub, rq, context, runtime)
+        let after = before + ChronoDuration::minutes(5) + ChronoDuration::seconds(1);
+        let outcome = harness.with_parts(|hub, bus, rq, context, runtime| {
+            handle_post_wake(before, after, hub, bus, rq, context, runtime)
         });
         assert_eq!(outcome, EventOutcome::Exit(ExitStatus::PowerOff));
     }
 
     #[test]
-    fn perform_suspend_resume_reschedules_suspend() {
+    fn perform_suspend_resume_schedules_wake_debounce() {
         let mut harness = LifecycleHarness::new();
         let (_before, _after) = harness.with_parts(|hub, _bus, _rq, context, runtime| {
             perform_suspend_resume(hub, context, runtime)
         });
-        assert!(has_task(&harness.tasks, DeviceTaskId::Suspend));
+        assert!(lock_alarms(&mut harness).is_alarm_scheduled(AlarmType::WakeDebounce));
         let power = harness.context.device.power_manager_for_test();
         assert!(power.was_suspend_called());
         assert!(power.was_resume_called());
@@ -407,41 +582,262 @@ mod tests {
     }
 
     #[test]
-    fn handle_might_suspend_below_threshold_noop() {
+    fn wake_debounce_reenters_sleep_without_begin_suspend() {
+        use crate::view::common::locate;
+        use crate::view::intermission::Intermission;
+
         let mut harness = LifecycleHarness::new();
-        harness.context.settings.auto_suspend = 5.0;
+        harness.with_parts(|hub, bus, rq, context, runtime| {
+            begin_suspend(context, runtime.view.as_mut(), hub, bus, rq, runtime.tasks);
+        });
+        harness.with_parts(|hub, bus, rq, context, runtime| {
+            handle_event(&Event::PrepareSuspend, hub, bus, rq, context, runtime);
+        });
         let outcome = harness.with_parts(|hub, bus, rq, context, runtime| {
-            handle_event(&Event::MightSuspend, hub, bus, rq, context, runtime)
+            handle_event(
+                &Event::RtcAlarmFired(AlarmType::Suspend),
+                hub,
+                bus,
+                rq,
+                context,
+                runtime,
+            )
+        });
+        assert_eq!(outcome, EventOutcome::Handled);
+        assert!(lock_alarms(&mut harness).is_alarm_scheduled(AlarmType::WakeDebounce));
+        assert_eq!(
+            harness
+                .context
+                .device
+                .power_manager_for_test()
+                .suspend_call_count(),
+            1
+        );
+
+        let outcome = harness.with_parts(|hub, bus, rq, context, runtime| {
+            handle_event(
+                &Event::RtcAlarmFired(AlarmType::WakeDebounce),
+                hub,
+                bus,
+                rq,
+                context,
+                runtime,
+            )
         });
         assert_eq!(outcome, EventOutcome::Handled);
         assert!(!has_task(&harness.tasks, DeviceTaskId::PrepareSuspend));
+        assert_eq!(
+            harness
+                .view
+                .children()
+                .iter()
+                .filter(|child| child.as_ref().is::<Intermission>())
+                .count(),
+            1
+        );
+        assert!(locate::<Intermission>(harness.view.as_ref()).is_some());
+        assert_eq!(
+            harness
+                .context
+                .device
+                .power_manager_for_test()
+                .suspend_call_count(),
+            2
+        );
+        assert!(lock_alarms(&mut harness).is_alarm_scheduled(AlarmType::WakeDebounce));
     }
 
     #[test]
-    fn handle_might_suspend_above_threshold_begins_suspend() {
+    fn handle_rtc_auto_suspend_future_noop_when_not_fired_via_event() {
         let mut harness = LifecycleHarness::new();
-        harness.context.settings.auto_suspend = 0.01;
-        harness.inactive_since = Instant::now() - Duration::from_secs(120);
+        harness.context.settings.auto_suspend = 5.0;
+        reschedule_auto_suspend_alarm(&mut harness.context);
+        assert!(!has_task(&harness.tasks, DeviceTaskId::PrepareSuspend));
+        assert!(lock_alarms(&mut harness).is_alarm_scheduled(AlarmType::AutoSuspend));
+    }
+
+    #[test]
+    fn handle_rtc_auto_suspend_fired_begins_suspend() {
+        let mut harness = LifecycleHarness::new();
+        harness.context.settings.auto_suspend = 30.0;
         let outcome = harness.with_parts(|hub, bus, rq, context, runtime| {
-            handle_event(&Event::MightSuspend, hub, bus, rq, context, runtime)
+            handle_event(
+                &Event::RtcAlarmFired(AlarmType::AutoSuspend),
+                hub,
+                bus,
+                rq,
+                context,
+                runtime,
+            )
         });
         assert_eq!(outcome, EventOutcome::Handled);
         assert!(has_task(&harness.tasks, DeviceTaskId::PrepareSuspend));
     }
 
     #[test]
-    fn handle_might_suspend_blocked_when_shared() {
+    fn handle_rtc_auto_power_off_exits() {
         let mut harness = LifecycleHarness::new();
-        harness.context.settings.auto_suspend = 0.01;
-        harness.context.shared = true;
-        harness.inactive_since = Instant::now() - Duration::from_secs(120);
-        let before = harness.inactive_since;
-        std::thread::sleep(Duration::from_millis(5));
         let outcome = harness.with_parts(|hub, bus, rq, context, runtime| {
-            handle_event(&Event::MightSuspend, hub, bus, rq, context, runtime)
+            handle_event(
+                &Event::RtcAlarmFired(AlarmType::AutoPowerOff),
+                hub,
+                bus,
+                rq,
+                context,
+                runtime,
+            )
+        });
+        assert_eq!(outcome, EventOutcome::Exit(ExitStatus::PowerOff));
+    }
+
+    #[test]
+    fn handle_rtc_auto_suspend_blocked_when_shared_reschedules() {
+        let mut harness = LifecycleHarness::new();
+        harness.context.settings.auto_suspend = 30.0;
+        harness.context.shared = true;
+        let outcome = harness.with_parts(|hub, bus, rq, context, runtime| {
+            handle_event(
+                &Event::RtcAlarmFired(AlarmType::AutoSuspend),
+                hub,
+                bus,
+                rq,
+                context,
+                runtime,
+            )
         });
         assert_eq!(outcome, EventOutcome::Handled);
         assert!(!has_task(&harness.tasks, DeviceTaskId::PrepareSuspend));
-        assert!(harness.inactive_since > before);
+        assert!(lock_alarms(&mut harness).is_alarm_scheduled(AlarmType::AutoSuspend));
+    }
+
+    #[test]
+    fn reschedule_auto_suspend_zero_cancels() {
+        let mut harness = LifecycleHarness::new();
+        harness.context.settings.auto_suspend = 30.0;
+        reschedule_auto_suspend_alarm(&mut harness.context);
+        assert!(lock_alarms(&mut harness).has_alarm(AlarmType::AutoSuspend));
+        harness.context.settings.auto_suspend = 0.0;
+        reschedule_auto_suspend_alarm(&mut harness.context);
+        assert!(!lock_alarms(&mut harness).has_alarm(AlarmType::AutoSuspend));
+    }
+
+    #[test]
+    fn reschedule_auto_suspend_moves_deadline_forward() {
+        let mut harness = LifecycleHarness::new();
+        harness.context.settings.auto_suspend = 30.0;
+        reschedule_auto_suspend_alarm(&mut harness.context);
+        let first = lock_alarms(&mut harness)
+            .time_until_alarm(AlarmType::AutoSuspend)
+            .unwrap();
+        std::thread::sleep(Duration::from_millis(20));
+        reschedule_auto_suspend_alarm(&mut harness.context);
+        let second = lock_alarms(&mut harness)
+            .time_until_alarm(AlarmType::AutoSuspend)
+            .unwrap();
+        assert!(second >= first);
+        assert!((second - 30 * 60).abs() < 2);
+    }
+
+    #[test]
+    fn reschedule_auto_suspend_sub_minute_clamps_nonzero() {
+        let mut harness = LifecycleHarness::new();
+        harness.context.settings.auto_suspend = 0.01;
+        assert_eq!(
+            (harness.context.settings.auto_suspend * 60.0) as i64,
+            0,
+            "precondition: whole-second cast truncates this setting to zero"
+        );
+        reschedule_auto_suspend_alarm(&mut harness.context);
+        assert!(
+            lock_alarms(&mut harness).is_alarm_scheduled(AlarmType::AutoSuspend),
+            "sub-minute AutoSuspend must schedule a future alarm"
+        );
+        let until = lock_alarms(&mut harness)
+            .time_until_alarm(AlarmType::AutoSuspend)
+            .unwrap();
+        assert!(until >= 0);
+    }
+
+    #[test]
+    fn begin_suspend_cancels_auto_suspend_alarm() {
+        let mut harness = LifecycleHarness::new();
+        harness.context.settings.auto_suspend = 30.0;
+        reschedule_auto_suspend_alarm(&mut harness.context);
+        harness.with_parts(|hub, bus, rq, context, runtime| {
+            begin_suspend(context, runtime.view.as_mut(), hub, bus, rq, runtime.tasks);
+        });
+        assert!(!lock_alarms(&mut harness).has_alarm(AlarmType::AutoSuspend));
+        assert!(has_task(&harness.tasks, DeviceTaskId::PrepareSuspend));
+    }
+
+    #[test]
+    fn cancel_prepare_suspend_reschedules_auto_suspend() {
+        let mut harness = LifecycleHarness::new();
+        harness.context.settings.auto_suspend = 30.0;
+        harness.with_parts(|hub, bus, rq, context, runtime| {
+            begin_suspend(context, runtime.view.as_mut(), hub, bus, rq, runtime.tasks);
+        });
+        assert!(has_task(&harness.tasks, DeviceTaskId::PrepareSuspend));
+        assert!(!lock_alarms(&mut harness).has_alarm(AlarmType::AutoSuspend));
+        harness.with_parts(|hub, _bus, rq, context, runtime| {
+            cancel_suspend_if_pending(context, runtime.tasks, runtime.view.as_mut(), hub, rq);
+        });
+        assert!(!has_task(&harness.tasks, DeviceTaskId::PrepareSuspend));
+        assert!(lock_alarms(&mut harness).is_alarm_scheduled(AlarmType::AutoSuspend));
+    }
+
+    #[test]
+    fn cancel_suspend_rtc_reschedules_auto_suspend() {
+        let mut harness = LifecycleHarness::new();
+        harness.context.settings.auto_suspend = 30.0;
+        harness.with_parts(|hub, bus, rq, context, runtime| {
+            begin_suspend(context, runtime.view.as_mut(), hub, bus, rq, runtime.tasks);
+        });
+        harness.tasks.clear();
+        {
+            let mut alarms = lock_alarms(&mut harness);
+            alarms
+                .schedule_alarm(AlarmType::Suspend, ChronoDuration::seconds(15))
+                .unwrap();
+        }
+        harness.with_parts(|hub, _bus, rq, context, runtime| {
+            cancel_suspend_if_pending(context, runtime.tasks, runtime.view.as_mut(), hub, rq);
+        });
+        assert!(lock_alarms(&mut harness).is_alarm_scheduled(AlarmType::AutoSuspend));
+        assert!(!lock_alarms(&mut harness).has_alarm(AlarmType::Suspend));
+    }
+
+    #[test]
+    fn stale_suspend_rtc_after_cancel_skips_hardware_sleep() {
+        let mut harness = LifecycleHarness::new();
+        harness.context.settings.auto_suspend = 30.0;
+        harness.with_parts(|hub, bus, rq, context, runtime| {
+            begin_suspend(context, runtime.view.as_mut(), hub, bus, rq, runtime.tasks);
+        });
+        harness.with_parts(|hub, bus, rq, context, runtime| {
+            handle_event(&Event::PrepareSuspend, hub, bus, rq, context, runtime);
+        });
+        assert!(lock_alarms(&mut harness).is_alarm_scheduled(AlarmType::Suspend));
+        harness.with_parts(|hub, _bus, rq, context, runtime| {
+            cancel_suspend_if_pending(context, runtime.tasks, runtime.view.as_mut(), hub, rq);
+        });
+        let outcome = harness.with_parts(|hub, bus, rq, context, runtime| {
+            handle_event(
+                &Event::RtcAlarmFired(AlarmType::Suspend),
+                hub,
+                bus,
+                rq,
+                context,
+                runtime,
+            )
+        });
+        assert_eq!(outcome, EventOutcome::Handled);
+        let power = harness.context.device.power_manager_for_test();
+        assert!(
+            !power.was_suspend_called(),
+            "stale Suspend after cancel must not call power.suspend"
+        );
+        assert!(lock_alarms(&mut harness).is_alarm_scheduled(AlarmType::AutoSuspend));
+        assert!(!lock_alarms(&mut harness).has_alarm(AlarmType::Suspend));
     }
 }

--- a/crates/core/src/device/kobo/lifecycle/test_helpers.rs
+++ b/crates/core/src/device/kobo/lifecycle/test_helpers.rs
@@ -26,7 +26,6 @@ use crate::framebuffer::Framebuffer as _;
 use crate::view::filler::Filler;
 use crate::view::{Bus, Event, Hub, RenderQueue, UpdateData, View};
 use std::sync::mpsc::Receiver;
-use std::time::Instant;
 
 /// Minimal runtime shell for lifecycle handler tests.
 ///
@@ -44,7 +43,6 @@ pub struct LifecycleHarness {
     pub tasks: Vec<DeviceTask>,
     pub history: Vec<HistoryItem>,
     pub updating: Vec<UpdateData>,
-    pub inactive_since: Instant,
 }
 
 impl LifecycleHarness {
@@ -64,7 +62,6 @@ impl LifecycleHarness {
             tasks: Vec::new(),
             history: Vec::new(),
             updating: Vec::new(),
-            inactive_since: Instant::now(),
         }
     }
 
@@ -94,7 +91,6 @@ impl LifecycleHarness {
             history: &mut self.history,
             tasks: &mut self.tasks,
             updating: &mut self.updating,
-            inactive_since: &mut self.inactive_since,
             settings_manager: None,
             startup_cwd: None,
             background_tasks: None,
@@ -118,7 +114,6 @@ impl LifecycleHarness {
             history: &mut self.history,
             tasks: &mut self.tasks,
             updating: &mut self.updating,
-            inactive_since: &mut self.inactive_since,
             settings_manager: None,
             startup_cwd: None,
             background_tasks: None,

--- a/crates/core/src/device/linux/rtc.rs
+++ b/crates/core/src/device/linux/rtc.rs
@@ -2,12 +2,16 @@
 
 use anyhow::Error;
 use chrono::{DateTime, Utc};
+use nix::poll::{PollFd, PollFlags, PollTimeout, poll};
 use nix::{ioctl_none, ioctl_read, ioctl_write_ptr};
 use std::fs::{File, OpenOptions};
+use std::io::Read;
 use std::mem;
+use std::os::fd::AsFd;
 use std::os::unix::io::AsRawFd;
 use std::path::Path;
 use std::sync::{Arc, Mutex};
+use std::time::Duration;
 
 use crate::device::rtc::{Rtc, RtcTime, RtcWkalrm};
 
@@ -23,7 +27,8 @@ ioctl_write_ptr!(rtc_set_time, b'p', 0x0a, RtcTime);
 /// `RTC_RD_TIME`, `RTC_SET_TIME`, `RTC_ALM_READ`, `RTC_ALM_SET`, and
 /// `RTC_AIE_OFF` ioctls (wrapped by the `rtc_*` helpers above). Concurrent
 /// callers are serialized through an internal mutex guarding the open file
-/// descriptor.
+/// descriptor. Alarm IRQ waits use a separate `dup` of that fd so a blocking
+/// `poll` does not hold the ioctl mutex.
 ///
 /// # Examples
 ///
@@ -35,7 +40,10 @@ ioctl_write_ptr!(rtc_set_time, b'p', 0x0a, RtcTime);
 /// # Ok::<(), Box<dyn std::error::Error>>(())
 /// ```
 #[derive(Clone)]
-pub struct LinuxRtc(Arc<Mutex<File>>);
+pub struct LinuxRtc {
+    file: Arc<Mutex<File>>,
+    wait_file: Arc<Mutex<File>>,
+}
 
 impl LinuxRtc {
     /// Opens the RTC device and creates a new interface handle.
@@ -57,7 +65,12 @@ impl LinuxRtc {
     /// ```
     pub fn new<P: AsRef<Path>>(path: P) -> Result<LinuxRtc, Error> {
         let file = OpenOptions::new().read(true).write(true).open(path)?;
-        Ok(LinuxRtc(Arc::new(Mutex::new(file))))
+        let wait_fd = nix::unistd::dup(file.as_fd())?;
+        let wait_file = File::from(wait_fd);
+        Ok(LinuxRtc {
+            file: Arc::new(Mutex::new(file)),
+            wait_file: Arc::new(Mutex::new(wait_file)),
+        })
     }
 }
 
@@ -66,7 +79,7 @@ impl Rtc for LinuxRtc {
     fn alarm(&self) -> Result<RtcWkalrm, Error> {
         let mut rwa = RtcWkalrm::default();
         let file = self
-            .0
+            .file
             .lock()
             .map_err(|e| anyhow::anyhow!("lock poisoned: {}", e))?;
         unsafe {
@@ -80,7 +93,7 @@ impl Rtc for LinuxRtc {
     fn set_alarm(&self, wake_time: DateTime<Utc>) -> Result<i32, Error> {
         let rwa = RtcWkalrm::for_wake_time(wake_time);
         let file = self
-            .0
+            .file
             .lock()
             .map_err(|e| anyhow::anyhow!("lock poisoned: {}", e))?;
         unsafe { rtc_write_alarm(file.as_raw_fd(), &rwa).map_err(|e| e.into()) }
@@ -89,7 +102,7 @@ impl Rtc for LinuxRtc {
     /// Issues `RTC_AIE_OFF` to disable alarm interrupts.
     fn disable_alarm(&self) -> Result<i32, Error> {
         let file = self
-            .0
+            .file
             .lock()
             .map_err(|e| anyhow::anyhow!("lock poisoned: {}", e))?;
         unsafe { rtc_disable_alarm(file.as_raw_fd()).map_err(|e| e.into()) }
@@ -99,7 +112,7 @@ impl Rtc for LinuxRtc {
     fn read_time(&self) -> Result<DateTime<Utc>, Error> {
         let mut rt = unsafe { mem::zeroed::<RtcTime>() };
         let file = self
-            .0
+            .file
             .lock()
             .map_err(|e| anyhow::anyhow!("lock poisoned: {}", e))?;
         unsafe {
@@ -112,12 +125,37 @@ impl Rtc for LinuxRtc {
     fn set_time(&self, time: DateTime<Utc>) -> Result<(), Error> {
         let rt: RtcTime = time.into();
         let file = self
-            .0
+            .file
             .lock()
             .map_err(|e| anyhow::anyhow!("lock poisoned: {}", e))?;
         unsafe {
             rtc_set_time(file.as_raw_fd(), &rt)?;
         }
         Ok(())
+    }
+
+    fn wait_for_alarm_irq(&self, timeout: Option<Duration>) -> Result<Option<u32>, Error> {
+        let mut wait_file = self
+            .wait_file
+            .lock()
+            .map_err(|e| anyhow::anyhow!("lock poisoned: {}", e))?;
+        let mut poll_fds = [PollFd::new(wait_file.as_fd(), PollFlags::POLLIN)];
+        let poll_timeout = match timeout {
+            Some(duration) => PollTimeout::try_from(duration).unwrap_or(PollTimeout::MAX),
+            None => PollTimeout::NONE,
+        };
+        let ready = poll(&mut poll_fds, poll_timeout)?;
+        if ready == 0 {
+            return Ok(None);
+        }
+        let revents = poll_fds[0].revents().unwrap_or_else(PollFlags::empty);
+        if !revents.contains(PollFlags::POLLIN) {
+            return Err(anyhow::anyhow!(
+                "RTC wait fd woke without POLLIN (revents={revents:?})"
+            ));
+        }
+        let mut buf = [0u8; 4];
+        wait_file.read_exact(&mut buf)?;
+        Ok(Some(u32::from_ne_bytes(buf)))
     }
 }

--- a/crates/core/src/device/mod.rs
+++ b/crates/core/src/device/mod.rs
@@ -89,7 +89,6 @@ use crate::view::{Bus, Event, Hub, RenderQueue, UpdateData, View};
 use std::fmt::Debug;
 use std::path::{Path, PathBuf};
 use std::sync::mpsc::Receiver;
-use std::time::Instant;
 
 pub struct HistoryItem {
     pub view: Box<dyn View>,
@@ -108,7 +107,6 @@ pub enum DeviceTaskId {
     CheckBattery,
     PrepareSuspend,
     Exit,
-    Suspend,
 }
 
 pub struct DeviceRuntime<'a> {
@@ -116,7 +114,6 @@ pub struct DeviceRuntime<'a> {
     pub history: &'a mut Vec<HistoryItem>,
     pub tasks: &'a mut Vec<DeviceTask>,
     pub updating: &'a mut Vec<UpdateData>,
-    pub inactive_since: &'a mut Instant,
     pub settings_manager: Option<&'a SettingsManager>,
     pub startup_cwd: Option<&'a Option<PathBuf>>,
     pub background_tasks: Option<&'a mut TaskManager>,

--- a/crates/core/src/device/rtc/manager.rs
+++ b/crates/core/src/device/rtc/manager.rs
@@ -2,6 +2,7 @@
 
 use anyhow::Error;
 use chrono::{DateTime, Utc};
+use std::time::Duration;
 
 use super::RtcWkalrm;
 
@@ -13,8 +14,8 @@ use super::RtcWkalrm;
 ///
 /// # Consumers
 ///
-/// [`super::AlarmManager`] multiplexes logical alarms onto one wake alarm and
-/// reads alarm state after wake to detect which alarms fired.
+/// [`super::AlarmManager`] multiplexes logical alarms onto one wake alarm,
+/// waits for alarm IRQs, and claims which logical alarms fired.
 /// [`crate::time_manager::TimeManager`] writes NTP-synced time back to the RTC
 /// after a successful sync so the battery-backed clock matches the system clock.
 ///
@@ -73,6 +74,17 @@ pub trait Rtc: Send + Sync {
     ///
     /// Returns an error when the clock cannot be updated.
     fn set_time(&self, time: DateTime<Utc>) -> Result<(), Error>;
+
+    /// Blocks until an alarm IRQ is readable, or until `timeout` elapses.
+    ///
+    /// Returns `Ok(Some(data))` with the kernel IRQ data word when an alarm
+    /// interrupt is delivered, `Ok(None)` when `timeout` expires without an
+    /// IRQ, or an error on I/O failure. A `timeout` of `None` waits indefinitely.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when waiting or reading the IRQ fails.
+    fn wait_for_alarm_irq(&self, timeout: Option<Duration>) -> Result<Option<u32>, Error>;
 }
 
 impl<T: Rtc + ?Sized> Rtc for std::sync::Arc<T> {
@@ -94,5 +106,9 @@ impl<T: Rtc + ?Sized> Rtc for std::sync::Arc<T> {
 
     fn set_time(&self, time: DateTime<Utc>) -> Result<(), Error> {
         (**self).set_time(time)
+    }
+
+    fn wait_for_alarm_irq(&self, timeout: Option<Duration>) -> Result<Option<u32>, Error> {
+        (**self).wait_for_alarm_irq(timeout)
     }
 }

--- a/crates/core/src/device/rtc/mod.rs
+++ b/crates/core/src/device/rtc/mod.rs
@@ -26,7 +26,10 @@ use anyhow::Error;
 use chrono::{DateTime, Datelike, Duration, TimeZone, Timelike, Utc};
 use std::collections::BTreeMap;
 use std::mem;
-use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
+use std::thread::{self, JoinHandle};
+use std::time::Duration as StdDuration;
 
 #[repr(C)]
 #[derive(Debug, Clone)]
@@ -104,6 +107,15 @@ impl RtcWkalrm {
         }
     }
 
+    #[cfg(any(feature = "emulator", docsrs))]
+    pub(crate) fn from_parts(enabled: bool, wake_time: DateTime<Utc>) -> Self {
+        Self {
+            enabled: u8::from(enabled),
+            pending: 0,
+            time: wake_time.into(),
+        }
+    }
+
     /// Returns whether the alarm is currently enabled.
     pub fn enabled(&self) -> bool {
         self.enabled == 1
@@ -118,9 +130,43 @@ impl RtcWkalrm {
 }
 
 /// Identifies a logical alarm managed by [`AlarmManager`].
+///
+/// # Auto Suspend
+///
+/// [`AlarmType::AutoSuspend`] is the wall-clock idle deadline for entering the
+/// suspend flow. Cadmus schedules it from the Auto Suspend setting (minutes from
+/// now) and **reschedules on user activity** so the deadline tracks real idle
+/// time. Soft sleep freezes monotonic clocks (`Instant::elapsed`), so Auto
+/// Suspend must not treat monotonic idle as authority — the RTC wake time is
+/// the source of truth. When the hardware IRQ fires, [`AlarmManager`]'s listener
+/// claims due alarms and emits [`crate::view::Event::RtcAlarmFired`]; lifecycle
+/// then calls `begin_suspend`. Entering an explicit suspend cancels Auto
+/// Suspend; returning to interactive use reschedules it. Unlike
+/// [`AlarmType::AutoPowerOff`] / [`AlarmType::CalendarUpdate`], Auto Suspend is
+/// not listed in [`AlarmType::alarms_to_cancel_after_resume`] — cancel-on-resume
+/// would drop the idle timer instead of re-arming it for the next idle window.
+///
+/// # Suspend
+///
+/// [`AlarmType::Suspend`] is the wall-clock delay after PrepareSuspend before
+/// entering sleep (`handle_suspend`). Power Released / long-hold cancel it to
+/// abort the cycle. Not listed in [`AlarmType::alarms_to_cancel_after_resume`].
+///
+/// # Wake Debounce
+///
+/// [`AlarmType::WakeDebounce`] is the wall-clock re-sleep deadline after leaving
+/// classic `state=mem`. Userspace `thread::sleep` cannot drive re-sleep under
+/// autosleep. When it fires, lifecycle calls `begin_suspend`. Power Released /
+/// long-hold cancel it. Not in [`AlarmType::alarms_to_cancel_after_resume`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub enum AlarmType {
     AutoPowerOff,
+    /// Idle timeout that starts the suspend flow.
+    AutoSuspend,
+    /// Enter sleep after PrepareSuspend unless Power cancels.
+    Suspend,
+    /// Re-enter suspend after wake unless Power cancels.
+    WakeDebounce,
     CalendarUpdate,
 }
 
@@ -165,12 +211,17 @@ pub struct ScheduledAlarm {
 ///
 /// The hardware RTC supports only one wake alarm at a time. `AlarmManager`
 /// maintains a map of logical alarms keyed by [`AlarmType`] and always
-/// programs the hardware with the earliest upcoming wake time. After each
-/// wake, [`AlarmManager::check_fired_alarms`] determines which logical alarms fired and
-/// reschedules the hardware for any remaining ones.
+/// programs the hardware with the earliest upcoming wake time. An owned IRQ
+/// listener thread waits on [`Rtc::wait_for_alarm_irq`], claims due alarms via
+/// [`AlarmManager::claim_due_alarms`], and delivers them through the callback
+/// passed to [`AlarmManager::start_irq_listener`]. After resume,
+/// [`AlarmManager::check_fired_alarms`] reuses the same claim path when the
+/// hardware likely fired during sleep.
 pub struct AlarmManager<R: Rtc> {
     rtc: Arc<R>,
     scheduled_alarms: BTreeMap<AlarmType, ScheduledAlarm>,
+    irq_thread: Option<JoinHandle<()>>,
+    stop: Arc<AtomicBool>,
 }
 
 impl<R: Rtc> AlarmManager<R> {
@@ -178,6 +229,8 @@ impl<R: Rtc> AlarmManager<R> {
         AlarmManager {
             rtc,
             scheduled_alarms: BTreeMap::new(),
+            irq_thread: None,
+            stop: Arc::new(AtomicBool::new(false)),
         }
     }
 
@@ -269,8 +322,6 @@ impl<R: Rtc> AlarmManager<R> {
         before: DateTime<Utc>,
         after: DateTime<Utc>,
     ) -> Result<Vec<AlarmType>, Error> {
-        let mut fired_types = Vec::new();
-
         if let Some((_, earliest_alarm)) = self
             .scheduled_alarms
             .iter()
@@ -284,34 +335,34 @@ impl<R: Rtc> AlarmManager<R> {
                     && ((after - before) - expected_duration).num_seconds().abs() < 3);
 
             if hardware_alarm_fired {
-                let mut removed: Vec<(AlarmType, ScheduledAlarm)> = Vec::new();
-
-                for (alarm_type, scheduled_alarm) in &self.scheduled_alarms {
-                    if (after - scheduled_alarm.wake_time).abs().num_milliseconds() <= 3000 {
-                        fired_types.push(*alarm_type);
-                        removed.push((
-                            *alarm_type,
-                            ScheduledAlarm {
-                                alarm_type: scheduled_alarm.alarm_type,
-                                wake_time: scheduled_alarm.wake_time,
-                            },
-                        ));
-                    }
-                }
-
-                for (alarm_type, _) in &removed {
-                    self.scheduled_alarms.remove(alarm_type);
-                }
-
-                if let Err(e) = self.update_hardware_alarm() {
-                    for (alarm_type, alarm) in removed {
-                        self.scheduled_alarms.insert(alarm_type, alarm);
-                    }
-                    return Err(e);
-                }
-
-                return Ok(fired_types);
+                return self.claim_due_alarms_at(after);
             }
+        }
+
+        self.update_hardware_alarm()?;
+        Ok(Vec::new())
+    }
+
+    /// Removes and returns logical alarms that are due at the current wall clock.
+    ///
+    /// An alarm is due when its wake time is at or before `at`. Reprograms the
+    /// hardware for any remaining future alarms.
+    pub fn claim_due_alarms(&mut self) -> Result<Vec<AlarmType>, Error> {
+        self.claim_due_alarms_at(Utc::now())
+    }
+
+    fn claim_due_alarms_at(&mut self, at: DateTime<Utc>) -> Result<Vec<AlarmType>, Error> {
+        let mut fired_types = Vec::new();
+        let to_remove: Vec<AlarmType> = self
+            .scheduled_alarms
+            .iter()
+            .filter(|(_, alarm)| alarm.wake_time <= at)
+            .map(|(alarm_type, _)| *alarm_type)
+            .collect();
+
+        for alarm_type in to_remove {
+            self.scheduled_alarms.remove(&alarm_type);
+            fired_types.push(alarm_type);
         }
 
         self.update_hardware_alarm()?;
@@ -333,6 +384,68 @@ impl<R: Rtc> AlarmManager<R> {
         }
 
         Ok(())
+    }
+}
+
+impl<R: Rtc + 'static> AlarmManager<R> {
+    /// Starts the owned IRQ listener thread once. Idempotent.
+    ///
+    /// `send` delivers each fired logical alarm to the hub. The join handle is
+    /// stored on this manager and joined on drop after the stop flag is set.
+    pub fn start_irq_listener(
+        manager: &Arc<Mutex<Self>>,
+        send: impl Fn(AlarmType) + Send + 'static,
+    ) {
+        let guard = manager.lock().unwrap_or_else(|e| e.into_inner());
+        if guard.irq_thread.is_some() {
+            return;
+        }
+
+        let stop = Arc::clone(&guard.stop);
+        let rtc = Arc::clone(&guard.rtc);
+        drop(guard);
+
+        let manager_for_thread = Arc::clone(manager);
+        let handle = thread::spawn(move || {
+            while !stop.load(Ordering::Relaxed) {
+                match rtc.wait_for_alarm_irq(Some(StdDuration::from_secs(1))) {
+                    Ok(Some(_)) => {
+                        let due = match manager_for_thread.lock() {
+                            Ok(mut locked) => locked.claim_due_alarms(),
+                            Err(poisoned) => poisoned.into_inner().claim_due_alarms(),
+                        };
+                        match due {
+                            Ok(alarm_types) => {
+                                for alarm_type in alarm_types {
+                                    send(alarm_type);
+                                }
+                            }
+                            Err(error) => {
+                                tracing::error!(error = %error, "claim_due_alarms failed");
+                            }
+                        }
+                    }
+                    Ok(None) => {
+                        tracing::warn!("RTC alarm wait returned with no IRQ data");
+                    }
+                    Err(error) => {
+                        tracing::error!(error = %error, "wait_for_alarm_irq failed");
+                        thread::sleep(StdDuration::from_secs(1));
+                    }
+                }
+            }
+        });
+
+        manager.lock().unwrap_or_else(|e| e.into_inner()).irq_thread = Some(handle);
+    }
+}
+
+impl<R: Rtc> Drop for AlarmManager<R> {
+    fn drop(&mut self) {
+        self.stop.store(true, Ordering::Relaxed);
+        if let Some(handle) = self.irq_thread.take() {
+            let _ = handle.join();
+        }
     }
 }
 
@@ -426,7 +539,7 @@ mod tests {
             .schedule_alarm(AlarmType::AutoPowerOff, Duration::minutes(5))
             .unwrap();
         rtc.simulate_alarm_fired();
-        let after = before + Duration::minutes(5);
+        let after = before + Duration::minutes(5) + Duration::seconds(1);
         let fired = manager.check_fired_alarms(before, after).unwrap();
         assert!(fired.contains(&AlarmType::AutoPowerOff));
     }
@@ -456,5 +569,117 @@ mod tests {
         let wake = rtc.scheduled_wake_time().unwrap();
         let expected = Utc::now() + Duration::minutes(30);
         assert!((wake - expected).num_seconds().abs() < 2);
+    }
+
+    #[test]
+    fn auto_suspend_can_be_earliest_alarm() {
+        let (rtc, mut manager) = test_alarm_manager();
+        manager
+            .schedule_alarm(AlarmType::AutoPowerOff, Duration::hours(2))
+            .unwrap();
+        manager
+            .schedule_alarm(AlarmType::AutoSuspend, Duration::minutes(10))
+            .unwrap();
+        let wake = rtc.scheduled_wake_time().unwrap();
+        let expected = Utc::now() + Duration::minutes(10);
+        assert!((wake - expected).num_seconds().abs() < 2);
+        assert!(manager.is_alarm_scheduled(AlarmType::AutoSuspend));
+    }
+
+    #[test]
+    fn auto_suspend_not_in_cancel_after_resume_list() {
+        assert!(
+            !AlarmType::alarms_to_cancel_after_resume()
+                .into_iter()
+                .any(|a| a == AlarmType::AutoSuspend)
+        );
+    }
+
+    #[test]
+    fn suspend_alarm_not_in_cancel_after_resume_list() {
+        assert!(
+            !AlarmType::alarms_to_cancel_after_resume()
+                .into_iter()
+                .any(|a| a == AlarmType::Suspend)
+        );
+    }
+
+    #[test]
+    fn wake_debounce_not_in_cancel_after_resume_list() {
+        assert!(
+            !AlarmType::alarms_to_cancel_after_resume()
+                .into_iter()
+                .any(|a| a == AlarmType::WakeDebounce)
+        );
+    }
+
+    #[test]
+    fn claim_due_alarms_returns_past_due_once() {
+        let (_rtc, mut manager) = test_alarm_manager();
+        manager
+            .schedule_alarm(AlarmType::AutoSuspend, Duration::seconds(-10))
+            .unwrap();
+        let first = manager.claim_due_alarms().unwrap();
+        assert_eq!(first, vec![AlarmType::AutoSuspend]);
+        let second = manager.claim_due_alarms().unwrap();
+        assert!(second.is_empty());
+        assert!(!manager.has_alarm(AlarmType::AutoSuspend));
+    }
+
+    #[test]
+    fn claim_due_alarms_ignores_near_future_wake() {
+        let (_rtc, mut manager) = test_alarm_manager();
+        manager
+            .schedule_alarm(AlarmType::AutoSuspend, Duration::seconds(2))
+            .unwrap();
+        let claimed = manager.claim_due_alarms().unwrap();
+        assert!(claimed.is_empty());
+        assert!(manager.is_alarm_scheduled(AlarmType::AutoSuspend));
+    }
+
+    #[test]
+    fn irq_listener_claims_past_due_on_simulated_irq() {
+        use std::sync::{Arc, Mutex};
+
+        let (rtc, manager) = test_alarm_manager();
+        let manager = Arc::new(Mutex::new(manager));
+        {
+            let mut locked = manager.lock().unwrap();
+            locked
+                .schedule_alarm(AlarmType::AutoSuspend, Duration::seconds(-10))
+                .unwrap();
+        }
+
+        let claimed = Arc::new(Mutex::new(Vec::new()));
+        let claimed_for_send = Arc::clone(&claimed);
+        AlarmManager::start_irq_listener(&manager, move |alarm_type| {
+            claimed_for_send.lock().unwrap().push(alarm_type);
+        });
+
+        std::thread::sleep(StdDuration::from_millis(50));
+        rtc.simulate_alarm_fired();
+
+        let deadline = std::time::Instant::now() + StdDuration::from_secs(3);
+        while claimed.lock().unwrap().is_empty() && std::time::Instant::now() < deadline {
+            std::thread::sleep(StdDuration::from_millis(50));
+        }
+
+        assert_eq!(*claimed.lock().unwrap(), vec![AlarmType::AutoSuspend]);
+        assert!(!manager.lock().unwrap().has_alarm(AlarmType::AutoSuspend));
+    }
+
+    #[test]
+    fn wait_for_alarm_irq_wakes_on_simulate() {
+        let (rtc, _manager) = test_alarm_manager();
+        let rtc_waiter = rtc.clone();
+        let handle = std::thread::spawn(move || {
+            rtc_waiter
+                .wait_for_alarm_irq(Some(StdDuration::from_secs(2)))
+                .unwrap()
+        });
+        std::thread::sleep(StdDuration::from_millis(50));
+        rtc.simulate_alarm_fired();
+        let data = handle.join().unwrap();
+        assert_eq!(data, Some(0x20));
     }
 }

--- a/crates/core/src/device/rtc/test.rs
+++ b/crates/core/src/device/rtc/test.rs
@@ -2,22 +2,27 @@
 
 use anyhow::Error;
 use chrono::{DateTime, Utc};
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Condvar, Mutex};
+use std::time::Duration;
 
 use super::manager::Rtc;
 use super::{RtcTime, RtcWkalrm};
+
+const RTC_AF: u32 = 0x20;
 
 #[derive(Debug)]
 struct TestRtcState {
     current_time: DateTime<Utc>,
     alarm_enabled: bool,
     alarm_wake_time: Option<DateTime<Utc>>,
+    irq_pending: bool,
 }
 
 /// Assertable RTC test double for unit tests.
 #[derive(Clone)]
 pub struct TestRtc {
     state: Arc<Mutex<TestRtcState>>,
+    cond: Arc<Condvar>,
 }
 
 impl TestRtc {
@@ -27,7 +32,9 @@ impl TestRtc {
                 current_time: Utc::now(),
                 alarm_enabled: false,
                 alarm_wake_time: None,
+                irq_pending: false,
             })),
+            cond: Arc::new(Condvar::new()),
         }
     }
 
@@ -42,12 +49,15 @@ impl TestRtc {
     pub fn simulate_alarm_fired(&self) {
         if let Ok(mut state) = self.state.lock() {
             state.alarm_enabled = false;
+            state.irq_pending = true;
+            self.cond.notify_all();
         }
     }
 
     pub fn set_current_time(&self, time: DateTime<Utc>) {
         if let Ok(mut state) = self.state.lock() {
             state.current_time = time;
+            self.cond.notify_all();
         }
     }
 }
@@ -82,6 +92,7 @@ impl Rtc for TestRtc {
             .map_err(|e| anyhow::anyhow!("lock poisoned: {}", e))?;
         state.alarm_enabled = true;
         state.alarm_wake_time = Some(wake_time);
+        self.cond.notify_all();
         Ok(0)
     }
 
@@ -91,6 +102,7 @@ impl Rtc for TestRtc {
             .lock()
             .map_err(|e| anyhow::anyhow!("lock poisoned: {}", e))?;
         state.alarm_enabled = false;
+        self.cond.notify_all();
         Ok(0)
     }
 
@@ -108,6 +120,39 @@ impl Rtc for TestRtc {
             .lock()
             .map_err(|e| anyhow::anyhow!("lock poisoned: {}", e))?;
         state.current_time = time;
+        self.cond.notify_all();
         Ok(())
+    }
+
+    fn wait_for_alarm_irq(&self, timeout: Option<Duration>) -> Result<Option<u32>, Error> {
+        let mut state = self
+            .state
+            .lock()
+            .map_err(|e| anyhow::anyhow!("lock poisoned: {}", e))?;
+        loop {
+            if state.irq_pending {
+                state.irq_pending = false;
+                return Ok(Some(RTC_AF));
+            }
+
+            match timeout {
+                Some(duration) => {
+                    let (guard, timed_out) = self
+                        .cond
+                        .wait_timeout(state, duration)
+                        .map_err(|e| anyhow::anyhow!("condvar wait poisoned: {}", e))?;
+                    state = guard;
+                    if timed_out.timed_out() && !state.irq_pending {
+                        return Ok(None);
+                    }
+                }
+                None => {
+                    state = self
+                        .cond
+                        .wait(state)
+                        .map_err(|e| anyhow::anyhow!("condvar wait poisoned: {}", e))?;
+                }
+            }
+        }
     }
 }

--- a/crates/core/src/view/intermission/mod.rs
+++ b/crates/core/src/view/intermission/mod.rs
@@ -57,7 +57,11 @@ impl Intermission {
                     let minutes_until_poweroff = context
                         .alarm_manager
                         .as_ref()
-                        .and_then(|am| am.time_until_alarm(AlarmType::AutoPowerOff))
+                        .and_then(|am| {
+                            am.lock()
+                                .ok()
+                                .and_then(|guard| guard.time_until_alarm(AlarmType::AutoPowerOff))
+                        })
                         .map(|secs| secs / 60);
                     let child = CalendarView::new(rect, minutes_until_poweroff, halt);
                     (Message::Calendar, vec![Box::new(child) as Box<dyn View>])

--- a/crates/core/src/view/mod.rs
+++ b/crates/core/src/view/mod.rs
@@ -497,9 +497,10 @@ pub enum Event {
     CheckBattery,
     /// Sets the WiFi operating mode (Off / AlwaysOn / Auto).
     SetWifiMode(crate::settings::WifiMode),
-    MightSuspend,
     /// Periodic check whether Auto-mode WiFi should power down after idle.
     MightDisableWifi,
+    /// An RTC logical alarm claimed by [`crate::device::rtc::AlarmManager`]'s IRQ listener.
+    RtcAlarmFired(crate::AlarmType),
     PrepareSuspend,
     Suspend,
     Share,

--- a/crates/core/src/view/settings_editor/kinds/general.rs
+++ b/crates/core/src/view/settings_editor/kinds/general.rs
@@ -147,6 +147,21 @@ impl SettingKind for AutoSuspend {
         }
     }
 
+    fn handle(
+        &self,
+        evt: &Event,
+        context: &mut AppContext,
+        _bus: &mut Bus,
+    ) -> (Option<String>, bool) {
+        if let Event::Submit(ViewId::AutoSuspendInput, text) = evt {
+            let display = self.apply_text(text, &mut context.settings);
+            context.reschedule_auto_suspend_alarm();
+            return (Some(display), true);
+        }
+
+        (None, false)
+    }
+
     fn as_input_kind(&self) -> Option<&dyn InputSettingKind> {
         Some(self)
     }
@@ -1077,6 +1092,76 @@ mod tests {
 
             assert_eq!(settings.auto_suspend, 30.0);
             assert_eq!(display, "30.0");
+        }
+
+        #[test]
+        fn handle_submit_reschedules_auto_suspend_alarm() {
+            use crate::AlarmType;
+
+            let setting = AutoSuspend;
+            let mut context = create_test_context();
+            context.settings.auto_suspend = 30.0;
+            context.reschedule_auto_suspend_alarm();
+            let first = context
+                .alarm_manager
+                .as_ref()
+                .unwrap()
+                .lock()
+                .unwrap()
+                .time_until_alarm(AlarmType::AutoSuspend)
+                .unwrap();
+            let mut bus: Bus = VecDeque::new();
+
+            std::thread::sleep(std::time::Duration::from_millis(20));
+            let (display, handled) = setting.handle(
+                &Event::Submit(ViewId::AutoSuspendInput, "15.0".to_string()),
+                &mut context,
+                &mut bus,
+            );
+
+            assert!(handled);
+            assert_eq!(display.as_deref(), Some("15.0"));
+            assert_eq!(context.settings.auto_suspend, 15.0);
+            let second = context
+                .alarm_manager
+                .as_ref()
+                .unwrap()
+                .lock()
+                .unwrap()
+                .time_until_alarm(AlarmType::AutoSuspend)
+                .unwrap();
+            assert!((second - 15 * 60).abs() < 2);
+            assert!(second < first);
+        }
+
+        #[test]
+        fn handle_submit_zero_cancels_auto_suspend_alarm() {
+            use crate::AlarmType;
+
+            let setting = AutoSuspend;
+            let mut context = create_test_context();
+            context.settings.auto_suspend = 30.0;
+            context.reschedule_auto_suspend_alarm();
+            let mut bus: Bus = VecDeque::new();
+
+            let (display, handled) = setting.handle(
+                &Event::Submit(ViewId::AutoSuspendInput, "0".to_string()),
+                &mut context,
+                &mut bus,
+            );
+
+            assert!(handled);
+            assert_eq!(display.as_deref(), Some("Never"));
+            assert_eq!(context.settings.auto_suspend, 0.0);
+            assert!(
+                !context
+                    .alarm_manager
+                    .as_ref()
+                    .unwrap()
+                    .lock()
+                    .unwrap()
+                    .has_alarm(AlarmType::AutoSuspend)
+            );
         }
     }
 

--- a/crates/core/src/view/settings_editor/setting_value.rs
+++ b/crates/core/src/view/settings_editor/setting_value.rs
@@ -274,6 +274,11 @@ impl View for SettingValue {
 
         if let (Some(display), handled) = self.kind.handle(evt, context, bus) {
             self.update(display, &context.settings, rq);
+            if let Event::Submit(submitted_id, _) = evt
+                && self.active_input == Some(*submitted_id)
+            {
+                self.active_input = None;
+            }
             if !self.kind.keep_menu_open() {
                 bus.push_back(Event::Close(ViewId::SettingsValueMenu));
             }
@@ -527,8 +532,23 @@ mod tests {
 
     #[test]
     fn test_auto_suspend_submit_updates_value() {
+        use crate::AlarmType;
+        use crate::view::{EntryId, ViewId};
+        use std::time::Duration;
+
         let mut context = create_test_context();
-        let settings = Settings::default();
+        context.settings.auto_suspend = 30.0;
+        context.reschedule_auto_suspend_alarm();
+        let first = context
+            .alarm_manager
+            .as_ref()
+            .unwrap()
+            .lock()
+            .unwrap()
+            .time_until_alarm(AlarmType::AutoSuspend)
+            .unwrap();
+
+        let settings = context.settings.clone();
         let rect = rect![0, 0, 200, 50];
 
         let mut value = SettingValue::new(
@@ -543,14 +563,93 @@ mod tests {
         let (hub, _receiver) = channel();
         let mut bus = VecDeque::new();
 
-        let update_event = Event::Settings(SettingsEvent::UpdateValue {
-            kind: SettingIdentity::AutoSuspend,
-            value: "15.0".to_string(),
-        });
-        value.handle_event(&update_event, &hub, &mut bus, &mut rq, &mut context);
+        value.handle_event(
+            &Event::Select(EntryId::EditAutoSuspend),
+            &hub,
+            &mut bus,
+            &mut rq,
+            &mut context,
+        );
+        std::thread::sleep(Duration::from_millis(20));
+        value.handle_event(
+            &Event::Submit(ViewId::AutoSuspendInput, "15.0".to_string()),
+            &hub,
+            &mut bus,
+            &mut rq,
+            &mut context,
+        );
 
+        assert_eq!(context.settings.auto_suspend, 15.0);
         assert_eq!(value.value(), "15.0");
-        assert!(!rq.is_empty());
+        let second = context
+            .alarm_manager
+            .as_ref()
+            .unwrap()
+            .lock()
+            .unwrap()
+            .time_until_alarm(AlarmType::AutoSuspend)
+            .unwrap();
+        assert!((second - 15 * 60).abs() < 2);
+        assert!(second < first);
+    }
+
+    #[test]
+    fn test_auto_suspend_submit_zero_cancels_alarm() {
+        use crate::AlarmType;
+        use crate::view::{EntryId, ViewId};
+
+        let mut context = create_test_context();
+        context.settings.auto_suspend = 30.0;
+        context.reschedule_auto_suspend_alarm();
+        assert!(
+            context
+                .alarm_manager
+                .as_ref()
+                .unwrap()
+                .lock()
+                .unwrap()
+                .has_alarm(AlarmType::AutoSuspend)
+        );
+
+        let settings = context.settings.clone();
+        let rect = rect![0, 0, 200, 50];
+        let mut value = SettingValue::new(
+            &AutoSuspend,
+            rect,
+            &settings,
+            &mut context.fonts,
+            context.device.dpi(),
+            &context.device.install_dir(),
+        );
+        let mut rq = RenderQueue::new();
+        let (hub, _receiver) = channel();
+        let mut bus = VecDeque::new();
+
+        value.handle_event(
+            &Event::Select(EntryId::EditAutoSuspend),
+            &hub,
+            &mut bus,
+            &mut rq,
+            &mut context,
+        );
+        value.handle_event(
+            &Event::Submit(ViewId::AutoSuspendInput, "0".to_string()),
+            &hub,
+            &mut bus,
+            &mut rq,
+            &mut context,
+        );
+
+        assert_eq!(context.settings.auto_suspend, 0.0);
+        assert!(
+            !context
+                .alarm_manager
+                .as_ref()
+                .unwrap()
+                .lock()
+                .unwrap()
+                .has_alarm(AlarmType::AutoSuspend)
+        );
     }
 
     #[test]


### PR DESCRIPTION
Replace Instant-based idle polling with AlarmType::AutoSuspend so soft sleep cannot erase the idle deadline. Clock tick drives MightSuspend checks.

Change-Id: 6a8d4b44e63062e28400cccf6de80fc2
Change-Id-Short: tprmvovvltwz

Ref: CAD-39
Ref: https://github.com/OGKevin/cadmus/issues/361

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches core suspend/power flows, RTC hardware and threading, and shared mutex state on the alarm manager—regressions could affect sleep, wake, or idle shutdown behavior.
> 
> **Overview**
> **Replaces monotonic idle tracking with wall-clock RTC alarms** so auto-suspend and suspend timing stay correct across soft sleep.
> 
> Auto Suspend no longer uses `inactive_since` plus a periodic `MightSuspend` poller. It arms `AlarmType::AutoSuspend` from the setting (minutes), reschedules on user activity and when returning from suspend, and starts suspend via `Event::RtcAlarmFired`. Sub-minute timeouts are clamped to at least one second.
> 
> **Suspend timing moves off `DeviceTaskId::Suspend` thread sleeps** onto `AlarmType::Suspend` (after PrepareSuspend) and `AlarmType::WakeDebounce` (brief wake before re-sleep). `AlarmManager` is shared behind `Arc<Mutex<…>>`, runs an IRQ listener on `Rtc::wait_for_alarm_irq`, and dispatches logical alarms as `RtcAlarmFired`. Linux RTC uses `poll` on a duplicated fd; the emulator gets a real `EmulatorRtc` instead of `NoopRtc`.
> 
> Lifecycle now tracks suspend with `suspend_cycle_active` and RTC presence (`is_suspend_rtc_pending`); cancel/resume paths clear competing alarms and re-arm Auto Suspend. Changing Auto Suspend in settings reschedules or cancels the alarm immediately.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a9b153063365e832038d651e356baec0d4ab8964. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->