### PR TITLE
feat(settings): add AutosleepMode under Power

### DIFF
--- a/contrib/Settings-sample.toml
+++ b/contrib/Settings-sample.toml
@@ -40,6 +40,14 @@ auto-suspend = 30.0
 # The delay, in days, after which a suspended device
 # will power off. *Zero* means *never*.
 auto-power-off = 3.0
+# Soft-suspend autosleep target. Possible values: "off", "freeze", "mem".
+# Unsupported values on the current device fall back to "off".
+autosleep-mode = "off"
+# When soft suspend is armed, keep the status LED on while awake.
+indicate-autosleep-led = false
+# Seconds to keep the wake lock after the last soft-suspend lease drops.
+# *Zero* unlocks immediately.
+autosleep-grace = 5.0
 # Formats used for the clock and the clock's pop-up menu.
 # The available specifiers are described at:
 # https://docs.rs/chrono/latest/chrono/format/strftime/index.html

--- a/crates/core/i18n/en-GB/cadmus_core.ftl
+++ b/crates/core/i18n/en-GB/cadmus_core.ftl
@@ -106,6 +106,8 @@ settings-power-autosleep-mode-mem = Memory
 settings-power-autosleep-mode-off = Off
 settings-power-enable-sleep-cover = Enable Sleep Cover
 settings-power-indicate-autosleep-led = Use LED to Indicate Soft Suspend
+settings-power-autosleep-grace = Soft Suspend Release Grace (seconds)
+settings-power-autosleep-grace-input = Soft Suspend Release Grace (seconds, 0 = immediate)
 
 # Settings - Startup Mode
 settings-startup-mode-home = Home

--- a/crates/core/src/context.rs
+++ b/crates/core/src/context.rs
@@ -107,6 +107,11 @@ impl<D: Device> Context<D> {
             }
         };
         let soft_suspend_session = crate::device::soft_suspend::SoftSuspendSession::new(leds);
+        soft_suspend_session.apply_settings(
+            settings.autosleep_mode,
+            settings.indicate_autosleep_led,
+            std::time::Duration::from_secs_f32(settings.autosleep_grace.max(0.0)),
+        );
         Context {
             device,
             alarm_manager,

--- a/crates/core/src/device/kobo/lifecycle/mod.rs
+++ b/crates/core/src/device/kobo/lifecycle/mod.rs
@@ -69,6 +69,11 @@ impl DeviceLifecycle for Device {
 
         let wants_on = context.settings.wifi.wants_radio_at_rest();
         context.wifi_session.set_mode(context.settings.wifi);
+        context.soft_suspend_session.apply_settings(
+            context.settings.autosleep_mode,
+            context.settings.indicate_autosleep_led,
+            std::time::Duration::from_secs_f32(context.settings.autosleep_grace.max(0.0)),
+        );
         if !wants_on {
             context.online = false;
         }

--- a/crates/core/src/settings/mod.rs
+++ b/crates/core/src/settings/mod.rs
@@ -415,6 +415,13 @@ pub struct Settings {
     pub button_scheme: ButtonScheme,
     pub auto_suspend: f32,
     pub auto_power_off: f32,
+    /// Soft-suspend autosleep target (`off`, `freeze`, or `mem`).
+    pub autosleep_mode: crate::device::soft_suspend::AutosleepMode,
+    /// When soft suspend is armed, keep the status LED on while awake.
+    pub indicate_autosleep_led: bool,
+    /// Seconds to keep the wake lock after the last soft-suspend lease drops.
+    /// Zero unlocks immediately.
+    pub autosleep_grace: f32,
     pub time_format: String,
     pub date_format: String,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1176,6 +1183,9 @@ impl Default for Settings {
             button_scheme: ButtonScheme::Natural,
             auto_suspend: 30.0,
             auto_power_off: 3.0,
+            autosleep_mode: crate::device::soft_suspend::AutosleepMode::Off,
+            indicate_autosleep_led: false,
+            autosleep_grace: 5.0,
             time_format: "%H:%M".to_string(),
             date_format: "%A, %B %-d, %Y".to_string(),
             intermissions: Intermissions {

--- a/crates/core/src/view/mod.rs
+++ b/crates/core/src/view/mod.rs
@@ -647,6 +647,7 @@ pub enum ViewId {
     LibraryRename,
     LibraryRenameInput,
     AutoSuspendInput,
+    AutosleepGraceInput,
     AutoPowerOffInput,
     WifiIdleTimeoutInput,
     AutoFrontlightBrightnessInput,
@@ -838,7 +839,9 @@ pub enum EntryId {
     #[deprecated(note = "Use ToggleEvent::Settings instead")]
     ToggleAutoShare,
     EditAutoSuspend,
+    EditAutosleepGrace,
     SetStartupMode(StartupMode),
+    SetAutosleepMode(crate::device::soft_suspend::AutosleepMode),
     EditAutoPowerOff,
     EditAutoFrontlightBrightness,
     EditAutoFrontlightManualCoordinates,

--- a/crates/core/src/view/settings_editor/category.rs
+++ b/crates/core/src/view/settings_editor/category.rs
@@ -8,7 +8,10 @@ use super::kinds::general::{
 use super::kinds::import::{AllowedKindsSetting, ForceFullImport, ImportSyncMetadata};
 use super::kinds::intermission::{IntermissionPowerOff, IntermissionShare, IntermissionSuspend};
 use super::kinds::library::LibraryInfo;
-use super::kinds::power::{AutoPowerOff, AutoSuspend, SleepCover};
+use super::kinds::power::{
+    AutoPowerOff, AutoSuspend, AutosleepGrace, AutosleepModeSetting, IndicateAutosleepLed,
+    SleepCover,
+};
 use super::kinds::reader::{DitheredKindsSetting, FinishedActionSetting, RefreshRateInfo};
 use super::kinds::telemetry::{LogLevel, LoggingEnabled};
 use crate::device::AppContext;
@@ -83,6 +86,9 @@ impl Category {
                 Box::new(StartupModeSetting),
             ],
             Category::Power => vec![
+                Box::new(AutosleepModeSetting),
+                Box::new(IndicateAutosleepLed),
+                Box::new(AutosleepGrace),
                 Box::new(AutoSuspend),
                 Box::new(AutoPowerOff),
                 Box::new(SleepCover),
@@ -203,5 +209,31 @@ impl Category {
     /// Returns the number of categories.
     pub fn count() -> usize {
         Self::all().len()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::context::test_helpers::create_test_context;
+    use crate::view::settings_editor::kinds::SettingIdentity;
+
+    #[test]
+    fn power_includes_soft_suspend_settings() {
+        let context = create_test_context();
+        let identities: Vec<_> = Category::Power
+            .settings(&context, None)
+            .iter()
+            .map(|setting| setting.identity())
+            .collect();
+
+        assert_eq!(
+            identities[..3],
+            [
+                SettingIdentity::AutosleepMode,
+                SettingIdentity::IndicateAutosleepLed,
+                SettingIdentity::AutosleepGrace,
+            ]
+        );
     }
 }

--- a/crates/core/src/view/settings_editor/category_editor.rs
+++ b/crates/core/src/view/settings_editor/category_editor.rs
@@ -818,6 +818,7 @@ impl CategoryEditor {
     ) -> bool {
         match view_id {
             ViewId::AutoSuspendInput
+            | ViewId::AutosleepGraceInput
             | ViewId::AutoPowerOffInput
             | ViewId::WifiIdleTimeoutInput
             | ViewId::SettingsRetentionInput

--- a/crates/core/src/view/settings_editor/kinds/identity.rs
+++ b/crates/core/src/view/settings_editor/kinds/identity.rs
@@ -66,4 +66,7 @@ pub enum SettingIdentity {
     RefreshRateByKindInverted(String),
     DitheredKinds,
     StartupMode,
+    AutosleepMode,
+    IndicateAutosleepLed,
+    AutosleepGrace,
 }

--- a/crates/core/src/view/settings_editor/kinds/mod.rs
+++ b/crates/core/src/view/settings_editor/kinds/mod.rs
@@ -36,6 +36,8 @@ use std::path::Path;
 pub enum ToggleSettings {
     /// Sleep cover enable/disable setting
     SleepCover,
+    /// Use status LED to indicate armed soft suspend while awake
+    IndicateAutosleepLed,
     /// Auto-share enable/disable setting
     AutoShare,
     /// Auto time sync enable/disable setting

--- a/crates/core/src/view/settings_editor/kinds/power.rs
+++ b/crates/core/src/view/settings_editor/kinds/power.rs
@@ -6,9 +6,12 @@ use super::{
 };
 use crate::device::AppContext;
 use crate::device::reschedule_auto_suspend_alarm;
+use crate::device::soft_suspend::{AutosleepMode, SoftSuspendPaths, discover_available_modes};
 use crate::fl;
+use crate::i18n::I18nDisplay;
 use crate::settings::Settings;
-use crate::view::{Bus, EntryId, Event, ToggleEvent, ViewId};
+use crate::view::{Bus, EntryId, EntryKind, Event, ToggleEvent, ViewId};
+use std::time::Duration;
 
 /// Auto suspend timeout setting
 pub struct AutoSuspend;
@@ -194,6 +197,184 @@ impl SettingKind for SleepCover {
             return (Some(context.settings.sleep_cover.to_string()), true);
         }
         (None, false)
+    }
+}
+
+/// Soft-suspend autosleep mode (`Off` / `Freeze` / `Mem`).
+pub struct AutosleepModeSetting;
+
+fn resolve_autosleep_mode(saved: AutosleepMode, available: &[AutosleepMode]) -> AutosleepMode {
+    if available.contains(&saved) {
+        saved
+    } else {
+        AutosleepMode::Off
+    }
+}
+
+impl SettingKind for AutosleepModeSetting {
+    fn identity(&self) -> SettingIdentity {
+        SettingIdentity::AutosleepMode
+    }
+
+    fn label(&self, _settings: &Settings) -> String {
+        fl!("settings-power-autosleep-mode")
+    }
+
+    fn fetch(&self, data: SettingsFetchData) -> SettingData {
+        let available = discover_available_modes(&SoftSuspendPaths::system().state);
+        let current = resolve_autosleep_mode(data.settings.autosleep_mode, &available);
+        let entries = available
+            .into_iter()
+            .map(|mode| {
+                EntryKind::RadioButton(
+                    mode.to_i18n_string(),
+                    EntryId::SetAutosleepMode(mode),
+                    current == mode,
+                )
+            })
+            .collect();
+
+        SettingData {
+            value: current.to_i18n_string(),
+            widget: WidgetKind::SubMenu(entries),
+        }
+    }
+
+    fn handle(
+        &self,
+        evt: &Event,
+        context: &mut AppContext,
+        _bus: &mut Bus,
+    ) -> (Option<String>, bool) {
+        if let Event::Select(EntryId::SetAutosleepMode(mode)) = evt {
+            context.settings.autosleep_mode = *mode;
+            context.soft_suspend_session.apply_settings(
+                context.settings.autosleep_mode,
+                context.settings.indicate_autosleep_led,
+                Duration::from_secs_f32(context.settings.autosleep_grace.max(0.0)),
+            );
+            return (Some(mode.to_i18n_string()), true);
+        }
+        (None, false)
+    }
+}
+
+/// Use the status LED to show that soft suspend is armed while awake.
+pub struct IndicateAutosleepLed;
+
+impl SettingKind for IndicateAutosleepLed {
+    fn identity(&self) -> SettingIdentity {
+        SettingIdentity::IndicateAutosleepLed
+    }
+
+    fn label(&self, _settings: &Settings) -> String {
+        fl!("settings-power-indicate-autosleep-led")
+    }
+
+    fn fetch(&self, data: SettingsFetchData) -> SettingData {
+        SettingData {
+            value: data.settings.indicate_autosleep_led.to_string(),
+            widget: WidgetKind::Toggle {
+                left_label: fl!("settings-general-toggle-on"),
+                right_label: fl!("settings-general-toggle-off"),
+                enabled: data.settings.indicate_autosleep_led,
+                tap_event: Event::Toggle(ToggleEvent::Setting(
+                    ToggleSettings::IndicateAutosleepLed,
+                )),
+            },
+        }
+    }
+
+    fn handle(
+        &self,
+        evt: &Event,
+        context: &mut AppContext,
+        _bus: &mut Bus,
+    ) -> (Option<String>, bool) {
+        if let Event::Toggle(ToggleEvent::Setting(ToggleSettings::IndicateAutosleepLed)) = evt {
+            context.settings.indicate_autosleep_led = !context.settings.indicate_autosleep_led;
+            context.soft_suspend_session.apply_settings(
+                context.settings.autosleep_mode,
+                context.settings.indicate_autosleep_led,
+                Duration::from_secs_f32(context.settings.autosleep_grace.max(0.0)),
+            );
+            return (
+                Some(context.settings.indicate_autosleep_led.to_string()),
+                true,
+            );
+        }
+        (None, false)
+    }
+}
+
+/// Delay after the last soft-suspend lease before writing `wake_unlock`.
+pub struct AutosleepGrace;
+
+impl SettingKind for AutosleepGrace {
+    fn identity(&self) -> SettingIdentity {
+        SettingIdentity::AutosleepGrace
+    }
+
+    fn label(&self, _settings: &Settings) -> String {
+        fl!("settings-power-autosleep-grace")
+    }
+
+    fn fetch(&self, data: SettingsFetchData) -> SettingData {
+        SettingData {
+            value: format!("{:.1}", data.settings.autosleep_grace),
+            widget: WidgetKind::ActionLabel(Event::Select(EntryId::EditAutosleepGrace)),
+        }
+    }
+
+    fn handle(
+        &self,
+        evt: &Event,
+        context: &mut AppContext,
+        _bus: &mut Bus,
+    ) -> (Option<String>, bool) {
+        if let Event::Submit(ViewId::AutosleepGraceInput, text) = evt {
+            let display = self.apply_text(text, &mut context.settings);
+            context.soft_suspend_session.apply_settings(
+                context.settings.autosleep_mode,
+                context.settings.indicate_autosleep_led,
+                Duration::from_secs_f32(context.settings.autosleep_grace.max(0.0)),
+            );
+            return (Some(display), true);
+        }
+        (None, false)
+    }
+
+    fn as_input_kind(&self) -> Option<&dyn InputSettingKind> {
+        Some(self)
+    }
+}
+
+impl InputSettingKind for AutosleepGrace {
+    fn submit_view_id(&self) -> ViewId {
+        ViewId::AutosleepGraceInput
+    }
+
+    fn open_entry_id(&self) -> EntryId {
+        EntryId::EditAutosleepGrace
+    }
+
+    fn input_label(&self) -> String {
+        fl!("settings-power-autosleep-grace-input")
+    }
+
+    fn input_max_chars(&self) -> usize {
+        10
+    }
+
+    fn current_text(&self, settings: &Settings) -> String {
+        format!("{:.1}", settings.autosleep_grace)
+    }
+
+    fn apply_text(&self, text: &str, settings: &mut Settings) -> String {
+        if let Ok(value) = text.parse::<f32>() {
+            settings.autosleep_grace = value.max(0.0);
+        }
+        format!("{:.1}", settings.autosleep_grace)
     }
 }
 
@@ -386,6 +567,331 @@ mod tests {
             let result = setting.handle(&Event::Select(EntryId::About), &mut context, &mut bus);
 
             assert!(result.0.is_none());
+        }
+    }
+
+    mod autosleep_mode {
+        use super::*;
+        use crate::context::test_helpers::create_test_context;
+        use crate::view::settings_editor::kinds::SettingsFetchData;
+
+        #[test]
+        fn identity_and_label() {
+            let setting = AutosleepModeSetting;
+            assert_eq!(setting.identity(), SettingIdentity::AutosleepMode);
+            assert_eq!(
+                setting.label(&Settings::default()),
+                fl!("settings-power-autosleep-mode")
+            );
+        }
+
+        #[test]
+        fn fetch_builds_radio_submenu_for_available_modes() {
+            let setting = AutosleepModeSetting;
+            let settings = Settings::default();
+            let available = discover_available_modes(&SoftSuspendPaths::system().state);
+
+            let data = setting.fetch(SettingsFetchData {
+                settings: &settings,
+                install_dir: None,
+            });
+
+            assert_eq!(data.value, AutosleepMode::Off.to_i18n_string());
+            let WidgetKind::SubMenu(entries) = data.widget else {
+                panic!("expected submenu widget");
+            };
+            assert_eq!(entries.len(), available.len());
+            assert!(matches!(
+                entries.first(),
+                Some(EntryKind::RadioButton(
+                    _,
+                    EntryId::SetAutosleepMode(AutosleepMode::Off),
+                    true
+                ))
+            ));
+        }
+
+        #[test]
+        fn resolve_falls_back_to_off_when_saved_mode_unavailable() {
+            assert_eq!(
+                resolve_autosleep_mode(AutosleepMode::Mem, &[AutosleepMode::Off]),
+                AutosleepMode::Off
+            );
+            assert_eq!(
+                resolve_autosleep_mode(
+                    AutosleepMode::Freeze,
+                    &[AutosleepMode::Off, AutosleepMode::Freeze]
+                ),
+                AutosleepMode::Freeze
+            );
+        }
+
+        #[test]
+        fn handle_select_updates_settings_and_session() {
+            let setting = AutosleepModeSetting;
+            let mut context = create_test_context();
+            context.settings = Settings::default();
+            let mut bus: Bus = VecDeque::new();
+            let event = Event::Select(EntryId::SetAutosleepMode(AutosleepMode::Off));
+
+            let result = setting.handle(&event, &mut context, &mut bus);
+
+            assert_eq!(result.0, Some(AutosleepMode::Off.to_i18n_string()));
+            assert!(result.1);
+            assert_eq!(context.settings.autosleep_mode, AutosleepMode::Off);
+            assert_eq!(context.soft_suspend_session.mode(), AutosleepMode::Off);
+            assert!(bus.is_empty());
+        }
+
+        #[test]
+        fn handle_select_persists_mode_even_if_session_sanitizes() {
+            let setting = AutosleepModeSetting;
+            let mut context = create_test_context();
+            context.settings = Settings::default();
+            let mut bus: Bus = VecDeque::new();
+            let event = Event::Select(EntryId::SetAutosleepMode(AutosleepMode::Mem));
+
+            let result = setting.handle(&event, &mut context, &mut bus);
+
+            assert_eq!(result.0, Some(AutosleepMode::Mem.to_i18n_string()));
+            assert!(result.1);
+            assert_eq!(context.settings.autosleep_mode, AutosleepMode::Mem);
+            assert_eq!(
+                context.soft_suspend_session.mode(),
+                context
+                    .soft_suspend_session
+                    .sanitize_mode(AutosleepMode::Mem)
+            );
+        }
+
+        #[test]
+        fn handle_returns_none_for_wrong_event() {
+            let setting = AutosleepModeSetting;
+            let mut context = create_test_context();
+            context.settings = Settings::default();
+            let mut bus: Bus = VecDeque::new();
+
+            let result = setting.handle(&Event::Select(EntryId::About), &mut context, &mut bus);
+
+            assert!(result.0.is_none());
+            assert!(!result.1);
+        }
+    }
+
+    mod indicate_autosleep_led {
+        use super::*;
+        use crate::context::test_helpers::create_test_context;
+        use crate::view::settings_editor::kinds::SettingsFetchData;
+
+        #[test]
+        fn identity_and_label() {
+            let setting = IndicateAutosleepLed;
+            assert_eq!(setting.identity(), SettingIdentity::IndicateAutosleepLed);
+            assert_eq!(
+                setting.label(&Settings::default()),
+                fl!("settings-power-indicate-autosleep-led")
+            );
+        }
+
+        #[test]
+        fn fetch_builds_toggle_widget() {
+            let setting = IndicateAutosleepLed;
+            let settings = Settings {
+                indicate_autosleep_led: true,
+                ..Default::default()
+            };
+
+            let data = setting.fetch(SettingsFetchData {
+                settings: &settings,
+                install_dir: None,
+            });
+
+            assert_eq!(data.value, "true");
+            match data.widget {
+                WidgetKind::Toggle {
+                    enabled,
+                    tap_event:
+                        Event::Toggle(ToggleEvent::Setting(ToggleSettings::IndicateAutosleepLed)),
+                    ..
+                } => assert!(enabled),
+                other => panic!("expected IndicateAutosleepLed toggle, got {other:?}"),
+            }
+        }
+
+        #[test]
+        fn handle_toggle_event_toggles_value_and_session() {
+            let setting = IndicateAutosleepLed;
+            let mut context = create_test_context();
+            context.settings = Settings {
+                indicate_autosleep_led: true,
+                ..Default::default()
+            };
+            let mut bus: Bus = VecDeque::new();
+            let event = Event::Toggle(ToggleEvent::Setting(ToggleSettings::IndicateAutosleepLed));
+
+            let result = setting.handle(&event, &mut context, &mut bus);
+
+            assert_eq!(result.0.as_deref(), Some("false"));
+            assert!(result.1);
+            assert!(!context.settings.indicate_autosleep_led);
+            assert!(!context.soft_suspend_session.indicate_autosleep_led());
+            assert!(bus.is_empty());
+        }
+
+        #[test]
+        fn handle_toggle_enables_when_disabled() {
+            let setting = IndicateAutosleepLed;
+            let mut context = create_test_context();
+            context.settings = Settings {
+                indicate_autosleep_led: false,
+                ..Default::default()
+            };
+            let mut bus: Bus = VecDeque::new();
+            let event = Event::Toggle(ToggleEvent::Setting(ToggleSettings::IndicateAutosleepLed));
+
+            let result = setting.handle(&event, &mut context, &mut bus);
+
+            assert_eq!(result.0.as_deref(), Some("true"));
+            assert!(result.1);
+            assert!(context.settings.indicate_autosleep_led);
+            assert!(context.soft_suspend_session.indicate_autosleep_led());
+        }
+
+        #[test]
+        fn handle_returns_none_for_wrong_event() {
+            let setting = IndicateAutosleepLed;
+            let mut context = create_test_context();
+            context.settings = Settings::default();
+            let mut bus: Bus = VecDeque::new();
+
+            let result = setting.handle(&Event::Select(EntryId::About), &mut context, &mut bus);
+
+            assert!(result.0.is_none());
+            assert!(!result.1);
+        }
+    }
+
+    mod autosleep_grace {
+        use super::*;
+        use crate::context::test_helpers::create_test_context;
+        use crate::view::settings_editor::kinds::{InputSettingKind, SettingsFetchData};
+
+        #[test]
+        fn identity_and_label() {
+            let setting = AutosleepGrace;
+            assert_eq!(setting.identity(), SettingIdentity::AutosleepGrace);
+            assert_eq!(
+                setting.label(&Settings::default()),
+                fl!("settings-power-autosleep-grace")
+            );
+        }
+
+        #[test]
+        fn fetch_builds_action_label() {
+            let setting = AutosleepGrace;
+            let settings = Settings {
+                autosleep_grace: 7.5,
+                ..Default::default()
+            };
+
+            let data = setting.fetch(SettingsFetchData {
+                settings: &settings,
+                install_dir: None,
+            });
+
+            assert_eq!(data.value, "7.5");
+            assert!(matches!(
+                data.widget,
+                WidgetKind::ActionLabel(Event::Select(EntryId::EditAutosleepGrace))
+            ));
+        }
+
+        #[test]
+        fn input_kind_metadata() {
+            let setting = AutosleepGrace;
+            let settings = Settings {
+                autosleep_grace: 3.0,
+                ..Default::default()
+            };
+
+            assert!(setting.as_input_kind().is_some());
+            assert_eq!(setting.submit_view_id(), ViewId::AutosleepGraceInput);
+            assert_eq!(setting.open_entry_id(), EntryId::EditAutosleepGrace);
+            assert_eq!(
+                setting.input_label(),
+                fl!("settings-power-autosleep-grace-input")
+            );
+            assert_eq!(setting.input_max_chars(), 10);
+            assert_eq!(setting.current_text(&settings), "3.0");
+        }
+
+        #[test]
+        fn apply_text_parses_and_updates() {
+            let setting = AutosleepGrace;
+            let mut settings = Settings::default();
+
+            let display = setting.apply_text("10.0", &mut settings);
+
+            assert_eq!(display, "10.0");
+            assert_eq!(settings.autosleep_grace, 10.0);
+        }
+
+        #[test]
+        fn apply_text_clamps_negative_to_zero() {
+            let setting = AutosleepGrace;
+            let mut settings = Settings::default();
+
+            let display = setting.apply_text("-1", &mut settings);
+
+            assert_eq!(display, "0.0");
+            assert_eq!(settings.autosleep_grace, 0.0);
+        }
+
+        #[test]
+        fn apply_text_ignores_invalid_input() {
+            let setting = AutosleepGrace;
+            let mut settings = Settings {
+                autosleep_grace: 5.0,
+                ..Default::default()
+            };
+
+            let display = setting.apply_text("invalid", &mut settings);
+
+            assert_eq!(settings.autosleep_grace, 5.0);
+            assert_eq!(display, "5.0");
+        }
+
+        #[test]
+        fn handle_submit_applies_grace_to_session() {
+            let setting = AutosleepGrace;
+            let mut context = create_test_context();
+            context.settings = Settings::default();
+            let mut bus: Bus = VecDeque::new();
+            let event = Event::Submit(ViewId::AutosleepGraceInput, "2.5".into());
+
+            let result = setting.handle(&event, &mut context, &mut bus);
+
+            assert_eq!(result.0.as_deref(), Some("2.5"));
+            assert!(result.1);
+            assert_eq!(context.settings.autosleep_grace, 2.5);
+            assert_eq!(
+                context.soft_suspend_session.autosleep_grace(),
+                Duration::from_secs_f32(2.5)
+            );
+            assert!(bus.is_empty());
+        }
+
+        #[test]
+        fn handle_returns_none_for_wrong_event() {
+            let setting = AutosleepGrace;
+            let mut context = create_test_context();
+            context.settings = Settings::default();
+            let mut bus: Bus = VecDeque::new();
+
+            let result = setting.handle(&Event::Select(EntryId::About), &mut context, &mut bus);
+
+            assert!(result.0.is_none());
+            assert!(!result.1);
         }
     }
 }


### PR DESCRIPTION
Expose soft-suspend mode, LED indicator, and release grace under the Power category so users can arm autosleep without editing TOML.

Closes: CAD-39

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Settings drive kernel soft-suspend mode, wake-lock timing, and LED behavior; misconfiguration could affect sleep or battery, though it uses existing session logic.
> 
> **Overview**
> Adds **persisted Power settings** for soft suspend: **Soft Suspend** mode (`Off` / `Freeze` / `Memory`), **LED while armed**, and **release grace** (seconds after the last lease before `wake_unlock`; `0` = immediate). Defaults are off, LED off, and 5s grace.
> 
> **Settings → Power** now lists these above auto-suspend, with a radio submenu for modes the device reports, a toggle for the status LED, and a numeric editor for grace (negative values clamp to zero).
> 
> Changing any of the three updates **`soft_suspend_session.apply_settings`** immediately, matching **context init** and **Kobo startup** so runtime behavior follows saved settings without editing TOML manually.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1f1415130bdfde607f0413283449f06e3b220cfa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->