### PR TITLE
docs(devenv): require cargo xtask setup

### DIFF
--- a/.agents/skills/build-cadmus-native/SKILL.md
+++ b/.agents/skills/build-cadmus-native/SKILL.md
@@ -29,6 +29,18 @@ it when documentation sources change.
 
 ## One-time setup
 
+### Custom SQLite
+
+**Required before any native compile** — `libsqlite3-sys` runs before
+`cadmus-core`'s `build.rs`, so the UDL-enabled SQLite library must already
+exist:
+
+```bash
+cargo xtask setup
+```
+
+Default (no flags) builds for the host and Kobo targets.
+
 ### Runtime assets
 
 **Required for Kobo builds** — run both before `cargo xtask build-kobo`:
@@ -41,9 +53,9 @@ cargo xtask download-fonts
 `download-assets` pulls Plato runtime directories (`bin/`, `resources/`,
 `hyphenation-patterns/`). `download-fonts` assembles the `fonts/`.
 
-Native dependencies (MuPDF, libwebp, and the C wrapper) are now built
+Other native dependencies (MuPDF, libwebp, and the C wrapper) are built
 automatically by `build.rs` when you run any Cargo command that compiles
-`cadmus-core`.
+`cadmus-core`. SQLite is the exception — use `cargo xtask setup` first.
 
 ## Daily workflow commands
 

--- a/docs/po/messages.pot
+++ b/docs/po/messages.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Cadmus Documentation\n"
-"POT-Creation-Date: 2026-08-13T20:37:30+02:00\n"
+"POT-Creation-Date: 2026-08-15T06:09:52+02:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"

--- a/docs/src/contributing/devenv-setup.md
+++ b/docs/src/contributing/devenv-setup.md
@@ -20,7 +20,23 @@ This guide covers setup on both Linux and macOS.
    devenv shell
    ```
 
-2. Download the packaged runtime assets used by Kobo builds:
+2. Build the custom SQLite library (required before any Cargo compile):
+
+   ```bash
+   cargo xtask setup
+   ```
+
+   > [!NOTE]
+   > Cadmus needs a custom SQLite build with `DELETE … LIMIT` support.
+   > `libsqlite3-sys` runs before `cadmus-core`'s `build.rs`, so these
+   > artifacts must already exist. Default `cargo xtask setup` (no flags)
+   > builds for the host and Kobo targets.
+   >
+   > Other thirdparty C/C++ dependencies (MuPDF, libwebp, zlib, etc.) are
+   > tracked as git submodules and built automatically by `build.rs` when
+   > you run `cargo build` or `cargo xtask run-emulator`.
+
+3. Download the packaged runtime assets used by Kobo builds:
 
    ```bash
    cargo xtask download-assets
@@ -32,12 +48,8 @@ This guide covers setup on both Linux and macOS.
    > directories. For Kobo builds, make sure `bin/`, `resources/`,
    > `hyphenation-patterns/`, and `fonts/` are present before
    > `cargo xtask build-kobo` so the generated asset list is complete.
-   >
-   > Thirdparty C/C++ dependencies (MuPDF, libwebp, zlib, etc.) are tracked as git
-   > submodules and built automatically by `build.rs` when you run `cargo build` or
-   > `cargo xtask run-emulator`. No separate setup step is required.
 
-3. Run the emulator:
+4. Run the emulator:
 
    ```bash
    cargo xtask run-emulator
@@ -49,6 +61,7 @@ Once inside the devenv shell, these commands are available:
 
 | Command                       | Description                                                 |
 | ----------------------------- | ----------------------------------------------------------- |
+| `cargo xtask setup`           | Build custom SQLite for host and Kobo (run before compile)  |
 | `cargo xtask download-assets` | Download packaged Plato runtime assets                      |
 | `cargo xtask download-fonts`  | Download bundled font files into `fonts/`                   |
 | `cargo xtask test`            | Run the test suite across the feature matrix                |
@@ -97,6 +110,9 @@ The `docs:build` task uses `execIfModified` to only rebuild when documentation f
 
 ## Kobo Build Notes
 
+- Run `cargo xtask setup` before host-side Cargo commands. `cargo xtask
+  build-kobo` also ensures the ARM SQLite artifacts, but running setup up
+  front covers both native and device paths.
 - `cargo xtask download-assets` and `cargo xtask download-fonts` must run before `cargo xtask build-kobo`.
 - OTA updates delete Cadmus-owned bundled files before reboot, then Kobo
   extracts the new `KoboRoot.tgz` over the install directory.
@@ -232,6 +248,16 @@ Set the environment variable before running tests:
 ```bash
 TEST_ROOT_DIR=$(pwd) cargo test
 ```
+
+### `libsqlite3-sys` fails with `sqlite3.h` not found
+
+Custom SQLite has not been built yet. Inside `devenv shell`, run:
+
+```bash
+cargo xtask setup
+```
+
+Then retry the build or `cargo xtask run-emulator`.
 
 ## Local Configuration
 


### PR DESCRIPTION
Quick Start claimed no setup step; SQLite must be built first or libsqlite3-sys fails on missing sqlite3.h.

Change-Id: 51d0a107d8330c0b134d619bf131dd51
Change-Id-Short: uymzpyzsmrww
Fixes: #854
Closes: CAD-136

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime or build-script behavior modified.
> 
> **Overview**
> Contributor docs no longer imply you can compile with zero setup. **Custom SQLite via `cargo xtask setup`** is documented as a required step before any Cargo build, because `libsqlite3-sys` runs before `cadmus-core`'s `build.rs` and needs the UDL-enabled `sqlite3.h` / library Cadmus builds separately.
> 
> **`docs/src/contributing/devenv-setup.md`** adds that step to Quick Start (renumbering asset download and emulator), documents it in the command table and Kobo build notes, and adds troubleshooting for missing `sqlite3.h`. **`build-cadmus-native` skill** gets a matching **Custom SQLite** section and clarifies that MuPDF/libwebp still come from `build.rs`—only SQLite is manual.
> 
> `docs/po/messages.pot` only reflects a regenerated POT timestamp from the doc edits.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 17d1dd6cb098228e7e5d959a414f1c0b58ec3fc9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->