### PR TITLE
ci: write cargo cache warmup only on push

### DIFF
--- a/.github/actions/cargo-cache-warmup/action.yml
+++ b/.github/actions/cargo-cache-warmup/action.yml
@@ -1,0 +1,125 @@
+name: Cargo cache warmup
+description: >
+  Warm Cargo build artifacts and save the shared caches used by Cargo CI.
+  Intended for push runs only; pull requests should no-op at the job level and
+  restore caches written on the default/base branch.
+
+inputs:
+  gh-token:
+    description: "GitHub token for downloading assets and font releases"
+    required: true
+  nextest-version:
+    description: "cargo-nextest version pin (e.g. 0.9.143)"
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
+      id: rust-toolchain
+      with:
+        targets: arm-unknown-linux-gnueabihf
+        components: llvm-tools
+
+    - name: Install apt packages
+      uses: ./.github/actions/apt
+
+    - name: Cache Linaro toolchain
+      id: cache-linaro
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      with:
+        path: ~/linaro-toolchain
+        key: linaro-gcc-4.9.4-2017.01
+
+    - name: Download Linaro toolchain
+      if: steps.cache-linaro.outputs.cache-hit != 'true'
+      shell: bash
+      run: |
+        mkdir -p ~/linaro-toolchain
+        cd ~/linaro-toolchain
+        wget -q https://developer.arm.com/-/cdn-downloads/permalink/legacy-linaro-gnu-toolchains/4.9-2017.01/gcc-linaro-4.9.4-2017.01-x86_64_arm-linux-gnueabihf.tar.xz
+        tar xf gcc-linaro-4.9.4-2017.01-x86_64_arm-linux-gnueabihf.tar.xz --strip-components=1
+        rm gcc-linaro-4.9.4-2017.01-x86_64_arm-linux-gnueabihf.tar.xz
+
+    - name: Setup Linaro toolchain
+      shell: bash
+      run: echo "$HOME/linaro-toolchain/bin" >> "$GITHUB_PATH"
+
+    - name: Cache shared cargo artifacts
+      id: cache
+      uses: ./.github/actions/cargo-cache
+      with:
+        cachekey: ${{ steps.rust-toolchain.outputs.cachekey }}
+        mode: save
+
+    - name: Install cargo-nextest
+      uses: taiki-e/install-action@91ddec75689c4c78665b598d188dc821c5a43e5c # v2.85.9
+      with:
+        tool: nextest@${{ inputs.nextest-version }}
+
+    - name: Cache cargo-llvm-cov
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      id: cargo-llvm-cov-cache
+      with:
+        path: ~/.cargo/bin/cargo-llvm-cov
+        key: ${{ runner.os }}-cargo-llvm-cov
+
+    - name: Install cargo-llvm-cov
+      if: steps.cargo-llvm-cov-cache.outputs.cache-hit != 'true'
+      uses: taiki-e/install-action@eba66cc6f87204a1e73f96e528e759b6c1fcf573 # cargo-llvm-cov
+
+    - name: Cache bundled fonts
+      uses: ./.github/actions/cache-fonts
+      with:
+        mode: save
+        gh-token: ${{ inputs.gh-token }}
+
+    - name: Download documentation EPUB
+      if: steps.cache.outputs.cache-hit != 'true'
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+      with:
+        name: docs-epub
+        path: docs/book/epub
+
+    - name: Cache Plato static assets
+      if: steps.cache.outputs.cache-hit != 'true'
+      uses: ./.github/actions/cache-assets
+
+    - name: Download static assets
+      if: steps.cache.outputs.cache-hit != 'true'
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.gh-token }}
+      run: cargo xtask download-assets
+
+    - name: Build SQLite from source
+      if: steps.cache.outputs.cache-hit != 'true'
+      shell: bash
+      run: cargo xtask setup
+
+    - name: Warmup build (native)
+      if: steps.cache.outputs.cache-hit != 'true'
+      shell: bash
+      run: |
+        cargo check --workspace --features emulator,test,telemetry
+        cargo check --workspace --features kobo,test,telemetry
+        cargo check --workspace --features deviceless
+
+    - name: Warmup llvm-cov build
+      if: steps.cache.outputs.cache-hit != 'true'
+      shell: bash
+      run: |
+        for features in emulator kobo deviceless; do
+          cargo llvm-cov nextest-archive \
+            --workspace --all-targets \
+            --features "$features" \
+            --archive-file "target/llvm-cov-warmup-${features}.tar.zst"
+          rm -f "target/llvm-cov-warmup-${features}.tar.zst"
+        done
+
+    - name: Warmup build (Kobo release)
+      if: steps.cache.outputs.cache-hit != 'true'
+      shell: bash
+      run: |
+        cargo build --release --target arm-unknown-linux-gnueabihf -p cadmus --features kobo
+        cargo build --release --target arm-unknown-linux-gnueabihf -p cadmus --features kobo,test

--- a/.github/workflows/cadmus-docs.yml
+++ b/.github/workflows/cadmus-docs.yml
@@ -78,15 +78,15 @@ jobs:
             echo "GIT_VERSION=$(git describe --tags --always)"
           } >> "$GITHUB_ENV"
 
-      - name: Install doc tools
-        uses: ./.github/actions/install-doc-tools
-        with:
-          node-version: ${{ env.NODE_VERSION }}
-
       - uses: ./.github/actions/cargo-cache
         with:
           cachekey: ${{ steps.rust-toolchain.outputs.cachekey }}
           mode: restore
+
+      - name: Install doc tools
+        uses: ./.github/actions/install-doc-tools
+        with:
+          node-version: ${{ env.NODE_VERSION }}
 
       - name: Build documentation portal
         env:

--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -43,6 +43,7 @@ jobs:
               - '.github/actions/build-kobo/**'
               - '.github/actions/build-docs-epub/**'
               - '.github/actions/cargo-cache/**'
+              - '.github/actions/cargo-cache-warmup/**'
               - '.github/actions/cache-fonts/**'
               - '.github/actions/install-doc-tools/**'
               - 'build-scripts/**'
@@ -68,6 +69,14 @@ jobs:
         uses: ./.github/actions/cargo-cache
         with:
           cachekey: ${{ steps.rust-toolchain.outputs.cachekey }}
+      - &set-build-metadata
+        name: Set build metadata
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            echo "PR_NUMBER=${{ github.event.pull_request.number }}" >> "$GITHUB_ENV"
+            echo "PR_HEAD_SHA=${{ github.event.pull_request.head.sha }}" >> "$GITHUB_ENV"
+          fi
+          echo "GIT_VERSION=$(git describe --tags --dirty --always)" >> "$GITHUB_ENV"
       - name: Check formatting
         run: cargo xtask fmt
 
@@ -122,108 +131,26 @@ jobs:
       contents: read
     runs-on: ubuntu-latest
     steps:
+      # PRs restore shared caches from the default/base branch; only push writes.
+      - name: Skip cache write on pull requests
+        if: github.event_name == 'pull_request'
+        run: echo "PRs restore the shared cargo cache from the default/base branch; warmup writes only on push."
+
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        if: github.event_name != 'pull_request'
         with:
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
-        id: rust-toolchain
-        with:
-          targets: arm-unknown-linux-gnueabihf
-          components: llvm-tools
 
-      - &set-build-metadata
-        name: Set build metadata
-        run: |
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            echo "PR_NUMBER=${{ github.event.pull_request.number }}" >> "$GITHUB_ENV"
-            echo "PR_HEAD_SHA=${{ github.event.pull_request.head.sha }}" >> "$GITHUB_ENV"
-          fi
-          echo "GIT_VERSION=$(git describe --tags --dirty --always)" >> "$GITHUB_ENV"
+      - name: Set build metadata
+        if: github.event_name != 'pull_request'
+        run: echo "GIT_VERSION=$(git describe --tags --dirty --always)" >> "$GITHUB_ENV"
 
-      - name: Install apt packages
-        uses: ./.github/actions/apt
-      - name: Cache Linaro toolchain
-        id: cache-linaro
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      - name: Warm and save shared caches
+        if: github.event_name != 'pull_request'
+        uses: ./.github/actions/cargo-cache-warmup
         with:
-          path: ~/linaro-toolchain
-          key: linaro-gcc-4.9.4-2017.01
-      - name: Download Linaro toolchain
-        if: steps.cache-linaro.outputs.cache-hit != 'true'
-        run: |
-          mkdir -p ~/linaro-toolchain
-          cd ~/linaro-toolchain
-          wget -q https://developer.arm.com/-/cdn-downloads/permalink/legacy-linaro-gnu-toolchains/4.9-2017.01/gcc-linaro-4.9.4-2017.01-x86_64_arm-linux-gnueabihf.tar.xz
-          tar xf gcc-linaro-4.9.4-2017.01-x86_64_arm-linux-gnueabihf.tar.xz --strip-components=1
-          rm gcc-linaro-4.9.4-2017.01-x86_64_arm-linux-gnueabihf.tar.xz
-      - name: Setup Linaro toolchain
-        run: echo "$HOME/linaro-toolchain/bin" >> "$GITHUB_PATH"
-      - name: Cache shared cargo artifacts
-        id: cache
-        uses: ./.github/actions/cargo-cache
-        with:
-          cachekey: ${{ steps.rust-toolchain.outputs.cachekey }}
-          mode: save
-
-      - name: Install cargo-nextest
-        uses: taiki-e/install-action@91ddec75689c4c78665b598d188dc821c5a43e5c # v2.85.9
-        with:
-          tool: nextest@${{ env.NEXTEST_VERSION }}
-
-      - name: Cache cargo-llvm-cov
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        id: cargo-llvm-cov-cache
-        with:
-          path: ~/.cargo/bin/cargo-llvm-cov
-          key: ${{ runner.os }}-cargo-llvm-cov
-
-      - name: Install cargo-llvm-cov
-        if: steps.cargo-llvm-cov-cache.outputs.cache-hit != 'true'
-        uses: taiki-e/install-action@eba66cc6f87204a1e73f96e528e759b6c1fcf573 # cargo-llvm-cov
-
-      - name: Cache bundled fonts
-        uses: ./.github/actions/cache-fonts
-        with:
-          mode: save
           gh-token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Download documentation EPUB
-        if: steps.cache.outputs.cache-hit != 'true'
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
-        with:
-          name: docs-epub
-          path: docs/book/epub
-      - name: Cache Plato static assets
-        if: steps.cache.outputs.cache-hit != 'true'
-        uses: ./.github/actions/cache-assets
-      - name: Download static assets
-        if: steps.cache.outputs.cache-hit != 'true'
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: cargo xtask download-assets
-      - name: Build SQLite from source
-        if: steps.cache.outputs.cache-hit != 'true'
-        run: cargo xtask setup
-      - name: Warmup build (native)
-        if: steps.cache.outputs.cache-hit != 'true'
-        run: |
-          cargo check --workspace --features emulator,test,telemetry
-          cargo check --workspace --features kobo,test,telemetry
-          cargo check --workspace --features deviceless
-      - name: Warmup llvm-cov build
-        if: steps.cache.outputs.cache-hit != 'true'
-        run: |
-          for features in emulator kobo deviceless; do
-            cargo llvm-cov nextest-archive \
-              --workspace --all-targets \
-              --features "$features" \
-              --archive-file "target/llvm-cov-warmup-${features}.tar.zst"
-            rm -f "target/llvm-cov-warmup-${features}.tar.zst"
-          done
-      - name: Warmup build (Kobo release)
-        if: steps.cache.outputs.cache-hit != 'true'
-        run: |
-          cargo build --release --target arm-unknown-linux-gnueabihf -p cadmus --features kobo
-          cargo build --release --target arm-unknown-linux-gnueabihf -p cadmus --features kobo,test
+          nextest-version: ${{ env.NEXTEST_VERSION }}
 
   clippy:
     if: github.event_name == 'pull_request' && needs.changes.outputs.cargo == 'true'
@@ -365,15 +292,15 @@ jobs:
         if: runner.os == 'macOS'
         run: brew install sdl2 freetype harfbuzz openjpeg jpeg-turbo libpng jbig2dec gumbo-parser djvulibre pkg-config
 
-      - name: Restore bundled fonts
-        uses: ./.github/actions/cache-fonts
-        with:
-          gh-token: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Restore shared cargo cache
         uses: ./.github/actions/cargo-cache
         with:
           cachekey: ${{ steps.rust-toolchain.outputs.cachekey }}
+
+      - name: Restore bundled fonts
+        uses: ./.github/actions/cache-fonts
+        with:
+          gh-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install cargo-nextest
         uses: taiki-e/install-action@91ddec75689c4c78665b598d188dc821c5a43e5c # v2.85.9


### PR DESCRIPTION
PRs no-op cache-warmup and restore from the default/base branch cache, cutting the serial warm gate and PR-scoped cache churn.

Change-Id: d7d422d0a75a7aba876420b46c839d41
Change-Id-Short: msmvxxmzpsup

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only workflow changes with no application code; PRs may see slightly colder caches until base-branch push warms them.
> 
> **Overview**
> **Pull requests no longer run the heavy Cargo cache warmup.** The `cache-warmup` job still exists for downstream `needs` wiring, but on PRs it only logs that caches are restored from the default branch; checkout, Linaro/toolchain setup, and compile warmup run **only on push**.
> 
> Warmup logic moves into a new composite action **`.github/actions/cargo-cache-warmup`** (same steps as before: shared `cargo-cache` save, fonts/assets, `cargo check` / llvm-cov / Kobo release builds). The `cargo` path filter now includes that action.
> 
> Minor workflow tweaks: **`format`** defines the shared `set-build-metadata` anchor; **`cadmus-docs`** restores the Cargo cache before installing doc tools; **`test`** restores bundled fonts after the shared Cargo cache.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit db15600e07c7c8c933d62060df1498d9987c190d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->