### PR TITLE
refactor(rtc): use RTC as AlarmManager clock authority

### DIFF
--- a/crates/core/src/context.rs
+++ b/crates/core/src/context.rs
@@ -259,7 +259,7 @@ impl<D: Device> Context<D> {
         }
 
         let duration = auto_suspend_chrono_duration(minutes);
-        if let Err(error) = alarm_manager.schedule_alarm(AlarmType::AutoSuspend, duration) {
+        if let Err(error) = alarm_manager.schedule_in(AlarmType::AutoSuspend, duration) {
             tracing::error!(error = %error, "failed to schedule AutoSuspend alarm");
         }
     }

--- a/crates/core/src/device/emulator/rtc.rs
+++ b/crates/core/src/device/emulator/rtc.rs
@@ -1,7 +1,7 @@
 //! In-memory emulator RTC with Condvar-backed alarm IRQ waits.
 
 use anyhow::Error;
-use chrono::{DateTime, Utc};
+use chrono::{DateTime, Duration as ChronoDuration, Utc};
 use std::sync::{Arc, Condvar, Mutex};
 use std::time::Duration;
 
@@ -11,9 +11,20 @@ const RTC_AF: u32 = 0x20;
 
 #[derive(Debug)]
 struct EmulatorRtcState {
+    /// Whether the in-memory hardware wake alarm is armed.
     alarm_enabled: bool,
+    /// Programmed wake instant on the emulated RTC timeline, if any.
     alarm_wake_time: Option<DateTime<Utc>>,
+    /// Set when an IRQ should unblock [`Rtc::wait_for_alarm_irq`].
     irq_pending: bool,
+    /// Emulated RTC timeline as `system_now + offset` (see [`Rtc::read_time`]).
+    offset: ChronoDuration,
+    /// `RTC_now − system_now`; for the emulator this equals [`Self::offset`].
+    ///
+    /// Positive means the emulated RTC reads ahead of civil time.
+    drift: ChronoDuration,
+    /// `new_time − old_time` from the latest [`Rtc::set_time`], if not yet taken.
+    pending_step: Option<ChronoDuration>,
 }
 
 /// Emulator RTC that schedules in-memory wake alarms and wakes IRQ waiters.
@@ -30,6 +41,9 @@ impl EmulatorRtc {
                 alarm_enabled: false,
                 alarm_wake_time: None,
                 irq_pending: false,
+                offset: ChronoDuration::zero(),
+                drift: ChronoDuration::zero(),
+                pending_step: None,
             })),
             cond: Arc::new(Condvar::new()),
         }
@@ -74,11 +88,38 @@ impl Rtc for EmulatorRtc {
     }
 
     fn read_time(&self) -> Result<DateTime<Utc>, Error> {
-        Ok(Utc::now())
+        self.state
+            .lock()
+            .map(|state| Utc::now() + state.offset)
+            .map_err(|e| anyhow::anyhow!("lock poisoned: {}", e))
     }
 
-    fn set_time(&self, _time: DateTime<Utc>) -> Result<(), Error> {
+    fn set_time(&self, time: DateTime<Utc>) -> Result<(), Error> {
+        let system_now = Utc::now();
+        let mut state = self
+            .state
+            .lock()
+            .map_err(|e| anyhow::anyhow!("lock poisoned: {}", e))?;
+        let old_time = system_now + state.offset;
+        state.offset = time.signed_duration_since(system_now);
+        state.drift = state.offset;
+        state.pending_step = Some(time.signed_duration_since(old_time));
+        self.cond.notify_all();
         Ok(())
+    }
+
+    fn drift(&self) -> Result<ChronoDuration, Error> {
+        self.state
+            .lock()
+            .map(|state| state.drift)
+            .map_err(|e| anyhow::anyhow!("lock poisoned: {}", e))
+    }
+
+    fn take_pending_step(&self) -> Result<Option<ChronoDuration>, Error> {
+        self.state
+            .lock()
+            .map(|mut state| state.pending_step.take())
+            .map_err(|e| anyhow::anyhow!("lock poisoned: {}", e))
     }
 
     fn wait_for_alarm_irq(&self, timeout: Option<Duration>) -> Result<Option<u32>, Error> {
@@ -94,7 +135,7 @@ impl Rtc for EmulatorRtc {
                 return Ok(Some(RTC_AF));
             }
 
-            let now = Utc::now();
+            let now = Utc::now() + state.offset;
             if state.alarm_enabled
                 && let Some(wake_time) = state.alarm_wake_time
                 && wake_time <= now

--- a/crates/core/src/device/kobo/lifecycle/device_events.rs
+++ b/crates/core/src/device/kobo/lifecycle/device_events.rs
@@ -388,7 +388,7 @@ mod tests {
                 .lock()
                 .unwrap();
             alarms
-                .schedule_alarm(
+                .schedule_in(
                     crate::AlarmType::Suspend,
                     crate::chrono::Duration::seconds(15),
                 )

--- a/crates/core/src/device/kobo/lifecycle/helpers.rs
+++ b/crates/core/src/device/kobo/lifecycle/helpers.rs
@@ -83,7 +83,7 @@ mod tests {
                 .lock()
                 .unwrap();
             alarms
-                .schedule_alarm(AlarmType::Suspend, ChronoDuration::seconds(15))
+                .schedule_in(AlarmType::Suspend, ChronoDuration::seconds(15))
                 .unwrap();
         }
         assert!(is_suspend_active(&harness.context, &harness.tasks));
@@ -107,7 +107,7 @@ mod tests {
                 .lock()
                 .unwrap();
             alarms
-                .schedule_alarm(AlarmType::Suspend, ChronoDuration::seconds(-1))
+                .schedule_in(AlarmType::Suspend, ChronoDuration::seconds(-1))
                 .unwrap();
             assert!(alarms.has_alarm(AlarmType::Suspend));
             assert!(!alarms.is_alarm_scheduled(AlarmType::Suspend));
@@ -148,7 +148,7 @@ mod tests {
                 .lock()
                 .unwrap();
             alarms
-                .schedule_alarm(AlarmType::Suspend, ChronoDuration::seconds(15))
+                .schedule_in(AlarmType::Suspend, ChronoDuration::seconds(15))
                 .unwrap();
         }
         cancel_suspend_if_pending(
@@ -174,7 +174,7 @@ mod tests {
                 .lock()
                 .unwrap();
             alarms
-                .schedule_alarm(AlarmType::WakeDebounce, ChronoDuration::seconds(15))
+                .schedule_in(AlarmType::WakeDebounce, ChronoDuration::seconds(15))
                 .unwrap();
         }
         cancel_suspend_if_pending(
@@ -222,7 +222,7 @@ mod tests {
                 .lock()
                 .unwrap();
             alarms
-                .schedule_alarm(AlarmType::Suspend, ChronoDuration::seconds(-1))
+                .schedule_in(AlarmType::Suspend, ChronoDuration::seconds(-1))
                 .unwrap();
         }
         cancel_suspend_if_pending(

--- a/crates/core/src/device/kobo/lifecycle/suspend.rs
+++ b/crates/core/src/device/kobo/lifecycle/suspend.rs
@@ -12,6 +12,7 @@
 use super::helpers::is_suspend_active;
 use super::{SUSPEND_WAIT_DELAY, begin_suspend, show_power_off_intermission};
 use crate::AlarmType;
+use crate::ClockInstant;
 use crate::chrono::{Duration as ChronoDuration, Local, Timelike};
 use crate::device::DeviceHardware as _;
 use crate::device::power::PowerManager;
@@ -65,7 +66,7 @@ pub(super) fn schedule_wake_debounce_alarm(context: &mut AppContext) {
     let mut alarm_manager = alarm_manager.lock().unwrap_or_else(|e| e.into_inner());
     let duration = ChronoDuration::from_std(super::SUSPEND_WAIT_DELAY)
         .unwrap_or_else(|_| ChronoDuration::seconds(15));
-    if let Err(error) = alarm_manager.schedule_alarm(AlarmType::WakeDebounce, duration) {
+    if let Err(error) = alarm_manager.schedule_in(AlarmType::WakeDebounce, duration) {
         tracing::error!(error = %error, "failed to schedule WakeDebounce alarm");
     }
 }
@@ -99,7 +100,7 @@ pub(super) fn schedule_suspend_alarm(context: &mut AppContext, delay: std::time:
     };
     let mut alarm_manager = alarm_manager.lock().unwrap_or_else(|e| e.into_inner());
     let duration = ChronoDuration::from_std(delay).unwrap_or_else(|_| ChronoDuration::seconds(15));
-    if let Err(error) = alarm_manager.schedule_alarm(AlarmType::Suspend, duration) {
+    if let Err(error) = alarm_manager.schedule_in(AlarmType::Suspend, duration) {
         tracing::error!(error = %error, "failed to schedule Suspend alarm");
     }
 }
@@ -326,6 +327,13 @@ fn schedule_alarms_before_sleep(
     context: &mut AppContext,
     runtime: &mut DeviceRuntime<'_>,
 ) -> Option<EventOutcome> {
+    let calendar_duration = (context.settings.intermissions[IntermKind::Suspend]
+        == crate::settings::IntermissionDisplay::Calendar)
+        .then(|| {
+            let now = Local::now();
+            let seconds_into_current_5min = (now.minute() as i64 % 5) * 60 + now.second() as i64;
+            ChronoDuration::seconds(300 - seconds_into_current_5min + 1)
+        });
     let alarm_manager = context.alarm_manager.as_ref()?;
     let mut alarm_manager = alarm_manager.lock().unwrap_or_else(|e| e.into_inner());
 
@@ -354,16 +362,11 @@ fn schedule_alarms_before_sleep(
         }
     }
 
-    if context.settings.intermissions[IntermKind::Suspend]
-        == crate::settings::IntermissionDisplay::Calendar
-    {
-        let now = Local::now();
-        let seconds_into_current_5min = (now.minute() as i64 % 5) * 60 + now.second() as i64;
-        let seconds_until_next_5min = 300 - seconds_into_current_5min + 1;
+    if let Some(duration) = calendar_duration {
         alarm_manager
             .ensure_scheduled(
                 AlarmType::CalendarUpdate,
-                ChronoDuration::seconds(seconds_until_next_5min),
+                duration,
                 PastDueAction::Reschedule,
             )
             .map_err(
@@ -428,7 +431,10 @@ fn handle_post_wake(
     if let Some(alarm_manager) = context.alarm_manager.as_ref() {
         let fired_alarms = {
             let mut alarm_manager = alarm_manager.lock().unwrap_or_else(|e| e.into_inner());
-            match alarm_manager.check_fired_alarms(before.to_utc(), after.to_utc()) {
+            match alarm_manager.check_fired_alarms(
+                ClockInstant::Civil(before.to_utc()),
+                ClockInstant::Civil(after.to_utc()),
+            ) {
                 Ok(fired) => {
                     tracing::info!(alarms = ?fired, "Checked fired alarms after wake");
                     fired
@@ -533,7 +539,7 @@ mod tests {
         let mut harness = LifecycleHarness::new();
         harness.context.settings.auto_power_off = 1.0;
         lock_alarms(&mut harness)
-            .schedule_alarm(AlarmType::AutoPowerOff, ChronoDuration::seconds(-10))
+            .schedule_in(AlarmType::AutoPowerOff, ChronoDuration::seconds(-10))
             .unwrap();
         let outcome = harness.with_runtime_only(schedule_alarms_before_sleep);
         assert_eq!(outcome, Some(EventOutcome::Exit(ExitStatus::PowerOff)));
@@ -554,13 +560,16 @@ mod tests {
         let before = Local::now();
         {
             lock_alarms(&mut harness)
-                .schedule_alarm(AlarmType::AutoPowerOff, ChronoDuration::minutes(5))
+                .schedule_in(AlarmType::AutoPowerOff, ChronoDuration::minutes(5))
                 .unwrap();
             if let Ok(rtc) = harness.context.device.rtc() {
                 rtc.simulate_alarm_fired();
             }
         }
         let after = before + ChronoDuration::minutes(5) + ChronoDuration::seconds(1);
+        if let Ok(rtc) = harness.context.device.rtc() {
+            rtc.set_current_time(after.to_utc());
+        }
         let outcome = harness.with_parts(|hub, bus, rq, context, runtime| {
             handle_post_wake(before, after, hub, bus, rq, context, runtime)
         });
@@ -797,7 +806,7 @@ mod tests {
         {
             let mut alarms = lock_alarms(&mut harness);
             alarms
-                .schedule_alarm(AlarmType::Suspend, ChronoDuration::seconds(15))
+                .schedule_in(AlarmType::Suspend, ChronoDuration::seconds(15))
                 .unwrap();
         }
         harness.with_parts(|hub, _bus, rq, context, runtime| {

--- a/crates/core/src/device/linux/rtc.rs
+++ b/crates/core/src/device/linux/rtc.rs
@@ -1,7 +1,7 @@
 //! Linux ioctl RTC implementation.
 
 use anyhow::Error;
-use chrono::{DateTime, Utc};
+use chrono::{DateTime, Duration as ChronoDuration, Utc};
 use nix::poll::{PollFd, PollFlags, PollTimeout, poll};
 use nix::{ioctl_none, ioctl_read, ioctl_write_ptr};
 use std::fs::{File, OpenOptions};
@@ -43,6 +43,23 @@ ioctl_write_ptr!(rtc_set_time, b'p', 0x0a, RtcTime);
 pub struct LinuxRtc {
     file: Arc<Mutex<File>>,
     wait_file: Arc<Mutex<File>>,
+    /// Cached RTC↔civil relationship and last `set_time` step.
+    clock: Arc<Mutex<LinuxRtcClock>>,
+}
+
+/// Cached conversion state between the hardware RTC and the civil system clock.
+#[derive(Debug)]
+struct LinuxRtcClock {
+    /// `RTC_now − system_now` from the last drift refresh (`new` / `set_time`).
+    ///
+    /// Positive means the RTC reads ahead of civil time. Used by [`Rtc::to_rtc`]
+    /// / [`Rtc::to_civil`].
+    drift: ChronoDuration,
+    /// `new_time − old_time` from the latest [`Rtc::set_time`], if not yet taken.
+    ///
+    /// [`AlarmManager::sync`] consumes this via [`Rtc::take_pending_step`] to
+    /// rebase relative and RTC-absolute alarms after a clock write.
+    pending_step: Option<ChronoDuration>,
 }
 
 impl LinuxRtc {
@@ -67,10 +84,30 @@ impl LinuxRtc {
         let file = OpenOptions::new().read(true).write(true).open(path)?;
         let wait_fd = nix::unistd::dup(file.as_fd())?;
         let wait_file = File::from(wait_fd);
-        Ok(LinuxRtc {
+        let rtc = LinuxRtc {
             file: Arc::new(Mutex::new(file)),
             wait_file: Arc::new(Mutex::new(wait_file)),
-        })
+            clock: Arc::new(Mutex::new(LinuxRtcClock {
+                drift: ChronoDuration::zero(),
+                pending_step: None,
+            })),
+        };
+        rtc.refresh_drift_from_hardware()?;
+        Ok(rtc)
+    }
+
+    fn refresh_drift_from_hardware(&self) -> Result<(), Error> {
+        match self.read_time() {
+            Ok(rtc_now) => {
+                self.clock
+                    .lock()
+                    .map_err(|e| anyhow::anyhow!("lock poisoned: {}", e))?
+                    .drift = rtc_now.signed_duration_since(Utc::now());
+                Ok(())
+            }
+            Err(_) if cfg!(test) => Ok(()),
+            Err(err) => Err(err),
+        }
     }
 }
 
@@ -123,6 +160,7 @@ impl Rtc for LinuxRtc {
 
     /// Issues `RTC_SET_TIME`; requires write access to the device node.
     fn set_time(&self, time: DateTime<Utc>) -> Result<(), Error> {
+        let old_time = self.read_time()?;
         let rt: RtcTime = time.into();
         let file = self
             .file
@@ -131,7 +169,28 @@ impl Rtc for LinuxRtc {
         unsafe {
             rtc_set_time(file.as_raw_fd(), &rt)?;
         }
+        drop(file);
+        let mut clock = self
+            .clock
+            .lock()
+            .map_err(|e| anyhow::anyhow!("lock poisoned: {}", e))?;
+        clock.drift = time.signed_duration_since(Utc::now());
+        clock.pending_step = Some(time.signed_duration_since(old_time));
         Ok(())
+    }
+
+    fn drift(&self) -> Result<ChronoDuration, Error> {
+        self.clock
+            .lock()
+            .map(|clock| clock.drift)
+            .map_err(|e| anyhow::anyhow!("lock poisoned: {}", e))
+    }
+
+    fn take_pending_step(&self) -> Result<Option<ChronoDuration>, Error> {
+        self.clock
+            .lock()
+            .map(|mut clock| clock.pending_step.take())
+            .map_err(|e| anyhow::anyhow!("lock poisoned: {}", e))
     }
 
     fn wait_for_alarm_irq(&self, timeout: Option<Duration>) -> Result<Option<u32>, Error> {

--- a/crates/core/src/device/rtc/manager.rs
+++ b/crates/core/src/device/rtc/manager.rs
@@ -1,7 +1,7 @@
 //! RTC trait definition.
 
 use anyhow::Error;
-use chrono::{DateTime, Utc};
+use chrono::{DateTime, Duration as ChronoDuration, Utc};
 use std::time::Duration;
 
 use super::RtcWkalrm;
@@ -67,13 +67,38 @@ pub trait Rtc: Send + Sync {
 
     /// Sets the RTC to `time`.
     ///
-    /// [`crate::time_manager::TimeManager`] calls this after a successful NTP
-    /// sync. May require elevated privileges on some platforms.
+    /// This low-level operation records a pending step but does not synchronize
+    /// logical alarms. App clock updates should call [`super::set_time`] so
+    /// [`super::AlarmManager::sync`] consumes the step immediately. May require
+    /// elevated privileges on some platforms.
     ///
     /// # Errors
     ///
     /// Returns an error when the clock cannot be updated.
     fn set_time(&self, time: DateTime<Utc>) -> Result<(), Error>;
+
+    /// Returns the RTC offset from the civil system clock (`RTC_now − system_now`).
+    ///
+    /// Positive means the RTC reads ahead of civil time. Implementations
+    /// establish this value during initialization and refresh it only after
+    /// [`Rtc::set_time`], while Cadmus retains exclusive RTC access.
+    fn drift(&self) -> Result<ChronoDuration, Error>;
+
+    /// Converts a civil system-clock instant to the RTC timeline.
+    fn to_rtc(&self, civil: DateTime<Utc>) -> Result<DateTime<Utc>, Error> {
+        Ok(civil + self.drift()?)
+    }
+
+    /// Converts an RTC-timeline instant to the civil system-clock timeline.
+    fn to_civil(&self, rtc: DateTime<Utc>) -> Result<DateTime<Utc>, Error> {
+        Ok(rtc - self.drift()?)
+    }
+
+    /// Takes the clock step recorded by the latest [`Rtc::set_time`] call.
+    ///
+    /// The returned duration is `new_time - old_time`. Taking it clears the
+    /// pending value.
+    fn take_pending_step(&self) -> Result<Option<ChronoDuration>, Error>;
 
     /// Blocks until an alarm IRQ is readable, or until `timeout` elapses.
     ///
@@ -106,6 +131,14 @@ impl<T: Rtc + ?Sized> Rtc for std::sync::Arc<T> {
 
     fn set_time(&self, time: DateTime<Utc>) -> Result<(), Error> {
         (**self).set_time(time)
+    }
+
+    fn drift(&self) -> Result<ChronoDuration, Error> {
+        (**self).drift()
+    }
+
+    fn take_pending_step(&self) -> Result<Option<ChronoDuration>, Error> {
+        (**self).take_pending_step()
     }
 
     fn wait_for_alarm_irq(&self, timeout: Option<Duration>) -> Result<Option<u32>, Error> {

--- a/crates/core/src/device/rtc/mod.rs
+++ b/crates/core/src/device/rtc/mod.rs
@@ -170,6 +170,39 @@ pub enum AlarmType {
     CalendarUpdate,
 }
 
+/// Instant on either the hardware RTC timeline or the civil system wall clock.
+///
+/// **Civil** means the system wall clock (`Utc::now()` / `Local`) — what the UI
+/// and NTP use — not the hardware RTC register.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ClockInstant {
+    /// Instant already expressed on the hardware RTC timeline.
+    Rtc(DateTime<Utc>),
+    /// Instant on the civil system wall clock; convert with [`Rtc::to_rtc`].
+    Civil(DateTime<Utc>),
+}
+
+/// Describes when a logical alarm should fire.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AlarmWhen {
+    /// Fires after the duration elapses on the RTC timeline.
+    In(Duration),
+    /// Fires at an absolute [`ClockInstant`] (RTC or civil).
+    At(ClockInstant),
+}
+
+impl From<Duration> for AlarmWhen {
+    fn from(duration: Duration) -> Self {
+        Self::In(duration)
+    }
+}
+
+impl From<ClockInstant> for AlarmWhen {
+    fn from(instant: ClockInstant) -> Self {
+        Self::At(instant)
+    }
+}
+
 /// Describes what [`AlarmManager::ensure_scheduled`] should do when an alarm
 /// exists in the map but its wake time is already in the past.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -202,8 +235,15 @@ impl AlarmType {
     }
 }
 
+/// One logical alarm retained by [`AlarmManager`] until claimed or cancelled.
 pub struct ScheduledAlarm {
+    /// Logical alarm identity multiplexed onto the single hardware wake slot.
     pub alarm_type: AlarmType,
+    /// Original scheduling intent; kept so [`AlarmManager::sync`] can rebase
+    /// after an RTC clock step (`In` / `At(Rtc)` shift by the step, `At(Civil)`
+    /// reconverts through refreshed drift).
+    pub when: AlarmWhen,
+    /// Resolved wake instant on the RTC timeline (what hardware is programmed with).
     pub wake_time: DateTime<Utc>,
 }
 
@@ -234,25 +274,19 @@ impl<R: Rtc> AlarmManager<R> {
         }
     }
 
-    /// Schedule a logical alarm to fire `duration` from now.
+    /// Schedules a logical alarm with an explicit relative or absolute intent.
     ///
-    /// If an alarm of the same type is already scheduled it is replaced.
-    /// The hardware RTC is updated to reflect the new earliest wake time.
-    pub fn schedule_alarm(
-        &mut self,
-        alarm_type: AlarmType,
-        duration: Duration,
-    ) -> Result<(), Error> {
-        let wake_time = Utc::now() + duration;
-        self.scheduled_alarms.insert(
-            alarm_type,
-            ScheduledAlarm {
-                alarm_type,
-                wake_time,
-            },
-        );
-        self.update_hardware_alarm()?;
-        Ok(())
+    /// Relative alarms use RTC time as their base. If the RTC cannot be read,
+    /// the operation uses system time consistently as its fallback.
+    pub fn schedule(&mut self, alarm_type: AlarmType, when: AlarmWhen) -> Result<(), Error> {
+        let now = self.authority_now();
+        self.schedule_at(alarm_type, when, now)?;
+        self.update_hardware_alarm_at(now)
+    }
+
+    /// Schedules a logical alarm to fire after `duration` on the RTC timeline.
+    pub fn schedule_in(&mut self, alarm_type: AlarmType, duration: Duration) -> Result<(), Error> {
+        self.schedule(alarm_type, AlarmWhen::In(duration))
     }
 
     /// Cancel a previously scheduled logical alarm.
@@ -260,16 +294,17 @@ impl<R: Rtc> AlarmManager<R> {
     /// If no alarm of that type is scheduled this is a no-op. The hardware
     /// RTC is updated to reflect the new earliest remaining wake time.
     pub fn cancel_alarm(&mut self, alarm_type: AlarmType) -> Result<(), Error> {
+        let now = self.authority_now();
         self.scheduled_alarms.remove(&alarm_type);
-        self.update_hardware_alarm()?;
-        Ok(())
+        self.update_hardware_alarm_at(now)
     }
 
     /// Returns `true` if an alarm of `alarm_type` is scheduled for a future time.
     pub fn is_alarm_scheduled(&self, alarm_type: AlarmType) -> bool {
+        let now = self.authority_now();
         self.scheduled_alarms
             .get(&alarm_type)
-            .map(|alarm| alarm.wake_time > Utc::now())
+            .map(|alarm| alarm.wake_time > now)
             .unwrap_or(false)
     }
 
@@ -278,77 +313,92 @@ impl<R: Rtc> AlarmManager<R> {
         self.scheduled_alarms.contains_key(&alarm_type)
     }
 
-    /// Ensures an alarm of `alarm_type` is active and scheduled for the future.
-    pub fn ensure_scheduled(
+    /// Ensures an alarm is active and scheduled for the future.
+    ///
+    /// Accepts either an [`AlarmWhen`] or a relative [`Duration`]. A stale
+    /// alarm is handled according to `past_due_action`.
+    pub fn ensure_scheduled<W: Into<AlarmWhen>>(
         &mut self,
         alarm_type: AlarmType,
-        duration: Duration,
+        when: W,
         past_due_action: PastDueAction,
     ) -> Result<EnsureAlarmOutcome, Error> {
-        if !self.has_alarm(alarm_type) {
-            self.schedule_alarm(alarm_type, duration)?;
-            return Ok(EnsureAlarmOutcome::Scheduled);
-        }
-
-        if self.is_alarm_scheduled(alarm_type) {
-            return Ok(EnsureAlarmOutcome::AlreadyScheduled);
-        }
-
-        self.cancel_alarm(alarm_type)?;
-
-        match past_due_action {
-            PastDueAction::Reschedule => {
-                self.schedule_alarm(alarm_type, duration)?;
-                Ok(EnsureAlarmOutcome::Scheduled)
+        let now = self.authority_now();
+        let when = when.into();
+        let outcome = match self.scheduled_alarms.get(&alarm_type) {
+            None => {
+                self.schedule_at(alarm_type, when, now)?;
+                EnsureAlarmOutcome::Scheduled
             }
-            PastDueAction::Cancel => Ok(EnsureAlarmOutcome::PastDue),
-        }
+            Some(alarm) if alarm.wake_time > now => EnsureAlarmOutcome::AlreadyScheduled,
+            Some(_) => {
+                self.scheduled_alarms.remove(&alarm_type);
+                match past_due_action {
+                    PastDueAction::Reschedule => {
+                        self.schedule_at(alarm_type, when, now)?;
+                        EnsureAlarmOutcome::Scheduled
+                    }
+                    PastDueAction::Cancel => EnsureAlarmOutcome::PastDue,
+                }
+            }
+        };
+        self.update_hardware_alarm_at(now)?;
+        Ok(outcome)
     }
 
     /// Returns the number of seconds until `alarm_type` fires, or `None` if
     /// it is not scheduled.
     pub fn time_until_alarm(&self, alarm_type: AlarmType) -> Option<i64> {
-        self.scheduled_alarms.get(&alarm_type).map(|alarm| {
-            alarm
-                .wake_time
-                .signed_duration_since(Utc::now())
-                .num_seconds()
-        })
+        let now = self.authority_now();
+        self.scheduled_alarms
+            .get(&alarm_type)
+            .map(|alarm| alarm.wake_time.signed_duration_since(now).num_seconds())
     }
 
     /// Determines which logical alarms fired during the last sleep cycle.
+    ///
+    /// `before` and `after` are tagged with [`ClockInstant`] so both ends are
+    /// normalized to the RTC timeline before comparing sleep length to the
+    /// expected wake. Prefer the same variant for both ends of one call.
     pub fn check_fired_alarms(
         &mut self,
-        before: DateTime<Utc>,
-        after: DateTime<Utc>,
+        before: ClockInstant,
+        after: ClockInstant,
     ) -> Result<Vec<AlarmType>, Error> {
+        let now = self.authority_now();
+        let before_rtc = self.resolve_instant(before)?;
+        let after_rtc = self.resolve_instant(after)?;
         if let Some((_, earliest_alarm)) = self
             .scheduled_alarms
             .iter()
             .min_by_key(|(_, alarm)| &alarm.wake_time)
         {
-            let expected_duration = earliest_alarm.wake_time.signed_duration_since(before);
+            let expected_duration = earliest_alarm.wake_time.signed_duration_since(before_rtc);
 
             let rwa = self.rtc.alarm()?;
             let hardware_alarm_fired = !rwa.enabled()
                 || (rwa.year() <= 1970
-                    && ((after - before) - expected_duration).num_seconds().abs() < 3);
+                    && ((after_rtc - before_rtc) - expected_duration)
+                        .num_seconds()
+                        .abs()
+                        < 3);
 
             if hardware_alarm_fired {
-                return self.claim_due_alarms_at(after);
+                return self.claim_due_alarms_at(now);
             }
         }
 
-        self.update_hardware_alarm()?;
+        self.update_hardware_alarm_at(now)?;
         Ok(Vec::new())
     }
 
-    /// Removes and returns logical alarms that are due at the current wall clock.
+    /// Removes and returns logical alarms due on the RTC authority clock.
     ///
-    /// An alarm is due when its wake time is at or before `at`. Reprograms the
-    /// hardware for any remaining future alarms.
+    /// Falls back to system time for the entire claim operation when RTC time
+    /// cannot be read.
     pub fn claim_due_alarms(&mut self) -> Result<Vec<AlarmType>, Error> {
-        self.claim_due_alarms_at(Utc::now())
+        let now = self.authority_now();
+        self.claim_due_alarms_at(now)
     }
 
     fn claim_due_alarms_at(&mut self, at: DateTime<Utc>) -> Result<Vec<AlarmType>, Error> {
@@ -365,13 +415,70 @@ impl<R: Rtc> AlarmManager<R> {
             fired_types.push(alarm_type);
         }
 
-        self.update_hardware_alarm()?;
+        self.update_hardware_alarm_at(at)?;
         Ok(fired_types)
     }
 
-    fn update_hardware_alarm(&self) -> Result<(), Error> {
-        let now = Utc::now();
+    /// Rebases scheduled alarms after an RTC clock write and reprograms hardware.
+    ///
+    /// Relative and RTC-absolute intents retain their remaining RTC duration.
+    /// Civil intents are converted again using the RTC's refreshed drift.
+    pub fn sync(&mut self) -> Result<(), Error> {
+        if let Some(step) = self.rtc.take_pending_step()? {
+            for alarm in self.scheduled_alarms.values_mut() {
+                alarm.wake_time = match alarm.when {
+                    AlarmWhen::In(_) | AlarmWhen::At(ClockInstant::Rtc(_)) => {
+                        alarm.wake_time + step
+                    }
+                    AlarmWhen::At(ClockInstant::Civil(civil)) => self.rtc.to_rtc(civil)?,
+                };
+            }
+        }
+        let now = self.authority_now();
+        self.update_hardware_alarm_at(now)
+    }
 
+    fn authority_now(&self) -> DateTime<Utc> {
+        self.rtc.read_time().unwrap_or_else(|error| {
+            tracing::warn!(error = %error, "RTC read failed; using system clock");
+            Utc::now()
+        })
+    }
+
+    fn resolve_instant(&self, instant: ClockInstant) -> Result<DateTime<Utc>, Error> {
+        match instant {
+            ClockInstant::Rtc(time) => Ok(time),
+            ClockInstant::Civil(civil) => self.rtc.to_rtc(civil),
+        }
+    }
+
+    fn schedule_at(
+        &mut self,
+        alarm_type: AlarmType,
+        when: AlarmWhen,
+        now: DateTime<Utc>,
+    ) -> Result<(), Error> {
+        let wake_time = match when {
+            AlarmWhen::In(duration) => now + duration,
+            AlarmWhen::At(instant) => self.resolve_instant(instant)?,
+        };
+        tracing::debug!(
+            alarm_type = ?alarm_type,
+            wake_at = %wake_time,
+            "Scheduled logical RTC alarm"
+        );
+        self.scheduled_alarms.insert(
+            alarm_type,
+            ScheduledAlarm {
+                alarm_type,
+                when,
+                wake_time,
+            },
+        );
+        Ok(())
+    }
+
+    fn update_hardware_alarm_at(&self, now: DateTime<Utc>) -> Result<(), Error> {
         if let Some((_, earliest_alarm)) = self
             .scheduled_alarms
             .iter()
@@ -385,6 +492,19 @@ impl<R: Rtc> AlarmManager<R> {
 
         Ok(())
     }
+}
+
+/// Sets RTC time and synchronizes logical alarms before returning.
+///
+/// App clock synchronization paths, including NTP, should use this helper so
+/// relative and civil alarm intents remain coherent across an RTC clock step.
+pub fn set_time<R: Rtc>(
+    rtc: &R,
+    alarms: &mut AlarmManager<R>,
+    time: DateTime<Utc>,
+) -> Result<(), Error> {
+    rtc.set_time(time)?;
+    alarms.sync()
 }
 
 impl<R: Rtc + 'static> AlarmManager<R> {
@@ -460,6 +580,107 @@ mod tests {
     }
 
     #[test]
+    fn relative_schedule_uses_rtc_now() {
+        let (rtc, mut manager) = test_alarm_manager();
+        let rtc_now = Utc::now() - Duration::hours(4);
+        rtc.set_current_time(rtc_now);
+
+        manager
+            .schedule_in(AlarmType::AutoSuspend, Duration::minutes(10))
+            .unwrap();
+
+        let wake_time = manager
+            .scheduled_alarms
+            .get(&AlarmType::AutoSuspend)
+            .unwrap()
+            .wake_time;
+        assert_eq!(wake_time, rtc_now + Duration::minutes(10));
+        assert_eq!(rtc.scheduled_wake_time(), Some(wake_time));
+    }
+
+    #[test]
+    fn rtc_lag_does_not_disable_future_hardware_alarm() {
+        let (rtc, mut manager) = test_alarm_manager();
+        rtc.set_current_time(Utc::now() - Duration::hours(1));
+
+        manager
+            .schedule_in(AlarmType::AutoSuspend, Duration::minutes(10))
+            .unwrap();
+        let claimed = manager.claim_due_alarms().unwrap();
+
+        assert!(claimed.is_empty());
+        assert!(manager.has_alarm(AlarmType::AutoSuspend));
+        assert!(rtc.alarm_enabled());
+    }
+
+    #[test]
+    fn helper_preserves_relative_remaining_time() {
+        let (rtc, mut manager) = test_alarm_manager();
+        let old_time = Utc::now() - Duration::hours(2);
+        rtc.set_current_time(old_time);
+        manager
+            .schedule_in(AlarmType::AutoPowerOff, Duration::minutes(20))
+            .unwrap();
+
+        let new_time = old_time + Duration::hours(1);
+        set_time(&rtc, &mut manager, new_time).unwrap();
+
+        let wake_time = manager
+            .scheduled_alarms
+            .get(&AlarmType::AutoPowerOff)
+            .unwrap()
+            .wake_time;
+        assert_eq!(
+            wake_time.signed_duration_since(new_time),
+            Duration::minutes(20)
+        );
+        assert_eq!(rtc.scheduled_wake_time(), Some(wake_time));
+    }
+
+    #[test]
+    fn civil_alarm_rebases_with_updated_drift() {
+        let (rtc, mut manager) = test_alarm_manager();
+        let rtc_now = Utc::now() - Duration::hours(3);
+        rtc.set_time(rtc_now).unwrap();
+        rtc.take_pending_step().unwrap();
+        let civil = Utc::now() + Duration::hours(2);
+
+        manager
+            .schedule(
+                AlarmType::CalendarUpdate,
+                AlarmWhen::At(ClockInstant::Civil(civil)),
+            )
+            .unwrap();
+        let initial_wake = manager
+            .scheduled_alarms
+            .get(&AlarmType::CalendarUpdate)
+            .unwrap()
+            .wake_time;
+
+        set_time(&rtc, &mut manager, rtc_now + Duration::hours(1)).unwrap();
+
+        let wake_time = manager
+            .scheduled_alarms
+            .get(&AlarmType::CalendarUpdate)
+            .unwrap()
+            .wake_time;
+        assert_ne!(wake_time, initial_wake);
+        assert_eq!(wake_time, rtc.to_rtc(civil).unwrap());
+        assert_eq!(rtc.to_civil(wake_time).unwrap(), civil);
+    }
+
+    #[test]
+    fn read_time_does_not_refresh_drift() {
+        let rtc = TestRtc::new();
+        let drift = rtc.drift().unwrap();
+        rtc.set_current_time(Utc::now() + Duration::days(1));
+
+        rtc.read_time().unwrap();
+
+        assert_eq!(rtc.drift().unwrap(), drift);
+    }
+
+    #[test]
     fn ensure_scheduled_fresh() {
         let (_rtc, mut manager) = test_alarm_manager();
         let outcome = manager
@@ -499,7 +720,7 @@ mod tests {
         let past = Utc::now() - Duration::hours(2);
         rtc.set_current_time(past + Duration::minutes(30));
         manager
-            .schedule_alarm(AlarmType::CalendarUpdate, Duration::minutes(-90))
+            .schedule_in(AlarmType::CalendarUpdate, Duration::minutes(-90))
             .unwrap();
         rtc.set_current_time(Utc::now());
         let outcome = manager
@@ -517,7 +738,7 @@ mod tests {
     fn ensure_scheduled_past_due_cancel() {
         let (rtc, mut manager) = test_alarm_manager();
         manager
-            .schedule_alarm(AlarmType::AutoPowerOff, Duration::seconds(-10))
+            .schedule_in(AlarmType::AutoPowerOff, Duration::seconds(-10))
             .unwrap();
         rtc.set_current_time(Utc::now());
         let outcome = manager
@@ -534,25 +755,54 @@ mod tests {
     #[test]
     fn check_fired_alarms_detects_fired() {
         let (rtc, mut manager) = test_alarm_manager();
-        let before = Utc::now();
+        let before = rtc.read_time().unwrap();
         manager
-            .schedule_alarm(AlarmType::AutoPowerOff, Duration::minutes(5))
+            .schedule_in(AlarmType::AutoPowerOff, Duration::minutes(5))
             .unwrap();
         rtc.simulate_alarm_fired();
         let after = before + Duration::minutes(5) + Duration::seconds(1);
-        let fired = manager.check_fired_alarms(before, after).unwrap();
+        rtc.set_current_time(after);
+        let fired = manager
+            .check_fired_alarms(ClockInstant::Rtc(before), ClockInstant::Rtc(after))
+            .unwrap();
+        assert!(fired.contains(&AlarmType::AutoPowerOff));
+    }
+
+    #[test]
+    fn check_fired_alarms_civil_window_under_rtc_lag() {
+        let (rtc, mut manager) = test_alarm_manager();
+        let civil_before = Utc::now();
+        rtc.set_time(civil_before - Duration::hours(1)).unwrap();
+        let _ = rtc.take_pending_step().unwrap();
+
+        manager
+            .schedule_in(AlarmType::AutoPowerOff, Duration::minutes(5))
+            .unwrap();
+        rtc.simulate_alarm_fired();
+
+        let civil_after = civil_before + Duration::minutes(5) + Duration::seconds(1);
+        rtc.set_current_time(rtc.to_rtc(civil_after).unwrap());
+
+        let fired = manager
+            .check_fired_alarms(
+                ClockInstant::Civil(civil_before),
+                ClockInstant::Civil(civil_after),
+            )
+            .unwrap();
         assert!(fired.contains(&AlarmType::AutoPowerOff));
     }
 
     #[test]
     fn check_fired_alarms_not_fired() {
         let (rtc, mut manager) = test_alarm_manager();
-        let before = Utc::now();
+        let before = rtc.read_time().unwrap();
         manager
-            .schedule_alarm(AlarmType::AutoPowerOff, Duration::hours(1))
+            .schedule_in(AlarmType::AutoPowerOff, Duration::hours(1))
             .unwrap();
         let after = before + Duration::minutes(1);
-        let fired = manager.check_fired_alarms(before, after).unwrap();
+        let fired = manager
+            .check_fired_alarms(ClockInstant::Rtc(before), ClockInstant::Rtc(after))
+            .unwrap();
         assert!(fired.is_empty());
         assert!(!rtc.alarm_enabled() || manager.has_alarm(AlarmType::AutoPowerOff));
     }
@@ -561,10 +811,10 @@ mod tests {
     fn multiplexing_earliest_alarm_wins() {
         let (rtc, mut manager) = test_alarm_manager();
         manager
-            .schedule_alarm(AlarmType::AutoPowerOff, Duration::hours(2))
+            .schedule_in(AlarmType::AutoPowerOff, Duration::hours(2))
             .unwrap();
         manager
-            .schedule_alarm(AlarmType::CalendarUpdate, Duration::minutes(30))
+            .schedule_in(AlarmType::CalendarUpdate, Duration::minutes(30))
             .unwrap();
         let wake = rtc.scheduled_wake_time().unwrap();
         let expected = Utc::now() + Duration::minutes(30);
@@ -575,10 +825,10 @@ mod tests {
     fn auto_suspend_can_be_earliest_alarm() {
         let (rtc, mut manager) = test_alarm_manager();
         manager
-            .schedule_alarm(AlarmType::AutoPowerOff, Duration::hours(2))
+            .schedule_in(AlarmType::AutoPowerOff, Duration::hours(2))
             .unwrap();
         manager
-            .schedule_alarm(AlarmType::AutoSuspend, Duration::minutes(10))
+            .schedule_in(AlarmType::AutoSuspend, Duration::minutes(10))
             .unwrap();
         let wake = rtc.scheduled_wake_time().unwrap();
         let expected = Utc::now() + Duration::minutes(10);
@@ -617,7 +867,7 @@ mod tests {
     fn claim_due_alarms_returns_past_due_once() {
         let (_rtc, mut manager) = test_alarm_manager();
         manager
-            .schedule_alarm(AlarmType::AutoSuspend, Duration::seconds(-10))
+            .schedule_in(AlarmType::AutoSuspend, Duration::seconds(-10))
             .unwrap();
         let first = manager.claim_due_alarms().unwrap();
         assert_eq!(first, vec![AlarmType::AutoSuspend]);
@@ -630,7 +880,7 @@ mod tests {
     fn claim_due_alarms_ignores_near_future_wake() {
         let (_rtc, mut manager) = test_alarm_manager();
         manager
-            .schedule_alarm(AlarmType::AutoSuspend, Duration::seconds(2))
+            .schedule_in(AlarmType::AutoSuspend, Duration::seconds(2))
             .unwrap();
         let claimed = manager.claim_due_alarms().unwrap();
         assert!(claimed.is_empty());
@@ -646,7 +896,7 @@ mod tests {
         {
             let mut locked = manager.lock().unwrap();
             locked
-                .schedule_alarm(AlarmType::AutoSuspend, Duration::seconds(-10))
+                .schedule_in(AlarmType::AutoSuspend, Duration::seconds(-10))
                 .unwrap();
         }
 

--- a/crates/core/src/device/rtc/test.rs
+++ b/crates/core/src/device/rtc/test.rs
@@ -1,7 +1,7 @@
 //! In-memory RTC for unit tests with assertion helpers.
 
 use anyhow::Error;
-use chrono::{DateTime, Utc};
+use chrono::{DateTime, Duration as ChronoDuration, Utc};
 use std::sync::{Arc, Condvar, Mutex};
 use std::time::Duration;
 
@@ -12,10 +12,20 @@ const RTC_AF: u32 = 0x20;
 
 #[derive(Debug)]
 struct TestRtcState {
+    /// Emulated hardware clock instant used by [`Rtc::read_time`] and due checks.
     current_time: DateTime<Utc>,
+    /// Whether the in-memory hardware wake alarm is armed.
     alarm_enabled: bool,
+    /// Programmed wake instant on the test RTC timeline, if any.
     alarm_wake_time: Option<DateTime<Utc>>,
+    /// Set when an IRQ should unblock [`Rtc::wait_for_alarm_irq`].
     irq_pending: bool,
+    /// `RTC_now − system_now` from the last drift refresh (`new` / `set_time`).
+    ///
+    /// Positive means the test RTC reads ahead of civil time.
+    drift: ChronoDuration,
+    /// `new_time − old_time` from the latest [`Rtc::set_time`], if not yet taken.
+    pending_step: Option<ChronoDuration>,
 }
 
 /// Assertable RTC test double for unit tests.
@@ -27,12 +37,15 @@ pub struct TestRtc {
 
 impl TestRtc {
     pub fn new() -> Self {
+        let current_time = Utc::now();
         Self {
             state: Arc::new(Mutex::new(TestRtcState {
-                current_time: Utc::now(),
+                current_time,
                 alarm_enabled: false,
                 alarm_wake_time: None,
                 irq_pending: false,
+                drift: current_time.signed_duration_since(Utc::now()),
+                pending_step: None,
             })),
             cond: Arc::new(Condvar::new()),
         }
@@ -119,9 +132,26 @@ impl Rtc for TestRtc {
             .state
             .lock()
             .map_err(|e| anyhow::anyhow!("lock poisoned: {}", e))?;
+        let old_time = state.current_time;
         state.current_time = time;
+        state.drift = time.signed_duration_since(Utc::now());
+        state.pending_step = Some(time.signed_duration_since(old_time));
         self.cond.notify_all();
         Ok(())
+    }
+
+    fn drift(&self) -> Result<ChronoDuration, Error> {
+        self.state
+            .lock()
+            .map(|state| state.drift)
+            .map_err(|e| anyhow::anyhow!("lock poisoned: {}", e))
+    }
+
+    fn take_pending_step(&self) -> Result<Option<ChronoDuration>, Error> {
+        self.state
+            .lock()
+            .map(|mut state| state.pending_step.take())
+            .map_err(|e| anyhow::anyhow!("lock poisoned: {}", e))
     }
 
     fn wait_for_alarm_irq(&self, timeout: Option<Duration>) -> Result<Option<u32>, Error> {

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -41,7 +41,7 @@ pub mod logging;
 pub mod metadata;
 pub mod network_address;
 pub mod ota;
-pub use device::rtc::{AlarmManager, AlarmType};
+pub use device::rtc::{AlarmManager, AlarmType, AlarmWhen, ClockInstant};
 pub mod runtime;
 pub mod settings;
 pub mod task;

--- a/crates/core/src/task/mod.rs
+++ b/crates/core/src/task/mod.rs
@@ -600,6 +600,11 @@ impl TaskManager {
             return;
         }
 
+        let Some(alarm_manager) = context.alarm_manager.as_ref() else {
+            tracing::warn!("alarm manager unavailable, cannot sync time");
+            return;
+        };
+
         match context.device.time_manager() {
             Ok(time_manager) => {
                 let task = Box::new(time_sync::TimeSyncTask::new(
@@ -607,6 +612,7 @@ impl TaskManager {
                     context.settings.ntp_server.clone(),
                     manual,
                     context.wifi_session.clone(),
+                    alarm_manager.clone(),
                 ));
                 if let Err(e) = self.start(task, hub.clone()) {
                     tracing::warn!(error = %e, "failed to start time sync task");

--- a/crates/core/src/task/time_sync.rs
+++ b/crates/core/src/task/time_sync.rs
@@ -1,7 +1,7 @@
-use std::sync::Arc;
 use std::sync::mpsc::Sender;
+use std::sync::{Arc, Mutex};
 
-use crate::device::rtc::Rtc;
+use crate::device::rtc::{AlarmManager, Rtc};
 use crate::device::wifi::WifiSession;
 use crate::geolocation::fetch_geolocation;
 use crate::http::Client;
@@ -15,6 +15,7 @@ pub struct TimeSyncTask<R: Rtc> {
     ntp_server: NetworkAddress,
     manual: bool,
     wifi_session: Arc<WifiSession>,
+    alarm_manager: Arc<Mutex<AlarmManager<R>>>,
 }
 
 impl<R: Rtc> TimeSyncTask<R> {
@@ -23,12 +24,14 @@ impl<R: Rtc> TimeSyncTask<R> {
         ntp_server: NetworkAddress,
         manual: bool,
         wifi_session: Arc<WifiSession>,
+        alarm_manager: Arc<Mutex<AlarmManager<R>>>,
     ) -> Self {
         TimeSyncTask {
             time_manager,
             ntp_server,
             manual,
             wifi_session,
+            alarm_manager,
         }
     }
 }
@@ -69,9 +72,9 @@ impl<R: Rtc + Send + 'static> BackgroundTask for TimeSyncTask<R> {
 
         let coordinates = geo.as_ref().map(|geo| geo.coordinates);
 
-        if let Err(e) = self
-            .time_manager
-            .sync(&self.ntp_server, self.manual, geo, hub)
+        if let Err(e) =
+            self.time_manager
+                .sync(&self.ntp_server, self.manual, geo, hub, &self.alarm_manager)
         {
             tracing::error!(error = %e, "time sync failed");
         }

--- a/crates/core/src/time_manager.rs
+++ b/crates/core/src/time_manager.rs
@@ -6,14 +6,14 @@ use std::net::{IpAddr, SocketAddr, ToSocketAddrs, UdpSocket};
 use std::sync::mpsc::Sender;
 use std::time::Duration;
 
-use crate::device::rtc::Rtc;
+use crate::device::rtc::{AlarmManager, Rtc};
 use crate::geolocation;
 use crate::geolocation::GeoLocation;
 use crate::http::Client as HttpClient;
 use crate::network_address::NetworkAddress;
 use crate::view::{Event, NotificationEvent};
 
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
 const NTP_PORT: u16 = 123;
 const NTP_TIMEOUT: Duration = Duration::from_secs(5);
@@ -38,6 +38,7 @@ impl<R: Rtc> TimeManager<R> {
         manual: bool,
         geolocation: Option<GeoLocation>,
         hub: &Sender<Event>,
+        alarm_manager: &Arc<Mutex<AlarmManager<R>>>,
     ) -> Result<(), Error> {
         if let Err(e) = self.detect_and_set_timezone(geolocation) {
             if manual {
@@ -64,9 +65,10 @@ impl<R: Rtc> TimeManager<R> {
             }
         };
 
-        let result = self
-            .set_system_clock(ntp_time)
-            .and_then(|()| self.rtc.set_time(ntp_time));
+        let result = self.set_system_clock(ntp_time).and_then(|()| {
+            let mut alarms = alarm_manager.lock().unwrap_or_else(|e| e.into_inner());
+            crate::device::rtc::set_time(self.rtc.as_ref(), &mut alarms, ntp_time)
+        });
 
         match result {
             Ok(()) => {


### PR DESCRIPTION
Schedule, claim, and hardware wake programming share the RTC timeline so civil/system skew cannot disable future wakes or stick alarms.

- AlarmWhen (In / AtRtc / AtCivil) plus schedule_in and sync after set_time
- Drift/pending_step on RTC backends; NTP path calls set_time then sync
- Callers migrate to relative RTC schedules; calendar N from system Local

Change-Id: 86e2dd87c1bca25cf3ba2f443137439d
Change-Id-Short: rtlxmmrsnyon

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches suspend, auto-power-off, wake debounce, and NTP clock writes—core power and timing paths where RTC/civil skew previously caused missed or premature wakes.
> 
> **Overview**
> **Alarm scheduling and wake detection now treat the hardware RTC as the time authority** instead of mixing `Utc::now()` with RTC-programmed wakes. Relative alarms (`schedule_in`) anchor to RTC “now”; due checks, hardware programming, and post-sleep fired-alarm inference all use that same timeline, with **`ClockInstant`** tagging civil vs RTC instants when comparing sleep windows.
> 
> The API shifts from **`schedule_alarm`** to **`schedule` / `schedule_in`** backed by **`AlarmWhen`** (`In` duration or `At` absolute). Each **`ScheduledAlarm`** keeps its original intent so **`AlarmManager::sync`** can rebase wake times after an RTC write: relative and RTC-absolute alarms shift by the pending step; civil targets are reconverted via refreshed **drift**.
> 
> **`Rtc`** implementations (Linux, emulator, test) gain **`drift`**, **`take_pending_step`**, and civil↔RTC helpers; the emulator RTC can lag or lead civil time. NTP/time sync now takes the shared alarm manager and calls **`device::rtc::set_time`** (RTC write + **`sync`**) instead of **`rtc.set_time`** alone. Suspend lifecycle and tests are updated to **`schedule_in`** and civil **`check_fired_alarms`** after wake.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bd8ced55c7319aceeb279113a611e3f76930e600. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->