### PR TITLE
feat(soft-suspend): wire wifi and task holders

### DIFF
--- a/crates/cadmus/src/app.rs
+++ b/crates/cadmus/src/app.rs
@@ -324,6 +324,7 @@ pub fn run() -> Result<(), Error> {
         &context.database,
         context.device.data_dir(),
         &context.device.install_dir(),
+        &context.soft_suspend_session,
     );
 
     let mut history: Vec<HistoryItem> = Vec::new();

--- a/crates/core/src/context.rs
+++ b/crates/core/src/context.rs
@@ -112,6 +112,7 @@ impl<D: Device> Context<D> {
             settings.indicate_autosleep_led,
             std::time::Duration::from_secs_f32(settings.autosleep_grace.max(0.0)),
         );
+        wifi_session.set_soft_suspend_session(std::sync::Arc::clone(&soft_suspend_session));
         Context {
             device,
             alarm_manager,

--- a/crates/core/src/device/wifi/session.rs
+++ b/crates/core/src/device/wifi/session.rs
@@ -1,12 +1,13 @@
 //! WiFi session: named leases over [`LeaseTracker`] plus radio bring-up.
 
+use crate::device::soft_suspend::{SoftSuspendLease, SoftSuspendSession};
 use crate::device::wifi::{WifiError, WifiManager};
 use crate::input::DeviceEvent;
-use crate::lease::{Lease, LeaseName, LeaseObserver, LeaseTracker};
+use crate::lease::{Lease, LeaseName, LeaseObserver, LeaseTracker, WeakLeaseTracker};
 use crate::settings::WifiMode;
 use crate::view::{Event, Hub};
 use std::sync::mpsc::Sender;
-use std::sync::{Arc, Condvar, Mutex};
+use std::sync::{Arc, Condvar, Mutex, OnceLock};
 use std::time::{Duration, Instant};
 use thiserror::Error;
 
@@ -36,13 +37,39 @@ pub enum WifiSessionError {
 struct SessionState {
     mode: WifiMode,
     online: bool,
+    /// Whether the radio was last successfully enabled (cleared by [`WifiSession::disable_radio`]).
+    radio_on: bool,
     idle_since: Option<Instant>,
     idle_wake: Option<Sender<()>>,
     hub: Option<Hub>,
+    soft_suspend: Option<Arc<SoftSuspendSession>>,
+    soft_suspend_lease: Option<SoftSuspendLease>,
 }
 
 struct IdleArmer {
     state: Arc<Mutex<SessionState>>,
+    tracker: OnceLock<WeakLeaseTracker>,
+}
+
+impl IdleArmer {
+    fn has_holders(&self) -> bool {
+        self.tracker
+            .get()
+            .is_some_and(|tracker| !tracker.is_empty())
+    }
+}
+
+fn sync_soft_suspend_lease(state: &mut SessionState, has_holders: bool) {
+    let should_hold = state.radio_on && (state.mode == WifiMode::AlwaysOn || has_holders);
+    if should_hold {
+        if state.soft_suspend_lease.is_none()
+            && let Some(soft_suspend) = state.soft_suspend.clone()
+        {
+            state.soft_suspend_lease = Some(soft_suspend.acquire("wifi"));
+        }
+    } else {
+        state.soft_suspend_lease = None;
+    }
 }
 
 impl LeaseObserver for IdleArmer {
@@ -50,17 +77,20 @@ impl LeaseObserver for IdleArmer {
         tracing::debug!(name = %name, "wifi lease first holder");
         if let Ok(mut state) = self.state.lock() {
             state.idle_since = None;
+            sync_soft_suspend_lease(&mut state, self.has_holders());
         }
     }
 
     fn on_last_release(&self, name: &LeaseName) {
         tracing::debug!(name = %name, "wifi lease last holder released");
-        if let Ok(mut state) = self.state.lock()
-            && state.mode == WifiMode::Auto
-        {
-            state.idle_since = Some(Instant::now());
-            if let Some(idle_wake) = state.idle_wake.as_ref() {
-                idle_wake.send(()).ok();
+        if let Ok(mut state) = self.state.lock() {
+            let has_holders = self.has_holders();
+            sync_soft_suspend_lease(&mut state, has_holders);
+            if !has_holders && state.mode == WifiMode::Auto {
+                state.idle_since = Some(Instant::now());
+                if let Some(idle_wake) = state.idle_wake.as_ref() {
+                    idle_wake.send(()).ok();
+                }
             }
         }
     }
@@ -116,15 +146,24 @@ impl WifiSession {
         let state = Arc::new(Mutex::new(SessionState {
             mode,
             online: false,
+            radio_on: false,
             idle_since: None,
             idle_wake: None,
             hub: None,
+            soft_suspend: None,
+            soft_suspend_lease: None,
         }));
         let observer = Arc::new(IdleArmer {
             state: Arc::clone(&state),
+            tracker: OnceLock::new(),
         });
+        let tracker = LeaseTracker::with_observer(observer.clone());
+        observer
+            .tracker
+            .set(tracker.downgrade())
+            .expect("wifi IdleArmer tracker already set");
         Arc::new(Self {
-            tracker: LeaseTracker::with_observer(observer),
+            tracker,
             wifi,
             state,
             online_cv: Condvar::new(),
@@ -144,6 +183,13 @@ impl WifiSession {
         self.state.lock().unwrap_or_else(|e| e.into_inner()).hub = Some(hub);
     }
 
+    /// Links soft-suspend so AlwaysOn or WiFi holders keep the device awake.
+    pub fn set_soft_suspend_session(&self, session: Arc<SoftSuspendSession>) {
+        let mut state = self.state.lock().unwrap_or_else(|e| e.into_inner());
+        state.soft_suspend = Some(session);
+        sync_soft_suspend_lease(&mut state, !self.tracker.is_empty());
+    }
+
     /// Updates the configured WiFi mode (from settings).
     #[cfg_attr(
         feature = "tracing",
@@ -158,6 +204,7 @@ impl WifiSession {
         } else if self.tracker.is_empty() && state.online {
             state.idle_since = Some(Instant::now());
         }
+        sync_soft_suspend_lease(&mut state, !self.tracker.is_empty());
         tracing::debug!(
             previous = %previous,
             mode = %mode,
@@ -323,6 +370,10 @@ impl WifiSession {
         );
 
         let inner = self.tracker.acquire(name.clone());
+        {
+            let mut state = self.state.lock().unwrap_or_else(|e| e.into_inner());
+            sync_soft_suspend_lease(&mut state, !self.tracker.is_empty());
+        }
 
         if self.is_online() {
             #[cfg(feature = "tracing")]
@@ -340,6 +391,12 @@ impl WifiSession {
                 tracing::error!(name = %name, error = %error, "failed to enable wifi radio");
                 return Err(error.into());
             }
+        }
+
+        {
+            let mut state = self.state.lock().unwrap_or_else(|e| e.into_inner());
+            state.radio_on = true;
+            sync_soft_suspend_lease(&mut state, !self.tracker.is_empty());
         }
 
         if matches!(self.wifi.network_info(), Ok(Some(_))) {
@@ -429,6 +486,11 @@ impl WifiSession {
         tracing::info!("enabling wifi radio");
         match self.wifi.enable() {
             Ok(()) => {
+                {
+                    let mut state = self.state.lock().unwrap_or_else(|e| e.into_inner());
+                    state.radio_on = true;
+                    sync_soft_suspend_lease(&mut state, !self.tracker.is_empty());
+                }
                 let connected =
                     self.wifi.is_enabled() && matches!(self.wifi.network_info(), Ok(Some(_)));
                 tracing::debug!(connected, "wifi radio enabled");
@@ -456,6 +518,11 @@ impl WifiSession {
             tracing::error!(error = %error, "failed to disable wifi radio");
         } else {
             tracing::debug!("wifi radio disabled");
+            {
+                let mut state = self.state.lock().unwrap_or_else(|e| e.into_inner());
+                state.radio_on = false;
+                sync_soft_suspend_lease(&mut state, !self.tracker.is_empty());
+            }
             self.notify_offline();
             self.clear_idle();
         }
@@ -593,5 +660,157 @@ mod tests {
             .unwrap();
         assert!(session.is_online());
         drop(lease);
+    }
+
+    fn soft_suspend_session() -> (
+        tempfile::TempDir,
+        Arc<crate::device::soft_suspend::SoftSuspendSession>,
+    ) {
+        use crate::device::soft_suspend::SoftSuspendPaths;
+        use std::fs;
+        let dir = tempfile::tempdir().expect("tempdir");
+        let paths = SoftSuspendPaths {
+            state: dir.path().join("state"),
+            autosleep: dir.path().join("autosleep"),
+            wake_lock: dir.path().join("wake_lock"),
+            wake_unlock: dir.path().join("wake_unlock"),
+        };
+        fs::write(&paths.state, "freeze mem\n").expect("state");
+        fs::write(&paths.autosleep, "off\n").expect("autosleep");
+        fs::write(&paths.wake_lock, "").expect("wake_lock");
+        fs::write(&paths.wake_unlock, "").expect("wake_unlock");
+        let session = crate::device::soft_suspend::SoftSuspendSession::with_paths(paths, None);
+        (dir, session)
+    }
+
+    #[test]
+    fn always_on_holds_soft_suspend_only_while_radio_on() {
+        let (_dir, soft) = soft_suspend_session();
+        let (session, _) = session(WifiMode::Auto);
+        session.set_soft_suspend_session(Arc::clone(&soft));
+        assert!(soft.is_empty());
+
+        session.set_mode(WifiMode::AlwaysOn);
+        assert!(
+            soft.is_empty(),
+            "AlwaysOn without radio must not pin soft-suspend"
+        );
+
+        session.enable_radio().unwrap();
+        assert!(!soft.is_empty());
+
+        session.disable_radio().unwrap();
+        assert!(
+            soft.is_empty(),
+            "disable_radio must drop soft-suspend wifi lease"
+        );
+
+        session.set_mode(WifiMode::Off);
+        assert!(soft.is_empty());
+    }
+
+    #[test]
+    fn always_on_keeps_soft_suspend_after_last_wifi_holder() {
+        let (_dir, soft) = soft_suspend_session();
+        let (session, _) = session(WifiMode::AlwaysOn);
+        session.set_soft_suspend_session(Arc::clone(&soft));
+        session.enable_radio().unwrap();
+        session.notify_online();
+        assert!(!soft.is_empty());
+
+        let lease = session.acquire("a").unwrap();
+        drop(lease);
+        assert!(!soft.is_empty());
+        assert!(!session.has_holders());
+    }
+
+    #[test]
+    fn leaving_always_on_keeps_soft_suspend_while_holders_remain() {
+        let (_dir, soft) = soft_suspend_session();
+        let (session, _) = session(WifiMode::AlwaysOn);
+        session.set_soft_suspend_session(Arc::clone(&soft));
+        session.enable_radio().unwrap();
+        session.notify_online();
+        let lease = session.acquire("a").unwrap();
+
+        session.set_mode(WifiMode::Auto);
+        assert!(!soft.is_empty());
+
+        drop(lease);
+        assert!(soft.is_empty());
+    }
+
+    #[test]
+    fn disable_radio_drops_always_on_soft_suspend_lease() {
+        let (_dir, soft) = soft_suspend_session();
+        let (session, _) = session(WifiMode::AlwaysOn);
+        session.set_soft_suspend_session(Arc::clone(&soft));
+        session.enable_radio().unwrap();
+        assert!(!soft.is_empty());
+
+        session.disable_radio().unwrap();
+        assert!(soft.is_empty());
+        assert_eq!(session.mode(), WifiMode::AlwaysOn);
+
+        session.enable_radio().unwrap();
+        assert!(!soft.is_empty());
+    }
+
+    #[test]
+    fn auto_holder_pins_soft_suspend_while_radio_on() {
+        let (_dir, soft) = soft_suspend_session();
+        let (session, _) = session(WifiMode::Auto);
+        session.set_soft_suspend_session(Arc::clone(&soft));
+        session.enable_radio().unwrap();
+        session.notify_online();
+
+        let lease = session.acquire("ntp").unwrap();
+        assert!(
+            !soft.is_empty(),
+            "Auto-mode WiFi holder must pin soft-suspend while radio is on"
+        );
+        drop(lease);
+        assert!(soft.is_empty());
+    }
+
+    #[test]
+    fn soft_suspend_stays_pinned_while_holder_active_under_churn() {
+        use std::sync::atomic::{AtomicBool, Ordering};
+
+        let (_dir, soft) = soft_suspend_session();
+        let (session, _) = session(WifiMode::Auto);
+        session.set_soft_suspend_session(Arc::clone(&soft));
+        session.enable_radio().unwrap();
+        session.notify_online();
+
+        let failed = Arc::new(AtomicBool::new(false));
+        let handles: Vec<_> = (0..4)
+            .map(|i| {
+                let session = Arc::clone(&session);
+                let soft = Arc::clone(&soft);
+                let failed = Arc::clone(&failed);
+                thread::spawn(move || {
+                    for n in 0..250 {
+                        if failed.load(Ordering::Relaxed) {
+                            break;
+                        }
+                        let lease = session.acquire(format!("t{i}-{n}")).unwrap();
+                        if session.has_holders() && soft.is_empty() {
+                            failed.store(true, Ordering::Relaxed);
+                            break;
+                        }
+                        drop(lease);
+                    }
+                })
+            })
+            .collect();
+
+        for handle in handles {
+            handle.join().expect("churn thread panicked");
+        }
+        assert!(
+            !failed.load(Ordering::Relaxed),
+            "soft-suspend wifi lease dropped while a WiFi holder was still active"
+        );
     }
 }

--- a/crates/core/src/lease.rs
+++ b/crates/core/src/lease.rs
@@ -31,7 +31,7 @@ use std::borrow::Cow;
 use std::collections::HashMap;
 use std::fmt;
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, Weak};
 
 /// Display name for a lease holder, used in logs.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -93,7 +93,9 @@ impl fmt::Display for LeaseId {
 ///
 /// Attach one with [`LeaseTracker::with_observer`]. Callbacks run while the
 /// tracker lock is **not** held, so they may acquire leases on the same
-/// tracker if needed.
+/// tracker if needed. Before invoking a callback, the tracker re-checks
+/// emptiness so a concurrent acquire/release can cancel a stale
+/// first/last notification.
 ///
 /// # Examples
 ///
@@ -146,6 +148,16 @@ struct TrackerState {
 #[derive(Clone)]
 pub struct LeaseTracker {
     inner: Arc<TrackerInner>,
+}
+
+/// Weak reference to a [`LeaseTracker`].
+///
+/// Use this from [`LeaseObserver`] implementations that need to re-query
+/// holder state without creating an `Arc` cycle through
+/// [`LeaseTracker::with_observer`].
+#[derive(Clone, Debug)]
+pub struct WeakLeaseTracker {
+    inner: Weak<TrackerInner>,
 }
 
 struct TrackerInner {
@@ -201,6 +213,13 @@ impl LeaseTracker {
         }
     }
 
+    /// Returns a weak reference to this tracker.
+    pub fn downgrade(&self) -> WeakLeaseTracker {
+        WeakLeaseTracker {
+            inner: Arc::downgrade(&self.inner),
+        }
+    }
+
     /// Acquires a named lease. Drop the returned guard to release it.
     #[must_use = "lease is released immediately if unused; bind it (e.g. `let _lease = …`)"]
     #[cfg_attr(
@@ -252,7 +271,10 @@ impl LeaseTracker {
             active: true,
         };
 
-        if became_first && let Some(observer) = &self.inner.observer {
+        if became_first
+            && let Some(observer) = &self.inner.observer
+            && !self.is_empty()
+        {
             tracing::debug!(name = %lease.name(), "notifying observer of first holder");
             observer.on_first_acquire(lease.name());
         }
@@ -338,10 +360,25 @@ impl LeaseTracker {
             empty
         };
 
-        if became_empty && let Some(observer) = &self.inner.observer {
+        if became_empty
+            && let Some(observer) = &self.inner.observer
+            && self.is_empty()
+        {
             tracing::debug!(name = %name, "notifying observer of last holder release");
             observer.on_last_release(name);
         }
+    }
+}
+
+impl WeakLeaseTracker {
+    /// Upgrades to a strong [`LeaseTracker`] if it still exists.
+    pub fn upgrade(&self) -> Option<LeaseTracker> {
+        self.inner.upgrade().map(|inner| LeaseTracker { inner })
+    }
+
+    /// Returns whether there are no active holders, or `true` if the tracker is gone.
+    pub fn is_empty(&self) -> bool {
+        self.upgrade().is_none_or(|tracker| tracker.is_empty())
     }
 }
 

--- a/crates/core/src/task/dictionary_index.rs
+++ b/crates/core/src/task/dictionary_index.rs
@@ -11,6 +11,7 @@ use walkdir::WalkDir;
 
 use crate::context::DICTIONARIES_DIRNAME;
 use crate::db::Database;
+use crate::device::soft_suspend::SoftSuspendSession;
 use crate::dictionary::{Entry, Metadata, normalize};
 use crate::fl;
 use crate::helpers::{Fingerprint, IsHidden};
@@ -18,6 +19,7 @@ use crate::runtime::RUNTIME;
 use crate::task::{BackgroundTask, ShutdownSignal, TaskId};
 use crate::view::notification::NotificationEvent;
 use crate::view::{Event, ID_FEEDER, ViewId};
+use std::sync::Arc;
 
 const BATCH_SIZE: usize = 5000;
 
@@ -72,14 +74,20 @@ fn decode_number(word: &str) -> Option<u64> {
 pub struct DictionaryIndexTask {
     database: Database,
     data_path: std::path::PathBuf,
+    soft_suspend_session: Arc<SoftSuspendSession>,
 }
 
 impl DictionaryIndexTask {
     /// Creates a new [`DictionaryIndexTask`].
-    pub fn new(database: Database, data_path: std::path::PathBuf) -> Self {
+    pub fn new(
+        database: Database,
+        data_path: std::path::PathBuf,
+        soft_suspend_session: Arc<SoftSuspendSession>,
+    ) -> Self {
         Self {
             database,
             data_path,
+            soft_suspend_session,
         }
     }
 
@@ -647,6 +655,7 @@ impl BackgroundTask for DictionaryIndexTask {
 
     #[cfg_attr(feature = "tracing", tracing::instrument(skip_all))]
     fn run(&mut self, hub: &crate::view::Hub, shutdown: &ShutdownSignal) {
+        let _soft_suspend = self.soft_suspend_session.acquire("dictionary-index");
         let glob = match Glob::new("**/*.index") {
             Ok(g) => g.compile_matcher(),
             Err(e) => {

--- a/crates/core/src/task/import.rs
+++ b/crates/core/src/task/import.rs
@@ -1,8 +1,10 @@
 //! Background task that imports library contents from disk.
 
 use std::path::PathBuf;
+use std::sync::Arc;
 
 use crate::db::Database;
+use crate::device::soft_suspend::SoftSuspendSession;
 use crate::library::Library;
 use crate::library::importer;
 use crate::settings::Settings;
@@ -22,6 +24,7 @@ pub struct ImportTask {
     /// When `true`, skip the mtime/size cache and re-fingerprint every file.
     force: bool,
     install_dir: PathBuf,
+    soft_suspend_session: Arc<SoftSuspendSession>,
 }
 
 impl ImportTask {
@@ -31,6 +34,7 @@ impl ImportTask {
         library_index: Option<usize>,
         force: bool,
         install_dir: impl Into<PathBuf>,
+        soft_suspend_session: Arc<SoftSuspendSession>,
     ) -> Self {
         Self {
             database,
@@ -38,6 +42,7 @@ impl ImportTask {
             library_index,
             force,
             install_dir: install_dir.into(),
+            soft_suspend_session,
         }
     }
 
@@ -84,6 +89,7 @@ impl BackgroundTask for ImportTask {
 
     #[cfg_attr(feature = "tracing", tracing::instrument(skip_all))]
     fn run(&mut self, hub: &crate::view::Hub, shutdown: &ShutdownSignal) {
+        let _soft_suspend = self.soft_suspend_session.acquire("library-import");
         match self.library_index {
             Some(index) => {
                 self.run_for_index(index, hub, shutdown);

--- a/crates/core/src/task/mod.rs
+++ b/crates/core/src/task/mod.rs
@@ -432,6 +432,7 @@ impl TaskManager {
                     &context.database,
                     &context.settings,
                     &context.device.install_dir(),
+                    &context.soft_suspend_session,
                 );
             }
             Event::ImportFinished { library_index } => {
@@ -440,6 +441,7 @@ impl TaskManager {
                     &context.database,
                     &context.settings,
                     &context.device.install_dir(),
+                    &context.soft_suspend_session,
                 );
                 self.schedule_thumbnail_extraction(
                     *library_index,
@@ -449,6 +451,7 @@ impl TaskManager {
                     context.device.dpi(),
                     context.device.color_samples(),
                     &context.device.install_dir(),
+                    &context.soft_suspend_session,
                 );
             }
             Event::ThumbnailExtractionFinished { .. } => {
@@ -459,10 +462,16 @@ impl TaskManager {
                     context.device.dpi(),
                     context.device.color_samples(),
                     &context.device.install_dir(),
+                    &context.soft_suspend_session,
                 );
             }
             Event::ReindexDictionaries => {
-                self.schedule_dictionary_index(hub, &context.database, context.device.data_dir());
+                self.schedule_dictionary_index(
+                    hub,
+                    &context.database,
+                    context.device.data_dir(),
+                    &context.soft_suspend_session,
+                );
             }
             Event::Device(DeviceEvent::NetUp) => {
                 #[cfg(feature = "kobo")]
@@ -507,6 +516,7 @@ impl TaskManager {
         database: &Database,
         settings: &Settings,
         install_dir: &std::path::Path,
+        soft_suspend_session: &std::sync::Arc<crate::device::soft_suspend::SoftSuspendSession>,
     ) {
         if self.is_running(&TaskId::Import) {
             tracing::info!(library_index = ?library_index, force, "import already running, queueing");
@@ -523,6 +533,7 @@ impl TaskManager {
             library_index,
             force,
             install_dir,
+            soft_suspend_session.clone(),
         ));
 
         if let Err(e) = self.start(task, hub.clone()) {
@@ -538,6 +549,7 @@ impl TaskManager {
         database: &Database,
         settings: &Settings,
         install_dir: &std::path::Path,
+        soft_suspend_session: &std::sync::Arc<crate::device::soft_suspend::SoftSuspendSession>,
     ) {
         if self.is_running(&TaskId::Import) || self.pending_import_indices.is_empty() {
             return;
@@ -546,7 +558,15 @@ impl TaskManager {
         let Some((next, force)) = self.pending_import_indices.pop_front() else {
             return;
         };
-        self.schedule_import(next, force, hub, database, settings, install_dir);
+        self.schedule_import(
+            next,
+            force,
+            hub,
+            database,
+            settings,
+            install_dir,
+            soft_suspend_session,
+        );
     }
 
     /// Schedules a dictionary index scan, stopping any running instance first.
@@ -556,6 +576,7 @@ impl TaskManager {
         hub: &crate::view::Hub,
         database: &Database,
         data_path: std::path::PathBuf,
+        soft_suspend_session: &std::sync::Arc<crate::device::soft_suspend::SoftSuspendSession>,
     ) {
         if self.is_running(&TaskId::DictionaryIndex) {
             tracing::debug!("stopping running dictionary index task for restart");
@@ -569,6 +590,7 @@ impl TaskManager {
         let task = Box::new(dictionary_index::DictionaryIndexTask::new(
             database.clone(),
             data_path,
+            soft_suspend_session.clone(),
         ));
 
         if let Err(e) = self.start(task, hub.clone()) {
@@ -642,6 +664,7 @@ impl TaskManager {
         dpi: u16,
         color_samples: usize,
         install_dir: &std::path::Path,
+        soft_suspend_session: &std::sync::Arc<crate::device::soft_suspend::SoftSuspendSession>,
     ) {
         if self.is_running(&TaskId::ThumbnailExtraction) {
             tracing::info!(library_index = ?library_index, "thumbnail extraction already running, queueing");
@@ -658,6 +681,7 @@ impl TaskManager {
             dpi,
             color_samples,
             install_dir,
+            soft_suspend_session.clone(),
         ));
 
         if let Err(e) = self.start(task, hub.clone()) {
@@ -675,6 +699,7 @@ impl TaskManager {
         dpi: u16,
         color_samples: usize,
         install_dir: &std::path::Path,
+        soft_suspend_session: &std::sync::Arc<crate::device::soft_suspend::SoftSuspendSession>,
     ) {
         if self.is_running(&TaskId::ThumbnailExtraction)
             || self.pending_thumbnail_indices.is_empty()
@@ -694,6 +719,7 @@ impl TaskManager {
             dpi,
             color_samples,
             install_dir,
+            soft_suspend_session,
         );
     }
 
@@ -731,7 +757,7 @@ impl Drop for TaskManager {
 /// - [`dbus_monitor::DbusMonitorTask`] - monitors D-Bus signals (test + kobo only, when `settings.logging.enable_dbus_log` is true)
 /// - [`import::ImportTask`] - runs an incremental import of all libraries on startup
 /// - [`dictionary_index::DictionaryIndexTask`] - indexes `.index` dictionary files into SQLite
-#[cfg_attr(feature = "tracing", tracing::instrument(skip(manager, hub, settings, database, data_path, install_dir), level = tracing::Level::TRACE))]
+#[cfg_attr(feature = "tracing", tracing::instrument(skip(manager, hub, settings, database, data_path, install_dir, soft_suspend_session), level = tracing::Level::TRACE))]
 pub fn register_startup_tasks(
     manager: &mut TaskManager,
     hub: crate::view::Hub,
@@ -739,6 +765,7 @@ pub fn register_startup_tasks(
     database: &Database,
     data_path: std::path::PathBuf,
     install_dir: &std::path::Path,
+    soft_suspend_session: &std::sync::Arc<crate::device::soft_suspend::SoftSuspendSession>,
 ) {
     #[cfg(feature = "kobo")]
     {
@@ -772,11 +799,20 @@ pub fn register_startup_tasks(
         }
     }
 
-    manager.schedule_import(None, false, &hub, database, settings, install_dir);
+    manager.schedule_import(
+        None,
+        false,
+        &hub,
+        database,
+        settings,
+        install_dir,
+        soft_suspend_session,
+    );
 
     let task = Box::new(dictionary_index::DictionaryIndexTask::new(
         database.clone(),
         data_path,
+        soft_suspend_session.clone(),
     ));
     if let Err(e) = manager.start(task, hub.clone()) {
         tracing::warn!(error = %e, "failed to start dictionary_index task");
@@ -906,6 +942,7 @@ mod tests {
         let mut database = Database::new(":memory:").unwrap();
         database.init_for_test(0).unwrap();
         let settings = Settings::default();
+        let context = create_test_context();
 
         manager.schedule_thumbnail_extraction(
             None,
@@ -915,6 +952,7 @@ mod tests {
             300,
             1,
             Path::new(""),
+            &context.soft_suspend_session,
         );
 
         // Task exits quickly on an unseeded database, so wait for
@@ -951,6 +989,7 @@ mod tests {
         let mut database = Database::new(":memory:").unwrap();
         database.init_for_test(0).unwrap();
         let settings = Settings::default();
+        let context = create_test_context();
 
         manager.schedule_thumbnail_extraction(
             Some(0),
@@ -960,6 +999,7 @@ mod tests {
             300,
             1,
             Path::new(""),
+            &context.soft_suspend_session,
         );
         manager.schedule_thumbnail_extraction(
             Some(1),
@@ -969,18 +1009,35 @@ mod tests {
             300,
             1,
             Path::new(""),
+            &context.soft_suspend_session,
         );
 
         assert_eq!(manager.pending_thumbnail_indices.len(), 2);
 
         manager.stop(&TaskId::ThumbnailExtraction).unwrap();
 
-        manager.drain_pending_thumbnails(&hub, &database, &settings, 300, 1, Path::new(""));
+        manager.drain_pending_thumbnails(
+            &hub,
+            &database,
+            &settings,
+            300,
+            1,
+            Path::new(""),
+            &context.soft_suspend_session,
+        );
         assert_eq!(manager.pending_thumbnail_indices.len(), 1);
 
         wait_until_not_running(&mut manager, &TaskId::ThumbnailExtraction);
 
-        manager.drain_pending_thumbnails(&hub, &database, &settings, 300, 1, Path::new(""));
+        manager.drain_pending_thumbnails(
+            &hub,
+            &database,
+            &settings,
+            300,
+            1,
+            Path::new(""),
+            &context.soft_suspend_session,
+        );
         assert!(manager.pending_thumbnail_indices.is_empty());
 
         wait_until_not_running(&mut manager, &TaskId::ThumbnailExtraction);

--- a/crates/core/src/task/thumbnail.rs
+++ b/crates/core/src/task/thumbnail.rs
@@ -1,8 +1,10 @@
 //! Background task that extracts book cover thumbnails.
 
 use std::path::PathBuf;
+use std::sync::Arc;
 
 use crate::db::Database;
+use crate::device::soft_suspend::SoftSuspendSession;
 use crate::document::open;
 use crate::library::Library;
 use crate::settings::Settings;
@@ -20,6 +22,7 @@ pub struct ThumbnailExtractionTask {
     dpi: u16,
     color_samples: usize,
     install_dir: PathBuf,
+    soft_suspend_session: Arc<SoftSuspendSession>,
 }
 
 impl ThumbnailExtractionTask {
@@ -30,6 +33,7 @@ impl ThumbnailExtractionTask {
         dpi: u16,
         color_samples: usize,
         install_dir: impl Into<PathBuf>,
+        soft_suspend_session: Arc<SoftSuspendSession>,
     ) -> Self {
         Self {
             database,
@@ -38,6 +42,7 @@ impl ThumbnailExtractionTask {
             dpi,
             color_samples,
             install_dir: install_dir.into(),
+            soft_suspend_session,
         }
     }
 
@@ -124,6 +129,7 @@ impl BackgroundTask for ThumbnailExtractionTask {
 
     #[cfg_attr(feature = "tracing", tracing::instrument(skip_all))]
     fn run(&mut self, hub: &crate::view::Hub, shutdown: &ShutdownSignal) {
+        let _soft_suspend = self.soft_suspend_session.acquire("thumbnail");
         match self.library_index {
             Some(index) => {
                 self.run_for_index(index, hub, shutdown);


### PR DESCRIPTION
Closes: CAD-39

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes device sleep/wake behavior and WiFi idle timing; mistakes could cause unexpected suspend during network or indexing work, though coverage is heavy on WiFi/soft-suspend interaction tests.
> 
> **Overview**
> Connects **soft-suspend** wake locks to WiFi and long-running background work so the device stays awake when those subsystems need it.
> 
> **WiFi:** `WifiSession` takes a `SoftSuspendSession` at startup and keeps a `"wifi"` soft-suspend lease while the radio is on and either WiFi is **AlwaysOn** or at least one WiFi lease holder exists. `radio_on` tracks successful enable/disable; turning the radio off drops the soft-suspend pin even if mode stays AlwaysOn. `IdleArmer` uses `WeakLeaseTracker` to read holder state without an `Arc` cycle with the lease observer.
> 
> **Background tasks:** Import, dictionary index, and thumbnail extraction each acquire a named soft-suspend lease for the whole `run()` (`library-import`, `dictionary-index`, `thumbnail`). Startup and task scheduling pass `context.soft_suspend_session` through.
> 
> **Lease tracker:** Adds `WeakLeaseTracker` / `downgrade()`, and re-checks `is_empty()` before firing `on_first_acquire` / `on_last_release` so concurrent acquire/release cannot deliver stale empty/non-empty notifications.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6aac37011996e197d091ddf709f14db7cbaec80d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->