### PR TITLE
feat(app): main-loop soft-suspend lease + TRACE

### DIFF
--- a/crates/cadmus/src/app.rs
+++ b/crates/cadmus/src/app.rs
@@ -64,6 +64,19 @@ fn drain_bus(bus: &mut Bus, tx: &Hub) {
     }
 }
 
+struct MainLoopSoftSuspendGuard {
+    _lease: cadmus_core::device::soft_suspend::SoftSuspendLease,
+}
+
+impl Drop for MainLoopSoftSuspendGuard {
+    fn drop(&mut self) {
+        tracing::trace!(
+            soft_suspend_lease = "main-loop",
+            "soft-suspend lease released for main-loop event"
+        );
+    }
+}
+
 /// Keeps the root view in sync after a rotation changes framebuffer dimensions.
 fn sync_view_after_rotation(
     view: &mut Box<dyn View>,
@@ -378,12 +391,35 @@ pub fn run() -> Result<(), Error> {
     tracing::info!(duration = ?start_time.elapsed(), "App started");
 
     while let Ok(evt) = rx.recv() {
+        let skip_main_loop_lease =
+            AppDevice::should_skip_main_loop_soft_suspend_lease(&context, &evt);
+        let _soft_suspend = if skip_main_loop_lease {
+            tracing::trace!(
+                event = ?evt,
+                "skipping main-loop soft-suspend lease during deep-idle cycle"
+            );
+            None
+        } else {
+            tracing::trace!(
+                soft_suspend_lease = "main-loop",
+                event = ?evt,
+                "soft-suspend lease acquired for main-loop event"
+            );
+            Some(MainLoopSoftSuspendGuard {
+                _lease: context.soft_suspend_session.acquire("main-loop"),
+            })
+        };
+
         #[cfg(feature = "tracing")]
         let span = tracing::trace_span!("main-event-loop", event = ?evt);
         #[cfg(feature = "tracing")]
         let _enter = span.enter();
         #[cfg(feature = "tracing")]
-        tracing::trace!(event = ?evt, "handling event");
+        tracing::trace!(
+            soft_suspend_lease = "main-loop",
+            event = ?evt,
+            "handling event"
+        );
 
         background_tasks.handle_event(&evt, &tx, &context);
 
@@ -840,6 +876,8 @@ pub fn run() -> Result<(), Error> {
         process_render_queue(view.as_ref(), &mut rq, &mut context, &mut updating);
         drain_bus(&mut bus, &tx);
     }
+
+    let _shutdown_wake = context.soft_suspend_session.acquire("shutdown");
 
     background_tasks.stop_all();
 

--- a/crates/core/src/device/kobo/lifecycle/mod.rs
+++ b/crates/core/src/device/kobo/lifecycle/mod.rs
@@ -152,6 +152,10 @@ impl DeviceLifecycle for Device {
         status: ExitStatus,
         runtime: &mut DeviceRuntime<'_>,
     ) -> Result<(), anyhow::Error> {
+        context
+            .soft_suspend_session
+            .set_mode(crate::device::soft_suspend::AutosleepMode::Off);
+
         if status == ExitStatus::Quit {
             restore_boot_rotation_if_needed(context);
         }
@@ -374,5 +378,27 @@ mod tests {
         restore_boot_rotation_if_needed(&mut harness.context);
 
         assert_eq!(harness.context.display.rotation, boot_rotation);
+    }
+
+    #[test]
+    fn on_shutdown_disarms_soft_suspend_without_changing_settings() {
+        use crate::device::soft_suspend::AutosleepMode;
+
+        let mut harness = DeviceRuntimeHarness::new();
+        harness.context.settings.autosleep_mode = AutosleepMode::Mem;
+        harness
+            .context
+            .soft_suspend_session
+            .set_mode(AutosleepMode::Mem);
+
+        harness.with_runtime_only(|context, runtime| {
+            Device::on_shutdown(context, ExitStatus::Quit, runtime).unwrap();
+        });
+
+        assert_eq!(harness.context.settings.autosleep_mode, AutosleepMode::Mem);
+        assert_eq!(
+            harness.context.soft_suspend_session.mode(),
+            AutosleepMode::Off
+        );
     }
 }

--- a/crates/core/src/device/mod.rs
+++ b/crates/core/src/device/mod.rs
@@ -714,15 +714,18 @@ pub trait DeviceLifecycle:
         let _ = (context, status, runtime);
         Ok(())
     }
-
-    /// Whether the main event loop should skip acquiring a soft-suspend lease
-    /// while handling `event`.
+    /// Whether the main loop should skip acquiring a soft-suspend lease for `event`.
     ///
-    /// Deep-idle cycles intentionally drop the cycle lease during
-    /// [`crate::device::suspend::SuspendPhase::InSleep`] so autosleep can enter
-    /// `mem`. Nested main-loop leases would pin `wake_lock` and block sleep.
+    /// During DeepIdle wait, and for prepare / suspend / poll events while the
+    /// cycle lease is held, the cycle already owns the wake lock — a nested
+    /// main-loop lease would block sleep.
     ///
-    /// Default: never skip.
+    /// Default: never skip (emulator and platforms without the shared suspend
+    /// orchestrator).
+    ///
+    /// TODO: Once the emulator drives [`crate::device::suspend`], move any
+    /// remaining main-loop soft-suspend policy fully behind that flow and drop
+    /// platform-specific special cases here.
     fn should_skip_main_loop_soft_suspend_lease(context: &AppContext, event: &Event) -> bool {
         let _ = (context, event);
         false


### PR DESCRIPTION
Hold a named main-loop soft-suspend lease around each event turn, with TRACE around acquire/release. Skip the lease while a deep-idle wait is armed or during PrepareSuspend/Suspend/PollDeepIdleWait in an explicit cycle so autosleep can enter mem.

Change-Id: 606d093084dd920c0e106f2245c057dc
Change-Id-Short: tztmzqwzrvmm

Closes: CAD-39