### PR TITLE
dev(xtask): auto-ensure host SQLite before cargo

### DIFF
--- a/xtask/src/tasks/build_kobo.rs
+++ b/xtask/src/tasks/build_kobo.rs
@@ -10,9 +10,8 @@
 //!
 //! 1. Verify the Linaro ARM toolchain (`arm-linux-gnueabihf-gcc`)
 //!    is on `PATH`.
-//! 2. Initialize git submodules when SQLite is not already cached.
-//! 3. Build SQLite from source with UDL support for the ARM target
-//!    (placed in `target/cadmus-build-deps/arm-unknown-linux-gnueabihf/sqlite/`).
+//! 2. Ensure custom SQLite with UDL support for the ARM target via the
+//!    shared sqlite preflight helper (submodules + build when cold).
 //!
 //! The Kobo build is only available on Linux and macOS hosts.
 
@@ -24,7 +23,7 @@ use clap::Args;
 use build_deps::build::sqlite;
 use build_deps::versions::CROSS_ENV;
 
-use super::util::{cmd, workspace};
+use super::util::{cmd, sqlite_preflight, workspace};
 
 /// Arguments for `cargo xtask build-kobo`.
 #[derive(Debug, Args)]
@@ -43,9 +42,8 @@ pub struct BuildKoboArgs {
 /// - The Linaro ARM toolchain is not on `PATH`.
 /// - The underlying `cargo build` invocation fails.
 ///
-/// The `ensure_submodules` and `ensure_sqlite` preflight steps run
-/// eagerly so that `libs/` and `target/cadmus-build-deps/...` are
-/// populated before `cargo build` starts.
+/// The shared SQLite preflight runs eagerly so that
+/// `target/cadmus-build-deps/...` is populated before `cargo build` starts.
 pub fn run(args: BuildKoboArgs) -> Result<()> {
     if !cfg!(any(target_os = "linux", target_os = "macos")) {
         bail!(
@@ -58,10 +56,8 @@ pub fn run(args: BuildKoboArgs) -> Result<()> {
 
     ensure_linaro_toolchain()?;
 
-    if !sqlite::is_cached(&root, sqlite::KOBO_TARGET) {
-        build_deps::ensure_submodules(&root).context("failed to initialise git submodules")?;
-    }
-    sqlite::ensure_sqlite(&root, sqlite::KOBO_TARGET).context("failed to build SQLite for Kobo")?;
+    sqlite_preflight::ensure_for_target(&root, sqlite::KOBO_TARGET)
+        .context("failed to build SQLite for Kobo")?;
 
     cargo_build_kobo(&root, args.features.as_deref())?;
 

--- a/xtask/src/tasks/clippy.rs
+++ b/xtask/src/tasks/clippy.rs
@@ -46,7 +46,7 @@ use anyhow::{Context, Result, bail};
 use clap::Args;
 use io_tee::WriteExt;
 
-use super::util::{cmd, matrix, workspace};
+use super::util::{cmd, matrix, sqlite_preflight, workspace};
 
 /// Arguments for `cargo xtask clippy`.
 #[derive(Debug, Args)]
@@ -103,6 +103,7 @@ pub struct ClippyArgs {
 /// Returns the first clippy error encountered, or a spawn/IO error.
 pub fn run(args: ClippyArgs) -> Result<()> {
     let root = workspace::root()?;
+    sqlite_preflight::ensure_host(&root)?;
     let entries = matrix::scan(&root, &["local"])?;
     let entries = filter(&entries, args.features.as_deref())?;
 

--- a/xtask/src/tasks/run_emulator.rs
+++ b/xtask/src/tasks/run_emulator.rs
@@ -1,9 +1,9 @@
 //! `cargo xtask run-emulator` — run the Cadmus emulator.
 //!
-//! Ensures the embedded documentation EPUB is ready, then launches
-//! `cargo run -p cadmus --features emulator`. Any extra arguments are forwarded
-//! to the cargo invocation. Native dependencies (MuPDF, libwebp) are built
-//! automatically by `build.rs`.
+//! Ensures host SQLite and the embedded documentation EPUB are ready, then
+//! launches `cargo run -p cadmus --features emulator`. Any extra arguments are
+//! forwarded to the cargo invocation. Other native dependencies (MuPDF,
+//! libwebp) are built automatically by `build.rs`.
 
 use std::collections::BTreeSet;
 use std::path::Path;
@@ -12,7 +12,7 @@ use anyhow::Result;
 use clap::Args;
 
 use super::docs::{self, DocsArgs};
-use super::util::{cmd, workspace};
+use super::util::{cmd, sqlite_preflight, workspace};
 
 /// Arguments for `cargo xtask run-emulator`.
 #[derive(Debug, Args)]
@@ -45,9 +45,11 @@ fn emulator_features(extra: Option<&str>) -> String {
     features.into_iter().collect::<Vec<_>>().join(",")
 }
 
-/// Ensures documentation is built then launches the emulator.
+/// Ensures host SQLite and documentation are built then launches the emulator.
 pub fn run(args: RunEmulatorArgs) -> Result<()> {
     let root = workspace::root()?;
+
+    sqlite_preflight::ensure_host(&root)?;
 
     if !mdbook_epub_built(&root) {
         println!("Documentation EPUB not found — building mdBook…");

--- a/xtask/src/tasks/setup.rs
+++ b/xtask/src/tasks/setup.rs
@@ -20,12 +20,12 @@
 //! After running, set the printed environment variables before
 //! `cargo build` or `cargo xtask build-kobo`.
 
-use anyhow::{Context, Result};
+use anyhow::Result;
 use clap::Args;
 
 use build_deps::build::sqlite;
 
-use super::util::workspace;
+use super::util::{sqlite_preflight, workspace};
 
 /// Arguments for `cargo xtask setup`.
 #[derive(Debug, Args)]
@@ -63,13 +63,8 @@ pub fn run(args: SetupArgs) -> Result<()> {
     let root = workspace::root()?;
     let targets = resolve_targets(&args);
 
-    let all_cached = targets.iter().all(|t| sqlite::is_cached(&root, t));
-    if !all_cached {
-        build_deps::ensure_submodules(&root).context("failed to initialise git submodules")?;
-    }
-
     for target in &targets {
-        let artifacts = sqlite::ensure_sqlite(&root, target).context("failed to build sqlite")?;
+        let artifacts = sqlite_preflight::ensure_for_target(&root, target)?;
 
         println!();
         println!("SQLite artifacts ready for {target}:");
@@ -97,28 +92,10 @@ fn resolve_targets(args: &SetupArgs) -> Vec<String> {
 
     let mut targets = Vec::new();
     if build_all || args.host {
-        targets.push(guess_host_triple());
+        targets.push(sqlite_preflight::guess_host_triple());
     }
     if build_all || args.kobo {
         targets.push(sqlite::KOBO_TARGET.to_string());
     }
     targets
-}
-
-/// Best-effort detection of the host target triple.
-#[must_use]
-fn guess_host_triple() -> String {
-    std::env::var("TARGET").unwrap_or_else(|_| {
-        if cfg!(target_arch = "x86_64") && cfg!(target_os = "linux") {
-            "x86_64-unknown-linux-gnu".to_string()
-        } else if cfg!(target_arch = "aarch64") && cfg!(target_os = "linux") {
-            "aarch64-unknown-linux-gnu".to_string()
-        } else if cfg!(target_arch = "x86_64") && cfg!(target_os = "macos") {
-            "x86_64-apple-darwin".to_string()
-        } else if cfg!(target_arch = "aarch64") && cfg!(target_os = "macos") {
-            "aarch64-apple-darwin".to_string()
-        } else {
-            "x86_64-unknown-linux-gnu".to_string()
-        }
-    })
 }

--- a/xtask/src/tasks/test.rs
+++ b/xtask/src/tasks/test.rs
@@ -16,7 +16,7 @@ use std::path::{Path, PathBuf};
 use anyhow::{Context, Result, bail};
 use clap::Args;
 
-use super::util::{cmd, matrix, workspace};
+use super::util::{cmd, matrix, sqlite_preflight, workspace};
 
 /// Paths excluded from coverage reports (vendored code, build scripts).
 const COVERAGE_IGNORE_RE: &str = r"(thirdparty/|mupdf_wrapper/|build\.rs)";
@@ -71,6 +71,7 @@ pub fn run(args: TestArgs) -> Result<()> {
     }
 
     let root = workspace::root()?;
+    sqlite_preflight::ensure_host(&root)?;
     let root_str = root.to_string_lossy().into_owned();
     let env = [("TEST_ROOT_DIR", root_str.as_str())];
 

--- a/xtask/src/tasks/util/mod.rs
+++ b/xtask/src/tasks/util/mod.rs
@@ -5,4 +5,5 @@ pub mod fs;
 pub mod github;
 pub mod http;
 pub mod matrix;
+pub mod sqlite_preflight;
 pub mod workspace;

--- a/xtask/src/tasks/util/sqlite_preflight.rs
+++ b/xtask/src/tasks/util/sqlite_preflight.rs
@@ -1,0 +1,49 @@
+//! Ensure custom SQLite artifacts exist before cargo invokes `libsqlite3-sys`.
+
+use std::path::Path;
+
+use anyhow::{Context, Result};
+use build_deps::build::sqlite::{self, SqliteArtifacts};
+
+/// Best-effort detection of the host target triple.
+#[must_use]
+pub fn guess_host_triple() -> String {
+    std::env::var("TARGET").unwrap_or_else(|_| {
+        if cfg!(target_arch = "x86_64") && cfg!(target_os = "linux") {
+            "x86_64-unknown-linux-gnu".to_string()
+        } else if cfg!(target_arch = "aarch64") && cfg!(target_os = "linux") {
+            "aarch64-unknown-linux-gnu".to_string()
+        } else if cfg!(target_arch = "x86_64") && cfg!(target_os = "macos") {
+            "x86_64-apple-darwin".to_string()
+        } else if cfg!(target_arch = "aarch64") && cfg!(target_os = "macos") {
+            "aarch64-apple-darwin".to_string()
+        } else {
+            "x86_64-unknown-linux-gnu".to_string()
+        }
+    })
+}
+
+/// Ensure UDL-enabled SQLite exists for `target` under `target/cadmus-build-deps/`.
+///
+/// When artifacts are missing, prints a cold-build message, initializes git
+/// submodules if needed, then builds SQLite. Warm cache skips the cold path.
+///
+/// # Errors
+///
+/// Returns an error if submodules cannot be initialised or the SQLite build fails.
+pub fn ensure_for_target(root: &Path, target: &str) -> Result<SqliteArtifacts> {
+    if !sqlite::is_cached(root, target) {
+        println!("SQLite not found for {target} — building…");
+        build_deps::ensure_submodules(root).context("failed to initialise git submodules")?;
+    }
+    sqlite::ensure_sqlite(root, target).context("failed to build sqlite")
+}
+
+/// Ensure SQLite artifacts for the native host target.
+///
+/// # Errors
+///
+/// See [`ensure_for_target`].
+pub fn ensure_host(root: &Path) -> Result<SqliteArtifacts> {
+    ensure_for_target(root, &guess_host_triple())
+}


### PR DESCRIPTION
Native entrypoints failed with missing sqlite3.h when setup was skipped; share preflight with build-kobo as a safety net.

Change-Id: 2f32d59cc92ba9d7681969ba976e03f9
Change-Id-Short: xkwxmuqnnqxo
Fixes: #854
Closes: CAD-136

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes only xtask developer workflows and reuses existing build_deps SQLite logic; no runtime or production behavior.
> 
> **Overview**
> Introduces a shared **`sqlite_preflight`** helper that checks the cache, initializes submodules when needed, and builds UDL-enabled SQLite under `target/cadmus-build-deps/`. **`ensure_host`** and **`ensure_for_target`** replace duplicated logic in **`build-kobo`** and **`setup`**, and **`guess_host_triple`** moves out of setup into the helper.
> 
> **`clippy`**, **`test`**, and **`run-emulator`** now call **`ensure_host`** before invoking cargo so native workflows no longer fail with missing `sqlite3.h` when **`cargo xtask setup`** was skipped.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 664fcff6ee21383a6db620b4984ae4760557742b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->