### PR TITLE
fix(emulator): migrate to SDL3 and Linux graphics deps

### DIFF
--- a/.cursor/Dockerfile
+++ b/.cursor/Dockerfile
@@ -55,7 +55,7 @@ RUN apt-get update \
         libxfixes3 \
         libxkbcommon0 \
         libxrandr2 \
-        libsdl2-dev \
+        libsdl3-dev \
         llvm-dev \
         meson \
         ninja-build \

--- a/.github/actions/apt/action.yml
+++ b/.github/actions/apt/action.yml
@@ -15,8 +15,8 @@ runs:
           meson ninja-build autoconf automake libtool gperf python3 tcl
           zlib1g-dev libbz2-dev libpng-dev libjpeg-dev libopenjp2-7-dev
           libjbig2dec0-dev libgumbo-dev libfreetype6-dev libharfbuzz-dev
-          libdjvulibre-dev libsdl2-dev
-        version: 1.0
+          libdjvulibre-dev libsdl3-dev
+        version: 1.1
     - name: Set LIBCLANG_PATH
       shell: bash
       run: |

--- a/.github/actions/apt/action.yml
+++ b/.github/actions/apt/action.yml
@@ -16,7 +16,7 @@ runs:
           zlib1g-dev libbz2-dev libpng-dev libjpeg-dev libopenjp2-7-dev
           libjbig2dec0-dev libgumbo-dev libfreetype6-dev libharfbuzz-dev
           libdjvulibre-dev libsdl3-dev
-        version: 1.1
+        version: 1.2
     - name: Set LIBCLANG_PATH
       shell: bash
       run: |

--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -363,7 +363,7 @@ jobs:
           restore-keys: ${{ runner.os }}-brew-
       - name: Install Homebrew packages (macOS)
         if: runner.os == 'macOS'
-        run: brew install sdl2 freetype harfbuzz openjpeg jpeg-turbo libpng jbig2dec gumbo-parser djvulibre pkg-config
+        run: brew install sdl3 freetype harfbuzz openjpeg jpeg-turbo libpng jbig2dec gumbo-parser djvulibre pkg-config
 
       - name: Restore bundled fonts
         uses: ./.github/actions/cache-fonts

--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -120,7 +120,7 @@ jobs:
     if: github.event_name != 'pull_request' || needs.changes.outputs.cargo == 'true'
     permissions:
       contents: read
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-26.04
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -257,6 +257,10 @@ jobs:
         with:
           name: docs-epub
           path: docs/book/epub
+
+      - name: Install apt packages (Linux)
+        if: runner.os == 'Linux'
+        uses: ./.github/actions/apt
 
       - name: Save clippy JSON artifact
         if: github.event_name == 'pull_request'
@@ -480,7 +484,7 @@ jobs:
   build-kobo:
     needs: [changes, cache-warmup, build-docs-epub]
     if: github.event_name != 'pull_request' || needs.changes.outputs.cargo == 'true'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-26.04
 
     permissions: &build-permissions
       id-token: write
@@ -554,7 +558,7 @@ jobs:
   build-kobo-test:
     needs: [changes, cache-warmup, build-docs-epub]
     if: github.event_name != 'pull_request' || needs.changes.outputs.cargo == 'true'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-26.04
 
     permissions: *build-permissions
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -293,7 +293,7 @@ version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags",
  "cexpr",
  "clang-sys",
  "itertools 0.13.0",
@@ -304,12 +304,6 @@ dependencies = [
  "shlex 1.3.0",
  "syn 2.0.119",
 ]
-
-[[package]]
-name = "bitflags"
-version = "1.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
@@ -417,7 +411,7 @@ version = "0.11.0"
 dependencies = [
  "anyhow",
  "arc-swap",
- "bitflags 2.13.1",
+ "bitflags",
  "blake3",
  "build-deps",
  "byteorder",
@@ -463,7 +457,7 @@ dependencies = [
  "reqwest",
  "rust-embed",
  "rustls",
- "sdl2",
+ "sdl3",
  "secrecy",
  "septem",
  "serde",
@@ -2312,7 +2306,7 @@ version = "0.31.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -2636,7 +2630,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97f6fccfd2d9d2df765ca23ff85fe5cc437fb0e6d3e164e4d3cbe09d14780c93"
 dependencies = [
  "arrayvec",
- "bitflags 2.13.1",
+ "bitflags",
  "thiserror 2.0.20",
  "zerocopy",
  "zerocopy-derive",
@@ -2751,7 +2745,7 @@ version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags",
  "crc32fast",
  "fdeflate",
  "flate2",
@@ -2866,7 +2860,7 @@ version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25485360a54d6861439d60facef26de713b1e126bf015ec8f98239467a2b82f7"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags",
  "chrono",
  "flate2",
  "procfs-core",
@@ -2879,7 +2873,7 @@ version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6401bf7b6af22f78b563665d15a22e9aef27775b79b149a66ca022468a4e405"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags",
  "chrono",
  "hex",
 ]
@@ -3105,7 +3099,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags",
 ]
 
 [[package]]
@@ -3260,7 +3254,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -3390,26 +3384,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
-name = "sdl2"
-version = "0.38.0"
+name = "sdl3"
+version = "0.18.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d42407afc6a8ab67e36f92e80b8ba34cbdc55aaeed05249efe9a2e8d0e9feef"
+checksum = "25bd22eb1bbc9137e914022b4994ed35591eea0884e9e3e98e6d9895cad6e1d2"
 dependencies = [
- "bitflags 1.3.2",
- "lazy_static",
+ "bitflags",
  "libc",
- "sdl2-sys",
+ "sdl3-sys",
 ]
 
 [[package]]
-name = "sdl2-sys"
-version = "0.38.0"
+name = "sdl3-sys"
+version = "0.6.8+SDL-3.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ff61407fc75d4b0bbc93dc7e4d6c196439965fbef8e4a4f003a36095823eac0"
+checksum = "b97e3d18c4994224aec3fb2d3d189f5fc88af0958fb8ed7b569272fde558f033"
 dependencies = [
- "cfg-if",
- "libc",
- "version-compare",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -3428,7 +3420,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -3806,7 +3798,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90b8020fe17c5f2c245bfa2505d7ef59c5604839527c740266ad2214acebea27"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags",
  "byteorder",
  "bytes",
  "chrono",
@@ -3835,7 +3827,7 @@ checksum = "87a2bdd6e83f6b3ea525ca9fee568030508b58355a43d0b2c1674d5f79dcd65e"
 dependencies = [
  "atoi",
  "base64",
- "bitflags 2.13.1",
+ "bitflags",
  "byteorder",
  "chrono",
  "crc",
@@ -4345,7 +4337,7 @@ version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags",
  "bytes",
  "futures-util",
  "http",
@@ -4653,12 +4645,6 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
-
-[[package]]
-name = "version-compare"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "579a42fc0b8e0c63b76519a339be31bed574929511fa53c1a3acae26eb258f29"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ rustls = { version = "0.23", default-features = false, features = [
   "std",
   "tls12",
 ] }
-sdl2 = "0.38.0"
+sdl3 = { version = "0.18.4", features = ["use-pkg-config"] }
 
 [workspace.lints]
 rustdoc.private_intra_doc_links = "allow"

--- a/crates/build-deps/src/manifest.rs
+++ b/crates/build-deps/src/manifest.rs
@@ -112,7 +112,7 @@ name = "cadmus-core"
 default = []
 device = []
 # device-list-start
-emulator = ["sdl2", "device"]
+emulator = ["sdl3", "device"]
 deviceless = ["device"]
 kobo = ["procfs", "device"]
 # device-list-end

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -79,7 +79,7 @@ sqlx = { version = "0.9", features = [
     "macros",
 ], default-features = false }
 tokio = { version = "1.40", features = ["fs", "macros", "rt", "rt-multi-thread", "sync"] }
-sdl2 = { workspace = true, optional = true }
+sdl3 = { workspace = true, optional = true }
 
 tracing = "0.1"
 tracing-log = "0.2"
@@ -126,7 +126,7 @@ uuid = { version = "1.20.0", features = ["v7"] }
 default = []
 device = []
 # device-list-start
-emulator = ["sdl2", "device"]
+emulator = ["sdl3", "device"]
 deviceless = ["device"]
 kobo = ["procfs", "zbus", "futures-util", "device"]
 # device-list-end
@@ -147,7 +147,7 @@ docs = [
     "deviceless",
     "zbus",
     "futures-util",
-    "sdl2",
+    "sdl3",
     "procfs",
     "device",
 ]

--- a/crates/core/src/device/emulator/mod.rs
+++ b/crates/core/src/device/emulator/mod.rs
@@ -31,13 +31,14 @@ use crate::view::common::locate;
 use crate::view::intermission::Intermission;
 use crate::view::{Bus, EntryId, Event, Hub, RenderData, RenderQueue, View};
 use anyhow::{Context as ResultExt, Error};
-use sdl2::Sdl;
-use sdl2::event::Event as SdlEvent;
-use sdl2::keyboard::{Keycode, Mod, Scancode};
-use sdl2::pixels::{Color as SdlColor, PixelFormatEnum};
-use sdl2::rect::Point as SdlPoint;
-use sdl2::rect::Rect as SdlRect;
-use sdl2::render::{BlendMode, WindowCanvas};
+use sdl3::Sdl;
+use sdl3::VideoSubsystem;
+use sdl3::event::Event as SdlEvent;
+use sdl3::keyboard::{Keycode, Mod, Scancode};
+use sdl3::pixels::{Color as SdlColor, PixelFormat};
+use sdl3::rect::Point as SdlPoint;
+use sdl3::rect::Rect as SdlRect;
+use sdl3::render::{BlendMode, WindowCanvas, create_renderer};
 use std::fs::File;
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -56,11 +57,11 @@ struct SendableSdl(Sdl);
 // into. The event pump is created and used exclusively on the spawned thread.
 unsafe impl Send for SendableSdl {}
 
-struct SendableEventPump(sdl2::EventPump);
+struct SendableEventPump(sdl3::EventPump);
 unsafe impl Send for SendableEventPump {}
 
 impl std::ops::Deref for SendableEventPump {
-    type Target = sdl2::EventPump;
+    type Target = sdl3::EventPump;
     fn deref(&self) -> &Self::Target {
         &self.0
     }
@@ -121,7 +122,8 @@ impl InputSource for EmulatorInputSource {
         if let Some(sendable_sdl) = self.sdl_context.take() {
             let hub = hub.clone();
             let sender = device_tx;
-            let mut event_pump = SendableEventPump(sendable_sdl.0.event_pump().unwrap());
+            let mut event_pump =
+                SendableEventPump(sendable_sdl.0.event_pump().expect("SDL3 event pump failed"));
             std::thread::spawn(move || {
                 'outer: loop {
                     while let Some(sdl_evt) = event_pump.poll_event() {
@@ -193,8 +195,8 @@ impl InputSource for EmulatorInputSource {
                                     }
                                     Scancode::I | Scancode::O => {
                                         let mouse_state = event_pump.mouse_state();
-                                        let x = mouse_state.x();
-                                        let y = mouse_state.y();
+                                        let x = mouse_state.x() as i32;
+                                        let y = mouse_state.y() as i32;
                                         let center = pt!(x, y);
                                         if scancode == Scancode::I {
                                             hub.send(Event::Gesture(GestureEvent::Spread {
@@ -272,6 +274,10 @@ impl InputSource for EmulatorInputSource {
 ///
 /// Rotation is unsupported: [`Framebuffer::rotation`] always returns
 /// [`DEFAULT_ROTATION`] and [`Framebuffer::set_rotation`] is a no-op.
+///
+/// The canvas must use SDL's software renderer: accelerated backends clear
+/// undefined regions on partial presents, so the UI goes black between
+/// updates that only redraw part of the framebuffer.
 pub struct FBCanvas(pub WindowCanvas);
 
 unsafe impl Send for FBCanvas {}
@@ -297,7 +303,7 @@ impl Framebuffer for FBCanvas {
     fn invert_region(&mut self, rect: &Rectangle) {
         let width = rect.width();
         let s_rect = Some(SdlRect::new(rect.min.x, rect.min.y, width, rect.height()));
-        if let Ok(data) = self.0.read_pixels(s_rect, PixelFormatEnum::RGB24) {
+        if let Ok(data) = read_rgb24_pixels(&self.0, s_rect) {
             for y in rect.min.y..rect.max.y {
                 let v = (y - rect.min.y) as u32;
                 for x in rect.min.x..rect.max.x {
@@ -317,7 +323,7 @@ impl Framebuffer for FBCanvas {
     fn shift_region(&mut self, rect: &Rectangle, drift: u8) {
         let width = rect.width();
         let s_rect = Some(SdlRect::new(rect.min.x, rect.min.y, width, rect.height()));
-        if let Ok(data) = self.0.read_pixels(s_rect, PixelFormatEnum::RGB24) {
+        if let Ok(data) = read_rgb24_pixels(&self.0, s_rect) {
             for y in rect.min.y..rect.max.y {
                 let v = (y - rect.min.y) as u32;
                 for x in rect.min.x..rect.max.x {
@@ -353,10 +359,7 @@ impl Framebuffer for FBCanvas {
         let mut writer = encoder
             .write_header()
             .with_context(|| format!("can't write PNG header for {}", path))?;
-        let data = self
-            .0
-            .read_pixels(self.0.viewport(), PixelFormatEnum::RGB24)
-            .unwrap_or_default();
+        let data = read_rgb24_pixels(&self.0, Some(self.0.viewport())).unwrap_or_default();
         writer
             .write_image_data(&data)
             .with_context(|| format!("can't write PNG data to {}", path))?;
@@ -409,16 +412,11 @@ pub struct EmulatorDevice {
 
 impl Default for EmulatorDevice {
     fn default() -> Self {
-        let sdl_context = sdl2::init().unwrap();
-        let video_subsystem = sdl_context.video().unwrap();
-
-        let window = video_subsystem
-            .window("Cadmus Emulator", EMULATOR_WIDTH, EMULATOR_HEIGHT)
-            .position_centered()
-            .build()
-            .unwrap();
-        let canvas = window.into_canvas().software().build().unwrap();
-
+        let sdl_context = sdl3::init().expect("SDL3 init failed");
+        let video_subsystem = sdl_context
+            .video()
+            .expect("SDL3 video subsystem init failed");
+        let canvas = create_emulator_canvas(&video_subsystem);
         Self::from_sdl_canvas(canvas, sdl_context)
     }
 }
@@ -679,8 +677,49 @@ impl DeviceLifecycle for EmulatorDevice {
 }
 
 #[inline]
-fn seconds(timestamp: u32) -> f64 {
-    timestamp as f64 / 1000.0
+fn seconds(timestamp: u64) -> f64 {
+    timestamp as f64 / 1_000_000_000.0
+}
+
+fn build_emulator_window(video: &VideoSubsystem) -> sdl3::video::Window {
+    video
+        .window("Cadmus Emulator", EMULATOR_WIDTH, EMULATOR_HEIGHT)
+        .position_centered()
+        .build()
+        .expect("SDL3 window creation failed")
+}
+
+/// Build the emulator canvas with SDL's software renderer.
+///
+/// Accelerated renderers clear undefined regions when only part of the
+/// framebuffer is presented, which blanks the UI during Cadmus's partial
+/// update path. Software rendering preserves prior pixels across those
+/// presents.
+fn create_emulator_canvas(video: &VideoSubsystem) -> WindowCanvas {
+    let window = build_emulator_window(video);
+    let canvas = create_renderer(window, Some(c"software"))
+        .unwrap_or_else(|err| panic!("SDL3 software renderer creation failed: {err}"));
+    tracing::debug!(
+        renderer = %canvas.renderer_name,
+        "using SDL3 software renderer"
+    );
+    canvas
+}
+
+fn read_rgb24_pixels(canvas: &WindowCanvas, rect: Option<SdlRect>) -> Result<Vec<u8>, sdl3::Error> {
+    let surface = canvas.read_pixels(rect)?;
+    let converted = surface.convert_format(PixelFormat::RGB24)?;
+    let width = converted.width() as usize;
+    let height = converted.height() as usize;
+    let pitch = converted.pitch() as usize;
+    Ok(converted.with_lock(|pixels| {
+        let mut tightly_packed = Vec::with_capacity(width * height * 3);
+        for row in 0..height {
+            let start = row * pitch;
+            tightly_packed.extend_from_slice(&pixels[start..start + width * 3]);
+        }
+        tightly_packed
+    }))
 }
 
 pub fn device_event(event: SdlEvent) -> Option<DeviceEvent> {
@@ -690,7 +729,7 @@ pub fn device_event(event: SdlEvent) -> Option<DeviceEvent> {
         } => Some(DeviceEvent::Finger {
             id: 0,
             status: FingerStatus::Down,
-            position: pt!(x, y),
+            position: pt!(x as i32, y as i32),
             time: seconds(timestamp),
         }),
         SdlEvent::MouseButtonUp {
@@ -698,7 +737,7 @@ pub fn device_event(event: SdlEvent) -> Option<DeviceEvent> {
         } => Some(DeviceEvent::Finger {
             id: 0,
             status: FingerStatus::Up,
-            position: pt!(x, y),
+            position: pt!(x as i32, y as i32),
             time: seconds(timestamp),
         }),
         SdlEvent::MouseMotion {
@@ -706,7 +745,7 @@ pub fn device_event(event: SdlEvent) -> Option<DeviceEvent> {
         } => Some(DeviceEvent::Finger {
             id: 0,
             status: FingerStatus::Motion,
-            position: pt!(x, y),
+            position: pt!(x as i32, y as i32),
             time: seconds(timestamp),
         }),
         _ => None,

--- a/devenv.nix
+++ b/devenv.nix
@@ -331,7 +331,7 @@ in
     pkgs.harfbuzz
 
     # Emulator dependency
-    pkgs.SDL2
+    pkgs.sdl3
 
     # Native build dependencies (development headers)
     pkgs.zlib
@@ -370,7 +370,21 @@ in
     # GCC - on macOS we use clang from Xcode
     pkgs.gcc
 
-    # This seems to be borken on macos
+    # SDL3 runtime backends (Wayland / X11 / GL)
+    pkgs.libGL
+    pkgs.libglvnd
+    pkgs.mesa
+    pkgs.wayland
+    pkgs.libxkbcommon
+    pkgs.libdecor
+    pkgs.xorg.libX11
+    pkgs.xorg.libXext
+    pkgs.xorg.libXcursor
+    pkgs.xorg.libXi
+    pkgs.xorg.libXrandr
+    pkgs.xorg.libXfixes
+    pkgs.xorg.libXrender
+    pkgs.vulkan-loader
   ]
   # macOS-specific packages
   ++ pkgs.lib.optionals isDarwin [

--- a/xtask/src/tasks/ci/clippy_report.rs
+++ b/xtask/src/tasks/ci/clippy_report.rs
@@ -4,7 +4,7 @@
 //! ## How it fits into CI
 //!
 //! The `clippy` matrix job runs `cargo xtask clippy --save-json <file>` for
-//! every feature label on `ubuntu-latest`, uploading each file as a GitHub
+//! every feature label on `ubuntu-26.04`, uploading each file as a GitHub
 //! Actions artifact.  After the matrix completes, the `clippy-report` job
 //! downloads all artifacts into a single directory and calls:
 //!

--- a/xtask/src/tasks/ci/matrix.rs
+++ b/xtask/src/tasks/ci/matrix.rs
@@ -7,8 +7,8 @@
 //! - `test-matrix` — feature entries for ubuntu test jobs
 //!
 //! ```text
-//! matrix={"include":[{"label":"default","features":"","os":"ubuntu-latest"},…]}
-//! test-matrix={"include":[{"label":"default","features":"","os":"ubuntu-latest"},…]}
+//! matrix={"include":[{"label":"default","features":"","os":"ubuntu-26.04"},…]}
+//! test-matrix={"include":[{"label":"default","features":"","os":"ubuntu-26.04"},…]}
 //! ```
 //!
 //! ## Usage in a workflow

--- a/xtask/src/tasks/util/matrix.rs
+++ b/xtask/src/tasks/util/matrix.rs
@@ -16,7 +16,11 @@ use anyhow::{Context, Result};
 use serde::Serialize;
 
 /// Operating systems included in the CI clippy matrix.
-pub const CI_CLIPPY_OS: &[&str] = &["ubuntu-latest"];
+///
+/// `libsdl3-dev` is unavailable on Ubuntu 24.04 (`ubuntu-latest`); match the
+/// Cursor Cloud Dockerfile and use Ubuntu 26.04 for native Linux builds.
+pub const CI_LINUX_OS: &str = "ubuntu-26.04";
+pub const CI_CLIPPY_OS: &[&str] = &[CI_LINUX_OS];
 
 /// One entry in the feature × OS matrix.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
@@ -26,7 +30,7 @@ pub struct MatrixEntry {
     /// Comma-separated feature list passed to `--features`, or empty for the
     /// default build.
     pub features: String,
-    /// GitHub Actions runner OS (e.g. `ubuntu-latest`, `macos-latest`).
+    /// GitHub Actions runner OS (e.g. `ubuntu-26.04`, `macos-latest`).
     pub os: String,
 }
 
@@ -76,7 +80,7 @@ pub fn scan(root: &Path, os_list: &[&str]) -> Result<Vec<MatrixEntry>> {
 /// without relying on matrix cross-product behavior:
 ///
 /// ```json
-/// {"include": [{"label": "default", "features": "", "os": "ubuntu-latest"}, ...]}
+/// {"include": [{"label": "default", "features": "", "os": "ubuntu-26.04"}, ...]}
 /// ```
 ///
 /// # Errors
@@ -97,7 +101,7 @@ pub fn to_github_test_matrix_json(entries: &[MatrixEntry]) -> Result<String> {
 
     let include: Vec<TestEntry<'_>> = entries
         .iter()
-        .filter(|e| e.os == "ubuntu-latest")
+        .filter(|e| e.os == CI_LINUX_OS)
         .map(|e| TestEntry {
             label: &e.label,
             features: &e.features,
@@ -304,7 +308,7 @@ mod tests {
     use super::*;
     use crate::tasks::util::workspace;
 
-    const ONE_OS: &[&str] = &["ubuntu-latest"];
+    const ONE_OS: &[&str] = &[CI_LINUX_OS];
 
     #[test]
     fn build_matrix_empty_features_yields_one_entry_per_os() {
@@ -313,7 +317,7 @@ mod tests {
         assert!(entries.iter().all(|e| e.label == "default"));
         assert!(entries.iter().all(|e| e.features.is_empty()));
         let oses: Vec<&str> = entries.iter().map(|e| e.os.as_str()).collect();
-        assert!(oses.contains(&"ubuntu-latest"));
+        assert!(oses.contains(&CI_LINUX_OS));
     }
 
     #[test]
@@ -386,7 +390,7 @@ mod tests {
         let entry = MatrixEntry {
             label: "default".to_owned(),
             features: String::new(),
-            os: "ubuntu-latest".to_owned(),
+            os: CI_LINUX_OS.to_owned(),
         };
         assert_eq!(entry.cargo_args(), vec!["--workspace"]);
     }
@@ -396,7 +400,7 @@ mod tests {
         let entry = MatrixEntry {
             label: "test + tracing".to_owned(),
             features: "test,tracing".to_owned(),
-            os: "ubuntu-latest".to_owned(),
+            os: CI_LINUX_OS.to_owned(),
         };
         assert_eq!(
             entry.cargo_args(),
@@ -414,12 +418,12 @@ mod tests {
         let entries = vec![MatrixEntry {
             label: "default".to_owned(),
             features: String::new(),
-            os: "ubuntu-latest".to_owned(),
+            os: CI_LINUX_OS.to_owned(),
         }];
         let json = to_github_matrix_json(&entries).unwrap();
         assert!(json.contains("\"include\""));
         assert!(json.contains("\"default\""));
-        assert!(json.contains("\"ubuntu-latest\""));
+        assert!(json.contains(&format!("\"{CI_LINUX_OS}\"")));
     }
 
     #[test]


### PR DESCRIPTION
Fedora/non-NixOS devenv could not create an SDL renderer because pkgs.SDL2 was sdl2-compat without GL/Wayland/X11 libs (#855).

- Replace sdl2 crate with sdl3 (default renderer, software fallback)
- Ship pkgs.sdl3 plus Linux graphics packages in devenv
- Update CI apt/brew and contributor docs

Closes: CAD-137

Change-Id: 9a9bbb96856f95728af6630851a39718
Change-Id-Short: qpqoooqtrutk