### PR TITLE
docs: exclude contributing pages from POT regeneration

### DIFF
--- a/.agents/skills/translations-sync/SKILL.md
+++ b/.agents/skills/translations-sync/SKILL.md
@@ -1,11 +1,16 @@
 ---
 name: translations-sync
-description: Regenerate the translations POT file after modifying English documentation sources. Use when docs/src/**/*.md files are changed.
+description: Regenerate the translations POT file after modifying English user-facing documentation. Use when docs/src/**/*.md files outside contributing/ are changed. Skip when only docs/src/contributing/** changes.
 ---
 
 # Regenerate Translations POT File
 
-Run after modifying any English documentation source (`docs/src/**/*.md`).
+Run after modifying English **user-facing** documentation
+(`docs/src/**/*.md` outside `docs/src/contributing/`).
+
+Contributor docs under `docs/src/contributing/**` are wrapped in
+`<!-- i18n:skip-start -->` / `<!-- i18n:skip-end -->` and are not
+extracted, so they do not require a POT update.
 
 ## Command
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -246,17 +246,17 @@ misses `#[cfg(not(feature = "..."))]` paths.
 
 For workflows, load the matching skill from [`.agents/skills/`](.agents/skills/):
 
-| Skill                 | Use when                                                  |
-| --------------------- | --------------------------------------------------------- |
-| `build-cadmus-native` | Compile, test, lint, or run the emulator on a native host |
-| `build-kobo`          | Cross-compile for Kobo (ARM); required after code changes |
-| `fmt`                 | Check or apply rustfmt                                    |
-| `clippy-diff-report`  | Lint only the current diff (matches CI reviewdog)         |
-| `dependency-updater`  | Fix failed Renovate/Dependabot dependency PRs             |
-| `sqlx`                | Regenerate `.sqlx/` after query macro changes             |
-| `docs`                | Build or preview the documentation site                   |
-| `translations-sync`   | Regenerate the translations POT after doc edits           |
-| `fetch-cadmus-logs`   | Look up device logs in Loki by run ID                     |
+| Skill                 | Use when                                                    |
+| --------------------- | ----------------------------------------------------------- |
+| `build-cadmus-native` | Compile, test, lint, or run the emulator on a native host   |
+| `build-kobo`          | Cross-compile for Kobo (ARM); required after code changes   |
+| `fmt`                 | Check or apply rustfmt                                      |
+| `clippy-diff-report`  | Lint only the current diff (matches CI reviewdog)           |
+| `dependency-updater`  | Fix failed Renovate/Dependabot dependency PRs               |
+| `sqlx`                | Regenerate `.sqlx/` after query macro changes               |
+| `docs`                | Build or preview the documentation site                     |
+| `translations-sync`   | Regenerate the translations POT after user-facing doc edits |
+| `fetch-cadmus-logs`   | Look up device logs in Loki by run ID                       |
 
 ## Testing
 

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -22,6 +22,8 @@ workflow, setting category, install path, CLI/dev command, subsystem):
   [`docs/REVIEW.md`](docs/REVIEW.md).
 - **Contributor/dev** — add or extend page(s) under `docs/src/contributing/**`
   (and `SUMMARY.md`); follow tone in [`docs/AGENTS.md`](docs/AGENTS.md).
+  Wrap pages in `<!-- i18n:skip-start -->` / `<!-- i18n:skip-end -->`.
+  POT sync is not required for contributor-only changes.
 - Prefer extending an existing page when the change is a small addition to an
   existing topic. Add a new page when it is a distinct workflow users or
   contributors must discover.

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -40,6 +40,12 @@ Source: <https://rust-lang.github.io/mdBook/format/markdown.html?highlight=note#
 
 Audience: developers and contributors. Technical terminology is appropriate.
 
+Contributor pages are not translated. Wrap the entire page in
+`<!-- i18n:skip-start -->` / `<!-- i18n:skip-end -->` so extraction omits
+them from `docs/po/messages.pot`. POT regeneration is not required for
+changes confined to `docs/src/contributing/**`; see
+[`docs/REVIEW.md`](REVIEW.md).
+
 - Clear and direct — get to the point.
 - Include code examples where helpful.
 - Document setup steps precisely.

--- a/docs/REVIEW.md
+++ b/docs/REVIEW.md
@@ -2,16 +2,24 @@
 
 ## Translations POT Sync
 
-When any English doc source (`docs/src/**/*.md`) is modified — including **new**
-user-facing pages — the POT file must be regenerated. New user-facing pages must
+When any English **user-facing** doc source (`docs/src/**/*.md` outside
+`docs/src/contributing/`) is modified — including **new** user-facing
+pages — the POT file must be regenerated. New user-facing pages must
 also appear in `docs/src/SUMMARY.md`.
+
+Contributor docs under `docs/src/contributing/**` are wrapped in
+`<!-- i18n:skip-start -->` / `<!-- i18n:skip-end -->` markers and are not
+translated, so they are excluded from POT regeneration.
 
 ### Checklist
 
 - [ ] New user-facing pages are listed in `docs/src/SUMMARY.md`.
-- [ ] `docs/po/messages.pot` is updated in the same commit or PR.
+- [ ] `docs/po/messages.pot` is updated in the same commit or PR when
+      user-facing English docs change.
 - [ ] New or changed English strings appear in `messages.pot`.
 - [ ] Removed strings are no longer present in `messages.pot`.
+- [ ] Contributor-only changes under `docs/src/contributing/**` do not
+      include a POT update.
 
 ## devenv.nix Sync
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Contributor docs under `docs/src/contributing/**` are wrapped in `<!-- i18n:skip-start -->` / `<!-- i18n:skip-end -->`, so they are not extracted for translation.

`docs/REVIEW.md` previously said any `docs/src/**/*.md` change required a POT update. That caused review bots to flag contributor-only PRs (for example #882) for a missing `docs/po/messages.pot` change.

This PR states the exception in the agent and review checklists:

- `docs/REVIEW.md` — POT sync applies to user-facing English docs only
- `docs/AGENTS.md` — contributor pages must stay skip-wrapped and are not translated
- `REVIEW.md` / `AGENTS.md` — same rule for PR review and the `translations-sync` skill

No user-facing `docs/src` pages change, so no POT regeneration is required.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-188ff2b5-b677-456d-83af-0977ed45a36d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-188ff2b5-b677-456d-83af-0977ed45a36d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

