### PR TITLE
docs(suspend): link contributor guides to hosted rustdocs

### DIFF
--- a/docs/src/contributing/device/suspend/kobo/suspend.md
+++ b/docs/src/contributing/device/suspend/kobo/suspend.md
@@ -31,7 +31,7 @@ orchestrator:
 1. RTC
    <a href="/api/cadmus_core/device/rtc/enum.AlarmType.html#variant.AutoSuspend">`AlarmType::AutoSuspend`</a>
    fires →
-   <a href="/api/cadmus_core/device/suspend/fn.start_cycle.html">`start_cycle`</a>
+   <a href="/api/cadmus_core/device/suspend/orchestrator/fn.start_cycle.html">`start_cycle`</a>
    (<a href="/api/cadmus_core/device/suspend/cycle/enum.SuspendKind.html#variant.Classic">`Classic`</a>)
 2. Intermission UI; wait prepare delay (3s) then PrepareSuspend teardown
 3. Wait suspend delay (15s) then

--- a/docs/src/contributing/device/suspend/kobo/suspend.md
+++ b/docs/src/contributing/device/suspend/kobo/suspend.md
@@ -7,19 +7,35 @@ Kobo-specific wiring for the shared
 live in [Soft Suspend](../soft-suspend.md). Research notes are in
 [investigation #361](../../../../investigations/kobo/issue-361-autosleep-wake-lock.md).
 
-Kobo `DeviceLifecycle` is a thin facade: PrepareSuspend / Suspend /
-PollDeepIdleWait / suspend-related RTC alarms forward to
-`crate::device::suspend`. Kind (`Classic` \| `DeepIdle`) and phase live on
-`AppContext::suspend`.
+Kobo
+<a href="/api/cadmus_core/device/trait.DeviceLifecycle.html">`DeviceLifecycle`</a>
+is a thin facade: PrepareSuspend / Suspend / PollDeepIdleWait / suspend-related
+RTC alarms forward to
+<a href="/api/cadmus_core/device/suspend/index.html">`crate::device::suspend`</a>.
+Kind
+(<a href="/api/cadmus_core/device/suspend/cycle/enum.SuspendKind.html#variant.Classic">`Classic`</a>
+\|
+<a href="/api/cadmus_core/device/suspend/cycle/enum.SuspendKind.html#variant.DeepIdle">`DeepIdle`</a>)
+and phase live on
+<a href="/api/cadmus_core/context/struct.Context.html#structfield.suspend">`AppContext::suspend`</a>.
 
 ## Classic hard suspend (soft suspend Off)
 
-When `AutosleepMode` is `Off`, Auto Suspend / power button / sleep cover use
-the classic path via the orchestrator:
+When
+<a href="/api/cadmus_core/device/soft_suspend/enum.AutosleepMode.html">`AutosleepMode`</a>
+is
+<a href="/api/cadmus_core/device/soft_suspend/enum.AutosleepMode.html#variant.Off">`Off`</a>,
+Auto Suspend / power button / sleep cover use the classic path via the
+orchestrator:
 
-1. RTC `AlarmType::AutoSuspend` fires → `start_cycle` (`Classic`)
+1. RTC
+   <a href="/api/cadmus_core/device/rtc/enum.AlarmType.html#variant.AutoSuspend">`AlarmType::AutoSuspend`</a>
+   fires →
+   <a href="/api/cadmus_core/device/suspend/fn.start_cycle.html">`start_cycle`</a>
+   (<a href="/api/cadmus_core/device/suspend/cycle/enum.SuspendKind.html#variant.Classic">`Classic`</a>)
 2. Intermission UI; wait prepare delay (3s) then PrepareSuspend teardown
-3. Wait suspend delay (15s) then `Event::Suspend`
+3. Wait suspend delay (15s) then
+   <a href="/api/cadmus_core/view/enum.Event.html#variant.Suspend">`Event::Suspend`</a>
 4. <a href="/api/cadmus_core/device/kobo/power/struct.KoboPowerManager.html#method.suspend">`KoboPowerManager::suspend`</a>:
    write `1` to `/sys/power/state-extended`, sync, write `mem` to
    `/sys/power/state`
@@ -28,14 +44,19 @@ the classic path via the orchestrator:
 
 ## Soft-suspend deep idle (mode armed)
 
-When soft suspend is armed, the same triggers use `DeepIdle`:
+When soft suspend is armed, the same triggers use
+<a href="/api/cadmus_core/device/suspend/cycle/enum.SuspendKind.html#variant.DeepIdle">`DeepIdle`</a>:
 
 1. Acquire a named `deep-idle` cycle lease through the orchestrator
 2. PrepareSuspend runs immediately, then deep-idle wait (no Suspend RTC)
-3. Force session autosleep to **`mem`**, arm `state-extended=1`, drop the lease
+3. Force session autosleep to
+   **<a href="/api/cadmus_core/device/soft_suspend/enum.AutosleepMode.html#variant.Mem">`mem`</a>**,
+   arm `state-extended=1`, drop the lease
 4. Poll until wake (boottime−monotonic) or timeout → retry / finish
 5. On wake: `state-extended=0`, restore autosleep mode; WakeDebounce /
-   CalendarUpdate re-enter with the same `DeepIdle` kind
+   CalendarUpdate re-enter with the same
+   <a href="/api/cadmus_core/device/suspend/cycle/enum.SuspendKind.html#variant.DeepIdle">`DeepIdle`</a>
+   kind
 
 ## `state-extended` is Kobo/NiX, not mainline
 

--- a/docs/src/contributing/device/suspend/orchestrator.md
+++ b/docs/src/contributing/device/suspend/orchestrator.md
@@ -15,7 +15,7 @@ orchestrator, for now.
 
 Callers that mean “go to sleep” (power button, AutoSuspend RTC, sleep cover)
 call
-**<a href="/api/cadmus_core/device/suspend/fn.start_cycle.html">`start_cycle`</a>**,
+**<a href="/api/cadmus_core/device/suspend/orchestrator/fn.start_cycle.html">`start_cycle`</a>**,
 not
 <a href="/api/cadmus_core/device/suspend/orchestrator/fn.enter_sleep.html">`enter_sleep`</a>.
 Sleep is a later phase.
@@ -36,13 +36,13 @@ flowchart TD
     debounce -->|"finish_cycle() / cancel_prepare() / start_cycle()"| interactive
 ```
 
-| Function                                                                                                           | Role                                                       |
-| ------------------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------- |
-| <a href="/api/cadmus_core/device/suspend/fn.start_cycle.html">`start_cycle`</a>                                     | Begin cycle: UI + schedule prepare                         |
-| <a href="/api/cadmus_core/device/suspend/orchestrator/fn.prepare_for_sleep.html">`prepare_for_sleep`</a>             | Shared teardown; arm classic RTC or enter DeepIdle         |
-| <a href="/api/cadmus_core/device/suspend/orchestrator/fn.enter_sleep.html">`enter_sleep`</a>                         | Actually sleep (classic `power.suspend` or deep-idle wait) |
-| <a href="/api/cadmus_core/device/suspend/orchestrator/fn.finish_cycle.html">`finish_cycle`</a>                       | Tear down cycle → interactive                              |
-| <a href="/api/cadmus_core/device/suspend/orchestrator/fn.cancel_prepare.html">`cancel_prepare`</a>                   | Abort during PrepareSuspend only                           |
+| Function                                                                                                 | Role                                                       |
+| -------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
+| <a href="/api/cadmus_core/device/suspend/orchestrator/fn.start_cycle.html">`start_cycle`</a>             | Begin cycle: UI + schedule prepare                         |
+| <a href="/api/cadmus_core/device/suspend/orchestrator/fn.prepare_for_sleep.html">`prepare_for_sleep`</a> | Shared teardown; arm classic RTC or enter DeepIdle         |
+| <a href="/api/cadmus_core/device/suspend/orchestrator/fn.enter_sleep.html">`enter_sleep`</a>             | Actually sleep (classic `power.suspend` or deep-idle wait) |
+| <a href="/api/cadmus_core/device/suspend/orchestrator/fn.finish_cycle.html">`finish_cycle`</a>           | Tear down cycle → interactive                              |
+| <a href="/api/cadmus_core/device/suspend/orchestrator/fn.cancel_prepare.html">`cancel_prepare`</a>       | Abort during PrepareSuspend only                           |
 
 <a href="/api/cadmus_core/view/enum.Event.html#variant.Suspend">`Event::Suspend`</a>
 /
@@ -52,14 +52,14 @@ mean **enter sleep now** (after prepare), not “start a new cycle”.
 ## Kind and phase
 
 An explicit suspend cycle is
-`Option<`<a href="/api/cadmus_core/device/suspend/struct.SuspendCycle.html">SuspendCycle</a>`>`
+`Option<`<a href="/api/cadmus_core/device/suspend/cycle/struct.SuspendCycle.html">SuspendCycle</a>`>`
 on <a href="/api/cadmus_core/device/type.AppContext.html">`AppContext`</a>
 (<a href="/api/cadmus_core/context/struct.Context.html#structfield.suspend">`suspend`</a>
 field). Interactive use is `None`.
 
-| Field   | Values                                                                                                                                                                                                                                                                                                                                                   |
-| ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `kind`  | <a href="/api/cadmus_core/device/suspend/cycle/enum.SuspendKind.html#variant.Classic">`Classic`</a> or <a href="/api/cadmus_core/device/suspend/cycle/enum.SuspendKind.html#variant.DeepIdle">`DeepIdle`</a> — chosen once at <a href="/api/cadmus_core/device/suspend/fn.start_cycle.html">`start_cycle`</a>, fixed for the cycle |
+| Field   | Values                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+| ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `kind`  | <a href="/api/cadmus_core/device/suspend/cycle/enum.SuspendKind.html#variant.Classic">`Classic`</a> or <a href="/api/cadmus_core/device/suspend/cycle/enum.SuspendKind.html#variant.DeepIdle">`DeepIdle`</a> — chosen once at <a href="/api/cadmus_core/device/suspend/orchestrator/fn.start_cycle.html">`start_cycle`</a>, fixed for the cycle                                                                                                                |
 | `phase` | <a href="/api/cadmus_core/device/suspend/cycle/enum.SuspendPhase.html#variant.Preparing">`Preparing`</a> → <a href="/api/cadmus_core/device/suspend/cycle/enum.SuspendPhase.html#variant.ArmingSleep">`ArmingSleep`</a> → <a href="/api/cadmus_core/device/suspend/cycle/enum.SuspendPhase.html#variant.InSleep">`InSleep`</a> / wait → <a href="/api/cadmus_core/device/suspend/cycle/enum.SuspendPhase.html#variant.PostWakeDebounce">`PostWakeDebounce`</a> |
 
 Mid-cycle handlers must not re-select Classic vs DeepIdle by probing
@@ -68,10 +68,10 @@ alone. WakeDebounce and CalendarUpdate re-enter with the same kind.
 
 ## Backends
 
-| Kind                                                                                                               | Sleep entry                                                                                                                                                                                                 |
-| ------------------------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| <a href="/api/cadmus_core/device/suspend/cycle/enum.SuspendKind.html#variant.Classic">`Classic`</a>                 | Blocking <a href="/api/cadmus_core/device/power/trait.PowerManager.html#method.suspend">`PowerManager::suspend`</a> / <a href="/api/cadmus_core/device/power/trait.PowerManager.html#method.resume">`resume`</a>, then WakeDebounce RTC |
-| <a href="/api/cadmus_core/device/suspend/cycle/enum.SuspendKind.html#variant.DeepIdle">`DeepIdle`</a>               | Force autosleep `mem`, <a href="/api/cadmus_core/device/power/trait.PowerManager.html#method.arm_deep_idle">`arm_deep_idle`</a>, drop cycle lease, poll until wake                                           |
+| Kind                                                                                                  | Sleep entry                                                                                                                                                                                                                             |
+| ----------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| <a href="/api/cadmus_core/device/suspend/cycle/enum.SuspendKind.html#variant.Classic">`Classic`</a>   | Blocking <a href="/api/cadmus_core/device/power/trait.PowerManager.html#method.suspend">`PowerManager::suspend`</a> / <a href="/api/cadmus_core/device/power/trait.PowerManager.html#method.resume">`resume`</a>, then WakeDebounce RTC |
+| <a href="/api/cadmus_core/device/suspend/cycle/enum.SuspendKind.html#variant.DeepIdle">`DeepIdle`</a> | Force autosleep `mem`, <a href="/api/cadmus_core/device/power/trait.PowerManager.html#method.arm_deep_idle">`arm_deep_idle`</a>, drop cycle lease, poll until wake                                                                      |
 
 Both kinds share prepare teardown (settings, frontlight, Wi‑Fi) and post-wake
 alarm handling (AutoPowerOff, CalendarUpdate, WakeDebounce).
@@ -91,9 +91,9 @@ the cycle (clear intermission, restore Auto Suspend) instead of stalling.
 
 ## Phase-aware Suspend
 
-| Situation                                                                                                                                                                                                 | Action                                      |
-| --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------- |
+| Situation                                                                                                                                                                                                                                                                                                          | Action                                      |
+| ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------- |
 | <a href="/api/cadmus_core/view/enum.Event.html#variant.Suspend">`Suspend`</a> during <a href="/api/cadmus_core/device/suspend/cycle/enum.SuspendPhase.html#variant.InSleep">`InSleep`</a> / <a href="/api/cadmus_core/device/suspend/cycle/enum.SuspendPhase.html#variant.PostWakeDebounce">`PostWakeDebounce`</a> | Ignore (do not finish)                      |
-| Interactive + soft armed + classic <a href="/api/cadmus_core/view/enum.Event.html#variant.Suspend">`Suspend`</a>                                                                                           | Refuse classic; do not invent a stuck cycle |
+| Interactive + soft armed + classic <a href="/api/cadmus_core/view/enum.Event.html#variant.Suspend">`Suspend`</a>                                                                                                                                                                                                   | Refuse classic; do not invent a stuck cycle |
 
 <!-- i18n:skip-end -->

--- a/docs/src/contributing/device/suspend/orchestrator.md
+++ b/docs/src/contributing/device/suspend/orchestrator.md
@@ -3,8 +3,9 @@
 # Suspend orchestrator
 
 Shared explicit-suspend orchestration lives in
-`crates/core/src/device/suspend/`. Soft-suspend leases / session details are in
-[Soft Suspend](soft-suspend.md). Kobo-specific `state-extended` wiring is in
+<a href="/api/cadmus_core/device/suspend/index.html">`device::suspend`</a>
+(`crates/core/src/device/suspend/`). Soft-suspend leases / session details are
+in [Soft Suspend](soft-suspend.md). Kobo-specific `state-extended` wiring is in
 [Kobo suspend](kobo/suspend.md).
 
 The **emulator** keeps a short UI-only suspend path and does **not** drive this
@@ -13,7 +14,11 @@ orchestrator, for now.
 ## Workflow
 
 Callers that mean “go to sleep” (power button, AutoSuspend RTC, sleep cover)
-call **`start_cycle`**, not `enter_sleep`. Sleep is a later phase.
+call
+**<a href="/api/cadmus_core/device/suspend/fn.start_cycle.html">`start_cycle`</a>**,
+not
+<a href="/api/cadmus_core/device/suspend/orchestrator/fn.enter_sleep.html">`enter_sleep`</a>.
+Sleep is a later phase.
 
 ```mermaid
 flowchart TD
@@ -31,36 +36,42 @@ flowchart TD
     debounce -->|"finish_cycle() / cancel_prepare() / start_cycle()"| interactive
 ```
 
-| Function            | Role                                                       |
-| ------------------- | ---------------------------------------------------------- |
-| `start_cycle`       | Begin cycle: UI + schedule prepare                         |
-| `prepare_for_sleep` | Shared teardown; arm classic RTC or enter DeepIdle         |
-| `enter_sleep`       | Actually sleep (classic `power.suspend` or deep-idle wait) |
-| `finish_cycle`      | Tear down cycle → interactive                              |
-| `cancel_prepare`    | Abort during PrepareSuspend only                           |
+| Function                                                                                                           | Role                                                       |
+| ------------------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------- |
+| <a href="/api/cadmus_core/device/suspend/fn.start_cycle.html">`start_cycle`</a>                                     | Begin cycle: UI + schedule prepare                         |
+| <a href="/api/cadmus_core/device/suspend/orchestrator/fn.prepare_for_sleep.html">`prepare_for_sleep`</a>             | Shared teardown; arm classic RTC or enter DeepIdle         |
+| <a href="/api/cadmus_core/device/suspend/orchestrator/fn.enter_sleep.html">`enter_sleep`</a>                         | Actually sleep (classic `power.suspend` or deep-idle wait) |
+| <a href="/api/cadmus_core/device/suspend/orchestrator/fn.finish_cycle.html">`finish_cycle`</a>                       | Tear down cycle → interactive                              |
+| <a href="/api/cadmus_core/device/suspend/orchestrator/fn.cancel_prepare.html">`cancel_prepare`</a>                   | Abort during PrepareSuspend only                           |
 
-`Event::Suspend` / `AlarmType::Suspend` mean **enter sleep now** (after
-prepare), not “start a new cycle”.
+<a href="/api/cadmus_core/view/enum.Event.html#variant.Suspend">`Event::Suspend`</a>
+/
+<a href="/api/cadmus_core/device/rtc/enum.AlarmType.html#variant.Suspend">`AlarmType::Suspend`</a>
+mean **enter sleep now** (after prepare), not “start a new cycle”.
 
 ## Kind and phase
 
-An explicit suspend cycle is `Option<SuspendCycle>` on `AppContext`. Interactive
-use is `None`.
+An explicit suspend cycle is
+`Option<`<a href="/api/cadmus_core/device/suspend/struct.SuspendCycle.html">SuspendCycle</a>`>`
+on <a href="/api/cadmus_core/device/type.AppContext.html">`AppContext`</a>
+(<a href="/api/cadmus_core/context/struct.Context.html#structfield.suspend">`suspend`</a>
+field). Interactive use is `None`.
 
-| Field   | Values                                                                      |
-| ------- | --------------------------------------------------------------------------- |
-| `kind`  | `Classic` or `DeepIdle` — chosen once at `start_cycle`, fixed for the cycle |
-| `phase` | `Preparing` → `ArmingSleep` → `InSleep` / wait → `PostWakeDebounce`         |
+| Field   | Values                                                                                                                                                                                                                                                                                                                                                   |
+| ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `kind`  | <a href="/api/cadmus_core/device/suspend/cycle/enum.SuspendKind.html#variant.Classic">`Classic`</a> or <a href="/api/cadmus_core/device/suspend/cycle/enum.SuspendKind.html#variant.DeepIdle">`DeepIdle`</a> — chosen once at <a href="/api/cadmus_core/device/suspend/fn.start_cycle.html">`start_cycle`</a>, fixed for the cycle |
+| `phase` | <a href="/api/cadmus_core/device/suspend/cycle/enum.SuspendPhase.html#variant.Preparing">`Preparing`</a> → <a href="/api/cadmus_core/device/suspend/cycle/enum.SuspendPhase.html#variant.ArmingSleep">`ArmingSleep`</a> → <a href="/api/cadmus_core/device/suspend/cycle/enum.SuspendPhase.html#variant.InSleep">`InSleep`</a> / wait → <a href="/api/cadmus_core/device/suspend/cycle/enum.SuspendPhase.html#variant.PostWakeDebounce">`PostWakeDebounce`</a> |
 
 Mid-cycle handlers must not re-select Classic vs DeepIdle by probing
-`is_armed()` alone. WakeDebounce and CalendarUpdate re-enter with the same kind.
+<a href="/api/cadmus_core/device/soft_suspend/enum.AutosleepMode.html#method.is_armed">`is_armed()`</a>
+alone. WakeDebounce and CalendarUpdate re-enter with the same kind.
 
 ## Backends
 
-| Kind       | Sleep entry                                                               |
-| ---------- | ------------------------------------------------------------------------- |
-| `Classic`  | Blocking `PowerManager::suspend` / `resume`, then WakeDebounce RTC        |
-| `DeepIdle` | Force autosleep `mem`, `arm_deep_idle`, drop cycle lease, poll until wake |
+| Kind                                                                                                               | Sleep entry                                                                                                                                                                                                 |
+| ------------------------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| <a href="/api/cadmus_core/device/suspend/cycle/enum.SuspendKind.html#variant.Classic">`Classic`</a>                 | Blocking <a href="/api/cadmus_core/device/power/trait.PowerManager.html#method.suspend">`PowerManager::suspend`</a> / <a href="/api/cadmus_core/device/power/trait.PowerManager.html#method.resume">`resume`</a>, then WakeDebounce RTC |
+| <a href="/api/cadmus_core/device/suspend/cycle/enum.SuspendKind.html#variant.DeepIdle">`DeepIdle`</a>               | Force autosleep `mem`, <a href="/api/cadmus_core/device/power/trait.PowerManager.html#method.arm_deep_idle">`arm_deep_idle`</a>, drop cycle lease, poll until wake                                           |
 
 Both kinds share prepare teardown (settings, frontlight, Wi‑Fi) and post-wake
 alarm handling (AutoPowerOff, CalendarUpdate, WakeDebounce).
@@ -69,16 +80,20 @@ alarm handling (AutoPowerOff, CalendarUpdate, WakeDebounce).
 
 Production wait uses `CLOCK_BOOTTIME` elapsed minus `CLOCK_MONOTONIC` elapsed
 (threshold ~1s). Realtime / NTP steps alone must not look like a wake. Tests
-inject `PollResult::{TimedOut, Woke}` via `AppContext::deep_idle_poll_inject`.
+inject
+<a href="/api/cadmus_core/device/suspend/wake/enum.PollResult.html#variant.TimedOut">`PollResult::TimedOut`</a>
+/
+<a href="/api/cadmus_core/device/suspend/wake/enum.PollResult.html#variant.Woke">`Woke`</a>
+via `AppContext::deep_idle_poll_inject`.
 
 On timeout: retry deep idle while soft suspend can re-arm; if it cannot, **finish**
 the cycle (clear intermission, restore Auto Suspend) instead of stalling.
 
 ## Phase-aware Suspend
 
-| Situation                                       | Action                                      |
-| ----------------------------------------------- | ------------------------------------------- |
-| `Suspend` during `InSleep` / `PostWakeDebounce` | Ignore (do not finish)                      |
-| Interactive + soft armed + classic `Suspend`    | Refuse classic; do not invent a stuck cycle |
+| Situation                                                                                                                                                                                                 | Action                                      |
+| --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------- |
+| <a href="/api/cadmus_core/view/enum.Event.html#variant.Suspend">`Suspend`</a> during <a href="/api/cadmus_core/device/suspend/cycle/enum.SuspendPhase.html#variant.InSleep">`InSleep`</a> / <a href="/api/cadmus_core/device/suspend/cycle/enum.SuspendPhase.html#variant.PostWakeDebounce">`PostWakeDebounce`</a> | Ignore (do not finish)                      |
+| Interactive + soft armed + classic <a href="/api/cadmus_core/view/enum.Event.html#variant.Suspend">`Suspend`</a>                                                                                           | Refuse classic; do not invent a stuck cycle |
 
 <!-- i18n:skip-end -->

--- a/docs/src/contributing/device/suspend/soft-suspend.md
+++ b/docs/src/contributing/device/suspend/soft-suspend.md
@@ -31,15 +31,25 @@ flowchart TD
   unlock --> kernel
 ```
 
-`SoftSuspendSession` owns:
+<a href="/api/cadmus_core/device/soft_suspend/struct.SoftSuspendSession.html">`SoftSuspendSession`</a>
+owns:
 
 - Reading `/sys/power/state` to discover available targets
-- Writing `/sys/power/autosleep` (`off` / `freeze` / `mem`)
-- A lease tracker whose observer maps 0→1 to the single kernel lock name
-  `cadmus`, and 1→0 to a deferred `wake_unlock` after autosleep grace
-  seconds (zero = unlock immediately). A new lease during the grace cancels
-  the pending unlock.
-- Optional LED indicator via `DeviceLeds`
+- Writing `/sys/power/autosleep`
+  (<a href="/api/cadmus_core/device/soft_suspend/enum.AutosleepMode.html#variant.Off">`off`</a>
+  /
+  <a href="/api/cadmus_core/device/soft_suspend/enum.AutosleepMode.html#variant.Freeze">`freeze`</a>
+  /
+  <a href="/api/cadmus_core/device/soft_suspend/enum.AutosleepMode.html#variant.Mem">`mem`</a>)
+- A
+  <a href="/api/cadmus_core/lease/struct.LeaseTracker.html">`LeaseTracker`</a>
+  whose observer maps 0→1 to the single kernel lock name `cadmus`, and 1→0 to a
+  deferred `wake_unlock` via
+  <a href="/api/cadmus_core/device/soft_suspend/session/struct.WakeLockArmer.html">`WakeLockArmer`</a>
+  after autosleep grace seconds (zero = unlock immediately). A new lease during
+  the grace cancels the pending unlock.
+- Optional LED indicator via
+  <a href="/api/cadmus_core/device/leds/trait.DeviceLeds.html">`DeviceLeds`</a>
 
 Missing autosleep / wake_lock sysfs is a no-op (emulator and hosts without
 those nodes).
@@ -53,6 +63,8 @@ Upstream references:
 Named leases only adjust the Cadmus refcount; the kernel still sees one lock
 (`cadmus`). Holders include the main loop, input, Wi‑Fi, and background
 tasks while they run. Dropping the last lease (after grace) lets the kernel
-enter the armed autosleep target.
+enter the armed
+<a href="/api/cadmus_core/device/soft_suspend/enum.AutosleepMode.html">`AutosleepMode`</a>
+target.
 
 <!-- i18n:skip-end -->

--- a/docs/src/contributing/device/suspend/soft-suspend.md
+++ b/docs/src/contributing/device/suspend/soft-suspend.md
@@ -45,7 +45,7 @@ owns:
   <a href="/api/cadmus_core/lease/struct.LeaseTracker.html">`LeaseTracker`</a>
   whose observer maps 0→1 to the single kernel lock name `cadmus`, and 1→0 to a
   deferred `wake_unlock` via
-  <a href="/api/cadmus_core/device/soft_suspend/session/struct.WakeLockArmer.html">`WakeLockArmer`</a>
+  <a href="/api/cadmus_core/device/linux/soft_suspend/session/struct.WakeLockArmer.html">`WakeLockArmer`</a>
   after autosleep grace seconds (zero = unlock immediately). A new lease during
   the grace cancels the pending unlock.
 - Optional LED indicator via


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds absolute `/api/cadmus_core/…` HTML anchors for Rust API symbols mentioned in the suspend contributor docs, matching [`docs/AGENTS.md`](docs/AGENTS.md) and the style already used in WiFi / Kobo Related APIs.

Refs: https://linear.app/ogcadmus/issue/CAD-39/implement-soft-suspend

## Changes

- [`orchestrator.md`](docs/src/contributing/device/suspend/orchestrator.md) — cycle API, kind/phase, backends, events/alarms, `PollResult`
- [`soft-suspend.md`](docs/src/contributing/device/suspend/soft-suspend.md) — `SoftSuspendSession`, `AutosleepMode`, `LeaseTracker`, `WakeLockArmer`, `DeviceLeds`
- [`kobo/suspend.md`](docs/src/contributing/device/suspend/kobo/suspend.md) — remaining prose symbols (`DeviceLifecycle`, kinds, `start_cycle`, etc.); Related APIs table unchanged

Sysfs paths and mermaid labels are left unlinked. `AppContext::deep_idle_poll_inject` is not field-linked (test-only cfg).

## Verification

- Built `cargo doc -p cadmus-core --no-deps --document-private-items --features docs` with `RUSTDOCFLAGS='--cfg docsrs'`
- Confirmed all 62 `/api/cadmus_core/…` hrefs resolve under `target/doc/cadmus_core/` (including fragments)
- Path corrections after verify: `start_cycle` / helpers live under `suspend/orchestrator/`, `SuspendCycle` under `suspend/cycle/`, private `WakeLockArmer` under `device/linux/soft_suspend/session/`
- `rumdl check` clean on the three files

## Test plan

- [x] cargo doc path verification
- [x] rumdl on touched markdown
- [ ] Spot-check links on a docs portal preview after merge
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e32767d9-483e-4d38-a8b8-f9a5116fe669?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e32767d9-483e-4d38-a8b8-f9a5116fe669&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

