### PR TITLE
dev(cursor): detect libclang path and bootstrap emulator assets

### DIFF
--- a/.cursor/CLOUD.md
+++ b/.cursor/CLOUD.md
@@ -8,7 +8,7 @@ Applies only to Cursor Cloud agents. Coding conventions and testing policy:
 | File                                                                        | Role                                                                                                                                                                                                           |
 | --------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | [.cursor/Dockerfile](Dockerfile)                                            | Baked Ubuntu image: apt (incl. clang/gettext), rustup, Linaro, mdbook/mdbook-epub/mdbook-mermaid, cargo-nextest, Node. `ENV` pins match CI (`MDBOOK_*`, `NEXTEST_VERSION`, `NODE_VERSION`). No project `COPY`. |
-| [.cursor/cloud-install.sh](cloud-install.sh)                                | Idempotent install on each agent boot: submodules, `cargo xtask ci install-doc-tools`, `cargo xtask setup --host`, `npm ci`, EPUB if missing, `cargo fetch`, `~/.bashrc` exports.                              |
+| [.cursor/cloud-install.sh](cloud-install.sh)                                | Idempotent install on each agent boot: submodules, `cargo xtask ci install-doc-tools`, `cargo xtask setup --host`, Plato assets and fonts when missing, `npm ci`, EPUB if missing, `cargo fetch`, `~/.bashrc` exports. |
 | [.cursor/environment.json](environment.json)                                | Wires Dockerfile build (`context: ..`) and `install`; `agentCanUpdateSnapshot` lets setup agents promote snapshots.                                                                                            |
 | [.cursor/verify-cloud-install.sh](verify-cloud-install.sh)                  | Post-install assertions (used by CI).                                                                                                                                                                          |
 | [.github/workflows/cursor-cloud.yml](../.github/workflows/cursor-cloud.yml) | Path-filtered CI: `check-jsonschema`, `docker build`, `container-structure-test`, `cloud-install` + verify.                                                                                                    |
@@ -28,7 +28,7 @@ Exported in `~/.bashrc` (managed by cloud-install) — re-source in non-login sh
 
 - `CADMUS_ROOT`, `SQLITE3_STATIC=1`, `SQLITE3_LIB_DIR`, `SQLITE3_INCLUDE_DIR`
 - `PKG_CONFIG_PATH_x86_64_unknown_linux_gnu`, `PKG_CONFIG_PATH_arm_unknown_linux_gnueabihf`
-- `SQLX_OFFLINE=true`, `PKG_CONFIG_ALLOW_CROSS=1`, `LIBCLANG_PATH=/usr/lib/llvm-18/lib`
+- `SQLX_OFFLINE=true`, `PKG_CONFIG_ALLOW_CROSS=1`, `LIBCLANG_PATH` (detected via [libclang-path.sh](libclang-path.sh); matches CI apt action logic)
 - `DISPLAY=:1`
 - `PATH` includes `/home/ubuntu/.local/bin`, `/home/ubuntu/linaro-toolchain/bin`, `/usr/local/cargo/bin`
 
@@ -49,7 +49,8 @@ If a fresh snapshot fails to compile, see the relevant skill:
 
 - Custom SQLite: `cargo xtask setup --host` (cloud-install runs this; rerun manually if needed)
 - EPUB: `build-cadmus-native` skill (`cargo xtask docs --mdbook-only`)
-- Kobo assets: `cargo xtask download-assets` if `bin/`, `resources/`, `hyphenation-patterns/` are missing (not part of cloud-install)
+- Plato assets: `cargo xtask download-assets` if `bin/`, `resources/`, or `hyphenation-patterns/` are missing (cloud-install fetches these on first boot)
+- Fonts: `cargo xtask download-fonts` (cloud-install runs this; rerun manually if `fonts/` is incomplete)
 
 ## Emulator
 

--- a/.cursor/Dockerfile
+++ b/.cursor/Dockerfile
@@ -68,8 +68,6 @@ RUN apt-get update \
         zlib1g-dev \
     && rm -rf /var/lib/apt/lists/*
 
-ENV LIBCLANG_PATH=/usr/lib/llvm-18/lib
-
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
         | sh -s -- -y --no-modify-path --default-toolchain stable \
     && rustup target add arm-unknown-linux-gnueabihf \
@@ -116,5 +114,10 @@ RUN export HOME=/home/ubuntu NVM_DIR=/home/ubuntu/.nvm \
     && ln -sf "$(dirname "$node_path")/npx" /home/ubuntu/.local/bin/npx
 
 RUN chown -R ubuntu:ubuntu /home/ubuntu
+
+COPY .cursor/libclang-path.sh /usr/local/bin/cadmus-libclang-path.sh
+RUN chmod +x /usr/local/bin/cadmus-libclang-path.sh \
+    && LIBCLANG_PATH="$(/usr/local/bin/cadmus-libclang-path.sh)" \
+    && printf 'export LIBCLANG_PATH=%s\n' "$LIBCLANG_PATH" > /etc/profile.d/cadmus-libclang.sh
 
 WORKDIR /workspace

--- a/.cursor/cloud-install.sh
+++ b/.cursor/cloud-install.sh
@@ -22,6 +22,12 @@ cargo xtask ci install-doc-tools \
 
 cargo xtask setup --host
 
+LIBCLANG_PATH="$(bash "${ROOT}/.cursor/libclang-path.sh")"
+export LIBCLANG_PATH
+
+cargo xtask download-assets
+cargo xtask download-fonts
+
 HOST_TRIPLE="$(rustc -vV | sed -n 's/^host: //p')"
 
 if [[ -f package-lock.json ]]; then
@@ -39,11 +45,11 @@ BASHRC="${HOME}/.bashrc"
 MARKER_START="# >>> cadmus-cloud-env >>>"
 MARKER_END="# <<< cadmus-cloud-env <<<"
 
-python3 - "$BASHRC" "$MARKER_START" "$MARKER_END" "$ROOT" "$HOST_TRIPLE" <<'PY'
+python3 - "$BASHRC" "$MARKER_START" "$MARKER_END" "$ROOT" "$HOST_TRIPLE" "$LIBCLANG_PATH" <<'PY'
 import pathlib
 import sys
 
-bashrc, start, end, root, host_triple = sys.argv[1:6]
+bashrc, start, end, root, host_triple, libclang_path = sys.argv[1:7]
 path = pathlib.Path(bashrc)
 block = f"""{start}
 # Managed by .cursor/cloud-install.sh — do not edit manually.
@@ -55,7 +61,7 @@ export PKG_CONFIG_PATH_x86_64_unknown_linux_gnu="{root}/target/cadmus-build-deps
 export PKG_CONFIG_PATH_arm_unknown_linux_gnueabihf="{root}/target/cadmus-build-deps/arm-unknown-linux-gnueabihf/sqlite/lib/pkgconfig"
 export SQLX_OFFLINE=true
 export PKG_CONFIG_ALLOW_CROSS=1
-export LIBCLANG_PATH=/usr/lib/llvm-18/lib
+export LIBCLANG_PATH="{libclang_path}"
 export DISPLAY=:1
 export PUPPETEER_ARGS="--no-sandbox --disable-setuid-sandbox"
 export CADMUS_HOME="/home/ubuntu"

--- a/.cursor/container-structure-test.yaml
+++ b/.cursor/container-structure-test.yaml
@@ -6,16 +6,20 @@ metadataTest:
       value: "true"
     - key: PKG_CONFIG_ALLOW_CROSS
       value: "1"
-    - key: LIBCLANG_PATH
-      value: "/usr/lib/llvm-18/lib"
 
 fileExistenceTests:
+  - name: cadmus-libclang-path
+    path: /usr/local/bin/cadmus-libclang-path.sh
+    shouldExist: true
+    permissions: "-rwxr-xr-x"
   - name: linaro-arm-gcc
     path: /home/ubuntu/linaro-toolchain/bin/arm-linux-gnueabihf-gcc
     shouldExist: true
     permissions: "-rwxr-xr-x"
 
 commandTests:
+  - name: libclang-path
+    command: /usr/local/bin/cadmus-libclang-path.sh
   - name: rustc
     command: rustc
     args: ["--version"]

--- a/.cursor/libclang-path.sh
+++ b/.cursor/libclang-path.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+libdir="$(llvm-config --libdir 2>/dev/null || true)"
+if [[ -z $libdir ]]; then
+  candidate="$(find /usr/lib \( -name 'libclang.so*' -o -name 'libclang-*.so*' \) 2>/dev/null | head -1)"
+  if [[ -n $candidate ]]; then
+    libdir="$(dirname "$candidate")"
+  fi
+fi
+
+if [[ -z $libdir || ! -d $libdir ]]; then
+  echo "Unable to locate libclang; install llvm/clang development packages or set LIBCLANG_PATH." >&2
+  exit 1
+fi
+
+echo "$libdir"

--- a/.cursor/verify-cloud-install.sh
+++ b/.cursor/verify-cloud-install.sh
@@ -10,6 +10,8 @@ export PATH="${CADMUS_HOME}/.local/bin:${CADMUS_HOME}/linaro-toolchain/bin:/usr/
 HOST_TRIPLE="$(rustc -vV | sed -n 's/^host: //p')"
 SQLITE_LIB="${ROOT}/target/cadmus-build-deps/${HOST_TRIPLE}/sqlite/lib/libsqlite3.a"
 EPUB_PATH="${ROOT}/docs/book/epub/Cadmus Documentation.epub"
+FONTS_DIR="${ROOT}/fonts"
+ASSET_DIRS=(bin resources hyphenation-patterns)
 
 for cmd in rustc cargo mdbook mdbook-epub mdbook-mermaid mdbook-gettext cargo-nextest node npm; do
   if ! command -v "$cmd" >/dev/null 2>&1; then
@@ -25,6 +27,24 @@ fi
 
 if [[ ! -f $EPUB_PATH ]]; then
   echo "missing documentation EPUB: $EPUB_PATH" >&2
+  exit 1
+fi
+
+if [[ ! -d $FONTS_DIR ]] || [[ -z "$(find "$FONTS_DIR" -maxdepth 1 -type f -name '*.ttf' -print -quit)" ]]; then
+  echo "missing bundled fonts in: $FONTS_DIR" >&2
+  exit 1
+fi
+
+for asset_dir in "${ASSET_DIRS[@]}"; do
+  if [[ ! -d "${ROOT}/${asset_dir}" ]]; then
+    echo "missing Plato asset directory: ${ROOT}/${asset_dir}" >&2
+    exit 1
+  fi
+done
+
+LIBCLANG_PATH="$(bash "${ROOT}/.cursor/libclang-path.sh")"
+if [[ ! -d $LIBCLANG_PATH ]] || [[ -z "$(find "$LIBCLANG_PATH" -maxdepth 1 \( -name 'libclang.so' -o -name 'libclang-*.so' \) -print -quit)" ]]; then
+  echo "missing libclang shared libraries in: $LIBCLANG_PATH" >&2
   exit 1
 fi
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes Cursor Cloud environment gaps encountered while capturing the PR #706 frontlight screenshot.

## Problems

1. **`LIBCLANG_PATH` was hardcoded to `/usr/lib/llvm-18/lib`**, but Ubuntu 26.04 ships LLVM 21 at `/usr/lib/llvm-21/lib`. This caused `libsqlite3-sys`/bindgen builds to fail unless agents manually exported a working path.
2. **Emulator startup required manual `download-assets` and `download-fonts`** — without them, `cargo run -p cadmus --features emulator` failed with `can't load fonts`.
3. **Non-login shells** still depend on sourcing `~/.bashrc`; the managed block now writes the detected libclang path instead of a stale hardcoded one.

## Changes

- Add `.cursor/libclang-path.sh` with the same detection logic as the CI apt action (`llvm-config --libdir`, falling back to `find`).
- Resolve and export `LIBCLANG_PATH` in `cloud-install.sh` and bake it into the managed `~/.bashrc` block.
- Bootstrap Plato assets (`download-assets`) and bundled fonts (`download-fonts`) during cloud-install.
- Update `verify-cloud-install.sh` to assert libclang, fonts, and asset directories exist.
- Replace the fixed `LIBCLANG_PATH` env assertion in `container-structure-test.yaml` with a runtime command test.
- Update `CLOUD.md` documentation.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-88cefca9-c110-4faa-9ed8-eab2987e0442?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-88cefca9-c110-4faa-9ed8-eab2987e0442&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

