### PR TITLE
fix(power): RTC wake-debounce after deep idle

### DIFF
--- a/crates/core/AGENTS.md
+++ b/crates/core/AGENTS.md
@@ -1,5 +1,20 @@
 # Core Crate — Agent Coding Conventions
 
+## Return Types
+
+Prefer meaningful enums or `Result<T, E>` over `bool` when a function can
+succeed in more than one way or fail for distinct reasons (for example a sysfs
+write that was applied, skipped because the path is missing, or failed with
+I/O). Leave logging and recovery policy to the caller.
+
+```rust
+// ✅ Good — caller decides how to treat Missing vs Io
+fn write_sysfs(path: &Path, value: &str) -> Result<SysfsWrite, SysfsWriteError>;
+
+// ❌ Bad — bool collapses distinct outcomes; logging is buried in the helper
+fn write_sysfs(path: &Path, value: &str) -> bool;
+```
+
 ## View Instrumentation
 
 All `handle_event` and `render` methods in view components must have

--- a/crates/core/i18n/en-GB/cadmus_core.ftl
+++ b/crates/core/i18n/en-GB/cadmus_core.ftl
@@ -100,7 +100,12 @@ settings-power-auto-power-off = Auto Power Off (days)
 settings-power-auto-power-off-input = Auto Power Off (days, 0 = never)
 settings-power-auto-suspend = Auto Suspend (minutes)
 settings-power-auto-suspend-input = Auto Suspend (minutes, 0 = never)
+settings-power-autosleep-mode = Soft Suspend
+settings-power-autosleep-mode-freeze = Freeze
+settings-power-autosleep-mode-mem = Memory
+settings-power-autosleep-mode-off = Off
 settings-power-enable-sleep-cover = Enable Sleep Cover
+settings-power-indicate-autosleep-led = Use LED to Indicate Soft Suspend
 
 # Settings - Startup Mode
 settings-startup-mode-home = Home

--- a/crates/core/src/context.rs
+++ b/crates/core/src/context.rs
@@ -67,6 +67,10 @@ pub struct Context<D: Device> {
     pub suspend_cycle_active: bool,
     pub wifi_session: std::sync::Arc<crate::device::wifi::WifiSession>,
     pub soft_suspend_session: std::sync::Arc<crate::device::soft_suspend::SoftSuspendSession>,
+    /// Named lease held for the whole deep-idle PrepareSuspend → Suspend cycle.
+    pub soft_suspend_cycle_lease: Option<crate::device::soft_suspend::SoftSuspendLease>,
+    /// Autosleep mode to restore after a deep-idle Mem force.
+    pub soft_suspend_deep_idle_restore: Option<crate::device::soft_suspend::AutosleepMode>,
 }
 
 impl<D: Device> Context<D> {
@@ -136,6 +140,8 @@ impl<D: Device> Context<D> {
             suspend_cycle_active: false,
             wifi_session,
             soft_suspend_session,
+            soft_suspend_cycle_lease: None,
+            soft_suspend_deep_idle_restore: None,
         }
     }
 

--- a/crates/core/src/context.rs
+++ b/crates/core/src/context.rs
@@ -66,6 +66,7 @@ pub struct Context<D: Device> {
     pub online: bool,
     pub suspend_cycle_active: bool,
     pub wifi_session: std::sync::Arc<crate::device::wifi::WifiSession>,
+    pub soft_suspend_session: std::sync::Arc<crate::device::soft_suspend::SoftSuspendSession>,
 }
 
 impl<D: Device> Context<D> {
@@ -106,6 +107,14 @@ impl<D: Device> Context<D> {
                 WifiSession::unavailable(wifi_mode)
             }
         };
+        let leds = match device.leds() {
+            Ok(leds) => Some(leds as std::sync::Arc<dyn crate::device::leds::DeviceLeds>),
+            Err(e) => {
+                tracing::warn!(error = %e, "LED controller unavailable");
+                None
+            }
+        };
+        let soft_suspend_session = crate::device::soft_suspend::SoftSuspendSession::new(leds);
         Context {
             device,
             alarm_manager,
@@ -126,6 +135,7 @@ impl<D: Device> Context<D> {
             online: false,
             suspend_cycle_active: false,
             wifi_session,
+            soft_suspend_session,
         }
     }
 

--- a/crates/core/src/device/emulator/leds.rs
+++ b/crates/core/src/device/emulator/leds.rs
@@ -1,0 +1,13 @@
+use crate::device::leds::{DeviceLeds, LedsError};
+
+pub struct EmulatorLeds;
+
+impl DeviceLeds for EmulatorLeds {
+    fn on(&self) -> Result<(), LedsError> {
+        Ok(())
+    }
+
+    fn off(&self) -> Result<(), LedsError> {
+        Ok(())
+    }
+}

--- a/crates/core/src/device/emulator/mod.rs
+++ b/crates/core/src/device/emulator/mod.rs
@@ -4,6 +4,7 @@
 //! reports [`DEFAULT_ROTATION`] and rotation APIs are no-ops. This avoids
 //! inconsistent state until faithful framebuffer and input tracking exists.
 
+mod leds;
 mod power;
 mod rtc;
 mod usb;
@@ -399,6 +400,7 @@ pub struct EmulatorDevice {
     wifi_manager: Arc<crate::device::emulator::wifi::EmulatorWifiManager>,
     usb_manager: Arc<crate::device::emulator::usb::EmulatorUsbManager>,
     power_manager: Arc<crate::device::emulator::power::EmulatorPowerManager>,
+    leds: Arc<crate::device::emulator::leds::EmulatorLeds>,
     rtc: Arc<EmulatorRtc>,
     time_manager: crate::time_manager::TimeManager<EmulatorRtc>,
     input: EmulatorInputSource,
@@ -436,6 +438,7 @@ impl EmulatorDevice {
             wifi_manager: Arc::new(crate::device::emulator::wifi::EmulatorWifiManager),
             usb_manager: Arc::new(crate::device::emulator::usb::EmulatorUsbManager),
             power_manager: Arc::new(crate::device::emulator::power::EmulatorPowerManager),
+            leds: Arc::new(crate::device::emulator::leds::EmulatorLeds),
             rtc,
             time_manager,
             input: EmulatorInputSource::new(dpi),
@@ -508,6 +511,7 @@ crate::impl_device_hardware!(
     WifiManager = crate::device::emulator::wifi::EmulatorWifiManager,
     UsbManager = crate::device::emulator::usb::EmulatorUsbManager,
     PowerManager = crate::device::emulator::power::EmulatorPowerManager,
+    Leds = crate::device::emulator::leds::EmulatorLeds,
     Rtc = crate::device::emulator::rtc::EmulatorRtc,
 );
 

--- a/crates/core/src/device/forward.rs
+++ b/crates/core/src/device/forward.rs
@@ -120,6 +120,7 @@ macro_rules! forward_device_rotation {
 ///     WifiManager = TestWifiManager,
 ///     UsbManager = TestUsbManager,
 ///     PowerManager = TestPowerManager,
+///     Leds = TestLeds,
 ///     Rtc = TestRtc,
 ///     override metadata_from metadata,
 /// );
@@ -197,6 +198,12 @@ macro_rules! impl_device_hardware {
                 &self,
             ) -> Result<std::sync::Arc<Self::PowerManager>, $crate::device::power::PowerError> {
                 Ok(self.power_manager.clone())
+            }
+
+            fn leds(
+                &self,
+            ) -> Result<std::sync::Arc<Self::Leds>, $crate::device::leds::LedsError> {
+                Ok(self.leds.clone())
             }
 
             fn rtc(&self) -> Result<std::sync::Arc<Self::Rtc>, anyhow::Error> {

--- a/crates/core/src/device/kobo/device.rs
+++ b/crates/core/src/device/kobo/device.rs
@@ -36,6 +36,7 @@ pub struct Device {
     wifi_manager: std::sync::Arc<crate::device::kobo::wifi::KoboWifiManager>,
     usb_manager: std::sync::Arc<crate::device::kobo::usb::KoboUsbManager>,
     power_manager: std::sync::Arc<crate::device::kobo::power::KoboPowerManager>,
+    leds: std::sync::Arc<crate::device::kobo::leds::KoboLeds>,
     rtc: std::sync::Arc<LinuxRtc>,
     time_manager: crate::time_manager::TimeManager<LinuxRtc>,
     input: InputSource,
@@ -68,6 +69,7 @@ impl Device {
         wifi_manager: std::sync::Arc<crate::device::kobo::wifi::KoboWifiManager>,
         usb_manager: std::sync::Arc<crate::device::kobo::usb::KoboUsbManager>,
         power_manager: std::sync::Arc<crate::device::kobo::power::KoboPowerManager>,
+        leds: std::sync::Arc<crate::device::kobo::leds::KoboLeds>,
         rtc: std::sync::Arc<LinuxRtc>,
         time_manager: crate::time_manager::TimeManager<LinuxRtc>,
         boot_transformed_rotation: i8,
@@ -83,6 +85,7 @@ impl Device {
             wifi_manager,
             usb_manager,
             power_manager,
+            leds,
             rtc,
             time_manager,
             input,
@@ -162,6 +165,7 @@ crate::impl_device_hardware!(
     WifiManager = crate::device::kobo::wifi::KoboWifiManager,
     UsbManager = crate::device::kobo::usb::KoboUsbManager,
     PowerManager = crate::device::kobo::power::KoboPowerManager,
+    Leds = crate::device::kobo::leds::KoboLeds,
     Rtc = LinuxRtc;
     override
         metadata_from metadata,

--- a/crates/core/src/device/kobo/factory.rs
+++ b/crates/core/src/device/kobo/factory.rs
@@ -91,6 +91,7 @@ impl Model {
         );
         let power_manager =
             std::sync::Arc::new(crate::device::kobo::power::KoboPowerManager::new(self));
+        let leds = std::sync::Arc::new(crate::device::kobo::leds::KoboLeds::for_model(self));
         let rtc =
             std::sync::Arc::new(LinuxRtc::new(RTC_DEVICE).context("failed to initialize RTC")?);
         let time_manager = crate::time_manager::TimeManager::new(rtc.clone(), |tz| {
@@ -107,6 +108,7 @@ impl Model {
             wifi_manager,
             usb_manager,
             power_manager,
+            leds,
             rtc,
             time_manager,
             initial_rotation,

--- a/crates/core/src/device/kobo/leds.rs
+++ b/crates/core/src/device/kobo/leds.rs
@@ -1,0 +1,156 @@
+//! Kobo status LED via sysfs brightness.
+//!
+//! Turns the LED on or off by writing `"1"` or `"0"` to a model-resolved
+//! brightness path under `/sys/class/leds/`. [`KoboLeds::for_model`] asks
+//! [`super::Model::led_brightness_path`]: known models (for example Libra
+//! Colour) return a hardcoded path; others probe
+//! [`LED_BRIGHTNESS_CANDIDATES`] and info-log the hit so new hardcodes can be
+//! crowd-sourced from device logs. If no path is found, writes target the
+//! default `LED` node and are skipped when that path is missing.
+
+use crate::device::kobo::Model;
+use crate::device::leds::{DeviceLeds, LedsError};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+/// Default brightness path used when discovery finds nothing (graceful no-op).
+pub(super) const LED_BRIGHTNESS_PATH: &str = "/sys/class/leds/LED/brightness";
+
+/// Known standard-LED brightness nodes, same order as `contrib/cadmus.sh`.
+pub(super) const LED_BRIGHTNESS_CANDIDATES: &[&str] = &[
+    LED_BRIGHTNESS_PATH,
+    "/sys/class/leds/GLED/brightness",
+    "/sys/class/leds/bd71828-green-led/brightness",
+];
+
+/// Returns the first candidate path that exists on the filesystem.
+pub(super) fn discover_led_brightness_path(candidates: &[&str]) -> Option<PathBuf> {
+    candidates
+        .iter()
+        .map(Path::new)
+        .find(|path| path.exists())
+        .map(Path::to_path_buf)
+}
+
+/// Kobo status LED controller writing a resolved sysfs brightness path.
+pub struct KoboLeds {
+    brightness_path: PathBuf,
+}
+
+impl KoboLeds {
+    /// Creates a controller for `model` using [`Model::led_brightness_path`].
+    ///
+    /// Falls back to [`LED_BRIGHTNESS_PATH`] when no path is known or
+    /// discovered so missing-path writes stay graceful.
+    pub fn for_model(model: Model) -> Self {
+        let path = model
+            .led_brightness_path()
+            .unwrap_or_else(|| PathBuf::from(LED_BRIGHTNESS_PATH));
+        Self::with_path(path)
+    }
+
+    /// Creates a controller targeting the default Kobo LED brightness path.
+    pub fn new() -> Self {
+        Self {
+            brightness_path: PathBuf::from(LED_BRIGHTNESS_PATH),
+        }
+    }
+
+    /// Creates a controller targeting `brightness_path` (used by unit tests).
+    pub fn with_path(brightness_path: impl Into<PathBuf>) -> Self {
+        Self {
+            brightness_path: brightness_path.into(),
+        }
+    }
+
+    fn write_brightness(&self, value: &str) -> Result<(), LedsError> {
+        let path = self.brightness_path.as_path();
+        if !Path::new(path).exists() {
+            tracing::warn!(path = %path.display(), "LED brightness path missing");
+            return Ok(());
+        }
+
+        tracing::debug!(path = %path.display(), value, "Writing LED brightness");
+        fs::write(path, value).map_err(|e| {
+            tracing::error!(error = %e, path = %path.display(), "Failed to write LED brightness");
+            LedsError::Io(e)
+        })
+    }
+}
+
+impl Default for KoboLeds {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl DeviceLeds for KoboLeds {
+    fn on(&self) -> Result<(), LedsError> {
+        self.write_brightness("1")
+    }
+
+    fn off(&self) -> Result<(), LedsError> {
+        self.write_brightness("0")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn on_writes_one() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("brightness");
+        fs::write(&path, "0").expect("seed");
+        let leds = KoboLeds::with_path(&path);
+
+        leds.on().expect("on");
+
+        assert_eq!(fs::read_to_string(&path).expect("read").trim(), "1");
+    }
+
+    #[test]
+    fn off_writes_zero() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("brightness");
+        fs::write(&path, "1").expect("seed");
+        let leds = KoboLeds::with_path(&path);
+
+        leds.off().expect("off");
+
+        assert_eq!(fs::read_to_string(&path).expect("read").trim(), "0");
+    }
+
+    #[test]
+    fn missing_path_is_graceful() {
+        let leds = KoboLeds::with_path("/nonexistent/leds/LED/brightness");
+
+        assert!(leds.on().is_ok());
+        assert!(leds.off().is_ok());
+    }
+
+    #[test]
+    fn discover_returns_first_existing_candidate() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let gled = dir.path().join("GLED");
+        fs::create_dir_all(&gled).expect("mkdir");
+        let brightness = gled.join("brightness");
+        fs::write(&brightness, "0").expect("seed");
+
+        let missing = dir.path().join("LED/brightness");
+        let candidates = [missing.to_str().unwrap(), brightness.to_str().unwrap()];
+
+        assert_eq!(discover_led_brightness_path(&candidates), Some(brightness));
+    }
+
+    #[test]
+    fn discover_returns_none_when_empty() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let a = dir.path().join("LED/brightness");
+        let b = dir.path().join("GLED/brightness");
+        let candidates = [a.to_str().unwrap(), b.to_str().unwrap()];
+
+        assert_eq!(discover_led_brightness_path(&candidates), None);
+    }
+}

--- a/crates/core/src/device/kobo/lifecycle/device_events.rs
+++ b/crates/core/src/device/kobo/lifecycle/device_events.rs
@@ -378,6 +378,9 @@ mod tests {
 
     #[test]
     fn handle_rotate_screen_blocked_during_suspend() {
+        use crate::AlarmType;
+        use crate::chrono::Duration as ChronoDuration;
+
         let mut harness = LifecycleHarness::new();
         {
             let mut alarms = harness
@@ -388,10 +391,7 @@ mod tests {
                 .lock()
                 .unwrap();
             alarms
-                .schedule_alarm(
-                    crate::AlarmType::Suspend,
-                    crate::chrono::Duration::seconds(15),
-                )
+                .schedule_alarm(AlarmType::Suspend, ChronoDuration::seconds(15))
                 .unwrap();
         }
         let hub = harness.hub_tx.clone();

--- a/crates/core/src/device/kobo/lifecycle/mod.rs
+++ b/crates/core/src/device/kobo/lifecycle/mod.rs
@@ -36,8 +36,23 @@ use std::sync::mpsc::{self, Sender};
 use std::thread;
 use std::time::Duration;
 
+/// Delay before [`Event::PrepareSuspend`] on the classic hard-suspend path.
+///
+/// Gives the suspend intermission time to paint and a short window to cancel
+/// before teardown. Soft deep idle skips this and schedules prepare immediately.
 pub(super) const PREPARE_SUSPEND_WAIT_DELAY: Duration = Duration::from_secs(3);
+
+/// Delay for [`crate::AlarmType::Suspend`] after prepare and for
+/// [`crate::AlarmType::WakeDebounce`] after leave-sleep.
+///
+/// Window where Power Released / long-hold can abort before enter-sleep or
+/// before re-entering suspend after a wake.
 pub(super) const SUSPEND_WAIT_DELAY: Duration = Duration::from_secs(15);
+
+/// Onboard path where a Nickel/OTA `KoboRoot.tgz` appears after USB mass storage.
+///
+/// After USB share ends, presence of this file triggers reboot instead of a
+/// plain app restart so the firmware update can apply.
 pub(super) const KOBO_UPDATE_BUNDLE: &str = "/mnt/onboard/.kobo/KoboRoot.tgz";
 
 /// Schedules a delayed [`Event`] and tracks it in `tasks`.
@@ -169,6 +184,9 @@ pub(super) fn restore_boot_rotation_if_needed(context: &mut AppContext) {
 /// [`Event::PrepareSuspend`] immediately (no [`PREPARE_SUSPEND_WAIT_DELAY`]).
 /// When soft suspend is off, schedules PrepareSuspend after
 /// [`PREPARE_SUSPEND_WAIT_DELAY`] for the classic path.
+///
+/// Reuses an existing suspend [`Intermission`] when re-entering from wake
+/// debounce so the sleep screen is not stacked.
 fn begin_suspend(
     context: &mut AppContext,
     view: &mut dyn View,
@@ -181,16 +199,22 @@ fn begin_suspend(
     suspend::cancel_suspend_rtcs(context);
     context.suspend_cycle_active = true;
     view.handle_event(&Event::Suspend, hub, bus, rq, context);
-    let interm = Intermission::new(
-        context.device.framebuffer().rect(),
-        crate::settings::IntermKind::Suspend,
-        context,
-    );
-    rq.add(RenderData::new(
-        interm.id(),
-        *interm.rect(),
-        UpdateMode::Full,
-    ));
+    if let Some(index) = locate::<Intermission>(view) {
+        let child = view.child(index);
+        rq.add(RenderData::new(child.id(), *child.rect(), UpdateMode::Full));
+    } else {
+        let interm = Intermission::new(
+            context.device.framebuffer().rect(),
+            crate::settings::IntermKind::Suspend,
+            context,
+        );
+        rq.add(RenderData::new(
+            interm.id(),
+            *interm.rect(),
+            UpdateMode::Full,
+        ));
+        view.children_mut().push(Box::new(interm));
+    }
     let prepare_delay = if suspend::arm_deep_idle_cycle(context) {
         Duration::ZERO
     } else {
@@ -203,7 +227,6 @@ fn begin_suspend(
         hub,
         tasks,
     );
-    view.children_mut().push(Box::new(interm));
 }
 
 /// Tears down the view stack and renders the power-off intermission.

--- a/crates/core/src/device/kobo/lifecycle/mod.rs
+++ b/crates/core/src/device/kobo/lifecycle/mod.rs
@@ -66,9 +66,9 @@ fn schedule_device_task(
 
 /// Ends an in-progress suspend cycle and returns to interactive use.
 ///
-/// Drops PrepareSuspend task channels, restores frontlight and wifi-at-rest,
-/// cancels post-resume alarms, re-arms AutoSuspend, and removes the suspend
-/// intermission.
+/// Drops PrepareSuspend task channels, leaves deep idle, restores frontlight and
+/// wifi-at-rest, cancels post-resume alarms, re-arms AutoSuspend, and removes the
+/// suspend intermission.
 pub(super) fn finish_suspend_cycle(
     context: &mut AppContext,
     tasks: &mut Vec<DeviceTask>,
@@ -77,6 +77,7 @@ pub(super) fn finish_suspend_cycle(
     rq: &mut crate::view::RenderQueue,
 ) {
     tasks.retain(|task| task.id != DeviceTaskId::PrepareSuspend);
+    suspend::leave_deep_idle_if_needed(context);
     context.set_frontlight(context.settings.frontlight);
     if context.settings.wifi.wants_radio_at_rest() {
         let session = context.wifi_session.clone();
@@ -114,9 +115,9 @@ pub(super) fn finish_suspend_cycle(
 
 /// Aborts an in-progress PrepareSuspend and restores UI without full resume.
 ///
-/// Drops the prepare task and clears the intermission, then re-arms AutoSuspend
-/// so aborting during prepare does not leave idle tracking disabled. Full cycle
-/// cancels after Suspend RTC arming use [`finish_suspend_cycle`].
+/// Drops the prepare task and deep-idle lease, clears the intermission, then
+/// re-arms AutoSuspend so aborting during prepare does not leave idle tracking
+/// disabled. Full cycle cancels after Suspend RTC arming use [`finish_suspend_cycle`].
 fn cancel_suspend(
     context: &mut AppContext,
     id: DeviceTaskId,
@@ -130,6 +131,7 @@ fn cancel_suspend(
     }
 
     tasks.retain(|task| task.id != DeviceTaskId::PrepareSuspend);
+    suspend::leave_deep_idle_if_needed(context);
     if let Some(index) = locate::<Intermission>(view) {
         let rect = *view.child(index).rect();
         view.children_mut().remove(index);
@@ -161,9 +163,12 @@ pub(super) fn restore_boot_rotation_if_needed(context: &mut AppContext) {
 /// [`crate::AlarmType::WakeDebounce`] so idle / arming / wake-debounce RTCs do
 /// not compete with AutoPowerOff / Calendar during the suspend cycle. Suspends
 /// the current view and shows the suspend intermission immediately, so the
-/// device already appears asleep to the user. A [`DeviceTaskId::PrepareSuspend`]
-/// task is scheduled to send [`Event::PrepareSuspend`] after
-/// [`PREPARE_SUSPEND_WAIT_DELAY`].
+/// device already appears asleep to the user.
+///
+/// When soft suspend is armed, acquires a `deep-idle` cycle lease and schedules
+/// [`Event::PrepareSuspend`] immediately (no [`PREPARE_SUSPEND_WAIT_DELAY`]).
+/// When soft suspend is off, schedules PrepareSuspend after
+/// [`PREPARE_SUSPEND_WAIT_DELAY`] for the classic path.
 fn begin_suspend(
     context: &mut AppContext,
     view: &mut dyn View,
@@ -186,10 +191,15 @@ fn begin_suspend(
         *interm.rect(),
         UpdateMode::Full,
     ));
+    let prepare_delay = if suspend::arm_deep_idle_cycle(context) {
+        Duration::ZERO
+    } else {
+        PREPARE_SUSPEND_WAIT_DELAY
+    };
     schedule_device_task(
         DeviceTaskId::PrepareSuspend,
         Event::PrepareSuspend,
-        PREPARE_SUSPEND_WAIT_DELAY,
+        prepare_delay,
         hub,
         tasks,
     );

--- a/crates/core/src/device/kobo/lifecycle/power.rs
+++ b/crates/core/src/device/kobo/lifecycle/power.rs
@@ -134,4 +134,116 @@ mod tests {
         assert_eq!(outcome, EventOutcome::Handled);
         assert!(has_task(&harness.tasks, DeviceTaskId::PrepareSuspend));
     }
+
+    #[test]
+    fn hold_button_long_power_cancels_pending_suspend_rtc() {
+        use crate::AlarmType;
+        use crate::chrono::Duration as ChronoDuration;
+
+        let mut harness = LifecycleHarness::new();
+        {
+            let mut alarms = harness
+                .context
+                .alarm_manager
+                .as_ref()
+                .unwrap()
+                .lock()
+                .unwrap();
+            alarms
+                .schedule_alarm(AlarmType::Suspend, ChronoDuration::seconds(15))
+                .unwrap();
+        }
+        let outcome = harness.with_parts(|hub, bus, rq, context, runtime| {
+            handle_event(
+                &Event::Gesture(GestureEvent::HoldButtonLong(ButtonCode::Power)),
+                hub,
+                bus,
+                rq,
+                context,
+                runtime,
+            )
+        });
+        assert_eq!(outcome, EventOutcome::Handled);
+        let alarms = harness
+            .context
+            .alarm_manager
+            .as_ref()
+            .unwrap()
+            .lock()
+            .unwrap();
+        assert!(!alarms.has_alarm(AlarmType::Suspend));
+    }
+
+    #[test]
+    fn hold_button_long_power_cancels_wake_debounce() {
+        use crate::AlarmType;
+        use crate::chrono::Duration as ChronoDuration;
+
+        let mut harness = LifecycleHarness::new();
+        {
+            let mut alarms = harness
+                .context
+                .alarm_manager
+                .as_ref()
+                .unwrap()
+                .lock()
+                .unwrap();
+            alarms
+                .schedule_alarm(AlarmType::WakeDebounce, ChronoDuration::seconds(15))
+                .unwrap();
+        }
+        let outcome = harness.with_parts(|hub, bus, rq, context, runtime| {
+            handle_event(
+                &Event::Gesture(GestureEvent::HoldButtonLong(ButtonCode::Power)),
+                hub,
+                bus,
+                rq,
+                context,
+                runtime,
+            )
+        });
+        assert_eq!(outcome, EventOutcome::Handled);
+        let alarms = harness
+            .context
+            .alarm_manager
+            .as_ref()
+            .unwrap()
+            .lock()
+            .unwrap();
+        assert!(!alarms.has_alarm(AlarmType::WakeDebounce));
+    }
+
+    #[test]
+    fn hold_button_long_power_cancels_pending_prepare_suspend() {
+        let mut harness = LifecycleHarness::new();
+        harness.push_task(DeviceTaskId::PrepareSuspend);
+        let outcome = harness.with_parts(|hub, bus, rq, context, runtime| {
+            handle_event(
+                &Event::Gesture(GestureEvent::HoldButtonLong(ButtonCode::Power)),
+                hub,
+                bus,
+                rq,
+                context,
+                runtime,
+            )
+        });
+        assert_eq!(outcome, EventOutcome::Handled);
+        assert!(!has_task(&harness.tasks, DeviceTaskId::PrepareSuspend));
+    }
+
+    #[test]
+    fn hold_button_long_power_exits_when_no_suspend_pending() {
+        let mut harness = LifecycleHarness::new();
+        let outcome = harness.with_parts(|hub, bus, rq, context, runtime| {
+            handle_event(
+                &Event::Gesture(GestureEvent::HoldButtonLong(ButtonCode::Power)),
+                hub,
+                bus,
+                rq,
+                context,
+                runtime,
+            )
+        });
+        assert_eq!(outcome, EventOutcome::Exit(ExitStatus::PowerOff));
+    }
 }

--- a/crates/core/src/device/kobo/lifecycle/suspend.rs
+++ b/crates/core/src/device/kobo/lifecycle/suspend.rs
@@ -205,7 +205,7 @@ pub(super) fn handle_event(
     runtime: &mut DeviceRuntime<'_>,
 ) -> EventOutcome {
     match event {
-        Event::PrepareSuspend => handle_prepare_suspend(hub, rq, context, runtime),
+        Event::PrepareSuspend => handle_prepare_suspend(hub, bus, rq, context, runtime),
         Event::Suspend => handle_suspend(hub, bus, rq, context, runtime),
         Event::RtcAlarmFired(alarm_type) => {
             handle_rtc_alarm_fired(*alarm_type, hub, bus, rq, context, runtime)
@@ -324,11 +324,13 @@ fn refresh_calendar_intermission(
 /// Handles [`Event::PrepareSuspend`]: persists state and schedules full suspend.
 ///
 /// Clears the prepare task, saves settings, turns off frontlight and WiFi,
-/// then schedules Suspend RTC. Soft deep-idle uses no
-/// [`super::SUSPEND_WAIT_DELAY`]; classic hard suspend keeps the delay.
+/// then enters sleep: soft deep idle calls [`handle_suspend`] immediately;
+/// classic hard suspend schedules [`AlarmType::Suspend`] for
+/// [`super::SUSPEND_WAIT_DELAY`].
 fn handle_prepare_suspend(
-    _hub: &Hub,
-    _rq: &mut RenderQueue,
+    hub: &Hub,
+    bus: &mut crate::view::Bus,
+    rq: &mut RenderQueue,
     context: &mut AppContext,
     runtime: &mut DeviceRuntime<'_>,
 ) -> EventOutcome {
@@ -355,13 +357,10 @@ fn handle_prepare_suspend(
         }
         context.online = false;
     }
-    let suspend_delay = if deep_idle_cycle_active(context) {
-        Duration::ZERO
-    } else {
-        SUSPEND_WAIT_DELAY
-    };
-    schedule_suspend_alarm(context, suspend_delay);
-
+    if deep_idle_cycle_active(context) {
+        return handle_suspend(hub, bus, rq, context, runtime);
+    }
+    schedule_suspend_alarm(context, SUSPEND_WAIT_DELAY);
     EventOutcome::Handled
 }
 
@@ -385,22 +384,24 @@ fn handle_suspend(
         let (before, after, wait_outcome) = perform_deep_idle_suspend_resume(context);
         if matches!(wait_outcome, DeepIdleWaitOutcome::TimedOut) {
             tracing::warn!("deep idle ended by timeout; returning to interactive");
-        }
-        let outcome = handle_post_wake(before, after, hub, bus, rq, context, runtime);
-        if matches!(outcome, EventOutcome::Exit(_)) {
+            let outcome = handle_post_wake(before, after, hub, bus, rq, context, runtime);
+            if matches!(outcome, EventOutcome::Exit(_)) {
+                return outcome;
+            }
+            super::finish_suspend_cycle(context, runtime.tasks, runtime.view.as_mut(), hub, rq);
             return outcome;
         }
-        if deep_idle_cycle_active(context) {
-            return outcome;
-        }
-        super::finish_suspend_cycle(context, runtime.tasks, runtime.view.as_mut(), hub, rq);
-        return outcome;
+        runtime
+            .tasks
+            .retain(|task| task.id != DeviceTaskId::PrepareSuspend);
+        schedule_wake_debounce_alarm(context);
+        return handle_post_wake(before, after, hub, bus, rq, context, runtime);
     }
 
     if context.soft_suspend_session.mode().is_armed() {
         let before = Local::now();
-        tracing::error!(
-            "refusing classic suspend while soft-suspend is armed without a deep-idle cycle lease"
+        tracing::debug!(
+            "soft-suspend armed without cycle lease; staying interactive (wake debounce or refused classic suspend)"
         );
         log_soft_suspend_holders(context, "classic suspend refused while soft-suspend armed");
         let after = Local::now();
@@ -487,8 +488,9 @@ fn schedule_alarms_before_sleep(
 /// arms vendor deep-idle prep, drops the lease so autosleep can sleep, and waits
 /// for wake. On wake, restores autosleep mode and disarms `state-extended` (same
 /// role as classic [`PowerManager::resume`]) before the caller runs post-wake
-/// work. Does not re-queue Suspend; the caller finishes the suspend cycle and
-/// returns to interactive use.
+/// work. The caller schedules [`AlarmType::WakeDebounce`] while keeping the
+/// suspend intermission; a wake Power Released finishes the cycle, or the RTC
+/// fires and lifecycle calls [`begin_suspend`] to re-enter.
 fn perform_deep_idle_suspend_resume(
     context: &mut AppContext,
 ) -> (
@@ -679,6 +681,7 @@ mod tests {
     use crate::device::rtc::AlarmManager;
     use crate::frontlight::{Frontlight, LightLevel};
     use crate::settings::IntermissionDisplay;
+    use crate::view::common::locate;
     use std::time::Duration;
 
     fn lock_alarms(
@@ -691,6 +694,13 @@ mod tests {
             .unwrap()
             .lock()
             .unwrap()
+    }
+
+    fn intermission_count(view: &dyn crate::view::View) -> usize {
+        view.children()
+            .iter()
+            .filter(|child| child.as_ref().is::<Intermission>())
+            .count()
     }
 
     #[test]
@@ -782,15 +792,34 @@ mod tests {
     #[test]
     fn perform_suspend_resume_schedules_wake_debounce() {
         let mut harness = LifecycleHarness::new();
+        harness.with_parts(|hub, bus, rq, context, runtime| {
+            begin_suspend(context, runtime.view.as_mut(), hub, bus, rq, runtime.tasks);
+        });
+        harness
+            .tasks
+            .retain(|task| task.id != DeviceTaskId::PrepareSuspend);
+        assert_eq!(intermission_count(harness.view.as_ref()), 1);
         let (_before, _after) = harness.with_parts(|hub, _bus, _rq, context, runtime| {
             perform_suspend_resume(hub, context, runtime)
         });
         assert!(lock_alarms(&mut harness).is_alarm_scheduled(AlarmType::WakeDebounce));
+        assert_eq!(intermission_count(harness.view.as_ref()), 1);
         let power = harness.context.device.power_manager_for_test();
         assert!(power.was_suspend_called());
         assert!(power.was_resume_called());
         assert_eq!(power.suspend_call_count(), 1);
         assert_eq!(power.resume_call_count(), 1);
+
+        harness.context.settings.auto_suspend = 30.0;
+        cancel_suspend_if_pending(
+            &mut harness.context,
+            &mut harness.tasks,
+            harness.view.as_mut(),
+            &harness.hub_tx,
+            &mut harness.rq,
+        );
+        assert!(locate::<Intermission>(harness.view.as_ref()).is_none());
+        assert!(lock_alarms(&mut harness).is_alarm_scheduled(AlarmType::AutoSuspend));
     }
 
     #[test]
@@ -1155,7 +1184,7 @@ mod tests {
     }
 
     #[test]
-    fn soft_prepare_suspend_keeps_holders_and_schedules_suspend() {
+    fn soft_prepare_suspend_enters_deep_idle() {
         let mut harness = LifecycleHarness::new();
         let (_dir, _paths) = install_armed_soft_suspend(&mut harness);
         harness.with_parts(|hub, bus, rq, context, runtime| {
@@ -1165,9 +1194,10 @@ mod tests {
             handle_event(&Event::PrepareSuspend, hub, bus, rq, context, runtime)
         });
         assert_eq!(outcome, EventOutcome::Handled);
-        assert!(harness.context.soft_suspend_cycle_lease.is_some());
-        assert!(harness.context.soft_suspend_session.has_holders());
-        assert!(lock_alarms(&mut harness).has_alarm(AlarmType::Suspend));
+        assert!(harness.context.soft_suspend_cycle_lease.is_none());
+        assert!(!harness.context.soft_suspend_session.has_holders());
+        assert!(lock_alarms(&mut harness).is_alarm_scheduled(AlarmType::WakeDebounce));
+        assert!(!lock_alarms(&mut harness).has_alarm(AlarmType::Suspend));
     }
 
     #[test]
@@ -1210,12 +1240,14 @@ mod tests {
         assert!(harness.context.soft_suspend_cycle_lease.is_none());
         assert!(!lock_alarms(&mut harness).has_alarm(AlarmType::Suspend));
         assert!(!has_task(&harness.tasks, DeviceTaskId::PrepareSuspend));
+        assert!(lock_alarms(&mut harness).is_alarm_scheduled(AlarmType::WakeDebounce));
         let autosleep = fs::read_to_string(&paths.autosleep).expect("autosleep");
         assert!(autosleep.trim() == "freeze" || autosleep.trim() == "Freeze");
+        assert_eq!(intermission_count(harness.view.as_ref()), 1);
     }
 
     #[test]
-    fn soft_deep_idle_exits_cycle_without_requeue() {
+    fn soft_deep_idle_schedules_wake_debounce_alarm() {
         use crate::device::soft_suspend::AutosleepMode;
 
         let mut harness = LifecycleHarness::new();
@@ -1228,19 +1260,20 @@ mod tests {
             handle_event(&Event::PrepareSuspend, hub, bus, rq, context, runtime)
         });
         assert_eq!(outcome, EventOutcome::Handled);
-        assert!(lock_alarms(&mut harness).has_alarm(AlarmType::Suspend));
-
-        let outcome = harness.with_parts(|hub, bus, rq, context, runtime| {
-            handle_event(&Event::Suspend, hub, bus, rq, context, runtime)
-        });
-        assert_eq!(outcome, EventOutcome::Handled);
         assert!(harness.context.soft_suspend_cycle_lease.is_none());
-        assert!(!lock_alarms(&mut harness).has_alarm(AlarmType::Suspend));
+        assert!(
+            !lock_alarms(&mut harness).has_alarm(AlarmType::Suspend),
+            "deep-idle prepare enters sleep immediately; no Suspend RTC"
+        );
+        assert!(lock_alarms(&mut harness).is_alarm_scheduled(AlarmType::WakeDebounce));
         assert_eq!(
             harness.context.soft_suspend_session.mode(),
             AutosleepMode::Freeze
         );
-        assert!(lock_alarms(&mut harness).is_alarm_scheduled(AlarmType::AutoSuspend));
+        assert!(
+            !lock_alarms(&mut harness).is_alarm_scheduled(AlarmType::AutoSuspend),
+            "AutoSuspend stays cancelled until valid-wake finish_suspend_cycle"
+        );
         assert!(
             !harness
                 .context
@@ -1248,6 +1281,86 @@ mod tests {
                 .power_manager_for_test()
                 .was_suspend_called()
         );
+        assert_eq!(intermission_count(harness.view.as_ref()), 1);
+        assert!(locate::<Intermission>(harness.view.as_ref()).is_some());
+    }
+
+    #[test]
+    fn soft_deep_idle_power_release_cancels_wake_debounce() {
+        use crate::device::DeviceLifecycle as _;
+        use crate::device::kobo::Device;
+        use crate::input::{ButtonCode, ButtonStatus, DeviceEvent};
+
+        let mut harness = LifecycleHarness::new();
+        let (_dir, _paths) = install_armed_soft_suspend(&mut harness);
+        harness.context.settings.auto_suspend = 30.0;
+        harness.with_parts(|hub, bus, rq, context, runtime| {
+            begin_suspend(context, runtime.view.as_mut(), hub, bus, rq, runtime.tasks);
+        });
+        harness.with_parts(|hub, bus, rq, context, runtime| {
+            handle_event(&Event::PrepareSuspend, hub, bus, rq, context, runtime)
+        });
+        assert!(lock_alarms(&mut harness).is_alarm_scheduled(AlarmType::WakeDebounce));
+        assert!(harness.context.soft_suspend_cycle_lease.is_none());
+        assert_eq!(intermission_count(harness.view.as_ref()), 1);
+
+        let wake_release = Event::Device(DeviceEvent::Button {
+            code: ButtonCode::Power,
+            status: ButtonStatus::Released,
+            time: 0.0,
+        });
+        let outcome = harness.with_parts(|hub, bus, rq, context, runtime| {
+            Device::handle_event(&wake_release, hub, bus, rq, context, runtime)
+        });
+        assert_eq!(outcome, EventOutcome::Handled);
+        assert!(!lock_alarms(&mut harness).has_alarm(AlarmType::WakeDebounce));
+        assert!(!has_task(&harness.tasks, DeviceTaskId::PrepareSuspend));
+        assert!(harness.context.soft_suspend_cycle_lease.is_none());
+        assert!(locate::<Intermission>(harness.view.as_ref()).is_none());
+        assert!(lock_alarms(&mut harness).is_alarm_scheduled(AlarmType::AutoSuspend));
+
+        let intentional = Event::Device(DeviceEvent::Button {
+            code: ButtonCode::Power,
+            status: ButtonStatus::Released,
+            time: 1.0,
+        });
+        let outcome = harness.with_parts(|hub, bus, rq, context, runtime| {
+            Device::handle_event(&intentional, hub, bus, rq, context, runtime)
+        });
+        assert_eq!(outcome, EventOutcome::Handled);
+        assert!(has_task(&harness.tasks, DeviceTaskId::PrepareSuspend));
+        assert!(harness.context.soft_suspend_cycle_lease.is_some());
+    }
+
+    #[test]
+    fn soft_deep_idle_wake_debounce_fired_begins_suspend() {
+        let mut harness = LifecycleHarness::new();
+        let (_dir, _paths) = install_armed_soft_suspend(&mut harness);
+        harness.context.settings.auto_suspend = 30.0;
+        harness.with_parts(|hub, bus, rq, context, runtime| {
+            begin_suspend(context, runtime.view.as_mut(), hub, bus, rq, runtime.tasks);
+        });
+        harness.with_parts(|hub, bus, rq, context, runtime| {
+            handle_event(&Event::PrepareSuspend, hub, bus, rq, context, runtime)
+        });
+        assert!(lock_alarms(&mut harness).is_alarm_scheduled(AlarmType::WakeDebounce));
+        assert_eq!(intermission_count(harness.view.as_ref()), 1);
+
+        let outcome = harness.with_parts(|hub, bus, rq, context, runtime| {
+            handle_event(
+                &Event::RtcAlarmFired(AlarmType::WakeDebounce),
+                hub,
+                bus,
+                rq,
+                context,
+                runtime,
+            )
+        });
+        assert_eq!(outcome, EventOutcome::Handled);
+        assert!(has_task(&harness.tasks, DeviceTaskId::PrepareSuspend));
+        assert!(harness.context.soft_suspend_cycle_lease.is_some());
+        assert!(!lock_alarms(&mut harness).has_alarm(AlarmType::WakeDebounce));
+        assert_eq!(intermission_count(harness.view.as_ref()), 1);
     }
 
     #[test]

--- a/crates/core/src/device/kobo/lifecycle/suspend.rs
+++ b/crates/core/src/device/kobo/lifecycle/suspend.rs
@@ -8,6 +8,16 @@
 //! which starts [`begin_suspend`]. Monotonic idle (`Instant::elapsed`) is not
 //! authoritative: soft sleep does not advance it, so the wall-clock RTC
 //! deadline is the idle source of truth.
+//!
+//! # Deep idle vs opportunistic soft nap
+//!
+//! Soft suspend **freeze** (or settings `mem`) is the light opportunistic nap
+//! between UI events while Cadmus holds named leases. **Deep idle** is the
+//! Auto Suspend / power-button / sleep-cover path once soft suspend is armed:
+//! force autosleep to [`AutosleepMode::Mem`], arm Kobo `state-extended`, drop
+//! the cycle wake lock, and let autosleep sleep — no userspace `/sys/power/state`
+//! write. Classic hard suspend (`power.suspend()` with delays) remains when
+//! soft suspend mode is [`AutosleepMode::Off`].
 
 use super::helpers::is_suspend_active;
 use super::{SUSPEND_WAIT_DELAY, begin_suspend, show_power_off_intermission};
@@ -16,6 +26,7 @@ use crate::chrono::{Duration as ChronoDuration, Local, Timelike};
 use crate::device::DeviceHardware as _;
 use crate::device::power::PowerManager;
 use crate::device::rtc::{EnsureAlarmOutcome, PastDueAction};
+use crate::device::soft_suspend::AutosleepMode;
 use crate::device::{AppContext, DeviceRuntime, DeviceTaskId, EventOutcome, ExitStatus};
 use crate::framebuffer::Framebuffer as _;
 use crate::frontlight::Frontlight as _;
@@ -23,6 +34,53 @@ use crate::settings::IntermKind;
 use crate::view::common::locate;
 use crate::view::intermission::Intermission;
 use crate::view::{Event, Hub, RenderData, RenderQueue, View, wait_for_all};
+use std::thread;
+use std::time::Duration;
+#[cfg(not(test))]
+use std::time::Instant;
+#[cfg(not(test))]
+use std::time::SystemTime;
+
+const DEEP_IDLE_CYCLE_LEASE: &str = "deep-idle";
+
+/// Acquires the deep-idle cycle lease when soft suspend is armed.
+///
+/// Returns `true` when the soft deep-idle path is active (caller should skip
+/// PrepareSuspend / Suspend delays). The lease keeps autosleep from freezing
+/// during PrepareSuspend teardown and Suspend handling.
+pub(super) fn arm_deep_idle_cycle(context: &mut AppContext) -> bool {
+    if !context.soft_suspend_session.mode().is_armed() {
+        return false;
+    }
+    if context.soft_suspend_cycle_lease.is_none() {
+        context.soft_suspend_cycle_lease =
+            Some(context.soft_suspend_session.acquire(DEEP_IDLE_CYCLE_LEASE));
+    }
+    true
+}
+
+/// Returns whether a deep-idle cycle lease is currently held.
+pub(super) fn deep_idle_cycle_active(context: &AppContext) -> bool {
+    context.soft_suspend_cycle_lease.is_some()
+}
+
+/// Drops the cycle lease, clears `state-extended`, and restores autosleep mode.
+pub(super) fn leave_deep_idle_if_needed(context: &mut AppContext) {
+    context.soft_suspend_cycle_lease = None;
+    if let Some(restore) = context.soft_suspend_deep_idle_restore.take() {
+        context.soft_suspend_session.set_mode(restore);
+    }
+    match context.device.power_manager() {
+        Ok(power) => {
+            if let Err(error) = power.disarm_deep_idle() {
+                tracing::error!(error = %error, "Failed to disarm deep idle");
+            }
+        }
+        Err(error) => {
+            tracing::error!(error = %error, "power_manager() failed while leaving deep idle");
+        }
+    }
+}
 
 /// Converts Auto Power Off days to a chrono duration of at least one second.
 fn auto_power_off_chrono_duration(days: f32) -> ChronoDuration {
@@ -212,8 +270,9 @@ fn handle_auto_suspend_fired(
 /// Re-enters sleep when [`AlarmType::WakeDebounce`] fires after a brief wake.
 ///
 /// Clears the fired alarm first (IRQ claim already removed it in production;
-/// synthetic test events may not). Reuses the existing intermission via
-/// [`handle_suspend`] instead of stacking another [`begin_suspend`].
+/// synthetic test events may not). Soft-suspend re-arms via [`begin_suspend`] so
+/// a new cycle lease is acquired before deep idle. Classic hard suspend reuses
+/// the existing intermission via [`handle_suspend`] (no stacked PrepareSuspend).
 fn handle_wake_debounce_fired(
     hub: &Hub,
     bus: &mut crate::view::Bus,
@@ -225,6 +284,12 @@ fn handle_wake_debounce_fired(
     if context.shared {
         return EventOutcome::Handled;
     }
+
+    if context.soft_suspend_session.mode().is_armed() {
+        begin_suspend(context, runtime.view.as_mut(), hub, bus, rq, runtime.tasks);
+        return EventOutcome::Handled;
+    }
+
     handle_suspend(hub, bus, rq, context, runtime)
 }
 
@@ -259,7 +324,8 @@ fn refresh_calendar_intermission(
 /// Handles [`Event::PrepareSuspend`]: persists state and schedules full suspend.
 ///
 /// Clears the prepare task, saves settings, turns off frontlight and WiFi,
-/// then schedules [`Event::Suspend`] after [`super::SUSPEND_WAIT_DELAY`].
+/// then schedules Suspend RTC. Soft deep-idle uses no
+/// [`super::SUSPEND_WAIT_DELAY`]; classic hard suspend keeps the delay.
 fn handle_prepare_suspend(
     _hub: &Hub,
     _rq: &mut RenderQueue,
@@ -289,7 +355,12 @@ fn handle_prepare_suspend(
         }
         context.online = false;
     }
-    schedule_suspend_alarm(context, SUSPEND_WAIT_DELAY);
+    let suspend_delay = if deep_idle_cycle_active(context) {
+        Duration::ZERO
+    } else {
+        SUSPEND_WAIT_DELAY
+    };
+    schedule_suspend_alarm(context, suspend_delay);
 
     EventOutcome::Handled
 }
@@ -297,7 +368,7 @@ fn handle_prepare_suspend(
 /// Handles [`Event::Suspend`]: schedules alarms, sleeps, and processes wake events.
 ///
 /// A late [`AlarmType::Suspend`] after user cancel has no intermission; treat that
-/// as stale and skip hardware sleep.
+/// as stale and skip hardware sleep (and do not arm sleep-only alarms).
 fn handle_suspend(
     hub: &Hub,
     bus: &mut crate::view::Bus,
@@ -306,6 +377,41 @@ fn handle_suspend(
     runtime: &mut DeviceRuntime<'_>,
 ) -> EventOutcome {
     cancel_suspend_alarm(context);
+
+    if deep_idle_cycle_active(context) {
+        if let Some(outcome) = schedule_alarms_before_sleep(context, runtime) {
+            return outcome;
+        }
+        let (before, after, wait_outcome) = perform_deep_idle_suspend_resume(context);
+        if matches!(wait_outcome, DeepIdleWaitOutcome::TimedOut) {
+            tracing::warn!("deep idle ended by timeout; returning to interactive");
+        }
+        let outcome = handle_post_wake(before, after, hub, bus, rq, context, runtime);
+        if matches!(outcome, EventOutcome::Exit(_)) {
+            return outcome;
+        }
+        if deep_idle_cycle_active(context) {
+            return outcome;
+        }
+        super::finish_suspend_cycle(context, runtime.tasks, runtime.view.as_mut(), hub, rq);
+        return outcome;
+    }
+
+    if context.soft_suspend_session.mode().is_armed() {
+        let before = Local::now();
+        tracing::error!(
+            "refusing classic suspend while soft-suspend is armed without a deep-idle cycle lease"
+        );
+        log_soft_suspend_holders(context, "classic suspend refused while soft-suspend armed");
+        let after = Local::now();
+        let outcome = handle_post_wake(before, after, hub, bus, rq, context, runtime);
+        if matches!(outcome, EventOutcome::Exit(_)) {
+            return outcome;
+        }
+        super::finish_suspend_cycle(context, runtime.tasks, runtime.view.as_mut(), hub, rq);
+        return outcome;
+    }
+
     if locate::<Intermission>(runtime.view.as_ref()).is_none() {
         return EventOutcome::Handled;
     }
@@ -375,6 +481,111 @@ fn schedule_alarms_before_sleep(
     None
 }
 
+/// Soft-suspend deep idle: Mem autosleep + `state-extended`, no `state=mem` write.
+///
+/// Holds the cycle lease through prep, forces autosleep to [`AutosleepMode::Mem`],
+/// arms vendor deep-idle prep, drops the lease so autosleep can sleep, and waits
+/// for wake. On wake, restores autosleep mode and disarms `state-extended` (same
+/// role as classic [`PowerManager::resume`]) before the caller runs post-wake
+/// work. Does not re-queue Suspend; the caller finishes the suspend cycle and
+/// returns to interactive use.
+fn perform_deep_idle_suspend_resume(
+    context: &mut AppContext,
+) -> (
+    chrono::DateTime<Local>,
+    chrono::DateTime<Local>,
+    DeepIdleWaitOutcome,
+) {
+    let before = Local::now();
+    tracing::info!(
+        "{}",
+        before.format("Entered deep idle on %B %-d, %Y at %H:%M:%S.")
+    );
+
+    let restore_mode = context.soft_suspend_session.mode();
+    context.soft_suspend_deep_idle_restore = Some(restore_mode);
+    context.soft_suspend_session.set_mode(AutosleepMode::Mem);
+
+    match context.device.power_manager() {
+        Ok(power) => {
+            if let Err(error) = power.arm_deep_idle() {
+                tracing::error!(error = %error, "Failed to arm deep idle");
+            }
+        }
+        Err(error) => {
+            tracing::error!(error = %error, "power_manager() failed arming deep idle");
+        }
+    }
+
+    nix::unistd::sync();
+    context.soft_suspend_cycle_lease = None;
+    log_soft_suspend_holders(context, "deep idle enter wait");
+    let wait_outcome = wait_for_autosleep_wake(context);
+
+    let after = Local::now();
+    tracing::info!(
+        "{}",
+        after.format("Left deep idle on %B %-d, %Y at %H:%M:%S.")
+    );
+    leave_deep_idle_if_needed(context);
+
+    (before, after, wait_outcome)
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum DeepIdleWaitOutcome {
+    Woke,
+    /// Produced only on device builds (`cfg(not(test))`).
+    #[cfg_attr(test, allow(dead_code))]
+    TimedOut,
+}
+
+/// Blocks until kernel autosleep has suspended and resumed, or until timeout.
+///
+/// Compares wall clock to monotonic time: during suspend wall advances while
+/// monotonic does not. Unit tests skip the wait (no real autosleep).
+fn wait_for_autosleep_wake(context: &AppContext) -> DeepIdleWaitOutcome {
+    #[cfg(test)]
+    {
+        let _ = context;
+        thread::sleep(Duration::from_millis(1));
+        DeepIdleWaitOutcome::Woke
+    }
+
+    #[cfg(not(test))]
+    {
+        let wall0 = SystemTime::now();
+        let mono0 = Instant::now();
+        loop {
+            thread::sleep(Duration::from_millis(100));
+            let wall = wall0.elapsed().unwrap_or_default();
+            let mono = mono0.elapsed();
+            if wall > mono + Duration::from_secs(1) {
+                return DeepIdleWaitOutcome::Woke;
+            }
+            if mono > Duration::from_secs(30) {
+                tracing::warn!("deep idle wait timed out without detecting suspend");
+                log_soft_suspend_holders(context, "deep idle wait timeout");
+                return DeepIdleWaitOutcome::TimedOut;
+            }
+        }
+    }
+}
+
+fn log_soft_suspend_holders(context: &AppContext, at: &str) {
+    let holders = context.soft_suspend_session.holders();
+    let holder_names: Vec<&str> = holders.iter().map(|h| h.as_str()).collect();
+    tracing::debug!(
+        at,
+        holders = holders.len(),
+        holder_names = ?holder_names,
+        mode = %context.soft_suspend_session.mode(),
+        grace_secs = context.soft_suspend_session.autosleep_grace().as_secs_f32(),
+        cycle_lease_held = context.soft_suspend_cycle_lease.is_some(),
+        "soft-suspend lease snapshot"
+    );
+}
+
 /// Suspends and resumes the device, then schedules wake-debounce RTC.
 fn perform_suspend_resume(
     hub: &Hub,
@@ -390,6 +601,7 @@ fn perform_suspend_resume(
         Ok(power) => {
             if let Err(error) = power.suspend() {
                 tracing::error!(error = %error, "Failed to suspend device");
+                log_soft_suspend_holders(context, "classic suspend failed");
             }
         }
         Err(error) => {
@@ -811,6 +1023,8 @@ mod tests {
     fn stale_suspend_rtc_after_cancel_skips_hardware_sleep() {
         let mut harness = LifecycleHarness::new();
         harness.context.settings.auto_suspend = 30.0;
+        harness.context.settings.auto_power_off = 1.0;
+        harness.context.settings.intermissions[IntermKind::Suspend] = IntermissionDisplay::Calendar;
         harness.with_parts(|hub, bus, rq, context, runtime| {
             begin_suspend(context, runtime.view.as_mut(), hub, bus, rq, runtime.tasks);
         });
@@ -839,5 +1053,251 @@ mod tests {
         );
         assert!(lock_alarms(&mut harness).is_alarm_scheduled(AlarmType::AutoSuspend));
         assert!(!lock_alarms(&mut harness).has_alarm(AlarmType::Suspend));
+        assert!(
+            !lock_alarms(&mut harness).has_alarm(AlarmType::AutoPowerOff),
+            "stale Suspend must not arm AutoPowerOff without sleeping"
+        );
+        assert!(
+            !lock_alarms(&mut harness).has_alarm(AlarmType::CalendarUpdate),
+            "stale Suspend must not arm CalendarUpdate without sleeping"
+        );
+    }
+
+    #[test]
+    fn finish_suspend_cycle_clears_auto_power_off_before_post_wake_can_see_it() {
+        let mut harness = LifecycleHarness::new();
+        harness.with_parts(|hub, bus, rq, context, runtime| {
+            begin_suspend(context, runtime.view.as_mut(), hub, bus, rq, runtime.tasks);
+        });
+        let before = Local::now() - ChronoDuration::minutes(10);
+        {
+            lock_alarms(&mut harness)
+                .schedule_alarm(AlarmType::AutoPowerOff, ChronoDuration::minutes(-5))
+                .unwrap();
+            if let Ok(rtc) = harness.context.device.rtc() {
+                rtc.simulate_alarm_fired();
+            }
+        }
+        harness.with_parts(|hub, _bus, rq, context, runtime| {
+            super::super::finish_suspend_cycle(
+                context,
+                runtime.tasks,
+                runtime.view.as_mut(),
+                hub,
+                rq,
+            );
+        });
+        assert!(!lock_alarms(&mut harness).has_alarm(AlarmType::AutoPowerOff));
+        let after = Local::now();
+        let outcome = harness.with_parts(|hub, bus, rq, context, runtime| {
+            handle_post_wake(before, after, hub, bus, rq, context, runtime)
+        });
+        assert_eq!(
+            outcome,
+            EventOutcome::Handled,
+            "finish_suspend_cycle cancels AutoPowerOff; post-wake must run first on deep idle"
+        );
+    }
+
+    fn install_armed_soft_suspend(
+        harness: &mut LifecycleHarness,
+    ) -> (
+        tempfile::TempDir,
+        crate::device::soft_suspend::SoftSuspendPaths,
+    ) {
+        use crate::device::soft_suspend::{AutosleepMode, SoftSuspendPaths, SoftSuspendSession};
+        use std::fs;
+        use std::sync::Arc;
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let paths = SoftSuspendPaths {
+            state: dir.path().join("state"),
+            autosleep: dir.path().join("autosleep"),
+            wake_lock: dir.path().join("wake_lock"),
+            wake_unlock: dir.path().join("wake_unlock"),
+        };
+        fs::write(&paths.state, "freeze mem\n").expect("state");
+        fs::write(&paths.autosleep, "off\n").expect("autosleep");
+        fs::write(&paths.wake_lock, "").expect("wake_lock");
+        fs::write(&paths.wake_unlock, "").expect("wake_unlock");
+        let session = SoftSuspendSession::with_paths(paths.clone(), None);
+        session.set_mode(AutosleepMode::Freeze);
+        harness.context.soft_suspend_session = Arc::clone(&session);
+        (dir, paths)
+    }
+
+    #[test]
+    fn classic_prepare_suspend_still_schedules_with_suspend_rtc() {
+        let mut harness = LifecycleHarness::new();
+        assert!(!harness.context.soft_suspend_session.mode().is_armed());
+        harness.with_parts(|hub, bus, rq, context, runtime| {
+            begin_suspend(context, runtime.view.as_mut(), hub, bus, rq, runtime.tasks);
+        });
+        assert!(harness.context.soft_suspend_cycle_lease.is_none());
+        assert!(has_task(&harness.tasks, DeviceTaskId::PrepareSuspend));
+        let outcome = harness.with_parts(|hub, bus, rq, context, runtime| {
+            handle_event(&Event::PrepareSuspend, hub, bus, rq, context, runtime)
+        });
+        assert_eq!(outcome, EventOutcome::Handled);
+        assert!(lock_alarms(&mut harness).is_alarm_scheduled(AlarmType::Suspend));
+    }
+
+    #[test]
+    fn soft_begin_suspend_acquires_cycle_lease() {
+        let mut harness = LifecycleHarness::new();
+        let (_dir, _paths) = install_armed_soft_suspend(&mut harness);
+        harness.with_parts(|hub, bus, rq, context, runtime| {
+            begin_suspend(context, runtime.view.as_mut(), hub, bus, rq, runtime.tasks);
+        });
+        assert!(harness.context.soft_suspend_cycle_lease.is_some());
+        assert!(harness.context.soft_suspend_session.has_holders());
+        assert!(has_task(&harness.tasks, DeviceTaskId::PrepareSuspend));
+    }
+
+    #[test]
+    fn soft_prepare_suspend_keeps_holders_and_schedules_suspend() {
+        let mut harness = LifecycleHarness::new();
+        let (_dir, _paths) = install_armed_soft_suspend(&mut harness);
+        harness.with_parts(|hub, bus, rq, context, runtime| {
+            begin_suspend(context, runtime.view.as_mut(), hub, bus, rq, runtime.tasks);
+        });
+        let outcome = harness.with_parts(|hub, bus, rq, context, runtime| {
+            handle_event(&Event::PrepareSuspend, hub, bus, rq, context, runtime)
+        });
+        assert_eq!(outcome, EventOutcome::Handled);
+        assert!(harness.context.soft_suspend_cycle_lease.is_some());
+        assert!(harness.context.soft_suspend_session.has_holders());
+        assert!(lock_alarms(&mut harness).has_alarm(AlarmType::Suspend));
+    }
+
+    #[test]
+    fn soft_deep_idle_has_no_holders_when_cycle_lease_dropped() {
+        let mut harness = LifecycleHarness::new();
+        let (_dir, _paths) = install_armed_soft_suspend(&mut harness);
+        harness.with_parts(|hub, bus, rq, context, runtime| {
+            begin_suspend(context, runtime.view.as_mut(), hub, bus, rq, runtime.tasks);
+        });
+        assert!(harness.context.soft_suspend_session.has_holders());
+        harness.context.soft_suspend_cycle_lease = None;
+        assert!(
+            !harness.context.soft_suspend_session.has_holders(),
+            "cycle lease must be the last soft-suspend holder before deep-idle wait"
+        );
+    }
+
+    #[test]
+    fn soft_deep_idle_forces_mem_without_state_mem_write() {
+        use crate::device::soft_suspend::AutosleepMode;
+        use std::fs;
+
+        let mut harness = LifecycleHarness::new();
+        let (_dir, paths) = install_armed_soft_suspend(&mut harness);
+        harness.with_parts(|hub, bus, rq, context, runtime| {
+            begin_suspend(context, runtime.view.as_mut(), hub, bus, rq, runtime.tasks);
+        });
+        let outcome = harness.with_parts(|hub, bus, rq, context, runtime| {
+            handle_event(&Event::Suspend, hub, bus, rq, context, runtime)
+        });
+        assert_eq!(outcome, EventOutcome::Handled);
+        let power = harness.context.device.power_manager_for_test();
+        assert!(!power.was_suspend_called());
+        assert!(power.arm_deep_idle_call_count() >= 1);
+        assert!(power.disarm_deep_idle_call_count() >= 1);
+        assert_eq!(
+            harness.context.soft_suspend_session.mode(),
+            AutosleepMode::Freeze
+        );
+        assert!(harness.context.soft_suspend_cycle_lease.is_none());
+        assert!(!lock_alarms(&mut harness).has_alarm(AlarmType::Suspend));
+        assert!(!has_task(&harness.tasks, DeviceTaskId::PrepareSuspend));
+        let autosleep = fs::read_to_string(&paths.autosleep).expect("autosleep");
+        assert!(autosleep.trim() == "freeze" || autosleep.trim() == "Freeze");
+    }
+
+    #[test]
+    fn soft_deep_idle_exits_cycle_without_requeue() {
+        use crate::device::soft_suspend::AutosleepMode;
+
+        let mut harness = LifecycleHarness::new();
+        let (_dir, _paths) = install_armed_soft_suspend(&mut harness);
+        harness.context.settings.auto_suspend = 30.0;
+        harness.with_parts(|hub, bus, rq, context, runtime| {
+            begin_suspend(context, runtime.view.as_mut(), hub, bus, rq, runtime.tasks);
+        });
+        let outcome = harness.with_parts(|hub, bus, rq, context, runtime| {
+            handle_event(&Event::PrepareSuspend, hub, bus, rq, context, runtime)
+        });
+        assert_eq!(outcome, EventOutcome::Handled);
+        assert!(lock_alarms(&mut harness).has_alarm(AlarmType::Suspend));
+
+        let outcome = harness.with_parts(|hub, bus, rq, context, runtime| {
+            handle_event(&Event::Suspend, hub, bus, rq, context, runtime)
+        });
+        assert_eq!(outcome, EventOutcome::Handled);
+        assert!(harness.context.soft_suspend_cycle_lease.is_none());
+        assert!(!lock_alarms(&mut harness).has_alarm(AlarmType::Suspend));
+        assert_eq!(
+            harness.context.soft_suspend_session.mode(),
+            AutosleepMode::Freeze
+        );
+        assert!(lock_alarms(&mut harness).is_alarm_scheduled(AlarmType::AutoSuspend));
+        assert!(
+            !harness
+                .context
+                .device
+                .power_manager_for_test()
+                .was_suspend_called()
+        );
+    }
+
+    #[test]
+    fn soft_armed_classic_suspend_refused_without_cycle_lease() {
+        let mut harness = LifecycleHarness::new();
+        let (_dir, _paths) = install_armed_soft_suspend(&mut harness);
+        harness.context.settings.auto_suspend = 30.0;
+        harness.context.soft_suspend_cycle_lease = None;
+
+        let outcome = harness.with_parts(|hub, bus, rq, context, runtime| {
+            handle_event(&Event::Suspend, hub, bus, rq, context, runtime)
+        });
+        assert_eq!(outcome, EventOutcome::Handled);
+        assert!(
+            !harness
+                .context
+                .device
+                .power_manager_for_test()
+                .was_suspend_called()
+        );
+        assert!(!lock_alarms(&mut harness).has_alarm(AlarmType::Suspend));
+        assert!(harness.context.soft_suspend_cycle_lease.is_none());
+        assert!(lock_alarms(&mut harness).is_alarm_scheduled(AlarmType::AutoSuspend));
+    }
+
+    #[test]
+    fn soft_cancel_suspend_drops_cycle_lease_and_restores_mode() {
+        use crate::device::soft_suspend::AutosleepMode;
+
+        let mut harness = LifecycleHarness::new();
+        let (_dir, _paths) = install_armed_soft_suspend(&mut harness);
+        harness.context.settings.auto_suspend = 30.0;
+        harness.with_parts(|hub, bus, rq, context, runtime| {
+            begin_suspend(context, runtime.view.as_mut(), hub, bus, rq, runtime.tasks);
+        });
+        harness.tasks.clear();
+        {
+            let mut alarms = lock_alarms(&mut harness);
+            alarms
+                .schedule_alarm(AlarmType::Suspend, ChronoDuration::seconds(15))
+                .unwrap();
+        }
+        harness.with_parts(|hub, _bus, rq, context, runtime| {
+            cancel_suspend_if_pending(context, runtime.tasks, runtime.view.as_mut(), hub, rq);
+        });
+        assert!(harness.context.soft_suspend_cycle_lease.is_none());
+        assert_eq!(
+            harness.context.soft_suspend_session.mode(),
+            AutosleepMode::Freeze
+        );
+        assert!(lock_alarms(&mut harness).is_alarm_scheduled(AlarmType::AutoSuspend));
     }
 }

--- a/crates/core/src/device/kobo/mod.rs
+++ b/crates/core/src/device/kobo/mod.rs
@@ -1,6 +1,7 @@
 mod device;
 mod factory;
 mod input;
+mod leds;
 mod lifecycle;
 mod model;
 mod power;

--- a/crates/core/src/device/kobo/model.rs
+++ b/crates/core/src/device/kobo/model.rs
@@ -1,6 +1,8 @@
+use crate::device::kobo::leds::{LED_BRIGHTNESS_CANDIDATES, discover_led_brightness_path};
 use crate::device::{DeviceCapabilities, DeviceIdentity, DeviceRotation, FrontlightKind};
 use crate::input::TouchProto;
 use std::fmt;
+use std::path::PathBuf;
 
 /// Kobo device model identifiers.
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
@@ -136,6 +138,34 @@ impl Model {
             Model::Libra2 | Model::Sage | Model::Elipsa2E | Model::LibraColour => |n| (6 - n) % 4,
             Model::Elipsa => |n| (4 - n) % 4,
             _ => |n| n,
+        }
+    }
+
+    /// Returns the status LED brightness sysfs path for this model.
+    ///
+    /// Known models return a hardcoded path. Otherwise the known candidate
+    /// nodes are probed and the first existing path is returned (and logged)
+    /// so new hardcodes can be crowd-sourced from device logs.
+    pub fn led_brightness_path(self) -> Option<PathBuf> {
+        if let Some(path) = self.known_led_brightness_path() {
+            return Some(PathBuf::from(path));
+        }
+        let Some(path) = discover_led_brightness_path(LED_BRIGHTNESS_CANDIDATES) else {
+            tracing::warn!(model = %self, "no status LED brightness path found");
+            return None;
+        };
+        tracing::info!(
+            model = %self,
+            path = %path.display(),
+            "discovered status LED brightness path"
+        );
+        Some(path)
+    }
+
+    fn known_led_brightness_path(self) -> Option<&'static str> {
+        match self {
+            Model::LibraColour => Some("/sys/class/leds/LED/brightness"),
+            _ => None,
         }
     }
 }
@@ -424,6 +454,14 @@ mod tests {
             assert_eq!(
                 DeviceIdentity::proto(&Model::LibraColour),
                 TouchProto::MultiB
+            );
+        }
+
+        #[test]
+        fn libra_colour_led_brightness_path_is_hardcoded() {
+            assert_eq!(
+                Model::LibraColour.led_brightness_path().as_deref(),
+                Some(std::path::Path::new("/sys/class/leds/LED/brightness"))
             );
         }
 

--- a/crates/core/src/device/kobo/power.rs
+++ b/crates/core/src/device/kobo/power.rs
@@ -46,6 +46,27 @@ impl KoboPowerManager {
             initial_cpu_states: Mutex::new(Vec::new()),
         }
     }
+
+    fn write_state_extended(&self, value: &str) -> Result<(), PowerError> {
+        tracing::debug!(path = %STATE_EXTENDED_PATH, value, "Writing state-extended");
+        fs::write(STATE_EXTENDED_PATH, value).map_err(|e| {
+            tracing::error!(error = %e, path = %STATE_EXTENDED_PATH, value, "Failed to write state-extended");
+            PowerError::Io(e)
+        })
+    }
+
+    fn restore_touch_controller(&self) -> Result<(), PowerError> {
+        match self.model {
+            Model::GloHD | Model::AuraH2O => {
+                tracing::debug!(path = %NEOCMD_PATH, value = "a", "Reinitializing touch controller");
+                fs::write(NEOCMD_PATH, "a").map_err(|e| {
+                    tracing::warn!(error = %e, path = %NEOCMD_PATH, "Failed to write neocmd");
+                    PowerError::Io(e)
+                })
+            }
+            _ => Ok(()),
+        }
+    }
 }
 
 impl PowerManager for KoboPowerManager {
@@ -62,13 +83,7 @@ impl PowerManager for KoboPowerManager {
     /// Returns [`PowerError::Io`] if writing to any of the sysfs control nodes fails.
     fn suspend(&self) -> Result<(), PowerError> {
         tracing::info!("Suspending device to RAM");
-        tracing::debug!(path = %STATE_EXTENDED_PATH, value = "1", "Deactivating touch screen");
-
-        fs::write(STATE_EXTENDED_PATH, "1").map_err(|e| {
-            tracing::error!(error = %e, path = %STATE_EXTENDED_PATH, "Failed to deactivate touch screen");
-
-            PowerError::Io(e)
-        })?;
+        self.arm_deep_idle()?;
 
         tracing::debug!("Sleeping to prevent write errors");
         thread::sleep(Duration::from_secs(2));
@@ -99,26 +114,18 @@ impl PowerManager for KoboPowerManager {
     /// Returns [`PowerError::Io`] if writing to any of the sysfs wake up nodes fails.
     fn resume(&self) -> Result<(), PowerError> {
         tracing::info!("Resuming device");
-        tracing::debug!(path = %STATE_EXTENDED_PATH, value = "0", "Reactivating touch screen");
+        self.disarm_deep_idle()
+    }
 
-        fs::write(STATE_EXTENDED_PATH, "0").map_err(|e| {
-            tracing::error!(error = %e, path = %STATE_EXTENDED_PATH, "Failed to reactivate touch screen");
+    fn arm_deep_idle(&self) -> Result<(), PowerError> {
+        tracing::debug!("Arming Kobo deep-idle peripheral state");
+        self.write_state_extended("1")
+    }
 
-            PowerError::Io(e)
-        })?;
-
-        match self.model {
-            Model::GloHD | Model::AuraH2O => {
-                tracing::debug!(path = %NEOCMD_PATH, value = "a", "Reinitializing touch controller");
-
-                fs::write(NEOCMD_PATH, "a").map_err(|e| {
-                    tracing::warn!(error = %e, path = %NEOCMD_PATH, "Failed to write neocmd");
-
-                    PowerError::Io(e)
-                })?;
-            }
-            _ => {}
-        }
+    fn disarm_deep_idle(&self) -> Result<(), PowerError> {
+        tracing::debug!("Clearing Kobo deep-idle peripheral state");
+        self.write_state_extended("0")?;
+        self.restore_touch_controller()?;
 
         Ok(())
     }

--- a/crates/core/src/device/leds/error.rs
+++ b/crates/core/src/device/leds/error.rs
@@ -1,0 +1,11 @@
+//! LED control error types.
+
+use thiserror::Error;
+
+/// Errors that can occur while controlling device LEDs.
+#[derive(Error, Debug)]
+pub enum LedsError {
+    /// Standard I/O error.
+    #[error("I/O error: {0}")]
+    Io(#[from] std::io::Error),
+}

--- a/crates/core/src/device/leds/manager.rs
+++ b/crates/core/src/device/leds/manager.rs
@@ -1,0 +1,43 @@
+//! Device LEDs trait definition.
+
+use crate::device::leds::error::LedsError;
+
+/// Trait for turning the device status LED on or off.
+pub trait DeviceLeds: Send + Sync {
+    /// Turns the status LED on.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`LedsError`] when the LED brightness sysfs node cannot be written.
+    fn on(&self) -> Result<(), LedsError>;
+
+    /// Turns the status LED off.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`LedsError`] when the LED brightness sysfs node cannot be written.
+    fn off(&self) -> Result<(), LedsError>;
+
+    /// Sets the status LED to on (`true`) or off (`false`).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`LedsError`] when the LED brightness sysfs node cannot be written.
+    fn set_on(&self, on: bool) -> Result<(), LedsError> {
+        if on { self.on() } else { self.off() }
+    }
+}
+
+impl<T: DeviceLeds + ?Sized> DeviceLeds for Box<T> {
+    fn on(&self) -> Result<(), LedsError> {
+        (**self).on()
+    }
+
+    fn off(&self) -> Result<(), LedsError> {
+        (**self).off()
+    }
+
+    fn set_on(&self, on: bool) -> Result<(), LedsError> {
+        (**self).set_on(on)
+    }
+}

--- a/crates/core/src/device/leds/mod.rs
+++ b/crates/core/src/device/leds/mod.rs
@@ -1,0 +1,7 @@
+//! Device LED control.
+
+mod error;
+mod manager;
+
+pub use error::LedsError;
+pub use manager::DeviceLeds;

--- a/crates/core/src/device/linux/mod.rs
+++ b/crates/core/src/device/linux/mod.rs
@@ -1,6 +1,7 @@
 //! Linux-specific device implementations.
 
 mod rtc;
+pub mod soft_suspend;
 mod time;
 
 pub use rtc::LinuxRtc;

--- a/crates/core/src/device/linux/soft_suspend/mod.rs
+++ b/crates/core/src/device/linux/soft_suspend/mod.rs
@@ -1,0 +1,19 @@
+//! Soft suspend via Linux kernel autosleep and a single `cadmus` wake lock.
+//!
+//! Arms `/sys/power/autosleep` and blocks sleep with `/sys/power/wake_lock`
+//! while named leases are held. Missing sysfs nodes are a no-op.
+//!
+//! See the [sysfs-power ABI](https://www.kernel.org/doc/Documentation/ABI/testing/sysfs-power)
+//! for `autosleep`, `wake_lock`, and `wake_unlock`. Device research that led to
+//! this design is in
+//! [soft suspend via autosleep and wake_lock](../../../../../guide/investigations/kobo/issue-361-autosleep-wake-lock.html).
+
+mod mode;
+mod paths;
+mod session;
+
+pub use mode::AutosleepMode;
+pub use paths::{SoftSuspendPaths, discover_available_modes};
+pub use session::{SoftSuspendLease, SoftSuspendSession};
+
+pub(crate) const WAKE_LOCK_NAME: &str = "cadmus";

--- a/crates/core/src/device/linux/soft_suspend/mode.rs
+++ b/crates/core/src/device/linux/soft_suspend/mode.rs
@@ -1,0 +1,110 @@
+//! Autosleep target mode for soft suspend.
+
+use crate::fl;
+use crate::i18n::I18nDisplay;
+use serde::{Deserialize, Serialize};
+use std::fmt;
+
+/// Kernel autosleep target selected by the user.
+#[derive(Debug, Copy, Clone, Default, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum AutosleepMode {
+    /// Autosleep disabled (`off`).
+    #[default]
+    Off,
+    /// Freeze userspace / light sleep.
+    Freeze,
+    /// Suspend to RAM (`mem`).
+    Mem,
+}
+
+impl AutosleepMode {
+    /// Returns the sysfs value written to `/sys/power/autosleep`.
+    pub fn as_sysfs(self) -> &'static str {
+        match self {
+            AutosleepMode::Off => "off",
+            AutosleepMode::Freeze => "freeze",
+            AutosleepMode::Mem => "mem",
+        }
+    }
+
+    /// Parses a token from `/sys/power/state` (not including `off`).
+    pub fn from_state_token(token: &str) -> Option<Self> {
+        match token {
+            "freeze" => Some(AutosleepMode::Freeze),
+            "mem" => Some(AutosleepMode::Mem),
+            _ => None,
+        }
+    }
+
+    /// Returns whether this mode arms autosleep.
+    pub fn is_armed(self) -> bool {
+        !matches!(self, AutosleepMode::Off)
+    }
+}
+
+impl fmt::Display for AutosleepMode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_sysfs())
+    }
+}
+
+impl I18nDisplay for AutosleepMode {
+    fn to_i18n_string(&self) -> String {
+        match self {
+            AutosleepMode::Off => fl!("settings-power-autosleep-mode-off"),
+            AutosleepMode::Freeze => fl!("settings-power-autosleep-mode-freeze"),
+            AutosleepMode::Mem => fl!("settings-power-autosleep-mode-mem"),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn as_sysfs_matches_kernel_tokens() {
+        assert_eq!(AutosleepMode::Off.as_sysfs(), "off");
+        assert_eq!(AutosleepMode::Freeze.as_sysfs(), "freeze");
+        assert_eq!(AutosleepMode::Mem.as_sysfs(), "mem");
+    }
+
+    #[test]
+    fn from_state_token_parses_known_targets() {
+        assert_eq!(
+            AutosleepMode::from_state_token("freeze"),
+            Some(AutosleepMode::Freeze)
+        );
+        assert_eq!(
+            AutosleepMode::from_state_token("mem"),
+            Some(AutosleepMode::Mem)
+        );
+    }
+
+    #[test]
+    fn from_state_token_rejects_off_and_unknown() {
+        assert_eq!(AutosleepMode::from_state_token("off"), None);
+        assert_eq!(AutosleepMode::from_state_token("disk"), None);
+        assert_eq!(AutosleepMode::from_state_token(""), None);
+    }
+
+    #[test]
+    fn is_armed_only_for_sleep_targets() {
+        assert!(!AutosleepMode::Off.is_armed());
+        assert!(AutosleepMode::Freeze.is_armed());
+        assert!(AutosleepMode::Mem.is_armed());
+    }
+
+    #[test]
+    fn display_uses_sysfs_token() {
+        assert_eq!(AutosleepMode::Off.to_string(), "off");
+        assert_eq!(AutosleepMode::Freeze.to_string(), "freeze");
+        assert_eq!(AutosleepMode::Mem.to_string(), "mem");
+    }
+
+    #[test]
+    fn default_is_off() {
+        assert_eq!(AutosleepMode::default(), AutosleepMode::Off);
+    }
+}

--- a/crates/core/src/device/linux/soft_suspend/paths.rs
+++ b/crates/core/src/device/linux/soft_suspend/paths.rs
@@ -1,0 +1,141 @@
+//! Sysfs paths and discovery helpers for soft suspend.
+
+use crate::device::soft_suspend::AutosleepMode;
+use std::fs;
+use std::path::{Path, PathBuf};
+use thiserror::Error;
+
+/// Sysfs paths used by soft suspend. Injectable for tests.
+#[derive(Debug, Clone)]
+pub struct SoftSuspendPaths {
+    /// `/sys/power/state` — discover available sleep targets.
+    pub state: PathBuf,
+    /// `/sys/power/autosleep` — arm or disarm autosleep.
+    pub autosleep: PathBuf,
+    /// `/sys/power/wake_lock` — take a named wake lock.
+    pub wake_lock: PathBuf,
+    /// `/sys/power/wake_unlock` — release a named wake lock.
+    pub wake_unlock: PathBuf,
+}
+
+impl SoftSuspendPaths {
+    /// Default Kobo / Linux power sysfs layout.
+    pub fn system() -> Self {
+        Self {
+            state: PathBuf::from("/sys/power/state"),
+            autosleep: PathBuf::from("/sys/power/autosleep"),
+            wake_lock: PathBuf::from("/sys/power/wake_lock"),
+            wake_unlock: PathBuf::from("/sys/power/wake_unlock"),
+        }
+    }
+
+    /// Returns whether autosleep and wake_lock nodes exist.
+    pub fn is_available(&self) -> bool {
+        self.autosleep.exists() && self.wake_lock.exists() && self.wake_unlock.exists()
+    }
+}
+
+/// Successful outcome of a soft-suspend sysfs write.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum SysfsWrite {
+    /// Value was written to an existing sysfs node.
+    Written,
+    /// Path was absent — no-op on hosts without autosleep / wake locks.
+    Missing,
+}
+
+/// Failure writing a soft-suspend sysfs node that exists.
+#[derive(Debug, Error)]
+#[error("failed to write soft-suspend sysfs {}: {source}", path.display())]
+pub(super) struct SysfsWriteError {
+    path: PathBuf,
+    #[source]
+    source: std::io::Error,
+}
+
+/// Reads `/sys/power/state` and returns supported soft-suspend modes (`Off` always included).
+pub fn discover_available_modes(state_path: &Path) -> Vec<AutosleepMode> {
+    let mut modes = vec![AutosleepMode::Off];
+    let Ok(contents) = fs::read_to_string(state_path) else {
+        return modes;
+    };
+    for token in contents.split_whitespace() {
+        if let Some(mode) = AutosleepMode::from_state_token(token)
+            && !modes.contains(&mode)
+        {
+            modes.push(mode);
+        }
+    }
+    modes
+}
+
+/// Writes `value` to a soft-suspend sysfs node.
+///
+/// Does not log — callers choose how to handle [`SysfsWrite::Missing`] vs
+/// [`SysfsWriteError`].
+pub(super) fn write_sysfs(path: &Path, value: &str) -> Result<SysfsWrite, SysfsWriteError> {
+    if !path.exists() {
+        return Ok(SysfsWrite::Missing);
+    }
+    fs::write(path, value)
+        .map(|()| SysfsWrite::Written)
+        .map_err(|source| SysfsWriteError {
+            path: path.to_path_buf(),
+            source,
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn discover_parses_freeze_and_mem() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("state");
+        fs::write(&path, "freeze mem\n").expect("write");
+
+        let modes = discover_available_modes(&path);
+
+        assert_eq!(
+            modes,
+            vec![
+                AutosleepMode::Off,
+                AutosleepMode::Freeze,
+                AutosleepMode::Mem
+            ]
+        );
+    }
+
+    #[test]
+    fn discover_missing_file_returns_off_only() {
+        let modes = discover_available_modes(Path::new("/nonexistent/sys/power/state"));
+        assert_eq!(modes, vec![AutosleepMode::Off]);
+    }
+
+    #[test]
+    fn write_sysfs_missing_path_is_noop() {
+        assert_eq!(
+            write_sysfs(Path::new("/nonexistent/sys/power/autosleep"), "mem").unwrap(),
+            SysfsWrite::Missing
+        );
+    }
+
+    #[test]
+    fn write_sysfs_io_error() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("autosleep");
+        fs::create_dir(&path).expect("dir instead of file");
+        let error = write_sysfs(&path, "mem").unwrap_err();
+        assert_eq!(error.path, path);
+    }
+
+    #[test]
+    fn write_sysfs_writes_value() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("autosleep");
+        fs::write(&path, "off\n").expect("create");
+        assert_eq!(write_sysfs(&path, "mem").unwrap(), SysfsWrite::Written);
+        assert_eq!(fs::read_to_string(&path).expect("read").trim(), "mem");
+    }
+}

--- a/crates/core/src/device/linux/soft_suspend/session.rs
+++ b/crates/core/src/device/linux/soft_suspend/session.rs
@@ -1,0 +1,854 @@
+//! Soft-suspend session: named leases over one `cadmus` wake lock.
+
+use crate::device::leds::DeviceLeds;
+use crate::device::soft_suspend::WAKE_LOCK_NAME;
+use crate::device::soft_suspend::mode::AutosleepMode;
+use crate::device::soft_suspend::paths::{
+    SoftSuspendPaths, SysfsWrite, discover_available_modes, write_sysfs,
+};
+use crate::lease::{Lease, LeaseName, LeaseObserver, LeaseTracker};
+use std::path::Path;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Condvar, Mutex};
+use std::thread;
+use std::time::{Duration, Instant};
+
+/// Writes soft-suspend sysfs and logs. Returns whether session state may advance.
+fn write_sysfs_applied(path: &Path, value: &str) -> bool {
+    match write_sysfs(path, value) {
+        Ok(SysfsWrite::Written) => {
+            tracing::debug!(path = %path.display(), value, "wrote soft-suspend sysfs");
+            true
+        }
+        Ok(SysfsWrite::Missing) => {
+            tracing::debug!(path = %path.display(), value, "soft-suspend sysfs path missing");
+            true
+        }
+        Err(error) => {
+            tracing::warn!(error = %error, value, "failed to write soft-suspend sysfs");
+            false
+        }
+    }
+}
+
+struct SessionState {
+    mode: AutosleepMode,
+    indicate_autosleep_led: bool,
+    autosleep_grace: Duration,
+}
+
+struct UnlockState {
+    /// When to write `wake_unlock` after the last lease dropped; `None` if idle
+    /// or a holder re-armed the lock.
+    due_at: Option<Instant>,
+    /// Whether the kernel `cadmus` wake lock is currently taken.
+    ///
+    /// Stays true across the release-grace window after the last lease drops
+    /// (`due_at` set, tracker empty) until unlock or session teardown.
+    held: bool,
+    /// Sysfs paths used for `wake_lock` / `wake_unlock` writes.
+    paths: SoftSuspendPaths,
+    /// Set by [`UnlockInner::shutdown`]; the worker exits its loop when true.
+    shutdown: bool,
+}
+
+struct UnlockInner {
+    /// Shared unlock / wake-lock state for the grace worker and arming path.
+    state: Mutex<UnlockState>,
+    /// Wakes the grace worker when `due_at`, `shutdown`, or arming changes.
+    cv: Condvar,
+    /// Count of in-flight [`SoftSuspendSession::acquire`] calls.
+    ///
+    /// Distinct from [`UnlockState::held`]: pins cover only the acquire stack
+    /// frame (tracker insert + `take_wake_lock`), so the grace worker can skip
+    /// or re-arm unlock when a concurrent acquire races `due_at` expiry.
+    /// Zero while leases are merely held, and during grace with no acquire.
+    pins: AtomicUsize,
+}
+
+impl UnlockInner {
+    fn new(paths: SoftSuspendPaths) -> Arc<Self> {
+        let inner = Arc::new(Self {
+            state: Mutex::new(UnlockState {
+                due_at: None,
+                held: false,
+                paths,
+                shutdown: false,
+            }),
+            cv: Condvar::new(),
+            pins: AtomicUsize::new(0),
+        });
+        let worker = Arc::clone(&inner);
+        thread::spawn(move || worker.run());
+        inner
+    }
+
+    fn run(self: &Arc<Self>) {
+        let mut state = self.state.lock().unwrap_or_else(|e| e.into_inner());
+        loop {
+            if state.shutdown {
+                break;
+            }
+
+            let Some(due) = state.due_at else {
+                state = self.cv.wait(state).unwrap_or_else(|e| e.into_inner());
+                continue;
+            };
+
+            let now = Instant::now();
+            if due > now {
+                let wait = due - now;
+                let (guard, _) = self
+                    .cv
+                    .wait_timeout(state, wait)
+                    .unwrap_or_else(|e| e.into_inner());
+                state = guard;
+                continue;
+            }
+
+            if state.due_at.is_some_and(|d| d <= Instant::now()) {
+                if self.pins.load(Ordering::SeqCst) != 0 {
+                    state.due_at = None;
+                    continue;
+                }
+                let paths = state.paths.clone();
+                state.due_at = None;
+                tracing::info!(
+                    wake_lock = WAKE_LOCK_NAME,
+                    "soft-suspend release grace elapsed; unlocking"
+                );
+                let unlocked = write_sysfs_applied(&paths.wake_unlock, WAKE_LOCK_NAME);
+                if self.pins.load(Ordering::SeqCst) != 0 {
+                    tracing::debug!(
+                        wake_lock = WAKE_LOCK_NAME,
+                        "soft-suspend re-arm after unlock raced with acquire"
+                    );
+                    if write_sysfs_applied(&paths.wake_lock, WAKE_LOCK_NAME) {
+                        state.held = true;
+                    } else if unlocked {
+                        state.held = false;
+                    }
+                } else if unlocked {
+                    state.held = false;
+                }
+            }
+        }
+    }
+
+    /// Marks an in-flight acquire so the grace worker will not unlock.
+    fn pin(&self) {
+        self.pins.fetch_add(1, Ordering::SeqCst);
+        self.cancel_pending_unlock();
+    }
+
+    /// Ends an in-flight acquire pin from [`Self::pin`].
+    fn unpin(&self) {
+        self.pins.fetch_sub(1, Ordering::SeqCst);
+    }
+
+    fn take_wake_lock(&self) {
+        let mut state = self.state.lock().unwrap_or_else(|e| e.into_inner());
+        let paths = state.paths.clone();
+        state.due_at = None;
+        self.cv.notify_one();
+        drop(state);
+        if write_sysfs_applied(&paths.wake_lock, WAKE_LOCK_NAME) {
+            let mut state = self.state.lock().unwrap_or_else(|e| e.into_inner());
+            state.held = true;
+        }
+    }
+
+    fn release_wake_lock_now(&self) {
+        let mut state = self.state.lock().unwrap_or_else(|e| e.into_inner());
+        let paths = state.paths.clone();
+        state.due_at = None;
+        self.cv.notify_one();
+        drop(state);
+        tracing::info!(
+            wake_lock = WAKE_LOCK_NAME,
+            "soft-suspend writing wake_unlock"
+        );
+        if write_sysfs_applied(&paths.wake_unlock, WAKE_LOCK_NAME) {
+            let mut state = self.state.lock().unwrap_or_else(|e| e.into_inner());
+            state.held = false;
+        }
+    }
+
+    fn schedule_unlock(&self, grace: Duration) {
+        if grace.is_zero() {
+            self.release_wake_lock_now();
+            return;
+        }
+
+        let mut state = self.state.lock().unwrap_or_else(|e| e.into_inner());
+        let due_at = Instant::now() + grace;
+        state.due_at = Some(due_at);
+        tracing::debug!(
+            wake_lock = WAKE_LOCK_NAME,
+            grace_secs = grace.as_secs_f32(),
+            "soft-suspend last holder released; scheduling unlock"
+        );
+        self.cv.notify_one();
+    }
+
+    fn cancel_pending_unlock(&self) {
+        let mut state = self.state.lock().unwrap_or_else(|e| e.into_inner());
+        if state.due_at.take().is_some() {
+            tracing::debug!(
+                wake_lock = WAKE_LOCK_NAME,
+                "soft-suspend pending unlock cancelled"
+            );
+        }
+        self.cv.notify_one();
+    }
+
+    fn is_held(&self) -> bool {
+        self.state.lock().unwrap_or_else(|e| e.into_inner()).held
+    }
+
+    fn shutdown(&self) {
+        let mut state = self.state.lock().unwrap_or_else(|e| e.into_inner());
+        let paths = state.paths.clone();
+        let should_unlock = state.held;
+        state.shutdown = true;
+        state.due_at = None;
+        state.held = false;
+        self.cv.notify_one();
+        drop(state);
+        if should_unlock {
+            tracing::info!(
+                wake_lock = WAKE_LOCK_NAME,
+                "soft-suspend session teardown; unlocking"
+            );
+            write_sysfs_applied(&paths.wake_unlock, WAKE_LOCK_NAME);
+        }
+    }
+}
+
+struct WakeLockArmer {
+    state: Arc<Mutex<SessionState>>,
+    unlock: Arc<UnlockInner>,
+    leds: Option<Arc<dyn DeviceLeds>>,
+}
+
+impl WakeLockArmer {
+    fn sync_led_awake(&self, state: &SessionState) {
+        let Some(leds) = self.leds.as_ref() else {
+            return;
+        };
+        if state.indicate_autosleep_led
+            && state.mode.is_armed()
+            && let Err(error) = leds.on()
+        {
+            tracing::warn!(error = %error, "failed to turn autosleep indicator LED on");
+        }
+    }
+
+    fn turn_led_off(&self) {
+        let Some(leds) = self.leds.as_ref() else {
+            return;
+        };
+        if let Err(error) = leds.off() {
+            tracing::warn!(error = %error, "failed to turn autosleep indicator LED off");
+        }
+    }
+
+    fn schedule_unlock(&self, name: &LeaseName) {
+        let grace = self
+            .state
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .autosleep_grace;
+        if grace.is_zero() {
+            tracing::debug!(
+                name = %name,
+                wake_lock = WAKE_LOCK_NAME,
+                "soft-suspend last holder released; unlocking immediately"
+            );
+        } else {
+            tracing::debug!(
+                name = %name,
+                wake_lock = WAKE_LOCK_NAME,
+                grace_secs = grace.as_secs_f32(),
+                "soft-suspend last holder released; scheduling unlock"
+            );
+        }
+        self.unlock.schedule_unlock(grace);
+    }
+}
+
+impl Drop for WakeLockArmer {
+    fn drop(&mut self) {
+        self.unlock.shutdown();
+    }
+}
+
+impl LeaseObserver for WakeLockArmer {
+    fn on_first_acquire(&self, name: &LeaseName) {
+        tracing::debug!(name = %name, wake_lock = WAKE_LOCK_NAME, "soft-suspend first holder");
+        self.unlock.take_wake_lock();
+        if let Ok(state) = self.state.lock() {
+            self.sync_led_awake(&state);
+        }
+    }
+
+    fn on_last_release(&self, name: &LeaseName) {
+        self.schedule_unlock(name);
+    }
+}
+
+/// Coordinates named soft-suspend leases, autosleep mode, and optional LED indicator.
+pub struct SoftSuspendSession {
+    tracker: LeaseTracker,
+    state: Arc<Mutex<SessionState>>,
+    paths: SoftSuspendPaths,
+    armer: Arc<WakeLockArmer>,
+}
+
+/// RAII guard holding a soft-suspend lease.
+#[must_use = "lease is released immediately if unused; bind it (e.g. `let _lease = …`)"]
+pub struct SoftSuspendLease {
+    inner: Option<Lease>,
+}
+
+impl SoftSuspendSession {
+    /// Creates a session using system sysfs paths and optional LED controller.
+    pub fn new(leds: Option<Arc<dyn DeviceLeds>>) -> Arc<Self> {
+        Self::with_paths(SoftSuspendPaths::system(), leds)
+    }
+
+    /// Creates a session with injectable sysfs paths (tests / unavailable hosts).
+    pub fn with_paths(paths: SoftSuspendPaths, leds: Option<Arc<dyn DeviceLeds>>) -> Arc<Self> {
+        let available = paths.is_available();
+        tracing::debug!(
+            available,
+            autosleep = %paths.autosleep.display(),
+            "creating soft-suspend session"
+        );
+        let state = Arc::new(Mutex::new(SessionState {
+            mode: AutosleepMode::Off,
+            indicate_autosleep_led: false,
+            autosleep_grace: Duration::ZERO,
+        }));
+        let unlock = UnlockInner::new(paths.clone());
+        let armer = Arc::new(WakeLockArmer {
+            state: Arc::clone(&state),
+            unlock,
+            leds,
+        });
+        Arc::new(Self {
+            tracker: LeaseTracker::with_observer(Arc::clone(&armer) as Arc<dyn LeaseObserver>),
+            state,
+            paths,
+            armer,
+        })
+    }
+
+    /// Acquires a named soft-suspend lease (holds the `cadmus` wake lock while any exist).
+    #[must_use = "lease is released immediately if unused; bind it (e.g. `let _lease = …`)"]
+    #[cfg_attr(
+        feature = "tracing",
+        tracing::instrument(
+            skip(self, name),
+            fields(name = tracing::field::Empty, holders = tracing::field::Empty),
+            level = tracing::Level::TRACE,
+        )
+    )]
+    pub fn acquire(&self, name: impl Into<LeaseName>) -> SoftSuspendLease {
+        let name = name.into();
+        #[cfg(feature = "tracing")]
+        tracing::Span::current().record("name", tracing::field::display(&name));
+        self.armer.unlock.pin();
+        let lease = self.tracker.acquire(name);
+        self.armer.unlock.unpin();
+        #[cfg(feature = "tracing")]
+        tracing::Span::current().record("holders", self.tracker.len());
+        SoftSuspendLease { inner: Some(lease) }
+    }
+
+    /// Runs `f` while holding a named soft-suspend lease.
+    pub fn with<R>(&self, name: impl Into<LeaseName>, f: impl FnOnce() -> R) -> R {
+        let _lease = self.acquire(name);
+        f()
+    }
+
+    /// Returns current lease holder count.
+    pub fn len(&self) -> usize {
+        self.tracker.len()
+    }
+
+    /// Returns whether any soft-suspend leases are held.
+    pub fn is_empty(&self) -> bool {
+        self.tracker.is_empty()
+    }
+
+    /// Returns whether any soft-suspend leases are held.
+    pub fn has_holders(&self) -> bool {
+        !self.is_empty()
+    }
+
+    /// Returns the names of all active soft-suspend lease holders.
+    pub fn holders(&self) -> Vec<crate::lease::LeaseName> {
+        self.tracker.holders()
+    }
+
+    /// Returns the current autosleep mode.
+    pub fn mode(&self) -> AutosleepMode {
+        self.state.lock().unwrap_or_else(|e| e.into_inner()).mode
+    }
+
+    /// Returns whether the status LED indicates armed soft suspend while awake.
+    ///
+    /// The LED tracks mode + this setting, not the `cadmus` wake lock. The kernel
+    /// clears it on suspend; Cadmus turns it off only when mode is [`AutosleepMode::Off`]
+    /// or this setting is disabled.
+    pub fn indicate_autosleep_led(&self) -> bool {
+        self.state
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .indicate_autosleep_led
+    }
+
+    /// Returns the delay after the last lease drops before writing `wake_unlock`.
+    pub fn autosleep_grace(&self) -> Duration {
+        self.state
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .autosleep_grace
+    }
+
+    /// Modes supported by this device (`Off` plus tokens from `/sys/power/state`).
+    pub fn available_modes(&self) -> Vec<AutosleepMode> {
+        discover_available_modes(&self.paths.state)
+    }
+
+    /// Sanitizes `mode` against discovery; unsupported values become [`AutosleepMode::Off`].
+    pub fn sanitize_mode(&self, mode: AutosleepMode) -> AutosleepMode {
+        if mode == AutosleepMode::Off {
+            return AutosleepMode::Off;
+        }
+        if self.available_modes().contains(&mode) {
+            mode
+        } else {
+            tracing::warn!(mode = %mode, "autosleep mode unsupported; falling back to off");
+            AutosleepMode::Off
+        }
+    }
+
+    /// Sets autosleep mode and writes `/sys/power/autosleep`.
+    ///
+    /// In-memory mode and LED policy update only after the sysfs write succeeds
+    /// (or the node is missing — a no-op on hosts without autosleep).
+    #[cfg_attr(
+        feature = "tracing",
+        tracing::instrument(skip(self), fields(mode = %mode), level = tracing::Level::TRACE)
+    )]
+    pub fn set_mode(&self, mode: AutosleepMode) {
+        let mode = self.sanitize_mode(mode);
+        let value = mode.as_sysfs();
+        match write_sysfs(&self.paths.autosleep, value) {
+            Ok(SysfsWrite::Written) => {
+                tracing::debug!(
+                    path = %self.paths.autosleep.display(),
+                    value,
+                    "wrote soft-suspend sysfs"
+                );
+            }
+            Ok(SysfsWrite::Missing) => {
+                tracing::debug!(
+                    path = %self.paths.autosleep.display(),
+                    value,
+                    "soft-suspend sysfs path missing"
+                );
+            }
+            Err(error) => {
+                tracing::warn!(
+                    error = %error,
+                    mode = %mode,
+                    "soft-suspend autosleep write failed; keeping previous mode"
+                );
+                return;
+            }
+        }
+        let mut state = self.state.lock().unwrap_or_else(|e| e.into_inner());
+        let previous = state.mode;
+        state.mode = mode;
+        tracing::info!(previous = %previous, mode = %mode, "soft-suspend mode updated");
+        let snapshot = SessionState {
+            mode: state.mode,
+            indicate_autosleep_led: state.indicate_autosleep_led,
+            autosleep_grace: state.autosleep_grace,
+        };
+        let sync_awake = mode.is_armed() && snapshot.indicate_autosleep_led;
+        let turn_off = !mode.is_armed() || !snapshot.indicate_autosleep_led;
+        drop(state);
+        if sync_awake {
+            self.armer.sync_led_awake(&snapshot);
+        } else if turn_off {
+            self.armer.turn_led_off();
+        }
+    }
+
+    /// Enables or disables the status LED while soft suspend is armed.
+    ///
+    /// Independent of lease holders: unlock does not clear the LED. The kernel
+    /// clears it on suspend.
+    #[cfg_attr(
+        feature = "tracing",
+        tracing::instrument(skip(self), level = tracing::Level::TRACE)
+    )]
+    pub fn set_indicate_autosleep_led(&self, enabled: bool) {
+        let mut state = self.state.lock().unwrap_or_else(|e| e.into_inner());
+        state.indicate_autosleep_led = enabled;
+        let mode = state.mode;
+        let autosleep_grace = state.autosleep_grace;
+        tracing::info!(enabled, mode = %mode, "soft-suspend LED indicator updated");
+        drop(state);
+        if enabled && mode.is_armed() {
+            self.armer.sync_led_awake(&SessionState {
+                mode,
+                indicate_autosleep_led: true,
+                autosleep_grace,
+            });
+        } else if !enabled {
+            self.armer.turn_led_off();
+        }
+    }
+
+    /// Sets how long to keep the wake lock after the last lease drops.
+    ///
+    /// Zero means unlock immediately. Changing grace cancels any pending unlock
+    /// and, if the wake lock is still held with no leases, reschedules.
+    #[cfg_attr(
+        feature = "tracing",
+        tracing::instrument(skip(self), level = tracing::Level::TRACE)
+    )]
+    pub fn set_autosleep_grace(&self, grace: Duration) {
+        let mut state = self.state.lock().unwrap_or_else(|e| e.into_inner());
+        state.autosleep_grace = grace;
+        tracing::info!(
+            grace_secs = grace.as_secs_f32(),
+            "soft-suspend release grace updated"
+        );
+        drop(state);
+        self.armer.unlock.cancel_pending_unlock();
+        if self.tracker.is_empty() && self.armer.unlock.is_held() {
+            self.armer.schedule_unlock(&LeaseName::from("grace-update"));
+        }
+    }
+
+    /// Applies mode, LED policy, and release grace from settings (boot / settings change).
+    pub fn apply_settings(
+        &self,
+        mode: AutosleepMode,
+        indicate_autosleep_led: bool,
+        autosleep_grace: Duration,
+    ) {
+        self.set_autosleep_grace(autosleep_grace);
+        self.set_indicate_autosleep_led(indicate_autosleep_led);
+        self.set_mode(mode);
+    }
+}
+
+impl SoftSuspendLease {
+    /// Returns whether this guard still holds the lease.
+    pub fn is_active(&self) -> bool {
+        self.inner.is_some()
+    }
+}
+
+impl Drop for SoftSuspendLease {
+    fn drop(&mut self) {
+        self.inner.take();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::device::leds::{DeviceLeds, LedsError};
+    use std::fs;
+    use std::sync::atomic::{AtomicU32, Ordering};
+
+    struct CountingLeds {
+        on_calls: AtomicU32,
+        off_calls: AtomicU32,
+    }
+
+    impl DeviceLeds for CountingLeds {
+        fn on(&self) -> Result<(), LedsError> {
+            self.on_calls.fetch_add(1, Ordering::SeqCst);
+            Ok(())
+        }
+
+        fn off(&self) -> Result<(), LedsError> {
+            self.off_calls.fetch_add(1, Ordering::SeqCst);
+            Ok(())
+        }
+    }
+
+    fn temp_paths() -> (tempfile::TempDir, SoftSuspendPaths) {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let paths = SoftSuspendPaths {
+            state: dir.path().join("state"),
+            autosleep: dir.path().join("autosleep"),
+            wake_lock: dir.path().join("wake_lock"),
+            wake_unlock: dir.path().join("wake_unlock"),
+        };
+        fs::write(&paths.state, "freeze mem\n").expect("state");
+        fs::write(&paths.autosleep, "off\n").expect("autosleep");
+        fs::write(&paths.wake_lock, "").expect("wake_lock");
+        fs::write(&paths.wake_unlock, "").expect("wake_unlock");
+        (dir, paths)
+    }
+
+    fn unlock_name(paths: &SoftSuspendPaths) -> String {
+        fs::read_to_string(&paths.wake_unlock)
+            .expect("read")
+            .trim()
+            .to_string()
+    }
+
+    fn make_unwritable(path: &std::path::Path) {
+        let mut perms = fs::metadata(path).expect("metadata").permissions();
+        perms.set_readonly(true);
+        fs::set_permissions(path, perms).expect("chmod");
+    }
+
+    #[test]
+    fn first_acquire_writes_wake_lock() {
+        let (_dir, paths) = temp_paths();
+        let session = SoftSuspendSession::with_paths(paths.clone(), None);
+        session.set_mode(AutosleepMode::Mem);
+
+        let lease = session.acquire("main-loop");
+
+        assert_eq!(
+            fs::read_to_string(&paths.wake_lock).expect("read").trim(),
+            WAKE_LOCK_NAME
+        );
+        drop(lease);
+        assert_eq!(unlock_name(&paths), WAKE_LOCK_NAME);
+    }
+
+    #[test]
+    fn set_mode_writes_autosleep() {
+        let (_dir, paths) = temp_paths();
+        let session = SoftSuspendSession::with_paths(paths.clone(), None);
+
+        session.set_mode(AutosleepMode::Freeze);
+
+        assert_eq!(
+            fs::read_to_string(&paths.autosleep).expect("read").trim(),
+            "freeze"
+        );
+        assert_eq!(session.mode(), AutosleepMode::Freeze);
+    }
+
+    #[test]
+    fn set_mode_keeps_previous_when_autosleep_write_fails() {
+        let (_dir, paths) = temp_paths();
+        let session = SoftSuspendSession::with_paths(paths.clone(), None);
+        session.set_mode(AutosleepMode::Freeze);
+        assert_eq!(session.mode(), AutosleepMode::Freeze);
+
+        make_unwritable(&paths.autosleep);
+        session.set_mode(AutosleepMode::Mem);
+
+        assert_eq!(session.mode(), AutosleepMode::Freeze);
+        assert_eq!(
+            fs::read_to_string(&paths.autosleep).expect("read").trim(),
+            "freeze"
+        );
+    }
+
+    #[test]
+    fn failed_wake_lock_write_does_not_claim_held() {
+        let (_dir, paths) = temp_paths();
+        let session = SoftSuspendSession::with_paths(paths.clone(), None);
+        session.set_mode(AutosleepMode::Mem);
+        session.set_autosleep_grace(Duration::from_secs(60));
+        make_unwritable(&paths.wake_lock);
+
+        let lease = session.acquire("main-loop");
+        assert_eq!(
+            fs::read_to_string(&paths.wake_lock).expect("read").trim(),
+            ""
+        );
+        drop(lease);
+        fs::write(&paths.wake_unlock, "").expect("clear unlock");
+
+        session.set_autosleep_grace(Duration::from_millis(30));
+        thread::sleep(Duration::from_millis(80));
+        assert_eq!(
+            unlock_name(&paths),
+            "",
+            "failed wake_lock must leave held=false so grace updates do not unlock"
+        );
+    }
+
+    #[test]
+    fn unsupported_mode_falls_back_to_off() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let paths = SoftSuspendPaths {
+            state: dir.path().join("state"),
+            autosleep: dir.path().join("autosleep"),
+            wake_lock: dir.path().join("wake_lock"),
+            wake_unlock: dir.path().join("wake_unlock"),
+        };
+        fs::write(&paths.state, "mem\n").expect("state");
+        fs::write(&paths.autosleep, "off\n").expect("autosleep");
+        fs::write(&paths.wake_lock, "").expect("wake_lock");
+        fs::write(&paths.wake_unlock, "").expect("wake_unlock");
+        let session = SoftSuspendSession::with_paths(paths.clone(), None);
+
+        session.set_mode(AutosleepMode::Freeze);
+
+        assert_eq!(session.mode(), AutosleepMode::Off);
+        assert_eq!(
+            fs::read_to_string(&paths.autosleep).expect("read").trim(),
+            "off"
+        );
+    }
+
+    #[test]
+    fn led_indicator_on_while_armed_when_enabled() {
+        let (_dir, paths) = temp_paths();
+        let leds = Arc::new(CountingLeds {
+            on_calls: AtomicU32::new(0),
+            off_calls: AtomicU32::new(0),
+        });
+        let session = SoftSuspendSession::with_paths(
+            paths.clone(),
+            Some(leds.clone() as Arc<dyn DeviceLeds>),
+        );
+        session.apply_settings(AutosleepMode::Mem, true, Duration::ZERO);
+
+        assert_eq!(leds.on_calls.load(Ordering::SeqCst), 1);
+        assert!(session.is_empty());
+
+        let lease = session.acquire("wifi");
+        drop(lease);
+        assert_eq!(unlock_name(&paths), WAKE_LOCK_NAME);
+        assert_eq!(leds.off_calls.load(Ordering::SeqCst), 0);
+
+        session.set_indicate_autosleep_led(false);
+        assert!(leds.off_calls.load(Ordering::SeqCst) >= 1);
+    }
+
+    #[test]
+    fn nested_leases_keep_single_wake_lock_cycle() {
+        let (_dir, paths) = temp_paths();
+        let session = SoftSuspendSession::with_paths(paths.clone(), None);
+        session.set_mode(AutosleepMode::Mem);
+
+        let a = session.acquire("a");
+        let b = session.acquire("b");
+        assert_eq!(session.len(), 2);
+        drop(a);
+        assert_eq!(unlock_name(&paths), "");
+        drop(b);
+        assert_eq!(unlock_name(&paths), WAKE_LOCK_NAME);
+    }
+
+    #[test]
+    fn grace_delays_wake_unlock() {
+        let (_dir, paths) = temp_paths();
+        let session = SoftSuspendSession::with_paths(paths.clone(), None);
+        session.set_mode(AutosleepMode::Mem);
+        session.set_autosleep_grace(Duration::from_millis(80));
+
+        let lease = session.acquire("main-loop");
+        drop(lease);
+
+        assert_eq!(unlock_name(&paths), "");
+        thread::sleep(Duration::from_millis(120));
+        assert_eq!(unlock_name(&paths), WAKE_LOCK_NAME);
+    }
+
+    #[test]
+    fn lease_during_grace_cancels_pending_unlock() {
+        let (_dir, paths) = temp_paths();
+        let session = SoftSuspendSession::with_paths(paths.clone(), None);
+        session.set_mode(AutosleepMode::Mem);
+        session.set_autosleep_grace(Duration::from_millis(80));
+
+        let lease = session.acquire("main-loop");
+        drop(lease);
+        let _again = session.acquire("main-loop");
+        thread::sleep(Duration::from_millis(120));
+
+        assert_eq!(unlock_name(&paths), "");
+        assert!(session.has_holders());
+    }
+
+    #[test]
+    fn reacquire_from_other_thread_during_grace_keeps_lock() {
+        let (_dir, paths) = temp_paths();
+        let session = SoftSuspendSession::with_paths(paths.clone(), None);
+        session.set_mode(AutosleepMode::Mem);
+        session.set_autosleep_grace(Duration::from_millis(100));
+
+        drop(session.acquire("main-loop"));
+
+        let session_thread = Arc::clone(&session);
+        let join = thread::spawn(move || {
+            thread::sleep(Duration::from_millis(40));
+            session_thread.acquire("worker")
+        });
+        let lease = join.join().expect("acquire thread");
+        thread::sleep(Duration::from_millis(120));
+        assert_eq!(unlock_name(&paths), "");
+        assert!(session.has_holders());
+        drop(lease);
+    }
+
+    #[test]
+    fn set_grace_while_empty_reschedules_deadline() {
+        let (_dir, paths) = temp_paths();
+        let session = SoftSuspendSession::with_paths(paths.clone(), None);
+        session.set_mode(AutosleepMode::Mem);
+        session.set_autosleep_grace(Duration::from_millis(50));
+
+        let lease = session.acquire("main-loop");
+        drop(lease);
+        session.set_autosleep_grace(Duration::from_millis(150));
+
+        thread::sleep(Duration::from_millis(80));
+        assert_eq!(unlock_name(&paths), "");
+        thread::sleep(Duration::from_millis(100));
+        assert_eq!(unlock_name(&paths), WAKE_LOCK_NAME);
+    }
+
+    #[test]
+    fn repeated_empty_cycles_reuse_worker() {
+        let (_dir, paths) = temp_paths();
+        let session = SoftSuspendSession::with_paths(paths.clone(), None);
+        session.set_mode(AutosleepMode::Mem);
+        session.set_autosleep_grace(Duration::from_millis(40));
+
+        for _ in 0..2 {
+            fs::write(&paths.wake_unlock, "").expect("clear unlock");
+            let lease = session.acquire("main-loop");
+            drop(lease);
+            assert_eq!(unlock_name(&paths), "");
+            thread::sleep(Duration::from_millis(80));
+            assert_eq!(unlock_name(&paths), WAKE_LOCK_NAME);
+        }
+    }
+
+    #[test]
+    fn drop_session_mid_grace_shuts_down_cleanly() {
+        let (_dir, paths) = temp_paths();
+        let session = SoftSuspendSession::with_paths(paths.clone(), None);
+        session.set_mode(AutosleepMode::Mem);
+        session.set_autosleep_grace(Duration::from_millis(200));
+
+        let lease = session.acquire("main-loop");
+        drop(lease);
+        drop(session);
+
+        thread::sleep(Duration::from_millis(50));
+        assert_eq!(unlock_name(&paths), WAKE_LOCK_NAME);
+    }
+}

--- a/crates/core/src/device/mod.rs
+++ b/crates/core/src/device/mod.rs
@@ -8,6 +8,7 @@
 
 mod error;
 mod forward;
+pub mod leds;
 mod metadata;
 pub mod migration;
 mod model;
@@ -535,6 +536,7 @@ pub trait DeviceHardware: Send {
     type WifiManager: crate::device::wifi::WifiManager + Send + Sync + 'static;
     type UsbManager: crate::device::usb::UsbManager + Send + Sync;
     type PowerManager: crate::device::power::PowerManager + Send + Sync;
+    type Leds: crate::device::leds::DeviceLeds + Send + Sync;
     type Rtc: crate::device::rtc::Rtc + Send + Sync + 'static;
 
     /// Returns a shared reference to the display framebuffer.
@@ -579,6 +581,13 @@ pub trait DeviceHardware: Send {
     fn power_manager(
         &self,
     ) -> Result<std::sync::Arc<Self::PowerManager>, crate::device::power::PowerError>;
+
+    /// Returns a shared LED controller handle.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`crate::device::leds::LedsError`] when LEDs are unavailable.
+    fn leds(&self) -> Result<std::sync::Arc<Self::Leds>, crate::device::leds::LedsError>;
 
     /// Returns a shared RTC handle.
     ///

--- a/crates/core/src/device/mod.rs
+++ b/crates/core/src/device/mod.rs
@@ -20,6 +20,8 @@ mod types;
 mod linux;
 #[cfg(unix)]
 pub use linux::LinuxRtc;
+#[cfg(unix)]
+pub use linux::soft_suspend;
 pub mod usb;
 pub mod wifi;
 
@@ -536,7 +538,7 @@ pub trait DeviceHardware: Send {
     type WifiManager: crate::device::wifi::WifiManager + Send + Sync + 'static;
     type UsbManager: crate::device::usb::UsbManager + Send + Sync;
     type PowerManager: crate::device::power::PowerManager + Send + Sync;
-    type Leds: crate::device::leds::DeviceLeds + Send + Sync;
+    type Leds: crate::device::leds::DeviceLeds + Send + Sync + 'static;
     type Rtc: crate::device::rtc::Rtc + Send + Sync + 'static;
 
     /// Returns a shared reference to the display framebuffer.

--- a/crates/core/src/device/power/manager.rs
+++ b/crates/core/src/device/power/manager.rs
@@ -24,6 +24,23 @@ pub trait PowerManager: Send + Sync {
     /// Returns [`PowerError`] if any write operation fails.
     fn resume(&self) -> Result<(), PowerError>;
 
+    /// Arms vendor deep-idle peripheral state without writing `/sys/power/state`.
+    ///
+    /// On Kobo this writes `1` to `/sys/power/state-extended` (touch prep). It does
+    /// **not** suspend by itself — callers pair it with autosleep `mem` and releasing
+    /// wake locks. Default is a no-op.
+    fn arm_deep_idle(&self) -> Result<(), PowerError> {
+        Ok(())
+    }
+
+    /// Clears vendor deep-idle peripheral state after wake or cancel.
+    ///
+    /// On Kobo this matches the touch-restore half of [`Self::resume`]. Default is a
+    /// no-op.
+    fn disarm_deep_idle(&self) -> Result<(), PowerError> {
+        Ok(())
+    }
+
     /// Initializes and enables all available CPU cores on startup.
     ///
     /// # Errors
@@ -49,6 +66,12 @@ impl<T: PowerManager + ?Sized> PowerManager for Box<T> {
     }
     fn resume(&self) -> Result<(), PowerError> {
         (**self).resume()
+    }
+    fn arm_deep_idle(&self) -> Result<(), PowerError> {
+        (**self).arm_deep_idle()
+    }
+    fn disarm_deep_idle(&self) -> Result<(), PowerError> {
+        (**self).disarm_deep_idle()
     }
     fn init_cores(&self) -> Result<(), PowerError> {
         (**self).init_cores()

--- a/crates/core/src/device/rtc/mod.rs
+++ b/crates/core/src/device/rtc/mod.rs
@@ -149,15 +149,19 @@ impl RtcWkalrm {
 /// # Suspend
 ///
 /// [`AlarmType::Suspend`] is the wall-clock delay after PrepareSuspend before
-/// entering sleep (`handle_suspend`). Power Released / long-hold cancel it to
-/// abort the cycle. Not listed in [`AlarmType::alarms_to_cancel_after_resume`].
+/// entering sleep (`handle_suspend`). Classic hard suspend uses a short delay;
+/// soft deep idle calls `handle_suspend` immediately and does not schedule this
+/// alarm. Power Released / long-hold cancel it to abort the cycle. Not listed
+/// in [`AlarmType::alarms_to_cancel_after_resume`].
 ///
 /// # Wake Debounce
 ///
 /// [`AlarmType::WakeDebounce`] is the wall-clock re-sleep deadline after leaving
-/// classic `state=mem`. Userspace `thread::sleep` cannot drive re-sleep under
-/// autosleep. When it fires, lifecycle calls `begin_suspend`. Power Released /
-/// long-hold cancel it. Not in [`AlarmType::alarms_to_cancel_after_resume`].
+/// sleep (soft deep idle or classic `state=mem`). Userspace `thread::sleep`
+/// cannot drive re-sleep under autosleep (Cadmus may be frozen). The RTC
+/// survives opportunistic sleep; when it fires, lifecycle calls `begin_suspend`.
+/// Power Released / long-hold cancel this alarm to stay interactive. Like Auto
+/// Suspend, it is not in [`AlarmType::alarms_to_cancel_after_resume`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub enum AlarmType {
     AutoPowerOff,

--- a/crates/core/src/device/test_device.rs
+++ b/crates/core/src/device/test_device.rs
@@ -255,6 +255,63 @@ impl crate::device::power::PowerManager for TestPowerManager {
     }
 }
 
+#[derive(Debug, Default)]
+struct TestLedsState {
+    on_calls: u32,
+    off_calls: u32,
+    is_on: bool,
+}
+
+/// Assertable LED controller test double.
+#[derive(Clone)]
+pub struct TestLeds {
+    state: Arc<Mutex<TestLedsState>>,
+}
+
+impl TestLeds {
+    pub fn new() -> Self {
+        Self {
+            state: Arc::new(Mutex::new(TestLedsState::default())),
+        }
+    }
+
+    pub fn on_call_count(&self) -> u32 {
+        self.state.lock().map(|s| s.on_calls).unwrap_or(0)
+    }
+
+    pub fn off_call_count(&self) -> u32 {
+        self.state.lock().map(|s| s.off_calls).unwrap_or(0)
+    }
+
+    pub fn is_on(&self) -> bool {
+        self.state.lock().map(|s| s.is_on).unwrap_or(false)
+    }
+}
+
+impl Default for TestLeds {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl crate::device::leds::DeviceLeds for TestLeds {
+    fn on(&self) -> Result<(), crate::device::leds::LedsError> {
+        if let Ok(mut state) = self.state.lock() {
+            state.on_calls += 1;
+            state.is_on = true;
+        }
+        Ok(())
+    }
+
+    fn off(&self) -> Result<(), crate::device::leds::LedsError> {
+        if let Ok(mut state) = self.state.lock() {
+            state.off_calls += 1;
+            state.is_on = false;
+        }
+        Ok(())
+    }
+}
+
 /// Stub input source for tests.
 pub struct TestInputSource;
 
@@ -281,6 +338,7 @@ pub struct TestDevice {
     wifi_manager: Arc<TestWifiManager>,
     usb_manager: Arc<TestUsbManager>,
     power_manager: Arc<TestPowerManager>,
+    leds: Arc<TestLeds>,
     rtc: Arc<TestRtc>,
     time_manager: crate::time_manager::TimeManager<TestRtc>,
     input: TestInputSource,
@@ -300,6 +358,7 @@ impl TestDevice {
             wifi_manager: Arc::new(TestWifiManager::new()),
             usb_manager: Arc::new(TestUsbManager::new()),
             power_manager: Arc::new(TestPowerManager::new()),
+            leds: Arc::new(TestLeds::new()),
             rtc,
             time_manager,
             input: TestInputSource,
@@ -319,6 +378,11 @@ impl TestDevice {
     /// Returns the power test double for lifecycle assertion helpers.
     pub fn power_manager_for_test(&self) -> &TestPowerManager {
         self.power_manager.as_ref()
+    }
+
+    /// Returns the LED test double for assertion helpers.
+    pub fn leds_for_test(&self) -> &TestLeds {
+        self.leds.as_ref()
     }
 }
 
@@ -416,6 +480,7 @@ crate::impl_device_hardware!(
     WifiManager = TestWifiManager,
     UsbManager = TestUsbManager,
     PowerManager = TestPowerManager,
+    Leds = TestLeds,
     Rtc = TestRtc,
 );
 

--- a/crates/core/src/device/test_device.rs
+++ b/crates/core/src/device/test_device.rs
@@ -201,6 +201,8 @@ impl crate::device::usb::UsbManager for TestUsbManager {
 struct TestPowerState {
     suspend_calls: u32,
     resume_calls: u32,
+    arm_deep_idle_calls: u32,
+    disarm_deep_idle_calls: u32,
 }
 
 /// Assertable power manager test double.
@@ -222,6 +224,20 @@ impl TestPowerManager {
 
     pub fn resume_call_count(&self) -> u32 {
         self.state.lock().map(|s| s.resume_calls).unwrap_or(0)
+    }
+
+    pub fn arm_deep_idle_call_count(&self) -> u32 {
+        self.state
+            .lock()
+            .map(|s| s.arm_deep_idle_calls)
+            .unwrap_or(0)
+    }
+
+    pub fn disarm_deep_idle_call_count(&self) -> u32 {
+        self.state
+            .lock()
+            .map(|s| s.disarm_deep_idle_calls)
+            .unwrap_or(0)
     }
 
     pub fn was_suspend_called(&self) -> bool {
@@ -250,6 +266,20 @@ impl crate::device::power::PowerManager for TestPowerManager {
     fn resume(&self) -> Result<(), crate::device::power::PowerError> {
         if let Ok(mut state) = self.state.lock() {
             state.resume_calls += 1;
+        }
+        Ok(())
+    }
+
+    fn arm_deep_idle(&self) -> Result<(), crate::device::power::PowerError> {
+        if let Ok(mut state) = self.state.lock() {
+            state.arm_deep_idle_calls += 1;
+        }
+        Ok(())
+    }
+
+    fn disarm_deep_idle(&self) -> Result<(), crate::device::power::PowerError> {
+        if let Ok(mut state) = self.state.lock() {
+            state.disarm_deep_idle_calls += 1;
         }
         Ok(())
     }

--- a/docs/po/messages.pot
+++ b/docs/po/messages.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Cadmus Documentation\n"
-"POT-Creation-Date: 2026-08-04T11:45:36+02:00\n"
+"POT-Creation-Date: 2026-08-04T12:18:06+02:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -179,6 +179,10 @@ msgid "DHCP IP Address Changes on WiFi Toggle"
 msgstr ""
 
 #: src/SUMMARY.md:54
+msgid "Soft suspend via autosleep and wake_lock"
+msgstr ""
+
+#: src/SUMMARY.md:55
 msgid "Reading IP and ESSID via dhcpcd-dbus"
 msgstr ""
 

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -35,6 +35,8 @@
 - [Code Style and Linting](contributing/code-style.md)
 - [Event System](contributing/event-system.md)
 - [WiFi Leases](contributing/wifi.md)
+- [Soft Suspend](contributing/soft-suspend.md)
+- [Kobo suspend](contributing/kobo/suspend.md)
 - [Telemetry](contributing/telemetry/index.md)
   - [Logging](contributing/telemetry/logging.md)
   - [Tracing](contributing/telemetry/tracing.md)

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -54,3 +54,4 @@
 - [Intro](investigations/index.md)
   - [DHCP IP Address Changes on WiFi Toggle](investigations/kobo/issue-51-dhcp-investigation.md)
   - [Reading IP and ESSID via dhcpcd-dbus](investigations/kobo/issue-261-dhcpcd-dbus-network-info.md)
+  - [Soft suspend via autosleep and wake_lock](investigations/kobo/issue-361-autosleep-wake-lock.md)

--- a/docs/src/contributing/kobo/suspend.md
+++ b/docs/src/contributing/kobo/suspend.md
@@ -1,0 +1,89 @@
+<!-- i18n:skip-start -->
+
+# Kobo suspend and deep idle
+
+Kobo-specific sleep paths for Cadmus. Generic soft-suspend lease/session
+details live in [Soft Suspend](../soft-suspend.md). Research notes are in
+[investigation #361](../../investigations/kobo/issue-361-autosleep-wake-lock.md).
+
+## Classic hard suspend (soft suspend Off)
+
+When `AutosleepMode` is `Off`, Auto Suspend / power button / sleep cover use
+the classic path:
+
+1. RTC [`AlarmType::AutoSuspend`](../../../../crates/core/src/device/rtc/mod.rs)
+   fires → lifecycle `begin_suspend`
+2. Intermission UI; wait [`PREPARE_SUSPEND_WAIT_DELAY`](../../../../crates/core/src/device/kobo/lifecycle/mod.rs)
+   (3s) then PrepareSuspend teardown (settings, frontlight, Wi‑Fi)
+3. Wait [`SUSPEND_WAIT_DELAY`](../../../../crates/core/src/device/kobo/lifecycle/mod.rs)
+   (15s) then `Event::Suspend`
+4. [`KoboPowerManager::suspend`](../../../../crates/core/src/device/kobo/power.rs):
+   write `1` to `/sys/power/state-extended`, sync, write `mem` to
+   `/sys/power/state`
+5. On wake: `state-extended=0` (+ model-specific touch re-init); AutoPowerOff /
+   Calendar RTC handling; re-sleep loop until the user cancels
+
+## Soft-suspend deep idle (mode armed)
+
+When soft suspend is armed (`freeze` or `mem` for light naps), the same
+user-facing sleep triggers enter **deep idle** instead of writing
+`/sys/power/state`:
+
+1. Acquire a named `deep-idle` cycle lease so autosleep cannot freeze mid-cycle
+2. PrepareSuspend / Suspend run **without** the 3s / 15s delays — the cycle
+   lease keeps the SoC awake through teardown and RTC work
+3. Force session autosleep to **`mem`** (deep idle always targets suspend-to-RAM,
+   even if settings mode is `freeze`)
+4. Arm vendor prep: `state-extended=1`
+5. Drop the cycle lease (and any other holders) so autosleep enters `mem` —
+   **no** userspace `state=mem` write
+6. On wake / cancel: `state-extended=0`, restore the previous settings autosleep
+   mode, drop the cycle lease, reschedule Auto Suspend RTC
+
+RTC AutoPowerOff / Calendar while deep-idle re-acquire the cycle lease for the
+processing window, then re-enter deep idle.
+
+```mermaid
+sequenceDiagram
+  participant Life as Lifecycle
+  participant Soft as SoftSuspendSession
+  participant Sys as Sysfs
+
+  Note over Life: RTC AutoSuspend or power button sleep
+  Life->>Life: PrepareSuspend teardown
+  alt autosleep was armed
+    Life->>Soft: set_mode Mem for deep idle
+    Life->>Sys: state-extended = 1
+    Life->>Soft: drop deep-idle lease
+    Soft->>Sys: autosleep mem
+  else autosleep Off
+    Life->>Sys: state-extended + state = mem
+  end
+  Note over Sys: power button wake
+  Life->>Sys: state-extended = 0
+  Life->>Soft: restore settings autosleep_mode
+```
+
+## `state-extended` is Kobo/NiX, not mainline
+
+[`/sys/power/state-extended`](https://www.kernel.org/doc/Documentation/ABI/testing/sysfs-power)
+does **not** appear in mainline `sysfs-power`. On Kobo it is a vendor kernel
+patch: writing `1` runs platform hooks (e.g. Neonode touch off); writing `0`
+reverses them. Writing `1` alone does **not** suspend the device.
+
+Upstream autosleep (`/sys/power/autosleep` + wake locks) is what actually
+sleeps when soft suspend is armed. See the
+[sysfs-power ABI](https://www.kernel.org/doc/Documentation/ABI/testing/sysfs-power)
+and [sleep-states admin guide](https://www.kernel.org/doc/html/latest/admin-guide/pm/sleep-states.html).
+
+## Related APIs
+
+| Piece                                                     | Role                                       |
+| --------------------------------------------------------- | ------------------------------------------ |
+| `AlarmType::AutoSuspend` / `AlarmManager`                 | Wall-clock idle deadline                   |
+| Kobo lifecycle `begin_suspend` / PrepareSuspend / Suspend | Orchestration                              |
+| `SoftSuspendSession`                                      | Autosleep mode + `cadmus` wake lock leases |
+| `PowerManager::arm_deep_idle` / `disarm_deep_idle`        | Kobo `state-extended`                      |
+| `KoboPowerManager::suspend`                               | Classic `state-extended` + `state=mem`     |
+
+<!-- i18n:skip-end -->

--- a/docs/src/contributing/soft-suspend.md
+++ b/docs/src/contributing/soft-suspend.md
@@ -1,0 +1,57 @@
+<!-- i18n:skip-start -->
+
+# Soft Suspend
+
+Cadmus soft suspend is an opt-in opportunistic sleep path driven by the
+kernel autosleep workqueue and a single userspace wake lock. User-facing
+behaviour is documented in [Soft Suspend](../soft-suspend.md). Research that
+led to this design is in
+[investigation #361](../investigations/kobo/issue-361-autosleep-wake-lock.md).
+
+Kobo Auto Suspend / deep-idle integration (RTC deadline, `state-extended`,
+cycle lease, PrepareSuspend delays) is documented separately in
+[Kobo suspend](kobo/suspend.md).
+
+## Architecture
+
+```mermaid
+flowchart TD
+  settings["AutosleepMode<br/>Off / Freeze / Mem"] --> apply["write autosleep sysfs"]
+  ledSetting["indicate autosleep LED"] --> led["LED brightness"]
+  graceSetting["autosleep grace seconds"] --> armer["WakeLockArmer"]
+  holders["Named soft-suspend leases"] --> tracker["LeaseTracker"]
+  tracker -->|"0 to 1"| lock["wake_lock cadmus"]
+  tracker -->|"0 to 1"| cancel["cancel pending unlock"]
+  tracker -->|"0 to 1"| ledOn["LED on if indicator<br/>enabled"]
+  tracker -->|"1 to 0"| armer
+  armer -->|"after grace or<br/>immediate if 0"| unlock["wake_unlock cadmus"]
+  apply --> kernel["kernel autosleep"]
+  lock --> kernel
+  unlock --> kernel
+```
+
+`SoftSuspendSession` owns:
+
+- Reading `/sys/power/state` to discover available targets
+- Writing `/sys/power/autosleep` (`off` / `freeze` / `mem`)
+- A lease tracker whose observer maps 0→1 to the single kernel lock name
+  `cadmus`, and 1→0 to a deferred `wake_unlock` after autosleep grace
+  seconds (zero = unlock immediately). A new lease during the grace cancels
+  the pending unlock.
+- Optional LED indicator via `DeviceLeds`
+
+Missing autosleep / wake_lock sysfs is a no-op (emulator and hosts without
+those nodes).
+
+Upstream references:
+[sysfs-power ABI](https://www.kernel.org/doc/Documentation/ABI/testing/sysfs-power)
+(`autosleep`, `wake_lock`, `wake_unlock`, `state`).
+
+## Lease holders
+
+Named leases only adjust the Cadmus refcount; the kernel still sees one lock
+(`cadmus`). Holders include the main loop, input, Wi‑Fi, and background
+tasks while they run. Dropping the last lease (after grace) lets the kernel
+enter the armed autosleep target.
+
+<!-- i18n:skip-end -->

--- a/docs/src/investigations/index.md
+++ b/docs/src/investigations/index.md
@@ -10,5 +10,6 @@ referred to in the future if needed.
 | ---------- | -------- | ------------------------------------------------------------------------------------ |
 | 2026-03-24 | Kobo     | [DHCP IP Address Changes on WiFi Toggle](./kobo/issue-51-dhcp-investigation.md)      |
 | 2026-07-29 | Kobo     | [Reading IP and ESSID via dhcpcd-dbus](./kobo/issue-261-dhcpcd-dbus-network-info.md) |
+| 2026-08-04 | Kobo     | [Soft suspend via autosleep and wake_lock](./kobo/issue-361-autosleep-wake-lock.md)  |
 
 <!-- i18n:skip-end -->

--- a/docs/src/investigations/kobo/issue-361-autosleep-wake-lock.md
+++ b/docs/src/investigations/kobo/issue-361-autosleep-wake-lock.md
@@ -1,0 +1,79 @@
+<!-- i18n:skip-start -->
+
+# Soft suspend via autosleep and wake_lock
+
+Research for [#361](https://github.com/OGKevin/cadmus/issues/361): can Kobo’s
+kernel drive opportunistic soft suspend without a Cadmus-owned sleep loop?
+
+How Cadmus wires this up lives in
+[Soft Suspend (contributor)](../../contributing/soft-suspend.md).
+
+---
+
+## Summary
+
+On KLC, `/sys/power/autosleep` and `/sys/power/wake_lock` /
+`wake_unlock` are present. Writing `freeze` or `mem` to autosleep arms the
+kernel’s opportunistic suspend workqueue; userspace stays awake by holding
+wake locks. That is enough for soft suspend — Cadmus does not need to poll
+and write `/sys/power/state` itself for this path.
+
+Hard suspend (power button / cover / Auto Suspend) remains a separate,
+explicit `state-extended` + `mem` path.
+
+## Device probes
+
+```sh
+$ cat /sys/power/state
+freeze mem
+
+$ ls /sys/power/
+… autosleep … state state-extended wake_lock wake_unlock …
+```
+
+Smoke test that worked on device:
+
+```sh
+$ echo test > /sys/power/wake_lock
+$ echo freeze > /sys/power/autosleep
+# stays awake
+
+$ echo test > /sys/power/wake_unlock
+# enters freeze when nothing else holds a wakeup source
+
+$ echo off > /sys/power/autosleep
+```
+
+### freeze vs mem
+
+With `freeze`, Wi‑Fi could stay associated across soft sleep. With `mem`,
+the link dropped and needed reconnect — consistent with deeper device
+suspend. Issue notes also observed charging LED / radio side effects under
+soft sleep.
+
+### Status LED
+
+```sh
+$ echo 1 > /sys/class/leds/LED/brightness
+$ echo 0 > /sys/class/leds/LED/brightness
+```
+
+Useful as an awake indicator while soft suspend is armed: the kernel clears
+the LED on sleep, and on wake it is turned back on automatically.
+
+## Design takeaway from the research
+
+Do **not** enable/disable autosleep as a stand-in for “busy”. Leave
+autosleep armed at the chosen target and use wake locks (refcount in
+userspace → one kernel lock) so the wake→handle→sleep race stays
+kernel-correct. Missing autosleep / wake_lock nodes → no-op.
+
+## Upstream references
+
+- [sysfs-power ABI](https://www.kernel.org/doc/Documentation/ABI/testing/sysfs-power)
+  — `/sys/power/autosleep`, `wake_lock`, `wake_unlock`, `state`
+- [Autosleep and wake locks (LWN)](https://lwn.net/Articles/479841/) —
+  opportunistic suspend + userspace wakeup sources
+- [`kernel/power/autosleep.c`](https://github.com/torvalds/linux/blob/master/kernel/power/autosleep.c)
+
+<!-- i18n:skip-end -->

--- a/docs/src/investigations/kobo/issue-361-autosleep-wake-lock.md
+++ b/docs/src/investigations/kobo/issue-361-autosleep-wake-lock.md
@@ -5,8 +5,10 @@
 Research for [#361](https://github.com/OGKevin/cadmus/issues/361): can Kobo’s
 kernel drive opportunistic soft suspend without a Cadmus-owned sleep loop?
 
-How Cadmus wires this up lives in
-[Soft Suspend (contributor)](../../contributing/soft-suspend.md).
+How Cadmus wires this up:
+
+- Generic leases / session: [Soft Suspend (contributor)](../../contributing/soft-suspend.md)
+- Kobo deep idle + Auto Suspend: [Kobo suspend](../../contributing/kobo/suspend.md)
 
 ---
 
@@ -16,10 +18,19 @@ On KLC, `/sys/power/autosleep` and `/sys/power/wake_lock` /
 `wake_unlock` are present. Writing `freeze` or `mem` to autosleep arms the
 kernel’s opportunistic suspend workqueue; userspace stays awake by holding
 wake locks. That is enough for soft suspend — Cadmus does not need to poll
-and write `/sys/power/state` itself for this path.
+and write `/sys/power/state` itself for light naps.
 
-Hard suspend (power button / cover / Auto Suspend) remains a separate,
-explicit `state-extended` + `mem` path.
+**Deep idle** (Auto Suspend timeout, power button, sleep cover once soft
+suspend is armed) also uses autosleep, forced to **`mem`**, plus Kobo
+`state-extended=1` for touch prep, then drops the `cadmus` (and cycle) wake
+lock so the kernel sleeps. There is no userspace `state=mem` write on that
+path. A named `deep-idle` cycle lease covers PrepareSuspend / Suspend / RTC
+post-wake work so autosleep cannot freeze mid-cycle; the classic 3s / 15s
+PrepareSuspend delays are skipped because the lease is sufficient.
+
+When soft suspend mode is **Off**, hard suspend remains the explicit
+[`KoboPowerManager`](../../../../crates/core/src/device/kobo/power.rs)
+`state-extended` + `state=mem` path (with those delays).
 
 ## Device probes
 
@@ -49,7 +60,7 @@ $ echo off > /sys/power/autosleep
 With `freeze`, Wi‑Fi could stay associated across soft sleep. With `mem`,
 the link dropped and needed reconnect — consistent with deeper device
 suspend. Issue notes also observed charging LED / radio side effects under
-soft sleep.
+soft sleep. Deep idle therefore always targets `mem`.
 
 ### Status LED
 
@@ -60,6 +71,14 @@ $ echo 0 > /sys/class/leds/LED/brightness
 
 Useful as an awake indicator while soft suspend is armed: the kernel clears
 the LED on sleep, and on wake it is turned back on automatically.
+
+### `state-extended` is not upstream
+
+`/sys/power/state-extended` is a **Kobo/NiX vendor** sysfs node, not part of
+mainline [sysfs-power](https://www.kernel.org/doc/Documentation/ABI/testing/sysfs-power).
+Writing `1` prepares peripherals (e.g. touch); it does **not** suspend by
+itself. Cadmus still needs either autosleep `mem` + clear wake locks, or an
+explicit `state=mem` write (classic path).
 
 ## Design takeaway from the research
 
@@ -75,5 +94,6 @@ kernel-correct. Missing autosleep / wake_lock nodes → no-op.
 - [Autosleep and wake locks (LWN)](https://lwn.net/Articles/479841/) —
   opportunistic suspend + userspace wakeup sources
 - [`kernel/power/autosleep.c`](https://github.com/torvalds/linux/blob/master/kernel/power/autosleep.c)
+- [sleep-states admin guide](https://www.kernel.org/doc/html/latest/admin-guide/pm/sleep-states.html)
 
 <!-- i18n:skip-end -->


### PR DESCRIPTION
Userspace cannot drive re-sleep under autosleep. Enter sleep from PrepareSuspend immediately on the soft path, keep the Suspend intermission across debounce, and cancel via Power Released or long-hold.

Change-Id: ba2f1367d39fe41f20fb2bf5c6be577a
Change-Id-Short: opxkywtsmwqk