### PR TITLE
chore(review): catch stale and missing docs in reviews

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -35,11 +35,28 @@ reviews:
       requirements: It should follow https://www.conventionalcommits.org/en/v1.0.0/
     description:
       mode: "off"
+    custom_checks:
+      - name: Docs freshness
+        mode: warning
+        instructions: >
+          Apply Documentation freshness in REVIEW.md (and nested REVIEW.md
+          files). Warn when docs are stale, or when a new user/contributor-facing
+          feature lacks matching docs/src coverage (and SUMMARY/POT where
+          required), unless the PR justifies skipping.
   tools:
     github-checks:
       timeout_ms: 900000
 chat: {}
-knowledge_base: {}
+knowledge_base:
+  code_guidelines:
+    enabled: true
+    filePatterns:
+      - files: "REVIEW.md"
+        applyTo: "**/*"
+      - files: "crates/core/REVIEW.md"
+        applyTo: "crates/core/**,crates/cadmus/**,contrib/Settings-sample.toml"
+      - files: "docs/REVIEW.md"
+        applyTo: "docs/**,devenv.nix"
 code_generation: {}
 issue_enrichment:
   planning:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -269,6 +269,9 @@ After code changes, complete every step before considering work done:
    compile `cadmus-core`)
 4. Kobo ARM build — `build-kobo` skill (**required**; host builds can pass while
    ARM fails)
+5. Documentation freshness — if the change updates or introduces
+   user/contributor-facing behavior, follow [`REVIEW.md`](REVIEW.md) (update or
+   add `docs/src` pages, or justify why not)
 
 After modifying `Cargo.toml`, run the full verification sequence above.
 

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -1,5 +1,37 @@
 # Cadmus — Review Checklists
 
+## Documentation freshness
+
+When a PR changes or introduces user-facing or contributor-facing behavior,
+docs under `docs/src/` must stay accurate. Docs-area detail (POT, devenv,
+formatting) lives in [`docs/REVIEW.md`](docs/REVIEW.md). Crate-local review
+pointers live in nested `REVIEW.md` files.
+
+### Update existing docs
+
+When a change alters already-documented behavior, update the matching pages
+under `docs/src/`.
+
+### Add new docs
+
+When a PR introduces a new user-facing or contributor-facing surface (feature,
+workflow, setting category, install path, CLI/dev command, subsystem):
+
+- **User-facing** — add or extend page(s) under `docs/src/**` outside
+  `contributing/`, list them in `docs/src/SUMMARY.md`, and run POT sync per
+  [`docs/REVIEW.md`](docs/REVIEW.md).
+- **Contributor/dev** — add or extend page(s) under `docs/src/contributing/**`
+  (and `SUMMARY.md`); follow tone in [`docs/AGENTS.md`](docs/AGENTS.md).
+- Prefer extending an existing page when the change is a small addition to an
+  existing topic. Add a new page when it is a distinct workflow users or
+  contributors must discover.
+
+### Skip only with justification
+
+Internal-only refactors, invisible bug fixes, or pure test/CI churn with no
+user or contributor surface may skip docs updates. Silence is not a
+justification — say why in the PR.
+
 ## DeepWiki Configuration (`.devin/wiki.json`)
 
 Review `wiki.json` when a change introduces or removes a **significant system,

--- a/crates/core/REVIEW.md
+++ b/crates/core/REVIEW.md
@@ -1,37 +1,14 @@
 # Core Crate — Review Checklists
 
-## Event System Documentation
+## Documentation
 
-When `crates/cadmus/src/app.rs` changes, check that
-`docs/src/contributing/event-system.md` still matches.
+Follow the Documentation freshness section in [`REVIEW.md`](../../REVIEW.md).
 
-### Checklist
-
-- [ ] New event types in the main loop match statement are documented.
-- [ ] `Event::Close(id)` handling still matches docs (uses `locate_by_id()`?
-      top-level children only?).
-- [ ] Hub (`tx.send()`) vs Bus (`bus.push_back()`) patterns are accurate.
-- [ ] View lifecycle changes (creation, removal, transitions) are reflected.
-- [ ] Mermaid diagrams match the current flow (use `<br/>` for line breaks in
-      node labels).
-- [ ] Code examples in docs match actual implementation.
-
-## Settings Documentation
-
-All locations must stay in sync:
-
-- `contrib/Settings-sample.toml`
-- `crates/core/src/settings/*`
-- `docs/src/settings/*`
-- [ ] If settings structures, fields, or defaults changed, do the docs match?
-
-## OTA Documentation
-
-The OTA view (`crates/core/src/view/ota.rs`) lets users download and install
-builds on device. Main/PR builds require GitHub device-flow authentication;
-stable releases are public.
-
-- [ ] If `ota.rs` changed, do the user-facing docs still match?
+When reviewing changes in this crate (and related app wiring), check that
+`docs/src/` still describes the user-facing and contributor-facing behavior
+accurately — update existing pages, add pages for new surfaces, or justify
+skipping. Keep related samples and docs (for example settings) consistent with
+the code.
 
 ## User-Facing String Translations
 

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -46,12 +46,8 @@ Audience: developers and contributors. Technical terminology is appropriate.
 
 ## devenv.nix Documentation Sync
 
-When modifying `devenv.nix`, update `docs/src/contributing/devenv-setup.md`:
-
-- **Available Commands** table — if scripts in `scripts = { ... }` change.
-- **Platform Support** — if `isLinux`/`isDarwin` conditionals change.
-- **Observability Stack** — if services/ports change.
-- **Troubleshooting** — for known platform-specific issues.
+When modifying `devenv.nix`, update docs per the devenv section in
+[`docs/REVIEW.md`](REVIEW.md).
 
 ## Formatting
 

--- a/docs/REVIEW.md
+++ b/docs/REVIEW.md
@@ -2,18 +2,27 @@
 
 ## Translations POT Sync
 
-When any English doc source (`docs/src/**/*.md`) is modified, the POT file must
-be regenerated.
+When any English doc source (`docs/src/**/*.md`) is modified — including **new**
+user-facing pages — the POT file must be regenerated. New user-facing pages must
+also appear in `docs/src/SUMMARY.md`.
 
 ### Checklist
 
+- [ ] New user-facing pages are listed in `docs/src/SUMMARY.md`.
 - [ ] `docs/po/messages.pot` is updated in the same commit or PR.
 - [ ] New or changed English strings appear in `messages.pot`.
 - [ ] Removed strings are no longer present in `messages.pot`.
 
 ## devenv.nix Sync
 
-When `devenv.nix` changes, verify `docs/src/contributing/devenv-setup.md`:
+When `devenv.nix` changes, update `docs/src/contributing/devenv-setup.md`:
+
+- **Available Commands** table — if scripts in `scripts = { ... }` change.
+- **Platform Support** — if `isLinux`/`isDarwin` conditionals change.
+- **Observability Stack** — if services/ports change.
+- **Troubleshooting** — for known platform-specific issues.
+
+### Checklist
 
 - [ ] New scripts documented in "Available Commands" table.
 - [ ] Platform limitations documented in "Platform Support" section.
@@ -22,5 +31,6 @@ When `devenv.nix` changes, verify `docs/src/contributing/devenv-setup.md`:
 
 ## Formatting
 
-- [ ] Markdown formatted with Prettier.
-- [ ] Markdown passes rumdl (`.rumdl.toml`).
+- [ ] Markdown formatted and linted with rumdl via treefmt (`.rumdl.toml`).
+- [ ] Docs markdown stays excluded from Prettier (`.prettierignore`) so i18n
+      list nesting is preserved.


### PR DESCRIPTION
Make REVIEW.md the docs-freshness source of truth and wire CodeRabbit applyTo plus a warning check so Cursor and PR reviews flag outdated or absent user/contributor docs.

Change-Id: 22c447701a9dd8ac49c571c86609ff5d
Change-Id-Short: xxnvvsszypqm

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Process and review-configuration only; no runtime, auth, or application code changes.
> 
> **Overview**
> Establishes **documentation freshness** as a shared review rule and wires it into **CodeRabbit** and agent workflows.
> 
> Root [`REVIEW.md`](REVIEW.md) now defines when to update `docs/src`, add pages (including `SUMMARY.md` / POT for user-facing content), or skip with an explicit PR justification. [`AGENTS.md`](AGENTS.md) adds a fifth post-change verification step pointing at that checklist.
> 
> [`.coderabbit.yaml`](.coderabbit.yaml) adds a **Docs freshness** pre-merge warning check and enables `knowledge_base.code_guidelines` so `REVIEW.md`, `crates/core/REVIEW.md`, and `docs/REVIEW.md` apply to the right path globs during reviews.
> 
> Nested review docs are consolidated: [`crates/core/REVIEW.md`](crates/core/REVIEW.md) drops duplicate event/settings/OTA doc checklists in favor of the root policy; [`docs/REVIEW.md`](docs/REVIEW.md) absorbs devenv sync bullets and clarifies POT/SUMMARY and rumdl formatting; [`docs/AGENTS.md`](docs/AGENTS.md) defers devenv doc updates to `docs/REVIEW.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0e9e3f5a4cfdcd9789e491014b619f6c713d00cc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->