### PR TITLE
feat(soft-suspend): lease hub messages for in-flight input

### DIFF
--- a/crates/cadmus/src/app.rs
+++ b/crates/cadmus/src/app.rs
@@ -60,7 +60,7 @@ pub const APP_NAME: &str = "Cadmus";
 
 fn drain_bus(bus: &mut Bus, tx: &Hub) {
     while let Some(ce) = bus.pop_front() {
-        tx.send(ce).ok();
+        tx.send(ce.into()).ok();
     }
 }
 
@@ -308,10 +308,11 @@ pub fn run() -> Result<(), Error> {
     context.load_dictionaries();
     context.load_keyboard_layouts();
 
-    let (tx, rx) = context
-        .device
-        .input_mut()
-        .start(context.display, context.settings.button_scheme);
+    let (tx, rx) = context.device.input_mut().start(
+        context.display,
+        context.settings.button_scheme,
+        std::sync::Arc::clone(&context.soft_suspend_session),
+    );
 
     let mut tasks: Vec<DeviceTask> = Vec::new();
     let mut background_tasks = TaskManager::new();
@@ -390,7 +391,8 @@ pub fn run() -> Result<(), Error> {
 
     tracing::info!(duration = ?start_time.elapsed(), "App started");
 
-    while let Ok(evt) = rx.recv() {
+    while let Ok(message) = rx.recv() {
+        let (evt, _input_wake) = message.into_parts();
         let skip_main_loop_lease =
             AppDevice::should_skip_main_loop_soft_suspend_lease(&context, &evt);
         let _soft_suspend = if skip_main_loop_lease {
@@ -486,7 +488,7 @@ pub fn run() -> Result<(), Error> {
                             Region::Corner(DiagDir::NorthWest),
                             Region::Corner(DiagDir::SouthEast),
                         ) => {
-                            tx.send(Event::Select(EntryId::TakeScreenshot)).ok();
+                            tx.send(Event::Select(EntryId::TakeScreenshot).into()).ok();
                         }
                         _ => (),
                     }

--- a/crates/core/src/device/emulator/mod.rs
+++ b/crates/core/src/device/emulator/mod.rs
@@ -104,22 +104,31 @@ impl InputSource for EmulatorInputSource {
         &mut self,
         _display: crate::framebuffer::Display,
         _button_scheme: crate::settings::ButtonScheme,
-    ) -> (Hub, Receiver<Event>) {
+        soft_suspend: Arc<crate::device::soft_suspend::SoftSuspendSession>,
+    ) -> (Hub, Receiver<crate::view::HubMessage>) {
         let (hub, rx) = mpsc::channel();
         let (device_tx, device_rx) = mpsc::channel();
         self.sender = Some(device_tx.clone());
 
         let gesture_rx = crate::gesture::gesture_events(device_rx, self.dpi);
         let hub_clone = hub.clone();
+        let gesture_soft_suspend = Arc::clone(&soft_suspend);
 
         std::thread::spawn(move || {
             while let Ok(event) = gesture_rx.recv() {
-                hub_clone.send(event).ok();
+                let _short = gesture_soft_suspend.acquire("input");
+                hub_clone
+                    .send(crate::view::HubMessage::with_soft_suspend(
+                        event,
+                        gesture_soft_suspend.acquire("input"),
+                    ))
+                    .ok();
             }
         });
 
         if let Some(sendable_sdl) = self.sdl_context.take() {
             let hub = hub.clone();
+            let sdl_soft_suspend = Arc::clone(&soft_suspend);
             let sender = device_tx;
             let mut event_pump = SendableEventPump(sendable_sdl.0.event_pump().unwrap());
             std::thread::spawn(move || {
@@ -139,7 +148,7 @@ impl InputSource for EmulatorInputSource {
                                 keymod: Mod::NOMOD,
                                 ..
                             } => {
-                                hub.send(Event::Select(EntryId::Quit)).ok();
+                                hub.send(Event::Select(EntryId::Quit).into()).ok();
                                 break 'outer;
                             }
                             SdlEvent::KeyUp {
@@ -167,7 +176,8 @@ impl InputSource for EmulatorInputSource {
                             } => match keymod {
                                 Mod::NOMOD => match scancode {
                                     Scancode::S => {
-                                        hub.send(Event::Select(EntryId::TakeScreenshot)).ok();
+                                        hub.send(Event::Select(EntryId::TakeScreenshot).into())
+                                            .ok();
                                     }
                                     Scancode::B
                                     | Scancode::F
@@ -197,18 +207,26 @@ impl InputSource for EmulatorInputSource {
                                         let y = mouse_state.y();
                                         let center = pt!(x, y);
                                         if scancode == Scancode::I {
-                                            hub.send(Event::Gesture(GestureEvent::Spread {
-                                                center,
-                                                factor: 2.0,
-                                                axis: Axis::Diagonal,
-                                            }))
+                                            let _short = sdl_soft_suspend.acquire("input");
+                                            hub.send(crate::view::HubMessage::with_soft_suspend(
+                                                Event::Gesture(GestureEvent::Spread {
+                                                    center,
+                                                    factor: 2.0,
+                                                    axis: Axis::Diagonal,
+                                                }),
+                                                sdl_soft_suspend.acquire("input"),
+                                            ))
                                             .ok();
                                         } else {
-                                            hub.send(Event::Gesture(GestureEvent::Pinch {
-                                                center,
-                                                factor: 0.5,
-                                                axis: Axis::Diagonal,
-                                            }))
+                                            let _short = sdl_soft_suspend.acquire("input");
+                                            hub.send(crate::view::HubMessage::with_soft_suspend(
+                                                Event::Gesture(GestureEvent::Pinch {
+                                                    center,
+                                                    factor: 0.5,
+                                                    axis: Axis::Diagonal,
+                                                }),
+                                                sdl_soft_suspend.acquire("input"),
+                                            ))
                                             .ok();
                                         }
                                     }
@@ -216,21 +234,30 @@ impl InputSource for EmulatorInputSource {
                                 },
                                 Mod::LSHIFTMOD | Mod::RSHIFTMOD => match scancode {
                                     Scancode::S => {
-                                        hub.send(Event::Select(EntryId::ShowIntermission(
-                                            IntermKind::Suspend,
-                                        )))
+                                        hub.send(
+                                            Event::Select(EntryId::ShowIntermission(
+                                                IntermKind::Suspend,
+                                            ))
+                                            .into(),
+                                        )
                                         .ok();
                                     }
                                     Scancode::P => {
-                                        hub.send(Event::Select(EntryId::ShowIntermission(
-                                            IntermKind::PowerOff,
-                                        )))
+                                        hub.send(
+                                            Event::Select(EntryId::ShowIntermission(
+                                                IntermKind::PowerOff,
+                                            ))
+                                            .into(),
+                                        )
                                         .ok();
                                     }
                                     Scancode::C => {
-                                        hub.send(Event::Select(EntryId::ShowIntermission(
-                                            IntermKind::Share,
-                                        )))
+                                        hub.send(
+                                            Event::Select(EntryId::ShowIntermission(
+                                                IntermKind::Share,
+                                            ))
+                                            .into(),
+                                        )
                                         .ok();
                                     }
                                     _ => (),
@@ -253,7 +280,7 @@ impl InputSource for EmulatorInputSource {
         std::thread::spawn(move || {
             loop {
                 std::thread::sleep(CLOCK_REFRESH_INTERVAL);
-                hub_clone.send(Event::ClockTick).ok();
+                hub_clone.send(Event::ClockTick.into()).ok();
             }
         });
 
@@ -544,7 +571,7 @@ fn handle_set_wifi_mode(
             let hub = hub.clone();
             std::thread::spawn(move || {
                 std::thread::sleep(std::time::Duration::from_secs(2));
-                hub.send(Event::Device(DeviceEvent::NetUp)).ok();
+                hub.send((Event::Device(DeviceEvent::NetUp)).into()).ok();
             });
         }
         crate::settings::WifiMode::Off | crate::settings::WifiMode::Auto => {
@@ -600,10 +627,15 @@ impl DeviceLifecycle for EmulatorDevice {
         if let Some(alarm_manager) = context.alarm_manager.clone() {
             reschedule_auto_suspend_alarm(context);
             let hub = hub.clone();
+            let soft_suspend = context.soft_suspend_session.clone();
             crate::device::rtc::AlarmManager::start_irq_listener(
                 &alarm_manager,
                 move |alarm_type| {
-                    hub.send(Event::RtcAlarmFired(alarm_type)).ok();
+                    hub.send(crate::view::HubMessage::with_soft_suspend(
+                        Event::RtcAlarmFired(alarm_type),
+                        soft_suspend.acquire("rtc"),
+                    ))
+                    .ok();
                 },
             );
         }
@@ -799,7 +831,7 @@ mod lifecycle {
 
     fn with_runtime<R>(
         f: impl FnOnce(
-            &mpsc::Sender<Event>,
+            &crate::view::Hub,
             &mut Bus,
             &mut RenderQueue,
             &mut crate::device::AppContext,

--- a/crates/core/src/device/kobo/input.rs
+++ b/crates/core/src/device/kobo/input.rs
@@ -3,6 +3,7 @@ use crate::input::{InputEvent, device_events, raw_events, usb_events};
 use crate::settings::ButtonScheme;
 use crate::view::Event;
 use std::path::Path;
+use std::sync::Arc;
 use std::sync::mpsc::{self, Sender};
 use std::thread;
 use std::time::Duration;
@@ -57,7 +58,7 @@ impl crate::device::InputSource for InputSource {
     #[cfg_attr(
         feature = "tracing",
         tracing::instrument(
-            skip(self, display, button_scheme),
+            skip(self, display, button_scheme, soft_suspend),
             level = tracing::Level::TRACE,
             fields(proto = ?self.info.proto),
         )
@@ -66,9 +67,10 @@ impl crate::device::InputSource for InputSource {
         &mut self,
         display: Display,
         button_scheme: ButtonScheme,
+        soft_suspend: Arc<crate::device::soft_suspend::SoftSuspendSession>,
     ) -> (
         crate::view::Hub,
-        std::sync::mpsc::Receiver<crate::view::Event>,
+        std::sync::mpsc::Receiver<crate::view::HubMessage>,
     ) {
         let mut paths = Vec::new();
         let touch_path = touch_input_path();
@@ -121,16 +123,28 @@ impl crate::device::InputSource for InputSource {
         let (tx, rx) = mpsc::channel();
 
         let tx2 = tx.clone();
+        let soft_suspend2 = Arc::clone(&soft_suspend);
         thread::spawn(move || {
             while let Ok(evt) = touch_screen.recv() {
-                tx2.send(evt).ok();
+                let _short = soft_suspend2.acquire("input");
+                tx2.send(crate::view::HubMessage::with_soft_suspend(
+                    evt,
+                    soft_suspend2.acquire("input"),
+                ))
+                .ok();
             }
         });
 
         let tx3 = tx.clone();
+        let soft_suspend3 = Arc::clone(&soft_suspend);
         thread::spawn(move || {
             while let Ok(evt) = usb_port.recv() {
-                tx3.send(Event::Device(evt)).ok();
+                let _short = soft_suspend3.acquire("input");
+                tx3.send(crate::view::HubMessage::with_soft_suspend(
+                    Event::Device(evt),
+                    soft_suspend3.acquire("input"),
+                ))
+                .ok();
             }
         });
 
@@ -138,7 +152,7 @@ impl crate::device::InputSource for InputSource {
         thread::spawn(move || {
             loop {
                 thread::sleep(CLOCK_REFRESH_INTERVAL);
-                tx4.send(Event::ClockTick).ok();
+                tx4.send(Event::ClockTick.into()).ok();
             }
         });
 
@@ -146,7 +160,7 @@ impl crate::device::InputSource for InputSource {
         thread::spawn(move || {
             loop {
                 thread::sleep(BATTERY_REFRESH_INTERVAL);
-                tx5.send(Event::BatteryTick).ok();
+                tx5.send(Event::BatteryTick.into()).ok();
             }
         });
 

--- a/crates/core/src/device/kobo/lifecycle/device_events.rs
+++ b/crates/core/src/device/kobo/lifecycle/device_events.rs
@@ -77,7 +77,7 @@ fn handle_power_button_released(
 
 /// Forwards a light-button press as [`Event::ToggleFrontlight`].
 fn handle_light_button_pressed(hub: &Hub) -> EventOutcome {
-    hub.send(Event::ToggleFrontlight).ok();
+    hub.send((Event::ToggleFrontlight).into()).ok();
     EventOutcome::Handled
 }
 
@@ -109,7 +109,7 @@ fn handle_rotate_screen(
         }
     }
 
-    hub.send(Event::Select(EntryId::Rotate(n))).ok();
+    hub.send((Event::Select(EntryId::Rotate(n))).into()).ok();
     EventOutcome::Handled
 }
 
@@ -138,7 +138,7 @@ fn handle_net_up(
                 ip = info.ip.to_string(),
                 essid = info.essid.to_string()
             );
-            hub.send(Event::Notification(NotificationEvent::Show(msg)))
+            hub.send((Event::Notification(NotificationEvent::Show(msg))).into())
                 .ok();
         }
         Ok(None) => {
@@ -243,7 +243,7 @@ fn handle_plug(
         PowerSource::Host => handle_plug_host(hub, rq, context, runtime),
     }
 
-    hub.send(Event::BatteryTick).ok();
+    hub.send((Event::BatteryTick).into()).ok();
 
     EventOutcome::Handled
 }
@@ -258,7 +258,7 @@ fn handle_plug_host(
     cancel_suspend_if_pending(context, runtime.tasks, runtime.view.as_mut(), hub, rq);
 
     if context.settings.auto_share {
-        hub.send(Event::PrepareShare).ok();
+        hub.send((Event::PrepareShare).into()).ok();
     } else {
         let dialog = Dialog::builder(ViewId::ShareDialog, "Share storage via USB?".to_string())
             .add_button("Cancel", Event::Close(ViewId::ShareDialog))
@@ -318,7 +318,7 @@ fn handle_unplug(
                 );
             }
         } else {
-            hub.send(Event::BatteryTick).ok();
+            hub.send((Event::BatteryTick).into()).ok();
         }
     }
 

--- a/crates/core/src/device/kobo/lifecycle/frontlight.rs
+++ b/crates/core/src/device/kobo/lifecycle/frontlight.rs
@@ -105,7 +105,6 @@ mod tests {
     use crate::frontlight::LightLevels;
     use crate::task::{BackgroundTask, ShutdownSignal, TaskId, TaskManager};
     use crate::view::Event;
-    use std::sync::mpsc::Sender;
     use std::time::Duration;
 
     struct WaitingTask;
@@ -115,7 +114,7 @@ mod tests {
             TaskId::AutoFrontlight
         }
 
-        fn run(&mut self, _hub: &Sender<Event>, shutdown: &ShutdownSignal) {
+        fn run(&mut self, _hub: &crate::view::Hub, shutdown: &ShutdownSignal) {
             shutdown.wait(Duration::from_secs(60));
         }
     }

--- a/crates/core/src/device/kobo/lifecycle/mod.rs
+++ b/crates/core/src/device/kobo/lifecycle/mod.rs
@@ -23,7 +23,7 @@ use crate::framebuffer::Framebuffer as _;
 use crate::frontlight::Frontlight as _;
 use crate::gesture::GestureEvent;
 use crate::input::{ButtonCode, DeviceEvent};
-use crate::view::{EntryId, Event};
+use crate::view::{EntryId, Event, HubMessage};
 use std::fs::File;
 use std::sync::mpsc;
 use std::thread;
@@ -86,7 +86,9 @@ impl DeviceLifecycle for Device {
                         let enabled = wifi_session.wifi_manager().is_enabled();
                         tracing::info!(wants_on, enabled, connected, "wifi startup reconcile");
                         if connected {
-                            hub_wifi.send(Event::Device(DeviceEvent::NetUp)).ok();
+                            hub_wifi
+                                .send((Event::Device(DeviceEvent::NetUp)).into())
+                                .ok();
                         }
                     }
                     Err(error) => {
@@ -128,14 +130,19 @@ impl DeviceLifecycle for Device {
             hub,
             runtime.tasks,
         );
-        hub.send(Event::WakeUp).ok();
+        hub.send((Event::WakeUp).into()).ok();
         reschedule_auto_suspend_alarm(context);
         if let Some(alarm_manager) = context.alarm_manager.clone() {
             let hub = hub.clone();
+            let soft_suspend = context.soft_suspend_session.clone();
             crate::device::rtc::AlarmManager::start_irq_listener(
                 &alarm_manager,
                 move |alarm_type| {
-                    hub.send(Event::RtcAlarmFired(alarm_type)).ok();
+                    hub.send(HubMessage::with_soft_suspend(
+                        Event::RtcAlarmFired(alarm_type),
+                        soft_suspend.acquire("rtc"),
+                    ))
+                    .ok();
                 },
             );
         }

--- a/crates/core/src/device/kobo/lifecycle/usb_share.rs
+++ b/crates/core/src/device/kobo/lifecycle/usb_share.rs
@@ -18,7 +18,6 @@ use crate::view::{
 };
 use std::env;
 use std::path::Path;
-use std::sync::mpsc::Sender;
 use std::time::Duration;
 
 /// Prepares the app for USB mass-storage sharing.
@@ -36,7 +35,7 @@ fn prepare_usb_share(
     settings_manager: &crate::settings::versioned::SettingsManager,
     updating: &mut Vec<UpdateData>,
     bus: &mut Bus,
-    hub: &Sender<Event>,
+    hub: &crate::view::Hub,
     rq: &mut RenderQueue,
 ) {
     tasks.clear();
@@ -82,7 +81,7 @@ fn prepare_usb_share(
         UpdateMode::Full,
     ));
     view.children_mut().push(Box::new(interm));
-    hub.send(Event::Share).ok();
+    hub.send((Event::Share).into()).ok();
 }
 
 /// Enables USB mass-storage mode.
@@ -92,16 +91,19 @@ fn prepare_usb_share(
 ///
 /// On failure, shows a notification and schedules a restart or reboot.
 #[cfg_attr(feature = "tracing", tracing::instrument(skip(hub, tasks, context)))]
-fn enable_usb_share(context: &mut AppContext, hub: &Sender<Event>, tasks: &mut Vec<DeviceTask>) {
+fn enable_usb_share(context: &mut AppContext, hub: &crate::view::Hub, tasks: &mut Vec<DeviceTask>) {
     if let Err(error) = crate::logging::redirect_log_to_dir(
         Path::new("/tmp/cadmus-logs"),
         &context.settings.logging,
     ) {
         eprintln!("Failed to redirect logging to /tmp: {error}");
 
-        hub.send(Event::Notification(NotificationEvent::Show(
-            "Failed to start USB session".to_string(),
-        )))
+        hub.send(
+            (Event::Notification(NotificationEvent::Show(
+                "Failed to start USB session".to_string(),
+            )))
+            .into(),
+        )
         .ok();
         schedule_device_task(
             DeviceTaskId::Exit,
@@ -124,9 +126,12 @@ fn enable_usb_share(context: &mut AppContext, hub: &Sender<Event>, tasks: &mut V
             }
             Err(error) => {
                 tracing::error!(error = %error, "Failed to enable USB sharing");
-                hub.send(Event::Notification(NotificationEvent::Show(
-                    "Failed to start USB session".to_string(),
-                )))
+                hub.send(
+                    (Event::Notification(NotificationEvent::Show(
+                        "Failed to start USB session".to_string(),
+                    )))
+                    .into(),
+                )
                 .ok();
                 schedule_device_task(
                     DeviceTaskId::Exit,
@@ -139,9 +144,12 @@ fn enable_usb_share(context: &mut AppContext, hub: &Sender<Event>, tasks: &mut V
         },
         Err(error) => {
             tracing::error!(error = %error, "Failed to create USB manager");
-            hub.send(Event::Notification(NotificationEvent::Show(
-                "Failed to start USB session".to_string(),
-            )))
+            hub.send(
+                (Event::Notification(NotificationEvent::Show(
+                    "Failed to start USB session".to_string(),
+                )))
+                .into(),
+            )
             .ok();
             schedule_device_task(
                 DeviceTaskId::Exit,
@@ -163,7 +171,7 @@ pub(super) fn disable_usb_share(
     context: &AppContext,
     startup_cwd: Option<&Path>,
     logging_settings: &crate::settings::LoggingSettings,
-    hub: &Sender<Event>,
+    hub: &crate::view::Hub,
 ) {
     tracing::info!("USB unplugged after sharing; disabling USB mass storage");
 
@@ -182,13 +190,13 @@ pub(super) fn disable_usb_share(
             }
             Err(error) => {
                 tracing::error!(error = %error, "Failed to disable USB sharing, triggering reboot");
-                hub.send(Event::Select(EntryId::Reboot)).ok();
+                hub.send((Event::Select(EntryId::Reboot)).into()).ok();
                 return;
             }
         },
         Err(error) => {
             tracing::error!(error = %error, "Failed to create USB manager, triggering reboot");
-            hub.send(Event::Select(EntryId::Reboot)).ok();
+            hub.send((Event::Select(EntryId::Reboot)).into()).ok();
             return;
         }
     }
@@ -204,10 +212,10 @@ pub(super) fn disable_usb_share(
 
     if update_bundle_exists {
         tracing::info!("KoboRoot.tgz detected; triggering reboot");
-        hub.send(Event::Select(EntryId::Reboot)).ok();
+        hub.send((Event::Select(EntryId::Reboot)).into()).ok();
     } else {
         tracing::info!("triggering app restart");
-        hub.send(Event::Select(EntryId::Restart)).ok();
+        hub.send((Event::Select(EntryId::Restart)).into()).ok();
     }
 }
 

--- a/crates/core/src/device/kobo/lifecycle/wifi.rs
+++ b/crates/core/src/device/kobo/lifecycle/wifi.rs
@@ -57,7 +57,7 @@ pub(super) fn spawn_wifi_idle_poller(
                         break;
                     }
                 }
-                if hub.send(Event::MightDisableWifi).is_err() {
+                if hub.send((Event::MightDisableWifi).into()).is_err() {
                     tracing::debug!("wifi idle poller stopping: hub closed");
                     break;
                 }
@@ -116,7 +116,7 @@ fn handle_set_wifi_mode(mode: WifiMode, hub: &Hub, context: &mut AppContext) -> 
             let hub = hub.clone();
             thread::spawn(move || match session.enable_radio() {
                 Ok(true) => {
-                    hub.send(Event::Device(DeviceEvent::NetUp)).ok();
+                    hub.send((Event::Device(DeviceEvent::NetUp)).into()).ok();
                 }
                 Ok(false) => {}
                 Err(error) => {

--- a/crates/core/src/device/mod.rs
+++ b/crates/core/src/device/mod.rs
@@ -102,6 +102,7 @@ use crate::time_manager::TimeManager;
 use crate::view::{Bus, Event, Hub, RenderQueue, UpdateData, View};
 use std::fmt::Debug;
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 use std::sync::mpsc::Receiver;
 
 pub struct HistoryItem {
@@ -183,7 +184,8 @@ pub trait InputSource: Send {
         &mut self,
         display: crate::framebuffer::Display,
         button_scheme: ButtonScheme,
-    ) -> (Hub, Receiver<Event>);
+        soft_suspend: Arc<crate::device::soft_suspend::SoftSuspendSession>,
+    ) -> (Hub, Receiver<crate::view::HubMessage>);
 
     /// Injects a raw [`InputEvent`] into the input pipeline.
     ///

--- a/crates/core/src/device/suspend/helpers.rs
+++ b/crates/core/src/device/suspend/helpers.rs
@@ -7,8 +7,7 @@ use super::orchestrator::{
 };
 use crate::device::AppContext;
 use crate::device::{DeviceTask, DeviceTaskId};
-use crate::view::{RenderQueue, View};
-use std::sync::mpsc::Sender;
+use crate::view::{Hub, RenderQueue, View};
 
 /// Returns whether `tasks` contains a task with the given `id`.
 pub(crate) fn has_task(tasks: &[DeviceTask], id: DeviceTaskId) -> bool {
@@ -34,7 +33,7 @@ pub(crate) fn cancel_suspend_if_pending(
     context: &mut AppContext,
     tasks: &mut Vec<DeviceTask>,
     view: &mut dyn View,
-    hub: &Sender<crate::view::Event>,
+    hub: &Hub,
     rq: &mut RenderQueue,
 ) {
     let had_cycle = context.suspend.is_some();

--- a/crates/core/src/device/suspend/orchestrator.rs
+++ b/crates/core/src/device/suspend/orchestrator.rs
@@ -35,7 +35,6 @@ use crate::view::common::locate;
 use crate::view::intermission::Intermission;
 use crate::view::{Event, Hub, RenderData, RenderQueue, View, wait_for_all};
 use std::sync::mpsc;
-use std::sync::mpsc::Sender;
 use std::time::Duration;
 
 const DEEP_IDLE_CYCLE_LEASE: &str = "deep-idle";
@@ -792,7 +791,7 @@ fn handle_post_wake(
 pub(crate) fn start_cycle(
     context: &mut AppContext,
     view: &mut dyn View,
-    hub: &Sender<Event>,
+    hub: &Hub,
     bus: &mut crate::view::Bus,
     rq: &mut crate::view::RenderQueue,
     tasks: &mut Vec<DeviceTask>,
@@ -853,7 +852,7 @@ pub(in crate::device::suspend) fn finish_cycle(
     context: &mut AppContext,
     tasks: &mut Vec<DeviceTask>,
     view: &mut dyn View,
-    hub: &Sender<Event>,
+    hub: &Hub,
     rq: &mut crate::view::RenderQueue,
 ) {
     tasks.retain(|task| {
@@ -867,7 +866,7 @@ pub(in crate::device::suspend) fn finish_cycle(
         let hub = hub.clone();
         std::thread::spawn(move || match session.enable_radio() {
             Ok(true) => {
-                hub.send(Event::Device(crate::input::DeviceEvent::NetUp))
+                hub.send((Event::Device(crate::input::DeviceEvent::NetUp)).into())
                     .ok();
             }
             Ok(false) => {}
@@ -892,8 +891,8 @@ pub(in crate::device::suspend) fn finish_cycle(
     } else {
         tracing::warn!("resume called but no intermission view found to remove");
     }
-    hub.send(Event::ClockTick).ok();
-    hub.send(Event::BatteryTick).ok();
+    hub.send((Event::ClockTick).into()).ok();
+    hub.send((Event::BatteryTick).into()).ok();
 }
 
 /// Abort during [`SuspendPhase::Preparing`] only (drop PrepareSuspend task + intermission).
@@ -905,7 +904,7 @@ pub(in crate::device::suspend) fn cancel_prepare(
     id: DeviceTaskId,
     tasks: &mut Vec<DeviceTask>,
     view: &mut dyn View,
-    hub: &Sender<Event>,
+    hub: &Hub,
     rq: &mut crate::view::RenderQueue,
 ) {
     if id != DeviceTaskId::PrepareSuspend {
@@ -924,8 +923,8 @@ pub(in crate::device::suspend) fn cancel_prepare(
     } else {
         tracing::warn!("resume called but no intermission view found to remove");
     }
-    hub.send(Event::ClockTick).ok();
-    hub.send(Event::BatteryTick).ok();
+    hub.send((Event::ClockTick).into()).ok();
+    hub.send((Event::BatteryTick).into()).ok();
     reschedule_auto_suspend_alarm(context);
 }
 

--- a/crates/core/src/device/tasks.rs
+++ b/crates/core/src/device/tasks.rs
@@ -1,8 +1,8 @@
 //! Delayed device tasks posted back to the main-loop hub.
 
 use crate::device::{DeviceTask, DeviceTaskId};
-use crate::view::Event;
-use std::sync::mpsc::{self, Sender};
+use crate::view::{Event, Hub};
+use std::sync::mpsc;
 use std::thread;
 use std::time::Duration;
 
@@ -15,7 +15,7 @@ pub(crate) fn schedule_device_task(
     id: DeviceTaskId,
     event: Event,
     delay: Duration,
-    hub: &Sender<Event>,
+    hub: &Hub,
     tasks: &mut Vec<DeviceTask>,
 ) {
     let (ty, ry) = mpsc::channel();
@@ -25,7 +25,7 @@ pub(crate) fn schedule_device_task(
     thread::spawn(move || {
         thread::sleep(delay);
         if ty.send(()).is_ok() {
-            hub2.send(event).ok();
+            hub2.send(event.into()).ok();
         }
     });
 }

--- a/crates/core/src/device/test_device.rs
+++ b/crates/core/src/device/test_device.rs
@@ -350,7 +350,8 @@ impl InputSource for TestInputSource {
         &mut self,
         _display: crate::framebuffer::Display,
         _button_scheme: crate::settings::ButtonScheme,
-    ) -> (Hub, Receiver<Event>) {
+        _soft_suspend: Arc<crate::device::soft_suspend::SoftSuspendSession>,
+    ) -> (Hub, Receiver<crate::view::HubMessage>) {
         std::sync::mpsc::channel()
     }
 }

--- a/crates/core/src/device/test_harness.rs
+++ b/crates/core/src/device/test_harness.rs
@@ -23,7 +23,7 @@ use crate::device::DeviceHardware as _;
 use crate::device::{DeviceRuntime, DeviceTask, DeviceTaskId, HistoryItem};
 use crate::framebuffer::Framebuffer as _;
 use crate::view::filler::Filler;
-use crate::view::{Bus, Event, Hub, RenderQueue, UpdateData, View};
+use crate::view::{Bus, Event, Hub, HubMessage, RenderQueue, UpdateData, View};
 use std::sync::mpsc::Receiver;
 
 /// Minimal runtime shell for device / suspend handler tests.
@@ -35,7 +35,7 @@ use std::sync::mpsc::Receiver;
 pub(crate) struct DeviceRuntimeHarness {
     pub(crate) context: AppContext,
     pub(crate) hub_tx: Hub,
-    hub_rx: Receiver<Event>,
+    hub_rx: Receiver<HubMessage>,
     pub(crate) bus: Bus,
     pub(crate) rq: RenderQueue,
     pub(crate) view: Box<dyn View>,
@@ -67,8 +67,8 @@ impl DeviceRuntimeHarness {
     /// Collects all events sent on the hub since the last drain.
     pub(crate) fn drain_hub(&self) -> Vec<Event> {
         let mut events = Vec::new();
-        while let Ok(event) = self.hub_rx.try_recv() {
-            events.push(event);
+        while let Ok(message) = self.hub_rx.try_recv() {
+            events.push(message.event);
         }
         events
     }

--- a/crates/core/src/device/wifi/session.rs
+++ b/crates/core/src/device/wifi/session.rs
@@ -352,7 +352,7 @@ impl WifiSession {
                 .hub
                 .as_ref()
             {
-                hub.send(Event::Device(DeviceEvent::NetUp)).ok();
+                hub.send((Event::Device(DeviceEvent::NetUp)).into()).ok();
             }
             return Ok(WifiLease { inner: Some(inner) });
         }

--- a/crates/core/src/library/importer.rs
+++ b/crates/core/src/library/importer.rs
@@ -9,7 +9,6 @@ use crate::task::ShutdownSignal;
 use crate::view::{Event, NotificationEvent, ViewId};
 use fxhash::FxHashMap;
 use std::path::{Path, PathBuf};
-use std::sync::mpsc::Sender;
 use std::time::{Duration, Instant, UNIX_EPOCH};
 use tracing::{debug, error, info};
 use walkdir::{DirEntry, WalkDir};
@@ -67,7 +66,7 @@ impl ProgressTracker {
 }
 
 struct ScanContext<'a> {
-    hub: &'a Sender<Event>,
+    hub: &'a crate::view::Hub,
     notif_id: ViewId,
     shutdown: &'a ShutdownSignal,
 }
@@ -328,7 +327,7 @@ fn scan_entries(
 }
 
 fn send_progress(
-    hub: &Sender<Event>,
+    hub: &crate::view::Hub,
     notif_id: ViewId,
     tracker: &mut ProgressTracker,
     idx: usize,
@@ -338,10 +337,8 @@ fn send_progress(
         return;
     };
     debug!(percent, "import progress");
-    hub.send(Event::Notification(NotificationEvent::UpdateProgress(
-        notif_id, percent,
-    )))
-    .ok();
+    hub.send((Event::Notification(NotificationEvent::UpdateProgress(notif_id, percent))).into())
+        .ok();
 }
 
 #[cfg_attr(
@@ -480,21 +477,24 @@ pub fn run(
     install_dir: &Path,
     settings: &ImportSettings,
     force: bool,
-    hub: &Sender<Event>,
+    hub: &crate::view::Hub,
     notif_id: ViewId,
     shutdown: &ShutdownSignal,
 ) {
-    hub.send(Event::Notification(NotificationEvent::ShowPinned(
-        notif_id,
-        fl!("importer-importing-library"),
-    )))
+    hub.send(
+        (Event::Notification(NotificationEvent::ShowPinned(
+            notif_id,
+            fl!("importer-importing-library"),
+        )))
+        .into(),
+    )
     .ok();
 
     let handles = match db.list_book_handles(library_id) {
         Ok(h) => h,
         Err(e) => {
             error!(error = %e, "failed to load book handles for import");
-            hub.send(Event::Close(notif_id)).ok();
+            hub.send((Event::Close(notif_id)).into()).ok();
             return;
         }
     };
@@ -555,7 +555,7 @@ pub fn run(
         &mut handles_by_fp,
         &mut handles_by_path,
     ) else {
-        hub.send(Event::Close(notif_id)).ok();
+        hub.send((Event::Close(notif_id)).into()).ok();
         return;
     };
 
@@ -583,7 +583,7 @@ pub fn run(
         result.thumbnails_to_delete,
     );
 
-    hub.send(Event::Close(notif_id)).ok();
+    hub.send((Event::Close(notif_id)).into()).ok();
 }
 
 #[cfg(test)]
@@ -619,7 +619,7 @@ mod tests {
             shutdown,
         );
         drop(tx);
-        rx.try_iter().collect()
+        rx.try_iter().map(|message| message.event).collect()
     }
 
     #[test]
@@ -675,7 +675,7 @@ mod tests {
             &shutdown,
         );
         drop(tx);
-        let events: Vec<Event> = rx.try_iter().collect();
+        let events: Vec<Event> = rx.try_iter().map(|message| message.event).collect();
 
         assert!(
             events.iter().any(|e| matches!(e, Event::Close(_))),
@@ -821,7 +821,7 @@ mod tests {
             &shutdown,
         );
         drop(tx);
-        let _events: Vec<Event> = rx.try_iter().collect();
+        let _events: Vec<Event> = rx.try_iter().map(|message| message.event).collect();
 
         let handles = lib.db.list_book_handles(lib.library_id).expect("handles");
         let paths: Vec<_> = handles.iter().map(|h| h.relat.clone()).collect();
@@ -864,7 +864,7 @@ mod tests {
             &shutdown,
         );
         drop(tx);
-        let _: Vec<Event> = rx.try_iter().collect();
+        let _: Vec<Event> = rx.try_iter().map(|message| message.event).collect();
 
         let handles = lib.db.list_book_handles(lib.library_id).expect("handles");
         assert_eq!(handles.len(), 2, "both files should be imported initially");
@@ -890,7 +890,7 @@ mod tests {
             &shutdown,
         );
         drop(tx2);
-        let _: Vec<Event> = rx2.try_iter().collect();
+        let _: Vec<Event> = rx2.try_iter().map(|message| message.event).collect();
 
         let handles = lib
             .db

--- a/crates/core/src/task/auto_frontlight.rs
+++ b/crates/core/src/task/auto_frontlight.rs
@@ -1,4 +1,3 @@
-use std::sync::mpsc::Sender;
 use std::time::Duration;
 
 use crate::task::{BackgroundTask, ShutdownSignal, TaskId};
@@ -16,9 +15,9 @@ impl BackgroundTask for AutoFrontlightTask {
         TaskId::AutoFrontlight
     }
 
-    fn run(&mut self, hub: &Sender<Event>, shutdown: &ShutdownSignal) {
+    fn run(&mut self, hub: &crate::view::Hub, shutdown: &ShutdownSignal) {
         while !shutdown.should_stop() {
-            if let Err(e) = hub.send(Event::UpdateAutoFrontlight) {
+            if let Err(e) = hub.send((Event::UpdateAutoFrontlight).into()) {
                 tracing::error!(error = %e, "failed to send auto-frontlight update event");
                 break;
             }

--- a/crates/core/src/task/dbus_monitor.rs
+++ b/crates/core/src/task/dbus_monitor.rs
@@ -27,7 +27,7 @@ impl BackgroundTask for DbusMonitorTask {
         TaskId::DbusMonitor
     }
 
-    fn run(&mut self, _hub: &Sender<Event>, shutdown: &ShutdownSignal) {
+    fn run(&mut self, _hub: &crate::view::Hub, shutdown: &ShutdownSignal) {
         let rt = match tokio::runtime::Runtime::new() {
             Ok(rt) => rt,
             Err(e) => {

--- a/crates/core/src/task/dictionary_index.rs
+++ b/crates/core/src/task/dictionary_index.rs
@@ -5,7 +5,6 @@ use std::collections::HashSet;
 use std::fs::File;
 use std::io::{BufRead, BufReader};
 use std::num::NonZeroU64;
-use std::sync::mpsc::Sender;
 
 use globset::Glob;
 use walkdir::WalkDir;
@@ -282,7 +281,7 @@ impl DictionaryIndexTask {
         &self,
         job: &IndexFileJob<'_>,
         skip_lines: u64,
-        hub: &Sender<Event>,
+        hub: &crate::view::Hub,
         shutdown: &ShutdownSignal,
     ) -> Option<u64> {
         let file = match File::open(job.index_path) {
@@ -380,7 +379,7 @@ impl DictionaryIndexTask {
     fn index_file(
         &self,
         index_path: &std::path::Path,
-        hub: &Sender<Event>,
+        hub: &crate::view::Hub,
         shutdown: &ShutdownSignal,
     ) {
         let path_str = index_path.display().to_string();
@@ -409,7 +408,7 @@ impl DictionaryIndexTask {
             };
 
         if is_new {
-            hub.send(Event::ReloadDictionaries).ok();
+            hub.send((Event::ReloadDictionaries).into()).ok();
         }
 
         let (case_sensitive, all_chars) = Self::detect_metadata(&path_str);
@@ -419,13 +418,16 @@ impl DictionaryIndexTask {
         };
 
         let notif_id = ViewId::MessageNotif(ID_FEEDER.next());
-        hub.send(Event::Notification(NotificationEvent::ShowPinned(
-            notif_id,
-            fl!(
-                "notification-dictionary-indexing",
-                name = dict_name.as_str()
-            ),
-        )))
+        hub.send(
+            (Event::Notification(NotificationEvent::ShowPinned(
+                notif_id,
+                fl!(
+                    "notification-dictionary-indexing",
+                    name = dict_name.as_str()
+                ),
+            )))
+            .into(),
+        )
         .ok();
 
         let job = IndexFileJob {
@@ -443,11 +445,11 @@ impl DictionaryIndexTask {
         match self.scan_and_batch(&job, skip_lines, hub, shutdown) {
             Some(current_line) => {
                 self.mark_completed(dict_id, &path_str, current_line, total_lines);
-                hub.send(Event::ReloadDictionaries).ok();
-                hub.send(Event::Close(notif_id)).ok();
+                hub.send((Event::ReloadDictionaries).into()).ok();
+                hub.send((Event::Close(notif_id)).into()).ok();
             }
             None => {
-                hub.send(Event::Close(notif_id)).ok();
+                hub.send((Event::Close(notif_id)).into()).ok();
             }
         }
     }
@@ -458,7 +460,7 @@ impl DictionaryIndexTask {
         job: &IndexFileJob<'_>,
         batch: &[(i64, String, i64, i64, Option<String>)],
         current_line: u64,
-        hub: &Sender<Event>,
+        hub: &crate::view::Hub,
     ) -> Result<(), anyhow::Error> {
         let pool = self.database.pool().clone();
         let indexed_lines = current_line as i64;
@@ -502,15 +504,11 @@ impl DictionaryIndexTask {
             .unwrap_or(0)
             .min(100) as u8;
         let msg = fl!("notification-dictionary-indexing", name = job.dict_name);
-        hub.send(Event::Notification(NotificationEvent::UpdateText(
-            job.notif_id,
-            msg,
-        )))
-        .ok();
-        hub.send(Event::Notification(NotificationEvent::UpdateProgress(
-            job.notif_id,
-            progress,
-        )))
+        hub.send((Event::Notification(NotificationEvent::UpdateText(job.notif_id, msg))).into())
+            .ok();
+        hub.send(
+            (Event::Notification(NotificationEvent::UpdateProgress(job.notif_id, progress))).into(),
+        )
         .ok();
 
         Ok(())
@@ -528,7 +526,7 @@ impl DictionaryIndexTask {
     fn delete_stale_entries(
         &self,
         on_disk_fingerprints: &[String],
-        hub: &Sender<Event>,
+        hub: &crate::view::Hub,
         shutdown: &ShutdownSignal,
     ) {
         let pool = self.database.pool().clone();
@@ -587,7 +585,7 @@ impl DictionaryIndexTask {
 
         match result {
             Ok(true) => {
-                hub.send(Event::ReloadDictionaries).ok();
+                hub.send((Event::ReloadDictionaries).into()).ok();
             }
             Ok(false) => {}
             Err(e) => {
@@ -648,7 +646,7 @@ impl BackgroundTask for DictionaryIndexTask {
     }
 
     #[cfg_attr(feature = "tracing", tracing::instrument(skip_all))]
-    fn run(&mut self, hub: &Sender<Event>, shutdown: &ShutdownSignal) {
+    fn run(&mut self, hub: &crate::view::Hub, shutdown: &ShutdownSignal) {
         let glob = match Glob::new("**/*.index") {
             Ok(g) => g.compile_matcher(),
             Err(e) => {

--- a/crates/core/src/task/hello_world.rs
+++ b/crates/core/src/task/hello_world.rs
@@ -22,7 +22,7 @@ impl BackgroundTask for HelloWorldTask {
         TaskId::HelloWorld
     }
 
-    fn run(&mut self, _hub: &Sender<Event>, shutdown: &ShutdownSignal) {
+    fn run(&mut self, _hub: &crate::view::Hub, shutdown: &ShutdownSignal) {
         tracing::info!("hello_world task started");
 
         loop {

--- a/crates/core/src/task/import.rs
+++ b/crates/core/src/task/import.rs
@@ -1,7 +1,6 @@
 //! Background task that imports library contents from disk.
 
 use std::path::PathBuf;
-use std::sync::mpsc::Sender;
 
 use crate::db::Database;
 use crate::library::Library;
@@ -43,7 +42,7 @@ impl ImportTask {
     }
 
     #[cfg_attr(feature = "tracing", tracing::instrument(skip(hub, shutdown, self)))]
-    fn run_for_index(&self, index: usize, hub: &Sender<Event>, shutdown: &ShutdownSignal) {
+    fn run_for_index(&self, index: usize, hub: &crate::view::Hub, shutdown: &ShutdownSignal) {
         let lib_settings = match self.settings.libraries.get(index) {
             Some(s) => s,
             None => {
@@ -84,7 +83,7 @@ impl BackgroundTask for ImportTask {
     }
 
     #[cfg_attr(feature = "tracing", tracing::instrument(skip_all))]
-    fn run(&mut self, hub: &Sender<Event>, shutdown: &ShutdownSignal) {
+    fn run(&mut self, hub: &crate::view::Hub, shutdown: &ShutdownSignal) {
         match self.library_index {
             Some(index) => {
                 self.run_for_index(index, hub, shutdown);

--- a/crates/core/src/task/mod.rs
+++ b/crates/core/src/task/mod.rs
@@ -12,11 +12,10 @@
 //! # Example
 //!
 //! ```no_run
-//! use std::sync::mpsc::Sender;
 //! use std::time::Duration;
 //!
 //! use cadmus_core::task::{BackgroundTask, ShutdownSignal, TaskId};
-//! use cadmus_core::view::Event;
+//! use cadmus_core::view::Hub;
 //!
 //! struct MyTask;
 //!
@@ -25,7 +24,7 @@
 //!         TaskId::Placeholder
 //!     }
 //!
-//!     fn run(&mut self, hub: &Sender<Event>, shutdown: &ShutdownSignal) {
+//!     fn run(&mut self, _hub: &Hub, shutdown: &ShutdownSignal) {
 //!         while !shutdown.should_stop() {
 //!             // Do work...
 //!             if shutdown.wait(Duration::from_secs(60)) {
@@ -234,7 +233,7 @@ pub trait BackgroundTask: Send {
     ///
     /// This method is called in a dedicated thread. Use `hub` to send
     /// events to the main loop and `shutdown` to check for termination.
-    fn run(&mut self, hub: &Sender<Event>, shutdown: &ShutdownSignal);
+    fn run(&mut self, hub: &crate::view::Hub, shutdown: &ShutdownSignal);
 
     /// Called when the task is being stopped.
     ///
@@ -293,7 +292,7 @@ impl TaskManager {
     pub fn start(
         &mut self,
         task: Box<dyn BackgroundTask>,
-        hub: Sender<Event>,
+        hub: crate::view::Hub,
     ) -> Result<TaskId, TaskError> {
         let id = task.id();
 
@@ -401,9 +400,9 @@ impl TaskManager {
     }
 
     /// Sends any buffered completion events from naturally finished tasks.
-    fn flush_buffered_events(&mut self, hub: &Sender<Event>) {
+    fn flush_buffered_events(&mut self, hub: &crate::view::Hub) {
         for evt in self.buffered_events.drain(..) {
-            hub.send(evt).ok();
+            hub.send((evt).into()).ok();
         }
     }
 
@@ -412,7 +411,12 @@ impl TaskManager {
     /// Must be called for every event before passing it to the view tree.
     /// Always returns `false` — it never consumes events.
     #[cfg_attr(feature = "tracing", tracing::instrument(skip(self, hub, context)))]
-    pub fn handle_event(&mut self, evt: &Event, hub: &Sender<Event>, context: &AppContext) -> bool {
+    pub fn handle_event(
+        &mut self,
+        evt: &Event,
+        hub: &crate::view::Hub,
+        context: &AppContext,
+    ) -> bool {
         self.cleanup_finished();
         self.flush_buffered_events(hub);
 
@@ -476,9 +480,12 @@ impl TaskManager {
                 #[cfg(feature = "kobo")]
                 {
                     if !context.online && !context.settings.wifi.allows_on_demand() {
-                        hub.send(Event::Notification(NotificationEvent::Show(fl!(
-                            "notification-not-online"
-                        ))))
+                        hub.send(
+                            (Event::Notification(NotificationEvent::Show(fl!(
+                                "notification-not-online"
+                            ))))
+                            .into(),
+                        )
                         .ok();
                     } else {
                         self.schedule_time_sync(true, hub, context);
@@ -496,7 +503,7 @@ impl TaskManager {
         &mut self,
         library_index: Option<usize>,
         force: bool,
-        hub: &Sender<Event>,
+        hub: &crate::view::Hub,
         database: &Database,
         settings: &Settings,
         install_dir: &std::path::Path,
@@ -527,7 +534,7 @@ impl TaskManager {
     #[cfg_attr(feature = "tracing", tracing::instrument(skip_all))]
     fn drain_pending_imports(
         &mut self,
-        hub: &Sender<Event>,
+        hub: &crate::view::Hub,
         database: &Database,
         settings: &Settings,
         install_dir: &std::path::Path,
@@ -546,7 +553,7 @@ impl TaskManager {
     #[cfg_attr(feature = "tracing", tracing::instrument(skip_all))]
     fn schedule_dictionary_index(
         &mut self,
-        hub: &Sender<Event>,
+        hub: &crate::view::Hub,
         database: &Database,
         data_path: std::path::PathBuf,
     ) {
@@ -571,7 +578,7 @@ impl TaskManager {
 
     #[cfg(feature = "kobo")]
     #[cfg_attr(feature = "tracing", tracing::instrument(skip_all))]
-    fn sync_auto_frontlight(&mut self, hub: &Sender<Event>, settings: &Settings) {
+    fn sync_auto_frontlight(&mut self, hub: &crate::view::Hub, settings: &Settings) {
         if self.is_running(&TaskId::AutoFrontlight) {
             tracing::debug!("stopping running auto_frontlight task for restart");
             if let Err(e) = self.stop(&TaskId::AutoFrontlight) {
@@ -593,7 +600,7 @@ impl TaskManager {
 
     #[cfg(feature = "kobo")]
     #[cfg_attr(feature = "tracing", tracing::instrument(skip_all))]
-    fn schedule_time_sync(&mut self, manual: bool, hub: &Sender<Event>, context: &AppContext) {
+    fn schedule_time_sync(&mut self, manual: bool, hub: &crate::view::Hub, context: &AppContext) {
         if self.is_running(&TaskId::TimeSync) {
             tracing::warn!("Time sync task already running, not scheduling");
 
@@ -629,7 +636,7 @@ impl TaskManager {
     pub fn schedule_thumbnail_extraction(
         &mut self,
         library_index: Option<usize>,
-        hub: &Sender<Event>,
+        hub: &crate::view::Hub,
         database: &Database,
         settings: &Settings,
         dpi: u16,
@@ -662,7 +669,7 @@ impl TaskManager {
     #[cfg_attr(feature = "tracing", tracing::instrument(skip_all))]
     fn drain_pending_thumbnails(
         &mut self,
-        hub: &Sender<Event>,
+        hub: &crate::view::Hub,
         database: &Database,
         settings: &Settings,
         dpi: u16,
@@ -727,7 +734,7 @@ impl Drop for TaskManager {
 #[cfg_attr(feature = "tracing", tracing::instrument(skip(manager, hub, settings, database, data_path, install_dir), level = tracing::Level::TRACE))]
 pub fn register_startup_tasks(
     manager: &mut TaskManager,
-    hub: Sender<Event>,
+    hub: crate::view::Hub,
     settings: &Settings,
     database: &Database,
     data_path: std::path::PathBuf,
@@ -802,7 +809,7 @@ mod tests {
             TaskId::TestTask2
         }
 
-        fn run(&mut self, _hub: &Sender<Event>, _shutdown: &ShutdownSignal) {}
+        fn run(&mut self, _hub: &crate::view::Hub, _shutdown: &ShutdownSignal) {}
     }
 
     struct WaitingTask;
@@ -812,7 +819,7 @@ mod tests {
             TaskId::TestTask
         }
 
-        fn run(&mut self, _hub: &Sender<Event>, shutdown: &ShutdownSignal) {
+        fn run(&mut self, _hub: &crate::view::Hub, shutdown: &ShutdownSignal) {
             shutdown.wait(Duration::from_secs(60));
         }
     }

--- a/crates/core/src/task/thumbnail.rs
+++ b/crates/core/src/task/thumbnail.rs
@@ -1,7 +1,6 @@
 //! Background task that extracts book cover thumbnails.
 
 use std::path::PathBuf;
-use std::sync::mpsc::Sender;
 
 use crate::db::Database;
 use crate::document::open;
@@ -43,7 +42,7 @@ impl ThumbnailExtractionTask {
     }
 
     #[cfg_attr(feature = "tracing", tracing::instrument(skip(hub, shutdown, self)))]
-    fn run_for_index(&self, index: usize, hub: &Sender<Event>, shutdown: &ShutdownSignal) {
+    fn run_for_index(&self, index: usize, hub: &crate::view::Hub, shutdown: &ShutdownSignal) {
         let lib_settings = match self.settings.libraries.get(index) {
             Some(s) => s,
             None => {
@@ -107,7 +106,7 @@ impl ThumbnailExtractionTask {
                     if let Err(e) = library.db.save_thumbnail(fp, &bytes) {
                         tracing::error!(error = %e, path = %path.display(), "failed to save thumbnail to database");
                     } else {
-                        hub.send(Event::RefreshBookPreview(path)).ok();
+                        hub.send((Event::RefreshBookPreview(path)).into()).ok();
                     }
                 }
                 None => {
@@ -124,7 +123,7 @@ impl BackgroundTask for ThumbnailExtractionTask {
     }
 
     #[cfg_attr(feature = "tracing", tracing::instrument(skip_all))]
-    fn run(&mut self, hub: &Sender<Event>, shutdown: &ShutdownSignal) {
+    fn run(&mut self, hub: &crate::view::Hub, shutdown: &ShutdownSignal) {
         match self.library_index {
             Some(index) => {
                 self.run_for_index(index, hub, shutdown);

--- a/crates/core/src/task/time_sync.rs
+++ b/crates/core/src/task/time_sync.rs
@@ -1,4 +1,3 @@
-use std::sync::mpsc::Sender;
 use std::sync::{Arc, Mutex};
 
 use crate::device::rtc::{AlarmManager, Rtc};
@@ -41,15 +40,18 @@ impl<R: Rtc + Send + 'static> BackgroundTask for TimeSyncTask<R> {
         TaskId::TimeSync
     }
 
-    fn run(&mut self, hub: &Sender<Event>, _shutdown: &ShutdownSignal) {
+    fn run(&mut self, hub: &crate::view::Hub, _shutdown: &ShutdownSignal) {
         let _wifi = match self.wifi_session.acquire("time-sync") {
             Ok(lease) => lease,
             Err(e) => {
                 tracing::error!(error = %e, "failed to acquire WiFi lease for time sync");
                 if self.manual {
-                    hub.send(Event::Notification(crate::view::NotificationEvent::Show(
-                        crate::fl!("notification-time-sync-failed"),
-                    )))
+                    hub.send(
+                        (Event::Notification(crate::view::NotificationEvent::Show(crate::fl!(
+                            "notification-time-sync-failed"
+                        ))))
+                        .into(),
+                    )
                     .ok();
                 }
                 return;
@@ -80,7 +82,8 @@ impl<R: Rtc + Send + 'static> BackgroundTask for TimeSyncTask<R> {
         }
 
         if let Some(coordinates) = coordinates {
-            hub.send(Event::AutoFrontlightCoordinates(coordinates)).ok();
+            hub.send((Event::AutoFrontlightCoordinates(coordinates)).into())
+                .ok();
         }
     }
 }

--- a/crates/core/src/task/wifi_status_monitor.rs
+++ b/crates/core/src/task/wifi_status_monitor.rs
@@ -6,7 +6,6 @@
 //! (enable/disable + `network_info`), not by probing dhcpcd here.
 
 use std::collections::HashMap;
-use std::sync::mpsc::Sender;
 use std::time::Duration;
 
 use futures_util::stream::StreamExt;
@@ -31,7 +30,7 @@ impl BackgroundTask for WifiStatusMonitorTask {
         TaskId::WifiStatusMonitor
     }
 
-    fn run(&mut self, hub: &Sender<Event>, shutdown: &ShutdownSignal) {
+    fn run(&mut self, hub: &crate::view::Hub, shutdown: &ShutdownSignal) {
         let rt = match tokio::runtime::Runtime::new() {
             Ok(rt) => rt,
             Err(e) => {
@@ -49,7 +48,7 @@ impl BackgroundTask for WifiStatusMonitorTask {
 }
 
 async fn monitor(
-    hub: &Sender<Event>,
+    hub: &crate::view::Hub,
     shutdown: &ShutdownSignal,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let connection = zbus::Connection::system().await?;
@@ -116,7 +115,7 @@ async fn monitor(
 #[cfg_attr(feature = "tracing", tracing::instrument(skip(msg, hub), ret(level=tracing::Level::TRACE)))]
 fn process_wpa_status(
     msg: &zbus::Message,
-    hub: &Sender<Event>,
+    hub: &crate::view::Hub,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let body = msg.body();
 
@@ -131,7 +130,7 @@ fn process_wpa_status(
 ///
 /// This is a separate function to enable unit testing without requiring
 /// a full zbus::Message.
-fn check_interfaces(interfaces: &HashMap<String, HashMap<String, String>>, hub: &Sender<Event>) {
+fn check_interfaces(interfaces: &HashMap<String, HashMap<String, String>>, hub: &crate::view::Hub) {
     for (interface_name, properties) in interfaces {
         if let Some(wpa_state) = properties.get("wpa_state") {
             tracing::debug!(
@@ -146,7 +145,7 @@ fn check_interfaces(interfaces: &HashMap<String, HashMap<String, String>>, hub: 
 
             if wpa_state == "COMPLETED" && has_ip {
                 tracing::info!("network up detected via dhcpcd-dbus");
-                hub.send(Event::Device(DeviceEvent::NetUp)).ok();
+                hub.send((Event::Device(DeviceEvent::NetUp)).into()).ok();
             }
         }
     }
@@ -170,7 +169,7 @@ mod tests {
         check_interfaces(&interfaces, &tx);
 
         let event = rx.try_recv().expect("should receive NetUp event");
-        assert!(matches!(event, Event::Device(DeviceEvent::NetUp)));
+        assert!(matches!(event.event, Event::Device(DeviceEvent::NetUp)));
     }
 
     #[test]

--- a/crates/core/src/time_manager.rs
+++ b/crates/core/src/time_manager.rs
@@ -3,7 +3,6 @@ use chrono::{DateTime, Utc};
 use sntpc::{NtpContext, StdTimestampGen};
 use sntpc_net_std::UdpSocketWrapper;
 use std::net::{IpAddr, SocketAddr, ToSocketAddrs, UdpSocket};
-use std::sync::mpsc::Sender;
 use std::time::Duration;
 
 use crate::device::rtc::{AlarmManager, Rtc};
@@ -37,14 +36,17 @@ impl<R: Rtc> TimeManager<R> {
         ntp_server: &NetworkAddress,
         manual: bool,
         geolocation: Option<GeoLocation>,
-        hub: &Sender<Event>,
+        hub: &crate::view::Hub,
         alarm_manager: &Arc<Mutex<AlarmManager<R>>>,
     ) -> Result<(), Error> {
         if let Err(e) = self.detect_and_set_timezone(geolocation) {
             if manual {
-                hub.send(Event::Notification(NotificationEvent::Show(crate::fl!(
-                    "notification-timezone-detection-failed"
-                ))))
+                hub.send(
+                    (Event::Notification(NotificationEvent::Show(crate::fl!(
+                        "notification-timezone-detection-failed"
+                    ))))
+                    .into(),
+                )
                 .ok();
             }
             tracing::warn!(error = %e, "timezone detection failed");
@@ -54,9 +56,12 @@ impl<R: Rtc> TimeManager<R> {
             Ok(t) => t,
             Err(e) => {
                 if manual {
-                    hub.send(Event::Notification(NotificationEvent::Show(crate::fl!(
-                        "notification-time-sync-failed"
-                    ))))
+                    hub.send(
+                        (Event::Notification(NotificationEvent::Show(crate::fl!(
+                            "notification-time-sync-failed"
+                        ))))
+                        .into(),
+                    )
                     .ok();
                 } else {
                     tracing::warn!(error = %e, address = %ntp_server, "ntp query failed");
@@ -73,14 +78,17 @@ impl<R: Rtc> TimeManager<R> {
         match result {
             Ok(()) => {
                 tracing::info!(time = %ntp_time, address = %ntp_server, "time synced");
-                hub.send(Event::ClockTick).ok();
+                hub.send((Event::ClockTick).into()).ok();
                 Ok(())
             }
             Err(e) => {
                 if manual {
-                    hub.send(Event::Notification(NotificationEvent::Show(crate::fl!(
-                        "notification-time-sync-failed"
-                    ))))
+                    hub.send(
+                        (Event::Notification(NotificationEvent::Show(crate::fl!(
+                            "notification-time-sync-failed"
+                        ))))
+                        .into(),
+                    )
                     .ok();
                 }
                 tracing::warn!(error = %e, "set_system_clock or rtc.set_time failed");

--- a/crates/core/src/view/calculator/mod.rs
+++ b/crates/core/src/view/calculator/mod.rs
@@ -96,7 +96,7 @@ impl Calculator {
             let reader = BufReader::new(stdout);
             for line_res in reader.lines() {
                 if let Ok(line) = line_res {
-                    hub2.send(Event::ProcessLine(LineOrigin::Output, line.clone()))
+                    hub2.send((Event::ProcessLine(LineOrigin::Output, line.clone())).into())
                         .ok();
                 } else {
                     break;
@@ -109,7 +109,7 @@ impl Calculator {
             let reader = BufReader::new(stderr);
             for line_res in reader.lines() {
                 if let Ok(line) = line_res {
-                    hub3.send(Event::ProcessLine(LineOrigin::Error, line.clone()))
+                    hub3.send((Event::ProcessLine(LineOrigin::Error, line.clone())).into())
                         .ok();
                 } else {
                     break;
@@ -250,7 +250,8 @@ impl Calculator {
         let lines_count = (code_area_rect.height() as i32 - 2 * margin_width_px) / line_height;
 
         rq.add(RenderData::new(id, rect, UpdateMode::Full));
-        hub.send(Event::Focus(Some(ViewId::CalculatorInput))).ok();
+        hub.send((Event::Focus(Some(ViewId::CalculatorInput))).into())
+            .ok();
 
         Ok(Calculator {
             id,
@@ -724,7 +725,7 @@ impl View for Calculator {
             Event::Gesture(GestureEvent::Rotate { quarter_turns, .. }) if quarter_turns != 0 => {
                 let (_, dir) = context.device.mirroring_scheme();
                 let n = (4 + (context.display.rotation - dir * quarter_turns)) % 4;
-                hub.send(Event::Select(EntryId::Rotate(n))).ok();
+                hub.send((Event::Select(EntryId::Rotate(n))).into()).ok();
                 true
             }
             Event::Gesture(GestureEvent::HoldFingerShort(center, ..))
@@ -755,7 +756,7 @@ impl View for Calculator {
             }
             Event::Back | Event::Select(EntryId::Quit) => {
                 self.quit(context);
-                hub.send(Event::Back).ok();
+                hub.send((Event::Back).into()).ok();
                 true
             }
             Event::Reseed => {

--- a/crates/core/src/view/device_auth.rs
+++ b/crates/core/src/view/device_auth.rs
@@ -75,7 +75,7 @@ impl DeviceAuthView {
             Ok((url, code)) => (format!("Go to: {}", url), format!("Enter code: {}", code)),
             Err(e) => {
                 tracing::error!(error = %e, "Device flow initiation failed");
-                hub.send(Event::Github(GithubEvent::DeviceAuthError(e.to_string())))
+                hub.send((Event::Github(GithubEvent::DeviceAuthError(e.to_string()))).into())
                     .ok();
                 (
                     "GitHub auth failed".to_owned(),
@@ -166,7 +166,7 @@ impl DeviceAuthView {
                 Ok(c) => c,
                 Err(e) => {
                     tracing::error!(error = %e, "Failed to create poll client");
-                    hub2.send(Event::Github(GithubEvent::DeviceAuthError(e.to_string())))
+                    hub2.send((Event::Github(GithubEvent::DeviceAuthError(e.to_string()))).into())
                         .ok();
                     return;
                 }
@@ -192,27 +192,30 @@ impl DeviceAuthView {
                     }
                     Ok(TokenPollResult::Complete(token)) => {
                         tracing::info!("Device flow authorization complete");
-                        hub2.send(Event::Github(GithubEvent::DeviceAuthComplete(token)))
+                        hub2.send((Event::Github(GithubEvent::DeviceAuthComplete(token))).into())
                             .ok();
                         return;
                     }
                     Ok(TokenPollResult::Expired) => {
                         tracing::warn!("Device flow code expired");
-                        hub2.send(Event::Github(GithubEvent::DeviceAuthExpired))
+                        hub2.send((Event::Github(GithubEvent::DeviceAuthExpired)).into())
                             .ok();
                         return;
                     }
                     Ok(TokenPollResult::Cancelled) => {
                         tracing::info!("Device flow cancelled by user on GitHub");
-                        hub2.send(Event::Github(GithubEvent::DeviceAuthError(
-                            "Authorization cancelled".to_owned(),
-                        )))
+                        hub2.send(
+                            (Event::Github(GithubEvent::DeviceAuthError(
+                                "Authorization cancelled".to_owned(),
+                            )))
+                            .into(),
+                        )
                         .ok();
                         return;
                     }
                     Err(e) => {
                         tracing::error!(error = %e, "Device flow poll error");
-                        hub2.send(Event::Github(GithubEvent::DeviceAuthError(e)))
+                        hub2.send((Event::Github(GithubEvent::DeviceAuthError(e))).into())
                             .ok();
                         return;
                     }

--- a/crates/core/src/view/dialog.rs
+++ b/crates/core/src/view/dialog.rs
@@ -335,7 +335,7 @@ impl View for Dialog {
     ) -> bool {
         match *evt {
             Event::Gesture(GestureEvent::Tap(center)) if !self.rect.includes(center) => {
-                hub.send(Event::Close(self.view_id)).ok();
+                hub.send((Event::Close(self.view_id)).into()).ok();
                 true
             }
             Event::Gesture(..) => true,

--- a/crates/core/src/view/dictionary/mod.rs
+++ b/crates/core/src/view/dictionary/mod.rs
@@ -257,10 +257,10 @@ impl Dictionary {
         rq.add(RenderData::new(id, rect, UpdateMode::Gui));
 
         if query.is_empty() {
-            hub.send(Event::Focus(Some(ViewId::DictionarySearchInput)))
+            hub.send((Event::Focus(Some(ViewId::DictionarySearchInput))).into())
                 .ok();
         } else {
-            hub.send(Event::Define(query.to_string())).ok();
+            hub.send((Event::Define(query.to_string())).into()).ok();
         }
 
         Dictionary {
@@ -440,7 +440,7 @@ impl Dictionary {
 
             context.kb_rect = Rectangle::default();
             rq.add(RenderData::expose(rect, UpdateMode::Gui));
-            hub.send(Event::Focus(None)).ok();
+            hub.send((Event::Focus(None)).into()).ok();
         } else {
             if !enable {
                 return;
@@ -542,7 +542,7 @@ impl Dictionary {
                 *edit_languages.rect(),
                 UpdateMode::Gui,
             ));
-            hub.send(Event::Focus(Some(ViewId::EditLanguagesInput)))
+            hub.send((Event::Focus(Some(ViewId::EditLanguagesInput))).into())
                 .ok();
 
             self.children
@@ -727,7 +727,7 @@ impl View for Dictionary {
                     let loc = self.location;
                     self.go_to_neighbor(cd, rq, context);
                     if self.location == loc {
-                        hub.send(Event::Back).ok();
+                        hub.send((Event::Back).into()).ok();
                     }
                 }
                 true
@@ -803,7 +803,7 @@ impl View for Dictionary {
                 false
             }
             Event::Close(ViewId::SearchBar) => {
-                hub.send(Event::Back).ok();
+                hub.send((Event::Back).into()).ok();
                 true
             }
             Event::Focus(v) => {
@@ -842,7 +842,7 @@ impl View for Dictionary {
                 true
             }
             Event::Gesture(GestureEvent::Cross(_)) => {
-                hub.send(Event::Back).ok();
+                hub.send((Event::Back).into()).ok();
                 true
             }
             _ => false,

--- a/crates/core/src/view/frontlight.rs
+++ b/crates/core/src/view/frontlight.rs
@@ -315,18 +315,18 @@ impl View for FrontlightWindow {
                 let mut levels = self.frontlight_levels;
                 levels.intensity = value.into();
                 self.frontlight_levels = levels;
-                hub.send(Event::SetFrontlightLevels(levels)).ok();
+                hub.send((Event::SetFrontlightLevels(levels)).into()).ok();
                 true
             }
             Event::Slider(SliderId::LightWarmth, value, _) => {
                 let mut levels = self.frontlight_levels;
                 levels.warmth = value.into();
                 self.frontlight_levels = levels;
-                hub.send(Event::SetFrontlightLevels(levels)).ok();
+                hub.send((Event::SetFrontlightLevels(levels)).into()).ok();
                 true
             }
             Event::Gesture(GestureEvent::Tap(center)) if !self.rect.includes(center) => {
-                hub.send(Event::Close(ViewId::Frontlight)).ok();
+                hub.send((Event::Close(ViewId::Frontlight)).into()).ok();
                 true
             }
             Event::Gesture(..) => true,
@@ -392,7 +392,8 @@ impl View for FrontlightWindow {
                 let frontlight_levels =
                     context.settings.frontlight_presets[index].frontlight_levels;
                 self.set_frontlight_levels(frontlight_levels, rq, context);
-                hub.send(Event::SetFrontlightLevels(frontlight_levels)).ok();
+                hub.send((Event::SetFrontlightLevels(frontlight_levels)).into())
+                    .ok();
                 true
             }
             Event::Guess => {
@@ -405,7 +406,7 @@ impl View for FrontlightWindow {
                     guess_frontlight(lightsensor_level, &context.settings.frontlight_presets)
                 {
                     self.set_frontlight_levels(*frontlight_levels, rq, context);
-                    hub.send(Event::SetFrontlightLevels(*frontlight_levels))
+                    hub.send((Event::SetFrontlightLevels(*frontlight_levels)).into())
                         .ok();
                 }
                 true

--- a/crates/core/src/view/home/book.rs
+++ b/crates/core/src/view/home/book.rs
@@ -65,7 +65,8 @@ impl View for Book {
                 self.active = true;
                 rq.add(RenderData::new(self.id, self.rect, UpdateMode::Gui));
 
-                hub.send(Event::Open(Box::new(self.info.clone()))).ok();
+                hub.send((Event::Open(Box::new(self.info.clone()))).into())
+                    .ok();
                 true
             }
             Event::Gesture(GestureEvent::HoldFingerShort(center, ..))

--- a/crates/core/src/view/home/mod.rs
+++ b/crates/core/src/view/home/mod.rs
@@ -620,7 +620,7 @@ impl Home {
             }
 
             context.kb_rect = Rectangle::default();
-            hub.send(Event::Focus(None)).ok();
+            hub.send((Event::Focus(None)).into()).ok();
             if update {
                 let rect = rect![self.rect.min.x, y_min, self.rect.max.x, y_min + delta_y];
                 rq.add(RenderData::expose(rect, UpdateMode::Gui));
@@ -1021,7 +1021,8 @@ impl Home {
                     has_keyboard = true;
                 }
 
-                hub.send(Event::Focus(Some(ViewId::HomeSearchInput))).ok();
+                hub.send((Event::Focus(Some(ViewId::HomeSearchInput))).into())
+                    .ok();
             }
 
             search_visible = true;
@@ -1123,7 +1124,7 @@ impl Home {
                 *ren_doc.rect(),
                 UpdateMode::Gui,
             ));
-            hub.send(Event::Focus(Some(ViewId::RenameDocumentInput)))
+            hub.send((Event::Focus(Some(ViewId::RenameDocumentInput))).into())
                 .ok();
             self.children.push(Box::new(ren_doc) as Box<dyn View>);
         }
@@ -1167,7 +1168,8 @@ impl Home {
                 *go_to_page.rect(),
                 UpdateMode::Gui,
             ));
-            hub.send(Event::Focus(Some(ViewId::GoToPageInput))).ok();
+            hub.send((Event::Focus(Some(ViewId::GoToPageInput))).into())
+                .ok();
             self.children.push(Box::new(go_to_page) as Box<dyn View>);
         }
     }
@@ -1778,14 +1780,15 @@ impl Home {
                 fetcher.process.wait().ok();
                 if update {
                     if let Some(sort_method) = fetcher.sort_method {
-                        hub.send(Event::Select(EntryId::Sort(sort_method))).ok();
+                        hub.send((Event::Select(EntryId::Sort(sort_method))).into())
+                            .ok();
                     }
                     if let Some(first_column) = fetcher.first_column {
-                        hub.send(Event::Select(EntryId::FirstColumn(first_column)))
+                        hub.send((Event::Select(EntryId::FirstColumn(first_column))).into())
                             .ok();
                     }
                     if let Some(second_column) = fetcher.second_column {
-                        hub.send(Event::Select(EntryId::SecondColumn(second_column)))
+                        hub.send((Event::Select(EntryId::SecondColumn(second_column))).into())
                             .ok();
                     }
                 } else {
@@ -1824,19 +1827,20 @@ impl Home {
                 let mut first_column = hook.first_column;
                 let mut second_column = hook.second_column;
                 if let Some(sort_method) = sort_method.replace(self.sort_method) {
-                    hub.send(Event::Select(EntryId::Sort(sort_method))).ok();
+                    hub.send((Event::Select(EntryId::Sort(sort_method))).into())
+                        .ok();
                 }
                 let selected_library = context.settings.selected_library;
                 if let Some(first_column) =
                     first_column.replace(context.settings.libraries[selected_library].first_column)
                 {
-                    hub.send(Event::Select(EntryId::FirstColumn(first_column)))
+                    hub.send((Event::Select(EntryId::FirstColumn(first_column))).into())
                         .ok();
                 }
                 if let Some(second_column) = second_column
                     .replace(context.settings.libraries[selected_library].second_column)
                 {
-                    hub.send(Event::Select(EntryId::SecondColumn(second_column)))
+                    hub.send((Event::Select(EntryId::SecondColumn(second_column))).into())
                         .ok();
                 }
                 self.background_fetchers.insert(
@@ -1890,9 +1894,12 @@ impl Home {
                             Some("notify") => {
                                 if let Some(msg) = event.get("message").and_then(JsonValue::as_str)
                                 {
-                                    hub2.send(Event::Notification(NotificationEvent::Show(
-                                        msg.to_string(),
-                                    )))
+                                    hub2.send(
+                                        (Event::Notification(NotificationEvent::Show(
+                                            msg.to_string(),
+                                        )))
+                                        .into(),
+                                    )
                                     .ok();
                                 }
                             }
@@ -1902,16 +1909,18 @@ impl Home {
                                     .map(ToString::to_string)
                                     .and_then(|v| serde_json::from_str(&v).ok())
                                 {
-                                    hub2.send(Event::FetcherAddDocument(id, Box::new(info)))
-                                        .ok();
+                                    hub2.send(
+                                        (Event::FetcherAddDocument(id, Box::new(info))).into(),
+                                    )
+                                    .ok();
                                 }
                             }
                             Some("removeDocument") => {
                                 if let Some(path) = event.get("path").and_then(JsonValue::as_str) {
-                                    hub2.send(Event::FetcherRemoveDocument(
-                                        id,
-                                        PathBuf::from(path),
-                                    ))
+                                    hub2.send(
+                                        (Event::FetcherRemoveDocument(id, PathBuf::from(path)))
+                                            .into(),
+                                    )
                                     .ok();
                                 }
                             }
@@ -1928,12 +1937,15 @@ impl Home {
                                     .get("sortBy")
                                     .map(ToString::to_string)
                                     .and_then(|v| serde_json::from_str(&v).ok());
-                                hub2.send(Event::FetcherSearch {
-                                    id,
-                                    path,
-                                    query,
-                                    sort_by,
-                                })
+                                hub2.send(
+                                    (Event::FetcherSearch {
+                                        id,
+                                        path,
+                                        query,
+                                        sort_by,
+                                    })
+                                    .into(),
+                                )
                                 .ok();
                             }
                             _ => (),
@@ -1943,7 +1955,7 @@ impl Home {
                     break;
                 }
             }
-            hub2.send(Event::CheckFetcher(id)).ok();
+            hub2.send((Event::CheckFetcher(id)).into()).ok();
         });
         Ok(process)
     }
@@ -2005,7 +2017,7 @@ impl View for Home {
             Event::Gesture(GestureEvent::Rotate { quarter_turns, .. }) if quarter_turns != 0 => {
                 let (_, dir) = context.device.mirroring_scheme();
                 let n = (4 + (context.display.rotation - dir * quarter_turns)) % 4;
-                hub.send(Event::Select(EntryId::Rotate(n))).ok();
+                hub.send((Event::Select(EntryId::Rotate(n))).into()).ok();
                 true
             }
             Event::Gesture(GestureEvent::Arrow { dir, .. }) => {
@@ -2391,7 +2403,7 @@ impl View for Home {
                     .is_none()
                 {
                     context.settings.auto_frontlight_last_coordinates = Some(coordinates);
-                    hub.send(Event::AutoFrontlightConfigChanged).ok();
+                    hub.send((Event::AutoFrontlightConfigChanged).into()).ok();
                 }
                 true
             }

--- a/crates/core/src/view/hub_message.rs
+++ b/crates/core/src/view/hub_message.rs
@@ -1,0 +1,123 @@
+//! Hub channel payloads that can carry an optional soft-suspend lease.
+//!
+//! Producers attach a [`HubLease`] so the wake lock stays held while the message
+//! sits in the hub queue. The main loop drops that lease after acquiring its own
+//! `main-loop` lease, keeping coverage continuous across the hand-off.
+
+use crate::device::soft_suspend::SoftSuspendLease;
+use crate::view::Event;
+
+/// RAII lease attached to a [`HubMessage`] while it is in flight on the hub.
+///
+/// Dropping the enclosing message (or the lease extracted via
+/// [`HubMessage::into_parts`]) releases the underlying resource.
+pub enum HubLease {
+    /// Soft-suspend wake lock for work that must keep autosleep from entering
+    /// `mem` until the main loop takes over.
+    SoftSuspend(SoftSuspendLease),
+}
+
+/// Event delivered on the hub, optionally pinning a [`HubLease`] until handled.
+///
+/// Bare messages (`From<Event>`) carry no lease. Input and other producers that
+/// must stay awake use [`Self::with_soft_suspend`] so the lease spans enqueue
+/// until the receiver overlaps with the main-loop lease.
+pub struct HubMessage {
+    /// View / device event to dispatch.
+    pub event: Event,
+    /// Held until this message is dropped or dismantled with [`Self::into_parts`].
+    _lease: Option<HubLease>,
+}
+
+impl HubMessage {
+    /// Wraps `event` and keeps `lease` alive for as long as this message exists.
+    pub fn with_lease(event: Event, lease: HubLease) -> Self {
+        Self {
+            event,
+            _lease: Some(lease),
+        }
+    }
+
+    /// Wraps `event` with a soft-suspend lease (see [`HubLease::SoftSuspend`]).
+    pub fn with_soft_suspend(event: Event, lease: SoftSuspendLease) -> Self {
+        Self::with_lease(event, HubLease::SoftSuspend(lease))
+    }
+
+    /// Splits into the event and any remaining lease without dropping the lease.
+    pub fn into_parts(self) -> (Event, Option<HubLease>) {
+        (self.event, self._lease)
+    }
+}
+
+impl From<Event> for HubMessage {
+    /// Builds a message with no attached lease.
+    fn from(event: Event) -> Self {
+        Self {
+            event,
+            _lease: None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::device::soft_suspend::{SoftSuspendPaths, SoftSuspendSession};
+    use std::fs;
+    use std::sync::Arc;
+
+    fn session() -> (tempfile::TempDir, Arc<SoftSuspendSession>) {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let paths = SoftSuspendPaths {
+            state: dir.path().join("state"),
+            autosleep: dir.path().join("autosleep"),
+            wake_lock: dir.path().join("wake_lock"),
+            wake_unlock: dir.path().join("wake_unlock"),
+        };
+        fs::write(&paths.state, "freeze mem\n").expect("state");
+        fs::write(&paths.autosleep, "off\n").expect("autosleep");
+        fs::write(&paths.wake_lock, "").expect("wake_lock");
+        fs::write(&paths.wake_unlock, "").expect("wake_unlock");
+        let session = SoftSuspendSession::with_paths(paths, None);
+        (dir, session)
+    }
+
+    #[test]
+    fn soft_suspend_message_holds_lease_until_dropped() {
+        let (_dir, session) = session();
+
+        let _short = session.acquire("input");
+        let message = HubMessage::with_soft_suspend(Event::ClockTick, session.acquire("input"));
+
+        assert!(!session.is_empty());
+        drop(_short);
+        assert!(!session.is_empty());
+        drop(message);
+        assert!(session.is_empty());
+    }
+
+    #[test]
+    fn rtc_alarm_message_holds_lease_until_dropped() {
+        let (_dir, session) = session();
+
+        let message = HubMessage::with_soft_suspend(
+            Event::RtcAlarmFired(crate::AlarmType::AutoSuspend),
+            session.acquire("rtc"),
+        );
+
+        assert!(!session.is_empty());
+        drop(message);
+        assert!(session.is_empty());
+    }
+
+    #[test]
+    fn bare_message_does_not_acquire_lease() {
+        let (_dir, session) = session();
+
+        let message = HubMessage::from(Event::ClockTick);
+
+        assert!(session.is_empty());
+        drop(message);
+        assert!(session.is_empty());
+    }
+}

--- a/crates/core/src/view/icon.rs
+++ b/crates/core/src/view/icon.rs
@@ -135,7 +135,7 @@ impl View for Icon {
                 match self.event {
                     Event::Page(dir) => bus.push_back(Event::Chapter(dir)),
                     Event::Show(ViewId::Frontlight) => {
-                        hub.send(Event::ToggleFrontlight).ok();
+                        hub.send((Event::ToggleFrontlight).into()).ok();
                     }
                     Event::Show(ViewId::MarginCropper) => {
                         bus.push_back(Event::ToggleNear(ViewId::MarginCropperMenu, self.rect));

--- a/crates/core/src/view/input_field.rs
+++ b/crates/core/src/view/input_field.rs
@@ -225,7 +225,7 @@ impl View for InputField {
         match *evt {
             Event::Gesture(GestureEvent::Tap(center)) if self.rect.includes(center) => {
                 if !self.focused {
-                    hub.send(Event::Focus(Some(self.view_id))).ok();
+                    hub.send((Event::Focus(Some(self.view_id))).into()).ok();
                 } else {
                     let index =
                         self.index_from_position(center, &mut context.fonts, context.device.dpi());
@@ -242,7 +242,7 @@ impl View for InputField {
             Event::Gesture(GestureEvent::HoldFingerShort(center, _))
                 if self.rect.includes(center) =>
             {
-                hub.send(Event::ToggleInputHistoryMenu(self.view_id, self.rect))
+                hub.send((Event::ToggleInputHistoryMenu(self.view_id, self.rect)).into())
                     .ok();
                 true
             }

--- a/crates/core/src/view/key.rs
+++ b/crates/core/src/view/key.rs
@@ -248,21 +248,27 @@ impl View for Key {
             {
                 match self.kind {
                     KeyKind::Delete(dir) => {
-                        hub.send(Event::Keyboard(KeyboardEvent::Delete {
-                            target: TextKind::Word,
-                            dir,
-                        }))
+                        hub.send(
+                            (Event::Keyboard(KeyboardEvent::Delete {
+                                target: TextKind::Word,
+                                dir,
+                            }))
+                            .into(),
+                        )
                         .ok();
                     }
                     KeyKind::Move(dir) => {
-                        hub.send(Event::Keyboard(KeyboardEvent::Move {
-                            target: TextKind::Word,
-                            dir,
-                        }))
+                        hub.send(
+                            (Event::Keyboard(KeyboardEvent::Move {
+                                target: TextKind::Word,
+                                dir,
+                            }))
+                            .into(),
+                        )
                         .ok();
                     }
                     KeyKind::Output(' ') => {
-                        hub.send(Event::ToggleNear(ViewId::KeyboardLayoutMenu, self.rect))
+                        hub.send((Event::ToggleNear(ViewId::KeyboardLayoutMenu, self.rect)).into())
                             .ok();
                     }
                     _ => (),

--- a/crates/core/src/view/keyboard.rs
+++ b/crates/core/src/view/keyboard.rs
@@ -227,17 +227,20 @@ impl View for Keyboard {
                     KeyKind::Output(ch) => {
                         if self.state.combine {
                             self.combine_buffer.push(ch);
-                            hub.send(Event::Keyboard(KeyboardEvent::Partial(ch))).ok();
+                            hub.send((Event::Keyboard(KeyboardEvent::Partial(ch))).into())
+                                .ok();
                             if self.combine_buffer.len() > 1 {
                                 if let Some(&ch) =
                                     DEFAULT_COMBINATIONS.get(&self.combine_buffer[..])
                                 {
-                                    hub.send(Event::Keyboard(KeyboardEvent::Append(ch))).ok();
+                                    hub.send((Event::Keyboard(KeyboardEvent::Append(ch))).into())
+                                        .ok();
                                 }
                                 self.release_combine(rq);
                             }
                         } else {
-                            hub.send(Event::Keyboard(KeyboardEvent::Append(ch))).ok();
+                            hub.send((Event::Keyboard(KeyboardEvent::Append(ch))).into())
+                                .ok();
                         }
                         if ch != ' ' {
                             self.release_modifiers(rq);
@@ -256,23 +259,30 @@ impl View for Keyboard {
                         }
                     }
                     KeyKind::Delete(dir) => {
-                        hub.send(Event::Keyboard(KeyboardEvent::Delete {
-                            target: TextKind::Char,
-                            dir,
-                        }))
+                        hub.send(
+                            (Event::Keyboard(KeyboardEvent::Delete {
+                                target: TextKind::Char,
+                                dir,
+                            }))
+                            .into(),
+                        )
                         .ok();
                     }
                     KeyKind::Move(dir) => {
-                        hub.send(Event::Keyboard(KeyboardEvent::Move {
-                            target: TextKind::Char,
-                            dir,
-                        }))
+                        hub.send(
+                            (Event::Keyboard(KeyboardEvent::Move {
+                                target: TextKind::Char,
+                                dir,
+                            }))
+                            .into(),
+                        )
                         .ok();
                     }
                     KeyKind::Combine => self.state.combine = !self.state.combine,
                     KeyKind::Return => {
                         self.release_combine(rq);
-                        hub.send(Event::Keyboard(KeyboardEvent::Submit)).ok();
+                        hub.send((Event::Keyboard(KeyboardEvent::Submit)).into())
+                            .ok();
                     }
                 };
                 true

--- a/crates/core/src/view/menu.rs
+++ b/crates/core/src/view/menu.rs
@@ -296,7 +296,7 @@ impl View for Menu {
                 let view_id = self.view_id;
                 thread::spawn(move || {
                     thread::sleep(CLOSE_IGNITION_DELAY);
-                    hub2.send(Event::Close(view_id)).ok();
+                    hub2.send((Event::Close(view_id)).into()).ok();
                 });
                 true
             }

--- a/crates/core/src/view/mod.rs
+++ b/crates/core/src/view/mod.rs
@@ -23,6 +23,7 @@ pub mod filler;
 pub mod frontlight;
 pub mod github;
 pub mod home;
+pub mod hub_message;
 pub mod icon;
 pub mod image;
 pub mod input_field;
@@ -106,7 +107,9 @@ pub const BIG_BAR_HEIGHT: f32 = 163.0;
 pub const CLOSE_IGNITION_DELAY: Duration = Duration::from_millis(150);
 
 pub type Bus = VecDeque<Event>;
-pub type Hub = Sender<Event>;
+pub type Hub = Sender<hub_message::HubMessage>;
+
+pub use hub_message::{HubLease, HubMessage};
 
 pub trait View: Downcast {
     fn handle_event(
@@ -419,7 +422,7 @@ pub enum Event {
     ///
     /// # Sending
     ///
-    /// Typically sent through the hub (`hub.send(...)`) by:
+    /// Typically sent through the hub (`hub.send((...).into())`) by:
     /// - An [`InputField`](input_field::InputField) when tapped while unfocused
     /// - A parent view after building a screen that contains an input field
     /// - A keyboard's hide method to clear focus
@@ -427,16 +430,16 @@ pub enum Event {
     /// # Example
     ///
     /// ```no_run
-    /// use cadmus_core::view::{Event, ViewId};
+    /// use cadmus_core::view::{Event, Hub, ViewId};
     /// use cadmus_core::view::ota::OtaViewId;
     ///
     /// // Focus the PR input field (e.g. after building the PR input screen).
     /// // Note: `hub` is provided by the application's event loop.
-    /// # let (hub, _) = std::sync::mpsc::channel();
-    /// hub.send(Event::Focus(Some(ViewId::Ota(OtaViewId::PrInput)))).ok();
+    /// # let (hub, _): (Hub, _) = std::sync::mpsc::channel();
+    /// hub.send(Event::Focus(Some(ViewId::Ota(OtaViewId::PrInput))).into()).ok();
     ///
     /// // Clear focus from all views.
-    /// hub.send(Event::Focus(None)).ok();
+    /// hub.send(Event::Focus(None).into()).ok();
     /// ```
     Focus(Option<ViewId>),
     Select(EntryId),

--- a/crates/core/src/view/notification.rs
+++ b/crates/core/src/view/notification.rs
@@ -114,7 +114,7 @@ impl Notification {
             let hub2 = hub.clone();
             thread::spawn(move || {
                 thread::sleep(NOTIFICATION_CLOSE_DELAY);
-                hub2.send(Event::Close(view_id)).ok();
+                hub2.send((Event::Close(view_id)).into()).ok();
             });
         }
 

--- a/crates/core/src/view/ota.rs
+++ b/crates/core/src/view/ota.rs
@@ -361,9 +361,10 @@ impl OtaView {
             rq.add(RenderData::new(self.id, self.rect, UpdateMode::Full));
             self.start_pr_download(pr_number, hub, context);
         } else {
-            hub.send(Event::Notification(NotificationEvent::Show(
-                "Invalid PR number".to_string(),
-            )))
+            hub.send(
+                (Event::Notification(NotificationEvent::Show("Invalid PR number".to_string())))
+                    .into(),
+            )
             .ok();
         }
     }
@@ -387,7 +388,7 @@ impl OtaView {
             && !context.kb_rect.includes(tap_position)
             && !context.kb_rect.is_empty()
         {
-            hub.send(Event::Close(self.view_id)).ok();
+            hub.send((Event::Close(self.view_id)).into()).ok();
         }
     }
 
@@ -445,10 +446,13 @@ impl OtaView {
                 Ok(lease) => lease,
                 Err(e) => {
                     error!(error = %e, "Failed to acquire WiFi lease for OTA download");
-                    hub2.send(Event::Close(ota_view_id)).ok();
-                    hub2.send(Event::Notification(NotificationEvent::Show(fl!(
-                        "notification-not-online"
-                    ))))
+                    hub2.send((Event::Close(ota_view_id)).into()).ok();
+                    hub2.send(
+                        (Event::Notification(NotificationEvent::Show(fl!(
+                            "notification-not-online"
+                        ))))
+                        .into(),
+                    )
                     .ok();
                     return;
                 }
@@ -457,30 +461,39 @@ impl OtaView {
                 Ok(c) => c,
                 Err(e) => {
                     error!(error = %e, "Failed to create GitHub client");
-                    hub2.send(Event::Close(ota_view_id)).ok();
-                    hub2.send(Event::Notification(NotificationEvent::Show(format!(
-                        "Failed to create client: {}",
-                        e
-                    ))))
+                    hub2.send((Event::Close(ota_view_id)).into()).ok();
+                    hub2.send(
+                        (Event::Notification(NotificationEvent::Show(format!(
+                            "Failed to create client: {}",
+                            e
+                        ))))
+                        .into(),
+                    )
                     .ok();
                     return;
                 }
             };
             let client = OtaClient::new(github, tmp_dir);
 
-            hub2.send(Event::OtaDownloadProgress {
-                label: format!("Downloading PR #{} build… 0%", pr_number),
-                percent: 0,
-            })
+            hub2.send(
+                (Event::OtaDownloadProgress {
+                    label: format!("Downloading PR #{} build… 0%", pr_number),
+                    percent: 0,
+                })
+                .into(),
+            )
             .ok();
 
             let download_result = client.download_pr_artifact(pr_number, |ota_progress| {
                 if let OtaProgress::DownloadingArtifact { downloaded, total } = ota_progress {
                     let percent = (downloaded as f32 / total as f32 * 100.0) as u8;
-                    hub2.send(Event::OtaDownloadProgress {
-                        label: format!("Downloading PR #{} build… {}%", pr_number, percent),
-                        percent,
-                    })
+                    hub2.send(
+                        (Event::OtaDownloadProgress {
+                            label: format!("Downloading PR #{} build… {}%", pr_number, percent),
+                            percent,
+                        })
+                        .into(),
+                    )
                     .ok();
                 }
             });
@@ -493,35 +506,45 @@ impl OtaView {
                             if let Err(e) = clean_bundled_files(&install_dir) {
                                 tracing::warn!(path = ?install_dir, error = %e, "Failed to clean bundled OTA files");
                             }
-                            hub2.send(Event::OtaDownloadProgress {
-                                label: "Installing and rebooting…".to_string(),
-                                percent: 100,
-                            })
+                            hub2.send(
+                                (Event::OtaDownloadProgress {
+                                    label: "Installing and rebooting…".to_string(),
+                                    percent: 100,
+                                })
+                                .into(),
+                            )
                             .ok();
                             send_reboot_after_delay(hub2.clone());
                         }
                         Err(e) => {
                             error!(error = %e, "Deployment failed");
-                            hub2.send(Event::Close(ota_view_id)).ok();
-                            hub2.send(Event::Notification(NotificationEvent::Show(format!(
-                                "Deployment failed: {}",
-                                e
-                            ))))
+                            hub2.send((Event::Close(ota_view_id)).into()).ok();
+                            hub2.send(
+                                (Event::Notification(NotificationEvent::Show(format!(
+                                    "Deployment failed: {}",
+                                    e
+                                ))))
+                                .into(),
+                            )
                             .ok();
                         }
                     }
                 }
                 Err(OtaError::Unauthorized) | Err(OtaError::InsufficientScopes(_)) => {
                     tracing::warn!(pr_number, "GitHub token rejected — triggering re-auth");
-                    hub2.send(Event::Github(GithubEvent::TokenInvalid)).ok();
+                    hub2.send((Event::Github(GithubEvent::TokenInvalid)).into())
+                        .ok();
                 }
                 Err(e) => {
                     error!(error = %e, "PR download failed");
-                    hub2.send(Event::Close(ota_view_id)).ok();
-                    hub2.send(Event::Notification(NotificationEvent::Show(format!(
-                        "Download failed: {}",
-                        e
-                    ))))
+                    hub2.send((Event::Close(ota_view_id)).into()).ok();
+                    hub2.send(
+                        (Event::Notification(NotificationEvent::Show(format!(
+                            "Download failed: {}",
+                            e
+                        ))))
+                        .into(),
+                    )
                     .ok();
                 }
             }
@@ -558,10 +581,13 @@ impl OtaView {
                 Ok(lease) => lease,
                 Err(e) => {
                     error!(error = %e, "Failed to acquire WiFi lease for OTA download");
-                    hub2.send(Event::Close(ota_view_id)).ok();
-                    hub2.send(Event::Notification(NotificationEvent::Show(fl!(
-                        "notification-not-online"
-                    ))))
+                    hub2.send((Event::Close(ota_view_id)).into()).ok();
+                    hub2.send(
+                        (Event::Notification(NotificationEvent::Show(fl!(
+                            "notification-not-online"
+                        ))))
+                        .into(),
+                    )
                     .ok();
                     return;
                 }
@@ -570,30 +596,39 @@ impl OtaView {
                 Ok(c) => c,
                 Err(e) => {
                     error!(error = %e, "Failed to create GitHub client");
-                    hub2.send(Event::Close(ota_view_id)).ok();
-                    hub2.send(Event::Notification(NotificationEvent::Show(format!(
-                        "Failed to create client: {}",
-                        e
-                    ))))
+                    hub2.send((Event::Close(ota_view_id)).into()).ok();
+                    hub2.send(
+                        (Event::Notification(NotificationEvent::Show(format!(
+                            "Failed to create client: {}",
+                            e
+                        ))))
+                        .into(),
+                    )
                     .ok();
                     return;
                 }
             };
             let client = OtaClient::new(github, tmp_dir);
 
-            hub2.send(Event::OtaDownloadProgress {
-                label: "Downloading main branch build… 0%".to_string(),
-                percent: 0,
-            })
+            hub2.send(
+                (Event::OtaDownloadProgress {
+                    label: "Downloading main branch build… 0%".to_string(),
+                    percent: 0,
+                })
+                .into(),
+            )
             .ok();
 
             let download_result = client.download_default_branch_artifact(|ota_progress| {
                 if let OtaProgress::DownloadingArtifact { downloaded, total } = ota_progress {
                     let percent = (downloaded as f32 / total as f32 * 100.0) as u8;
-                    hub2.send(Event::OtaDownloadProgress {
-                        label: format!("Downloading main branch build… {}%", percent),
-                        percent,
-                    })
+                    hub2.send(
+                        (Event::OtaDownloadProgress {
+                            label: format!("Downloading main branch build… {}%", percent),
+                            percent,
+                        })
+                        .into(),
+                    )
                     .ok();
                 }
             });
@@ -606,35 +641,45 @@ impl OtaView {
                             if let Err(e) = clean_bundled_files(&install_dir) {
                                 tracing::warn!(path = ?install_dir, error = %e, "Failed to clean bundled OTA files");
                             }
-                            hub2.send(Event::OtaDownloadProgress {
-                                label: "Installing and rebooting…".to_string(),
-                                percent: 100,
-                            })
+                            hub2.send(
+                                (Event::OtaDownloadProgress {
+                                    label: "Installing and rebooting…".to_string(),
+                                    percent: 100,
+                                })
+                                .into(),
+                            )
                             .ok();
                             send_reboot_after_delay(hub2.clone());
                         }
                         Err(e) => {
                             error!(error = %e, "Deployment failed");
-                            hub2.send(Event::Close(ota_view_id)).ok();
-                            hub2.send(Event::Notification(NotificationEvent::Show(format!(
-                                "Deployment failed: {}",
-                                e
-                            ))))
+                            hub2.send((Event::Close(ota_view_id)).into()).ok();
+                            hub2.send(
+                                (Event::Notification(NotificationEvent::Show(format!(
+                                    "Deployment failed: {}",
+                                    e
+                                ))))
+                                .into(),
+                            )
                             .ok();
                         }
                     }
                 }
                 Err(OtaError::Unauthorized) | Err(OtaError::InsufficientScopes(_)) => {
                     tracing::warn!("GitHub token rejected — triggering re-auth");
-                    hub2.send(Event::Github(GithubEvent::TokenInvalid)).ok();
+                    hub2.send((Event::Github(GithubEvent::TokenInvalid)).into())
+                        .ok();
                 }
                 Err(e) => {
                     error!(error = %e, "Main branch download failed");
-                    hub2.send(Event::Close(ota_view_id)).ok();
-                    hub2.send(Event::Notification(NotificationEvent::Show(format!(
-                        "Download failed: {}",
-                        e
-                    ))))
+                    hub2.send((Event::Close(ota_view_id)).into()).ok();
+                    hub2.send(
+                        (Event::Notification(NotificationEvent::Show(format!(
+                            "Download failed: {}",
+                            e
+                        ))))
+                        .into(),
+                    )
                     .ok();
                 }
             }
@@ -671,10 +716,13 @@ impl OtaView {
                 Ok(lease) => lease,
                 Err(e) => {
                     error!(error = %e, "Failed to acquire WiFi lease for OTA download");
-                    hub2.send(Event::Close(ota_view_id)).ok();
-                    hub2.send(Event::Notification(NotificationEvent::Show(fl!(
-                        "notification-not-online"
-                    ))))
+                    hub2.send((Event::Close(ota_view_id)).into()).ok();
+                    hub2.send(
+                        (Event::Notification(NotificationEvent::Show(fl!(
+                            "notification-not-online"
+                        ))))
+                        .into(),
+                    )
                     .ok();
                     return;
                 }
@@ -683,30 +731,39 @@ impl OtaView {
                 Ok(c) => c,
                 Err(e) => {
                     error!(error = %e, "Failed to create GitHub client");
-                    hub2.send(Event::Close(ota_view_id)).ok();
-                    hub2.send(Event::Notification(NotificationEvent::Show(format!(
-                        "Failed to create client: {}",
-                        e
-                    ))))
+                    hub2.send((Event::Close(ota_view_id)).into()).ok();
+                    hub2.send(
+                        (Event::Notification(NotificationEvent::Show(format!(
+                            "Failed to create client: {}",
+                            e
+                        ))))
+                        .into(),
+                    )
                     .ok();
                     return;
                 }
             };
             let client = OtaClient::new(github, tmp_dir);
 
-            hub2.send(Event::OtaDownloadProgress {
-                label: "Downloading stable release… 0%".to_string(),
-                percent: 0,
-            })
+            hub2.send(
+                (Event::OtaDownloadProgress {
+                    label: "Downloading stable release… 0%".to_string(),
+                    percent: 0,
+                })
+                .into(),
+            )
             .ok();
 
             let download_result = client.download_stable_release_artifact(|ota_progress| {
                 if let OtaProgress::DownloadingArtifact { downloaded, total } = ota_progress {
                     let percent = (downloaded as f32 / total as f32 * 100.0) as u8;
-                    hub2.send(Event::OtaDownloadProgress {
-                        label: format!("Downloading stable release… {}%", percent),
-                        percent,
-                    })
+                    hub2.send(
+                        (Event::OtaDownloadProgress {
+                            label: format!("Downloading stable release… {}%", percent),
+                            percent,
+                        })
+                        .into(),
+                    )
                     .ok();
                 }
             });
@@ -719,35 +776,45 @@ impl OtaView {
                             if let Err(e) = clean_bundled_files(&install_dir) {
                                 tracing::warn!(path = ?install_dir, error = %e, "Failed to clean bundled OTA files");
                             }
-                            hub2.send(Event::OtaDownloadProgress {
-                                label: "Installing and rebooting…".to_string(),
-                                percent: 100,
-                            })
+                            hub2.send(
+                                (Event::OtaDownloadProgress {
+                                    label: "Installing and rebooting…".to_string(),
+                                    percent: 100,
+                                })
+                                .into(),
+                            )
                             .ok();
                             send_reboot_after_delay(hub2.clone());
                         }
                         Err(e) => {
                             error!(error = %e, "Deployment failed");
-                            hub2.send(Event::Close(ota_view_id)).ok();
-                            hub2.send(Event::Notification(NotificationEvent::Show(format!(
-                                "Deployment failed: {}",
-                                e
-                            ))))
+                            hub2.send((Event::Close(ota_view_id)).into()).ok();
+                            hub2.send(
+                                (Event::Notification(NotificationEvent::Show(format!(
+                                    "Deployment failed: {}",
+                                    e
+                                ))))
+                                .into(),
+                            )
                             .ok();
                         }
                     }
                 }
                 Err(OtaError::Unauthorized) | Err(OtaError::InsufficientScopes(_)) => {
                     tracing::warn!("GitHub token rejected on stable release — triggering re-auth");
-                    hub2.send(Event::Github(GithubEvent::TokenInvalid)).ok();
+                    hub2.send((Event::Github(GithubEvent::TokenInvalid)).into())
+                        .ok();
                 }
                 Err(e) => {
                     error!(error = %e, "Stable release download failed");
-                    hub2.send(Event::Close(ota_view_id)).ok();
-                    hub2.send(Event::Notification(NotificationEvent::Show(format!(
-                        "Download failed: {}",
-                        e
-                    ))))
+                    hub2.send((Event::Close(ota_view_id)).into()).ok();
+                    hub2.send(
+                        (Event::Notification(NotificationEvent::Show(format!(
+                            "Download failed: {}",
+                            e
+                        ))))
+                        .into(),
+                    )
                     .ok();
                 }
             }
@@ -762,7 +829,7 @@ impl OtaView {
 fn send_reboot_after_delay(hub: Hub) {
     thread::spawn(move || {
         thread::sleep(std::time::Duration::from_secs(1));
-        hub.send(Event::Select(EntryId::Reboot)).ok();
+        hub.send((Event::Select(EntryId::Reboot)).into()).ok();
     });
 }
 
@@ -794,11 +861,14 @@ impl OtaView {
             Ok(c) => c,
             Err(e) => {
                 tracing::error!(error = %e, "Failed to create GitHub client");
-                hub.send(Event::Close(ota_view_id)).ok();
-                hub.send(Event::Notification(NotificationEvent::Show(format!(
-                    "Failed to create client: {}",
-                    e
-                ))))
+                hub.send((Event::Close(ota_view_id)).into()).ok();
+                hub.send(
+                    (Event::Notification(NotificationEvent::Show(format!(
+                        "Failed to create client: {}",
+                        e
+                    ))))
+                    .into(),
+                )
                 .ok();
                 return true;
             }
@@ -809,11 +879,14 @@ impl OtaView {
             Ok(version) => version,
             Err(e) => {
                 tracing::error!(error = %e, "Failed to fetch or parse latest release version");
-                hub.send(Event::Close(ota_view_id)).ok();
-                hub.send(Event::Notification(NotificationEvent::Show(format!(
-                    "Failed to check for updates: {}",
-                    e
-                ))))
+                hub.send((Event::Close(ota_view_id)).into()).ok();
+                hub.send(
+                    (Event::Notification(NotificationEvent::Show(format!(
+                        "Failed to check for updates: {}",
+                        e
+                    ))))
+                    .into(),
+                )
                 .ok();
                 return true;
             }
@@ -830,39 +903,51 @@ impl OtaView {
         match current_version.compare(&remote_version) {
             Ok(VersionComparison::Equal) => {
                 tracing::info!("Current version equals remote version - already latest");
-                hub.send(Event::Close(ota_view_id)).ok();
-                hub.send(Event::Notification(NotificationEvent::Show(
-                    "You already have the latest version".to_string(),
-                )))
+                hub.send((Event::Close(ota_view_id)).into()).ok();
+                hub.send(
+                    (Event::Notification(NotificationEvent::Show(
+                        "You already have the latest version".to_string(),
+                    )))
+                    .into(),
+                )
                 .ok();
             }
             Ok(VersionComparison::Newer) => {
                 tracing::info!("Current version is newer than remote version");
-                hub.send(Event::Close(ota_view_id)).ok();
-                hub.send(Event::Notification(NotificationEvent::Show(
-                    "Your version is newer than the latest release".to_string(),
-                )))
+                hub.send((Event::Close(ota_view_id)).into()).ok();
+                hub.send(
+                    (Event::Notification(NotificationEvent::Show(
+                        "Your version is newer than the latest release".to_string(),
+                    )))
+                    .into(),
+                )
                 .ok();
             }
             Ok(VersionComparison::Older) => {
                 tracing::info!("Remote version is newer - proceeding with download");
-                hub.send(Event::StartStableReleaseDownload).ok();
+                hub.send((Event::StartStableReleaseDownload).into()).ok();
             }
             Ok(VersionComparison::Incomparable) => {
                 tracing::warn!("Cannot compare versions - divergent branches");
-                hub.send(Event::Close(ota_view_id)).ok();
-                hub.send(Event::Notification(NotificationEvent::Show(
-                    "Cannot compare versions - divergent branches".to_string(),
-                )))
+                hub.send((Event::Close(ota_view_id)).into()).ok();
+                hub.send(
+                    (Event::Notification(NotificationEvent::Show(
+                        "Cannot compare versions - divergent branches".to_string(),
+                    )))
+                    .into(),
+                )
                 .ok();
             }
             Err(e) => {
                 tracing::error!(error = %e, "Version comparison error");
-                hub.send(Event::Close(ota_view_id)).ok();
-                hub.send(Event::Notification(NotificationEvent::Show(format!(
-                    "Version comparison error: {}",
-                    e
-                ))))
+                hub.send((Event::Close(ota_view_id)).into()).ok();
+                hub.send(
+                    (Event::Notification(NotificationEvent::Show(format!(
+                        "Version comparison error: {}",
+                        e
+                    ))))
+                    .into(),
+                )
                 .ok();
             }
         }
@@ -883,7 +968,7 @@ impl OtaView {
         self.build_pr_input_screen(context);
         rq.add(RenderData::new(self.id, self.rect, UpdateMode::Gui));
         self.toggle_keyboard(true, hub, rq, context);
-        hub.send(Event::Focus(Some(ViewId::Ota(OtaViewId::PrInput))))
+        hub.send((Event::Focus(Some(ViewId::Ota(OtaViewId::PrInput)))).into())
             .ok();
         true
     }
@@ -941,7 +1026,7 @@ impl OtaView {
                 self.build_pr_input_screen(context);
                 rq.add(RenderData::new(self.id, self.rect, UpdateMode::Gui));
                 self.toggle_keyboard(true, hub, rq, context);
-                hub.send(Event::Focus(Some(ViewId::Ota(OtaViewId::PrInput))))
+                hub.send((Event::Focus(Some(ViewId::Ota(OtaViewId::PrInput)))).into())
                     .ok();
             }
             Some(PendingDownload::Pr(pr_number)) => {
@@ -983,11 +1068,14 @@ impl OtaView {
     fn on_device_auth_expired(&mut self, hub: &Hub) -> bool {
         tracing::warn!("Device flow code expired");
         self.pending_download = None;
-        hub.send(Event::Notification(NotificationEvent::Show(
-            "GitHub authorization timed out. Please try again.".to_string(),
-        )))
+        hub.send(
+            (Event::Notification(NotificationEvent::Show(
+                "GitHub authorization timed out. Please try again.".to_string(),
+            )))
+            .into(),
+        )
         .ok();
-        hub.send(Event::Close(self.view_id)).ok();
+        hub.send((Event::Close(self.view_id)).into()).ok();
         true
     }
 
@@ -995,12 +1083,15 @@ impl OtaView {
     fn on_device_auth_error(&mut self, msg: &str, hub: &Hub) -> bool {
         tracing::error!(error = %msg, "Device flow error");
         self.pending_download = None;
-        hub.send(Event::Notification(NotificationEvent::Show(format!(
-            "GitHub auth error: {}",
-            msg
-        ))))
+        hub.send(
+            (Event::Notification(NotificationEvent::Show(format!(
+                "GitHub auth error: {}",
+                msg
+            ))))
+            .into(),
+        )
         .ok();
-        hub.send(Event::Close(self.view_id)).ok();
+        hub.send((Event::Close(self.view_id)).into()).ok();
         true
     }
 }
@@ -1253,7 +1344,8 @@ mod tests {
             &mut context,
         );
 
-        while let Ok(evt) = rx.try_recv() {
+        while let Ok(message) = rx.try_recv() {
+            let (evt, _) = message.into_parts();
             handle_event(&mut parent, &evt, &hub, &mut bus, &mut rq, &mut context);
         }
 

--- a/crates/core/src/view/reader/mod.rs
+++ b/crates/core/src/view/reader/mod.rs
@@ -458,7 +458,7 @@ impl Reader {
 
             info!("{}", info.file.path.display());
 
-            hub.send(Event::Update(UpdateMode::Partial)).ok();
+            hub.send((Event::Update(UpdateMode::Partial)).into()).ok();
 
             Some(Reader {
                 id,
@@ -530,7 +530,7 @@ impl Reader {
             }
         }
 
-        hub.send(Event::Update(UpdateMode::Partial)).ok();
+        hub.send((Event::Update(UpdateMode::Partial)).into()).ok();
 
         Reader {
             id,
@@ -591,7 +591,7 @@ impl Reader {
         doc.set_margin_width(mm_to_px(0.0, context.device.dpi()) as i32);
         let pages_count = doc.pages_count();
 
-        hub.send(Event::Update(UpdateMode::Partial)).ok();
+        hub.send((Event::Update(UpdateMode::Partial)).into()).ok();
 
         Some(Reader {
             id,
@@ -1152,7 +1152,7 @@ impl Reader {
                         }
                         FinishedAction::Close => {
                             self.quit(context);
-                            hub.send(Event::Back).ok();
+                            hub.send((Event::Back).into()).ok();
                         }
                         FinishedAction::GoToNext => {
                             let next = self
@@ -1164,10 +1164,10 @@ impl Reader {
 
                             match next {
                                 Some(next_info) => {
-                                    hub.send(Event::Open(Box::new(next_info))).ok();
+                                    hub.send((Event::Open(Box::new(next_info))).into()).ok();
                                 }
                                 None => {
-                                    hub.send(Event::Back).ok();
+                                    hub.send((Event::Back).into()).ok();
                                 }
                             }
                         }
@@ -1560,7 +1560,7 @@ impl Reader {
             thread::spawn(move || {
                 let mut doc = doc2.lock().unwrap();
                 if let Some(next_location) = doc.resolve_location(Location::Next(last_location)) {
-                    hub2.send(Event::LoadPixmap(next_location)).ok();
+                    hub2.send((Event::LoadPixmap(next_location)).into()).ok();
                 }
             });
             let doc3 = self.doc.clone();
@@ -1570,7 +1570,8 @@ impl Reader {
                 if let Some(previous_location) =
                     doc.resolve_location(Location::Previous(first_location))
                 {
-                    hub3.send(Event::LoadPixmap(previous_location)).ok();
+                    hub3.send((Event::LoadPixmap(previous_location)).into())
+                        .ok();
                 }
             });
         }
@@ -1625,7 +1626,8 @@ impl Reader {
                                 for (_, rect) in rects.range(*first..m.end()) {
                                     match_rects.push(*rect);
                                 }
-                                hub2.send(Event::SearchResult(location, match_rects)).ok();
+                                hub2.send((Event::SearchResult(location, match_rects)).into())
+                                    .ok();
                             }
                         }
                     }
@@ -1644,7 +1646,7 @@ impl Reader {
             }
 
             running.store(false, AtomicOrdering::Relaxed);
-            hub2.send(Event::EndOfSearch).ok();
+            hub2.send((Event::EndOfSearch).into()).ok();
         });
 
         if self.search.is_some() {
@@ -1696,7 +1698,7 @@ impl Reader {
             }
 
             context.kb_rect = Rectangle::default();
-            hub.send(Event::Focus(None)).ok();
+            hub.send((Event::Focus(None)).into()).ok();
         } else {
             if !enable {
                 return;
@@ -1974,7 +1976,8 @@ impl Reader {
             }
 
             self.toggle_keyboard(true, Some(ViewId::ReaderSearchInput), hub, rq, context);
-            hub.send(Event::Focus(Some(ViewId::ReaderSearchInput))).ok();
+            hub.send((Event::Focus(Some(ViewId::ReaderSearchInput))).into())
+                .ok();
         }
     }
 
@@ -2002,7 +2005,7 @@ impl Reader {
 
                 rq.add(RenderData::expose(top_rect, UpdateMode::Gui));
                 rq.add(RenderData::expose(bottom_rect, UpdateMode::Gui));
-                hub.send(Event::Focus(None)).ok();
+                hub.send((Event::Focus(None)).into()).ok();
             }
         } else {
             if let Some(false) = enable {
@@ -2295,7 +2298,8 @@ impl Reader {
                 *edit_note.rect(),
                 UpdateMode::Gui,
             ));
-            hub.send(Event::Focus(Some(ViewId::EditNoteInput))).ok();
+            hub.send((Event::Focus(Some(ViewId::EditNoteInput))).into())
+                .ok();
 
             self.children.push(Box::new(edit_note) as Box<dyn View>);
         }
@@ -2343,7 +2347,8 @@ impl Reader {
                 *name_page.rect(),
                 UpdateMode::Gui,
             ));
-            hub.send(Event::Focus(Some(ViewId::NamePageInput))).ok();
+            hub.send((Event::Focus(Some(ViewId::NamePageInput))).into())
+                .ok();
 
             self.children.push(Box::new(name_page) as Box<dyn View>);
         }
@@ -2392,7 +2397,7 @@ impl Reader {
                 *go_to_page.rect(),
                 UpdateMode::Gui,
             ));
-            hub.send(Event::Focus(Some(input_id))).ok();
+            hub.send((Event::Focus(Some(input_id))).into()).ok();
 
             self.children.push(Box::new(go_to_page) as Box<dyn View>);
         }
@@ -3914,7 +3919,7 @@ impl View for Reader {
             Event::Gesture(GestureEvent::Rotate { quarter_turns, .. }) if quarter_turns != 0 => {
                 let (_, dir) = context.device.mirroring_scheme();
                 let n = (4 + (context.display.rotation - dir * quarter_turns)) % 4;
-                hub.send(Event::Select(EntryId::Rotate(n))).ok();
+                hub.send((Event::Select(EntryId::Rotate(n))).into()).ok();
                 true
             }
             Event::Gesture(GestureEvent::Swipe { dir, start, end })
@@ -4036,10 +4041,12 @@ impl View for Reader {
                     DiagDir::NorthEast => self.go_to_bookmark(CycleDir::Next, hub, rq, context),
                     DiagDir::SouthEast => match context.settings.reader.bottom_right_gesture {
                         BottomRightGestureAction::ToggleDithered => {
-                            hub.send(Event::Select(EntryId::ToggleDithered)).ok();
+                            hub.send((Event::Select(EntryId::ToggleDithered)).into())
+                                .ok();
                         }
                         BottomRightGestureAction::ToggleInverted => {
-                            hub.send(Event::Select(EntryId::ToggleInverted)).ok();
+                            hub.send((Event::Select(EntryId::ToggleInverted)).into())
+                                .ok();
                         }
                     },
                     DiagDir::SouthWest => {
@@ -4068,7 +4075,7 @@ impl View for Reader {
                                 }
                             }
                         } else {
-                            hub.send(Event::ToggleFrontlight).ok();
+                            hub.send((Event::ToggleFrontlight).into()).ok();
                         }
                     }
                 };
@@ -4086,7 +4093,7 @@ impl View for Reader {
             }
             Event::Gesture(GestureEvent::Cross(_)) => {
                 self.quit(context);
-                hub.send(Event::Back).ok();
+                hub.send((Event::Back).into()).ok();
                 true
             }
             Event::Gesture(GestureEvent::Diamond(_)) => {
@@ -4405,8 +4412,8 @@ impl View for Reader {
                         };
                         if let Some(location) = loc_opt {
                             self.quit(context);
-                            hub.send(Event::Back).ok();
-                            hub.send(Event::GoToLocation(location)).ok();
+                            hub.send((Event::Back).into()).ok();
+                            hub.send((Event::GoToLocation(location)).into()).ok();
                         }
                     } else if let Some(caps) = pdf_page.captures(&link.text) {
                         if let Ok(index) = caps[1].parse::<usize>() {
@@ -4426,7 +4433,7 @@ impl View for Reader {
                         let mut doc = self.doc.lock().unwrap();
                         let loc = Location::LocalUri(self.current_page, link.text.clone());
                         if let Some(location) = doc.resolve_location(loc) {
-                            hub.send(Event::GoTo(location)).ok();
+                            hub.send((Event::GoTo(location)).into()).ok();
                         } else if link.text.starts_with("https:") || link.text.starts_with("http:")
                         {
                             if let Some(path) = context.settings.external_urls_queue.as_ref() {
@@ -4500,9 +4507,10 @@ impl View for Reader {
                             if self.search.is_none() {
                                 match context.settings.reader.south_east_corner {
                                     SouthEastCornerAction::GoToPage => {
-                                        hub.send(Event::Toggle(ToggleEvent::View(
-                                            ViewId::GoToPage,
-                                        )))
+                                        hub.send(
+                                            (Event::Toggle(ToggleEvent::View(ViewId::GoToPage)))
+                                                .into(),
+                                        )
                                         .ok();
                                     }
                                     SouthEastCornerAction::NextPage => {
@@ -4519,9 +4527,9 @@ impl View for Reader {
                                     && self.info.file.path == PathBuf::from(MEM_SCHEME)
                                 {
                                     self.quit(context);
-                                    hub.send(Event::Back).ok();
+                                    hub.send((Event::Back).into()).ok();
                                 } else {
-                                    hub.send(Event::Show(ViewId::TableOfContents)).ok();
+                                    hub.send((Event::Show(ViewId::TableOfContents)).into()).ok();
                                 }
                             } else {
                                 self.go_to_neighbor(CycleDir::Previous, hub, rq, context);
@@ -4651,10 +4659,10 @@ impl View for Reader {
                         .trim_matches(|c: char| !c.is_alphanumeric())
                         .to_string();
                     let language = self.info.language.clone();
-                    hub.send(Event::Select(EntryId::Launch(AppCmd::Dictionary {
-                        query,
-                        language,
-                    })))
+                    hub.send(
+                        (Event::Select(EntryId::Launch(AppCmd::Dictionary { query, language })))
+                            .into(),
+                    )
                     .ok();
                 }
                 self.selection = None;
@@ -4957,7 +4965,7 @@ impl View for Reader {
                         Location::Exact(offset) => Some(format!("@{}", offset)),
                         _ => None,
                     });
-                    hub.send(Event::OpenHtml(html, link_uri)).ok();
+                    hub.send((Event::OpenHtml(html, link_uri)).into()).ok();
                 }
                 true
             }
@@ -4981,7 +4989,7 @@ impl View for Reader {
                         .filter(|annot| annot.selection[0].location() <= self.current_page)
                         .max_by_key(|annot| annot.selection[0])
                         .map(|annot| format!("@{}", annot.selection[0].location()));
-                    hub.send(Event::OpenHtml(html, link_uri)).ok();
+                    hub.send((Event::OpenHtml(html, link_uri)).into()).ok();
                 }
                 true
             }
@@ -4993,7 +5001,7 @@ impl View for Reader {
                         .range(..=self.current_page)
                         .next_back()
                         .map(|index| format!("@{}", index));
-                    hub.send(Event::OpenHtml(html, link_uri)).ok();
+                    hub.send((Event::OpenHtml(html, link_uri)).into()).ok();
                 }
                 true
             }
@@ -5061,7 +5069,8 @@ impl View for Reader {
                     );
                     self.children.push(Box::new(notif) as Box<dyn View>);
                     self.toggle_search_bar(true, hub, rq, context);
-                    hub.send(Event::Focus(Some(ViewId::ReaderSearchInput))).ok();
+                    hub.send((Event::Focus(Some(ViewId::ReaderSearchInput))).into())
+                        .ok();
                 }
                 true
             }
@@ -5094,10 +5103,10 @@ impl View for Reader {
                         .trim_matches(|c: char| !c.is_alphanumeric())
                         .to_string();
                     let language = self.info.language.clone();
-                    hub.send(Event::Select(EntryId::Launch(AppCmd::Dictionary {
-                        query,
-                        language,
-                    })))
+                    hub.send(
+                        (Event::Select(EntryId::Launch(AppCmd::Dictionary { query, language })))
+                            .into(),
+                    )
                     .ok();
                 }
                 self.selection = None;
@@ -5299,7 +5308,7 @@ impl View for Reader {
                 ..
             }) => {
                 self.quit(context);
-                hub.send(Event::Back).ok();
+                hub.send((Event::Back).into()).ok();
                 true
             }
             Event::Select(EntryId::Quit)

--- a/crates/core/src/view/rotation_values/mod.rs
+++ b/crates/core/src/view/rotation_values/mod.rs
@@ -130,7 +130,7 @@ impl View for RotationValues {
                     let dir = if next.x < next.y { polarity } else { -polarity };
                     info!("Startup rotation: {}.", startup_rotation);
                     info!("Mirroring scheme: ({}, {}).", center, dir);
-                    hub.send(Event::Back).ok();
+                    hub.send((Event::Back).into()).ok();
                 } else {
                     rq.add(RenderData::new(self.id, self.rect, UpdateMode::Full));
                 }

--- a/crates/core/src/view/settings_editor/category_editor.rs
+++ b/crates/core/src/view/settings_editor/category_editor.rs
@@ -507,7 +507,7 @@ impl CategoryEditor {
             crate::view::named_input::NamedInput::new(label, view_id, view_id, max_chars, context);
         named_input.set_text(&initial_text, rq, context);
         self.children.push(Box::new(named_input));
-        hub.send(Event::Focus(Some(view_id))).ok();
+        hub.send((Event::Focus(Some(view_id))).into()).ok();
         rq.add(RenderData::new(self.id, self.rect, UpdateMode::Gui));
         true
     }
@@ -582,10 +582,13 @@ impl CategoryEditor {
         let wifi_session = context.wifi_session.clone();
 
         let download_id = ViewId::MessageNotif(ID_FEEDER.next());
-        hub.send(Event::Notification(NotificationEvent::ShowPinned(
-            download_id,
-            fl!("notification-downloading-dictionary", lang = lang),
-        )))
+        hub.send(
+            (Event::Notification(NotificationEvent::ShowPinned(
+                download_id,
+                fl!("notification-downloading-dictionary", lang = lang),
+            )))
+            .into(),
+        )
         .ok();
 
         thread::spawn(move || {
@@ -597,11 +600,14 @@ impl CategoryEditor {
                 Err(e) => {
                     tracing::error!(error = %e, "Failed to acquire WiFi lease for dictionary download");
                     service.finish_install(&lang_owned);
-                    hub2.send(Event::Close(download_id)).ok();
-                    hub2.send(crate::view::Event::DictionaryInstallComplete {
-                        lang: lang_owned,
-                        result: Err(e.to_string()),
-                    })
+                    hub2.send((Event::Close(download_id)).into()).ok();
+                    hub2.send(
+                        (crate::view::Event::DictionaryInstallComplete {
+                            lang: lang_owned,
+                            result: Err(e.to_string()),
+                        })
+                        .into(),
+                    )
                     .ok();
                     return;
                 }
@@ -617,30 +623,39 @@ impl CategoryEditor {
                         let downloaded_str = humanize_bytes_decimal!(downloaded).to_string();
                         let total_str = humanize_bytes_decimal!(total).to_string();
                         let percent = (downloaded as f64 / total as f64 * 100.0) as u8;
-                        hub2.send(Event::Notification(NotificationEvent::UpdateProgress(
-                            download_id,
-                            percent,
-                        )))
+                        hub2.send(
+                            (Event::Notification(NotificationEvent::UpdateProgress(
+                                download_id,
+                                percent,
+                            )))
+                            .into(),
+                        )
                         .ok();
-                        hub2.send(Event::Notification(NotificationEvent::UpdateText(
-                            download_id,
-                            fl!(
-                                "notification-downloading-dictionary-progress",
-                                lang = lang_owned.as_str(),
-                                downloaded = downloaded_str.as_str(),
-                                total = total_str.as_str()
-                            ),
-                        )))
+                        hub2.send(
+                            (Event::Notification(NotificationEvent::UpdateText(
+                                download_id,
+                                fl!(
+                                    "notification-downloading-dictionary-progress",
+                                    lang = lang_owned.as_str(),
+                                    downloaded = downloaded_str.as_str(),
+                                    total = total_str.as_str()
+                                ),
+                            )))
+                            .into(),
+                        )
                         .ok();
                     },
                 )
                 .map_err(|e| e.to_string());
 
-            hub2.send(Event::Close(download_id)).ok();
-            hub2.send(crate::view::Event::DictionaryInstallComplete {
-                lang: lang_owned,
-                result,
-            })
+            hub2.send((Event::Close(download_id)).into()).ok();
+            hub2.send(
+                (crate::view::Event::DictionaryInstallComplete {
+                    lang: lang_owned,
+                    result,
+                })
+                .into(),
+            )
             .ok();
         });
 
@@ -658,9 +673,10 @@ impl CategoryEditor {
         context: &mut AppContext,
     ) -> bool {
         if !context.online && !context.settings.wifi.allows_on_demand() {
-            hub.send(Event::Notification(NotificationEvent::Show(fl!(
-                "notification-not-online"
-            ))))
+            hub.send(
+                (Event::Notification(NotificationEvent::Show(fl!("notification-not-online"))))
+                    .into(),
+            )
             .ok();
 
             return true;
@@ -759,9 +775,10 @@ impl CategoryEditor {
         self.remove_dictionary_download_confirm(rq);
 
         if !context.online && !context.settings.wifi.allows_on_demand() {
-            hub.send(Event::Notification(NotificationEvent::Show(fl!(
-                "notification-not-online"
-            ))))
+            hub.send(
+                (Event::Notification(NotificationEvent::Show(fl!("notification-not-online"))))
+                    .into(),
+            )
             .ok();
 
             return true;
@@ -805,7 +822,7 @@ impl CategoryEditor {
 
         self.current_page = 0;
         self.update_rows_list(rq, context);
-        hub.send(Event::ReindexDictionaries).ok();
+        hub.send((Event::ReindexDictionaries).into()).ok();
         true
     }
 
@@ -836,7 +853,7 @@ impl CategoryEditor {
                     self.children.remove(index);
                     rq.add(RenderData::expose(input_rect, UpdateMode::Gui));
                 }
-                hub.send(Event::Focus(None)).ok();
+                hub.send((Event::Focus(None)).into()).ok();
                 true
             }
             #[cfg(feature = "tracing")]
@@ -846,7 +863,7 @@ impl CategoryEditor {
                     self.children.remove(index);
                     rq.add(RenderData::expose(input_rect, UpdateMode::Gui));
                 }
-                hub.send(Event::Focus(None)).ok();
+                hub.send((Event::Focus(None)).into()).ok();
                 true
             }
             #[cfg(feature = "profiling")]
@@ -856,7 +873,7 @@ impl CategoryEditor {
                     self.children.remove(index);
                     rq.add(RenderData::expose(input_rect, UpdateMode::Gui));
                 }
-                hub.send(Event::Focus(None)).ok();
+                hub.send((Event::Focus(None)).into()).ok();
                 true
             }
             _ => false,
@@ -927,12 +944,15 @@ impl View for CategoryEditor {
 
                         self.current_page = 0;
                         self.update_rows_list(rq, context);
-                        hub.send(Event::ReindexDictionaries).ok();
+                        hub.send((Event::ReindexDictionaries).into()).ok();
 
-                        hub.send(Event::Notification(NotificationEvent::Show(fl!(
-                            "notification-downloading-dictionary-completed",
-                            lang = lang
-                        ))))
+                        hub.send(
+                            (Event::Notification(NotificationEvent::Show(fl!(
+                                "notification-downloading-dictionary-completed",
+                                lang = lang
+                            ))))
+                            .into(),
+                        )
                         .ok();
                     }
                     Err(e) => {
@@ -941,10 +961,13 @@ impl View for CategoryEditor {
                         self.current_page = 0;
                         self.update_rows_list(rq, context);
 
-                        hub.send(Event::Notification(NotificationEvent::Show(fl!(
-                            "notification-dictionary-install-failed",
-                            lang = lang
-                        ))))
+                        hub.send(
+                            (Event::Notification(NotificationEvent::Show(fl!(
+                                "notification-dictionary-install-failed",
+                                lang = lang
+                            ))))
+                            .into(),
+                        )
                         .ok();
                     }
                 }
@@ -1624,7 +1647,7 @@ mod tests {
             assert!(locate_by_id(&editor, view_id).is_some());
 
             let focus_event = receiver.recv().unwrap();
-            assert!(matches!(focus_event, Event::Focus(Some(id)) if id == view_id));
+            assert!(matches!(focus_event.event, Event::Focus(Some(id)) if id == view_id));
             editor.focus = Some(view_id);
 
             let handled = editor.handle_event(
@@ -1639,8 +1662,8 @@ mod tests {
             assert!(locate_by_id(&editor, view_id).is_none());
 
             let focus_event = receiver.recv().unwrap();
-            assert!(matches!(focus_event, Event::Focus(None)));
-            editor.handle_event(&focus_event, &hub, &mut bus, &mut rq, &mut context);
+            assert!(matches!(focus_event.event, Event::Focus(None)));
+            editor.handle_event(&focus_event.event, &hub, &mut bus, &mut rq, &mut context);
             assert_eq!(editor.focus, None);
         }
     }

--- a/crates/core/src/view/settings_editor/library_editor.rs
+++ b/crates/core/src/view/settings_editor/library_editor.rs
@@ -291,17 +291,21 @@ impl LibraryEditor {
     #[inline]
     fn handle_validate_event(&self, hub: &Hub, bus: &mut Bus) -> bool {
         if self.library.name.trim().is_empty() {
-            hub.send(Event::Notification(NotificationEvent::Show(
-                "Library name cannot be empty".to_string(),
-            )))
+            hub.send(
+                (Event::Notification(NotificationEvent::Show(
+                    "Library name cannot be empty".to_string(),
+                )))
+                .into(),
+            )
             .ok();
             return true;
         }
 
         if !self.library.path.exists() {
-            hub.send(Event::Notification(NotificationEvent::Show(
-                "Path does not exist".to_string(),
-            )))
+            hub.send(
+                (Event::Notification(NotificationEvent::Show("Path does not exist".to_string())))
+                    .into(),
+            )
             .ok();
             return true;
         }
@@ -334,7 +338,7 @@ impl LibraryEditor {
         self.children.push(Box::new(name_input));
         rq.add(RenderData::new(self.id, self.rect, UpdateMode::Gui));
 
-        hub.send(Event::Focus(Some(ViewId::LibraryRenameInput)))
+        hub.send((Event::Focus(Some(ViewId::LibraryRenameInput))).into())
             .ok();
         true
     }
@@ -476,7 +480,7 @@ impl LibraryEditor {
                     self.children.remove(index);
                     rq.add(RenderData::new(self.id, self.rect, UpdateMode::Gui));
                 }
-                hub.send(Event::Focus(None)).ok();
+                hub.send((Event::Focus(None)).into()).ok();
                 true
             }
             ViewId::FileChooser => {
@@ -590,7 +594,11 @@ mod tests {
         assert!(handled);
         assert_eq!(bus.len(), 0);
 
-        if let Ok(Event::Notification(NotificationEvent::Show(msg))) = receiver.try_recv() {
+        if let Ok(crate::view::HubMessage {
+            event: Event::Notification(NotificationEvent::Show(msg)),
+            ..
+        }) = receiver.try_recv()
+        {
             assert_eq!(msg, "Library name cannot be empty");
         } else {
             panic!("Expected notification event about empty name");
@@ -616,7 +624,11 @@ mod tests {
         assert!(handled);
         assert_eq!(bus.len(), 0);
 
-        if let Ok(Event::Notification(NotificationEvent::Show(msg))) = receiver.try_recv() {
+        if let Ok(crate::view::HubMessage {
+            event: Event::Notification(NotificationEvent::Show(msg)),
+            ..
+        }) = receiver.try_recv()
+        {
             assert_eq!(msg, "Path does not exist");
         } else {
             panic!("Expected notification event about nonexistent path");
@@ -690,7 +702,11 @@ mod tests {
         assert_eq!(editor.children.len(), initial_children_count + 1);
         assert!(!rq.is_empty());
 
-        if let Ok(Event::Focus(Some(ViewId::LibraryRenameInput))) = receiver.try_recv() {
+        if let Ok(crate::view::HubMessage {
+            event: Event::Focus(Some(ViewId::LibraryRenameInput)),
+            ..
+        }) = receiver.try_recv()
+        {
         } else {
             panic!("Expected Focus event for LibraryRenameInput");
         }

--- a/crates/core/src/view/settings_editor/mod.rs
+++ b/crates/core/src/view/settings_editor/mod.rs
@@ -115,10 +115,10 @@
 //! // partial snippet and cannot compile standalone.
 //! fn handle_my_new_setting(&mut self, value: f32, hub: &Hub, context: &mut AppContext) -> bool {
 //!     context.settings.my_new_setting = value;
-//!     hub.send(Event::Settings(SettingsEvent::UpdateValue {
+//!     hub.send((Event::Settings(SettingsEvent::UpdateValue {
 //!         kind: SettingIdentity::MyNewSetting,
 //!         value: value.to_string(),
-//!     }))
+//!     })).into())
 //!     .ok();
 //!     true
 //! }

--- a/crates/core/src/view/settings_editor/refresh_rate_by_kind_editor.rs
+++ b/crates/core/src/view/settings_editor/refresh_rate_by_kind_editor.rs
@@ -427,7 +427,7 @@ impl RefreshRateByKindEditor {
             NamedInput::new(label.to_string(), view_id, view_id, max_chars, context);
         named_input.set_text(initial_text, rq, context);
         self.children.push(Box::new(named_input));
-        hub.send(Event::Focus(Some(view_id))).ok();
+        hub.send((Event::Focus(Some(view_id))).into()).ok();
         rq.add(RenderData::new(self.id, self.rect, UpdateMode::Gui));
         true
     }
@@ -449,7 +449,7 @@ impl RefreshRateByKindEditor {
                     self.children.remove(index);
                     rq.add(RenderData::expose(input_rect, UpdateMode::Gui));
                 }
-                hub.send(Event::Focus(None)).ok();
+                hub.send((Event::Focus(None)).into()).ok();
                 true
             }
             _ => false,
@@ -669,9 +669,12 @@ impl RefreshRateKindPairEditor {
     #[cfg_attr(feature = "tracing", tracing::instrument(skip(self, hub, bus)))]
     fn handle_validate(&self, hub: &Hub, bus: &mut Bus) -> bool {
         if !self.regular_input_valid || !self.inverted_input_valid {
-            hub.send(Event::Notification(NotificationEvent::Show(fl!(
-                "notification-refresh-rate-invalid"
-            ))))
+            hub.send(
+                (Event::Notification(NotificationEvent::Show(fl!(
+                    "notification-refresh-rate-invalid"
+                ))))
+                .into(),
+            )
             .ok();
             return true;
         }
@@ -731,7 +734,7 @@ impl RefreshRateKindPairEditor {
             NamedInput::new(label.to_string(), view_id, view_id, max_chars, context);
         named_input.set_text(initial_text, rq, context);
         self.children.push(Box::new(named_input));
-        hub.send(Event::Focus(Some(view_id))).ok();
+        hub.send((Event::Focus(Some(view_id))).into()).ok();
         rq.add(RenderData::new(self.id, self.rect, UpdateMode::Gui));
         true
     }
@@ -746,7 +749,7 @@ impl RefreshRateKindPairEditor {
                     self.children.remove(index);
                     rq.add(RenderData::expose(input_rect, UpdateMode::Gui));
                 }
-                hub.send(Event::Focus(None)).ok();
+                hub.send((Event::Focus(None)).into()).ok();
                 true
             }
             _ => false,

--- a/crates/core/src/view/sketch/mod.rs
+++ b/crates/core/src/view/sketch/mod.rs
@@ -237,10 +237,13 @@ impl Sketch {
     }
 
     fn quit(&self, hub: &Hub, context: &AppContext) {
-        hub.send(Event::ImportLibrary {
-            library_index: Some(context.settings.selected_library),
-            force: false,
-        })
+        hub.send(
+            (Event::ImportLibrary {
+                library_index: Some(context.settings.selected_library),
+                force: false,
+            })
+            .into(),
+        )
         .ok();
     }
 }
@@ -416,7 +419,7 @@ impl View for Sketch {
             }
             Event::Select(EntryId::Quit) => {
                 self.quit(hub, context);
-                hub.send(Event::Back).ok();
+                hub.send((Event::Back).into()).ok();
                 true
             }
             _ => false,

--- a/crates/core/src/view/toggleable_keyboard.rs
+++ b/crates/core/src/view/toggleable_keyboard.rs
@@ -192,7 +192,7 @@ impl ToggleableKeyboard {
         self.rect = Rectangle::default();
         self.visible = false;
 
-        hub.send(Event::Focus(None)).ok();
+        hub.send((Event::Focus(None)).into()).ok();
         rq.add(RenderData::expose(rect, UpdateMode::Gui));
     }
 }
@@ -363,7 +363,7 @@ mod tests {
         assert_eq!(context.kb_rect, Rectangle::default());
 
         let focus_event = receiver.try_recv().unwrap();
-        assert!(matches!(focus_event, Event::Focus(None)));
+        assert!(matches!(focus_event.event, Event::Focus(None)));
     }
 
     #[test]
@@ -432,7 +432,7 @@ mod tests {
         assert_eq!(context.kb_rect, Rectangle::default());
 
         let focus_event = receiver.try_recv().unwrap();
-        assert!(matches!(focus_event, Event::Focus(None)));
+        assert!(matches!(focus_event.event, Event::Focus(None)));
     }
 
     #[test]


### PR DESCRIPTION
HubMessage lives in view with HubLease::SoftSuspend so the wake_lock spans the hub queue until the main loop overlaps main-loop.

Closes: CAD-39

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes soft-suspend wake-lock timing across the main event loop and all hub producers on device hardware; a gap or double-hold could affect autosleep/suspend behavior, though most edits are mechanical type migration.
> 
> **Overview**
> The hub channel now carries **`HubMessage`** (event plus an optional soft-suspend lease) instead of bare **`Event`**, so wake locks stay held while events sit in the queue until the main loop takes over.
> 
> **`InputSource::start`** receives **`SoftSuspendSession`**; Kobo and emulator input threads wrap touch, gesture, USB, and similar traffic with **`HubMessage::with_soft_suspend`**, and RTC alarm callbacks use the same pattern. The app main loop calls **`into_parts()`** to dispatch the event while dropping the producer lease as it acquires the usual **`main-loop`** lease (except during deep-idle suspend where that lease is skipped). Call sites that do not need a lease send **`(...).into()`**; background tasks and lifecycle code are updated to use **`Hub`** instead of **`Sender<Event>`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1c50c8a692058b3d7d3ba568eb75a5bc4112e5ce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->