### PR TITLE
fix(rtc): clear alarms and release FDs on exit

### DIFF
--- a/crates/cadmus/src/app.rs
+++ b/crates/cadmus/src/app.rs
@@ -6,6 +6,7 @@ use cadmus_core::device::AppContext;
 use cadmus_core::device::AppDevice;
 use cadmus_core::device::DeviceHardware as _;
 use cadmus_core::device::DeviceRotation as _;
+use cadmus_core::device::rtc::shutdown_rtc;
 use cadmus_core::device::soft_suspend::SoftSuspendBackend as _;
 use cadmus_core::device::wifi::WifiManager;
 use cadmus_core::device::{
@@ -882,6 +883,8 @@ pub fn run() -> Result<(), Error> {
     let _shutdown_wake = context.soft_suspend_session.acquire("shutdown");
 
     background_tasks.stop_all();
+
+    shutdown_rtc(&context);
 
     let save_settings = match &exit_status {
         ExitStatus::Restart | ExitStatus::Reboot => !context.shared,

--- a/crates/core/src/device/kobo/lifecycle/mod.rs
+++ b/crates/core/src/device/kobo/lifecycle/mod.rs
@@ -259,6 +259,7 @@ mod suspend_tests;
 #[cfg(all(test, feature = "kobo"))]
 mod tests {
     use super::*;
+    use crate::device::rtc::{AlarmType, shutdown_rtc};
     use crate::device::test_harness::DeviceRuntimeHarness;
     use crate::device::wifi::{Essid, NetworkInfo};
     use crate::input::{ButtonCode, ButtonStatus, DeviceEvent};
@@ -405,5 +406,119 @@ mod tests {
             harness.context.soft_suspend_session.mode(),
             AutosleepMode::Off
         );
+    }
+
+    #[test]
+    fn on_shutdown_clears_scheduled_alarms_for_power_off() {
+        let mut harness = DeviceRuntimeHarness::new();
+        {
+            let mut alarms = harness
+                .context
+                .alarm_manager
+                .as_ref()
+                .unwrap()
+                .lock()
+                .unwrap();
+            alarms
+                .schedule_in(AlarmType::WakeDebounce, chrono::Duration::seconds(15))
+                .unwrap();
+            alarms
+                .schedule_in(AlarmType::AutoPowerOff, chrono::Duration::hours(1))
+                .unwrap();
+        }
+        let rtc = harness.context.device.rtc().unwrap();
+        let _ = std::fs::remove_file("/tmp/power_off");
+
+        harness.with_runtime_only(|context, runtime| {
+            shutdown_rtc(context);
+            Device::on_shutdown(context, ExitStatus::PowerOff, runtime).unwrap();
+        });
+
+        let alarms = harness
+            .context
+            .alarm_manager
+            .as_ref()
+            .unwrap()
+            .lock()
+            .unwrap();
+        assert!(!alarms.has_alarm(AlarmType::WakeDebounce));
+        assert!(!alarms.has_alarm(AlarmType::AutoPowerOff));
+        assert!(!rtc.alarm_enabled());
+        assert!(rtc.is_released());
+        assert!(std::path::Path::new("/tmp/power_off").exists());
+        let _ = std::fs::remove_file("/tmp/power_off");
+    }
+
+    #[test]
+    fn on_shutdown_clears_scheduled_alarms_for_quit() {
+        let mut harness = DeviceRuntimeHarness::new();
+        {
+            let mut alarms = harness
+                .context
+                .alarm_manager
+                .as_ref()
+                .unwrap()
+                .lock()
+                .unwrap();
+            alarms
+                .schedule_in(AlarmType::AutoSuspend, chrono::Duration::minutes(10))
+                .unwrap();
+        }
+        let rtc = harness.context.device.rtc().unwrap();
+
+        harness.with_runtime_only(|context, runtime| {
+            shutdown_rtc(context);
+            Device::on_shutdown(context, ExitStatus::Quit, runtime).unwrap();
+        });
+
+        let alarms = harness
+            .context
+            .alarm_manager
+            .as_ref()
+            .unwrap()
+            .lock()
+            .unwrap();
+        assert!(!alarms.has_alarm(AlarmType::AutoSuspend));
+        assert!(!rtc.alarm_enabled());
+    }
+
+    #[test]
+    fn on_shutdown_completes_when_rtc_alarm_disable_fails() {
+        let mut harness = DeviceRuntimeHarness::new();
+        {
+            let mut alarms = harness
+                .context
+                .alarm_manager
+                .as_ref()
+                .unwrap()
+                .lock()
+                .unwrap();
+            alarms
+                .schedule_in(AlarmType::WakeDebounce, chrono::Duration::seconds(15))
+                .unwrap();
+        }
+        let rtc = harness.context.device.rtc().unwrap();
+        rtc.set_fail_disable(true);
+        let _ = std::fs::remove_file("/tmp/restart");
+
+        harness.with_runtime_only(|context, runtime| {
+            shutdown_rtc(context);
+            Device::on_shutdown(context, ExitStatus::Restart, runtime).unwrap();
+        });
+
+        let alarms = harness
+            .context
+            .alarm_manager
+            .as_ref()
+            .unwrap()
+            .lock()
+            .unwrap();
+        assert!(!alarms.has_alarm(AlarmType::WakeDebounce));
+        assert!(
+            rtc.alarm_enabled(),
+            "hardware alarm should stay armed when disable_alarm fails"
+        );
+        assert!(std::path::Path::new("/tmp/restart").exists());
+        let _ = std::fs::remove_file("/tmp/restart");
     }
 }

--- a/crates/core/src/device/linux/rtc.rs
+++ b/crates/core/src/device/linux/rtc.rs
@@ -2,14 +2,15 @@
 
 use anyhow::Error;
 use chrono::{DateTime, Duration as ChronoDuration, Utc};
+use nix::fcntl::{FcntlArg, fcntl};
 use nix::poll::{PollFd, PollFlags, PollTimeout, poll};
 use nix::{ioctl_none, ioctl_read, ioctl_write_ptr};
 use std::fs::{File, OpenOptions};
 use std::io::Read;
 use std::mem;
-use std::os::fd::AsFd;
-use std::os::unix::io::AsRawFd;
+use std::os::fd::{AsFd, AsRawFd, FromRawFd};
 use std::path::Path;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
@@ -41,8 +42,9 @@ ioctl_write_ptr!(rtc_set_time, b'p', 0x0a, RtcTime);
 /// ```
 #[derive(Clone)]
 pub struct LinuxRtc {
-    file: Arc<Mutex<File>>,
-    wait_file: Arc<Mutex<File>>,
+    file: Arc<Mutex<Option<File>>>,
+    wait_file: Arc<Mutex<Option<File>>>,
+    released: Arc<AtomicBool>,
     /// Cached RTC↔civil relationship and last `set_time` step.
     clock: Arc<Mutex<LinuxRtcClock>>,
 }
@@ -65,6 +67,15 @@ struct LinuxRtcClock {
 impl LinuxRtc {
     /// Opens the RTC device and creates a new interface handle.
     ///
+    /// Opens the ioctl fd and a close-on-exec duplicate (`F_DUPFD_CLOEXEC`) used
+    /// for IRQ `poll`/`read`.
+    ///
+    /// # Safety
+    ///
+    /// `F_DUPFD_CLOEXEC` returns a new fd number. That fd is wrapped in [`File`]
+    /// via [`File::from_raw_fd`]; ownership transfers to this struct and it is
+    /// closed on [`Self::release`] or drop.
+    ///
     /// # Arguments
     ///
     /// * `path` - Path to the RTC device file (typically `/dev/rtc0` or `/dev/rtc`)
@@ -82,11 +93,12 @@ impl LinuxRtc {
     /// ```
     pub fn new<P: AsRef<Path>>(path: P) -> Result<LinuxRtc, Error> {
         let file = OpenOptions::new().read(true).write(true).open(path)?;
-        let wait_fd = nix::unistd::dup(file.as_fd())?;
-        let wait_file = File::from(wait_fd);
+        let wait_fd = fcntl(&file, FcntlArg::F_DUPFD_CLOEXEC(0))?;
+        let wait_file = unsafe { File::from_raw_fd(wait_fd) };
         let rtc = LinuxRtc {
-            file: Arc::new(Mutex::new(file)),
-            wait_file: Arc::new(Mutex::new(wait_file)),
+            file: Arc::new(Mutex::new(Some(file))),
+            wait_file: Arc::new(Mutex::new(Some(wait_file))),
+            released: Arc::new(AtomicBool::new(false)),
             clock: Arc::new(Mutex::new(LinuxRtcClock {
                 drift: ChronoDuration::zero(),
                 pending_step: None,
@@ -96,12 +108,59 @@ impl LinuxRtc {
         Ok(rtc)
     }
 
+    /// Closes ioctl and IRQ wait file descriptors so another process can open the RTC.
+    ///
+    /// Idempotent. After release, RTC operations return an error until the handle
+    /// is dropped.
+    pub fn release(&self) -> Result<(), Error> {
+        if self.released.swap(true, Ordering::SeqCst) {
+            return Ok(());
+        }
+        {
+            let mut file = self
+                .file
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            *file = None;
+        }
+        {
+            let mut wait_file = self
+                .wait_file
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            *wait_file = None;
+        }
+        Ok(())
+    }
+
+    fn ioctl_file(&self) -> Result<std::sync::MutexGuard<'_, Option<File>>, Error> {
+        self.file
+            .lock()
+            .map_err(|e| anyhow::anyhow!("lock poisoned: {e}"))
+    }
+
+    fn wait_file(&self) -> Result<std::sync::MutexGuard<'_, Option<File>>, Error> {
+        self.wait_file
+            .lock()
+            .map_err(|e| anyhow::anyhow!("lock poisoned: {e}"))
+    }
+
+    fn require_file(file: &Option<File>) -> Result<&File, Error> {
+        file.as_ref()
+            .ok_or_else(|| anyhow::anyhow!("RTC device released"))
+    }
+
+    fn require_file_mut(file: &mut Option<File>) -> Result<&mut File, Error> {
+        file.as_mut()
+            .ok_or_else(|| anyhow::anyhow!("RTC device released"))
+    }
+
     fn refresh_drift_from_hardware(&self) -> Result<(), Error> {
         match self.read_time() {
             Ok(rtc_now) => {
                 self.clock
                     .lock()
-                    .map_err(|e| anyhow::anyhow!("lock poisoned: {}", e))?
+                    .map_err(|e| anyhow::anyhow!("lock poisoned: {e}"))?
                     .drift = rtc_now.signed_duration_since(Utc::now());
                 Ok(())
             }
@@ -109,16 +168,19 @@ impl LinuxRtc {
             Err(err) => Err(err),
         }
     }
+
+    #[cfg(test)]
+    pub(crate) fn is_released(&self) -> bool {
+        self.released.load(Ordering::SeqCst)
+    }
 }
 
 impl Rtc for LinuxRtc {
     /// Issues `RTC_ALM_READ` on the open device file.
     fn alarm(&self) -> Result<RtcWkalrm, Error> {
         let mut rwa = RtcWkalrm::default();
-        let file = self
-            .file
-            .lock()
-            .map_err(|e| anyhow::anyhow!("lock poisoned: {}", e))?;
+        let file = self.ioctl_file()?;
+        let file = Self::require_file(&file)?;
         unsafe {
             rtc_read_alarm(file.as_raw_fd(), &mut rwa)
                 .map(|_| rwa)
@@ -129,29 +191,23 @@ impl Rtc for LinuxRtc {
     /// Issues `RTC_ALM_SET` with the alarm enabled and `pending` cleared.
     fn set_alarm(&self, wake_time: DateTime<Utc>) -> Result<i32, Error> {
         let rwa = RtcWkalrm::for_wake_time(wake_time);
-        let file = self
-            .file
-            .lock()
-            .map_err(|e| anyhow::anyhow!("lock poisoned: {}", e))?;
+        let file = self.ioctl_file()?;
+        let file = Self::require_file(&file)?;
         unsafe { rtc_write_alarm(file.as_raw_fd(), &rwa).map_err(|e| e.into()) }
     }
 
     /// Issues `RTC_AIE_OFF` to disable alarm interrupts.
     fn disable_alarm(&self) -> Result<i32, Error> {
-        let file = self
-            .file
-            .lock()
-            .map_err(|e| anyhow::anyhow!("lock poisoned: {}", e))?;
+        let file = self.ioctl_file()?;
+        let file = Self::require_file(&file)?;
         unsafe { rtc_disable_alarm(file.as_raw_fd()).map_err(|e| e.into()) }
     }
 
     /// Issues `RTC_RD_TIME` and converts the kernel `struct rtc_time` to UTC.
     fn read_time(&self) -> Result<DateTime<Utc>, Error> {
         let mut rt = unsafe { mem::zeroed::<RtcTime>() };
-        let file = self
-            .file
-            .lock()
-            .map_err(|e| anyhow::anyhow!("lock poisoned: {}", e))?;
+        let file = self.ioctl_file()?;
+        let file = Self::require_file(&file)?;
         unsafe {
             rtc_read_time(file.as_raw_fd(), &mut rt)?;
         }
@@ -162,18 +218,15 @@ impl Rtc for LinuxRtc {
     fn set_time(&self, time: DateTime<Utc>) -> Result<(), Error> {
         let old_time = self.read_time()?;
         let rt: RtcTime = time.into();
-        let file = self
-            .file
-            .lock()
-            .map_err(|e| anyhow::anyhow!("lock poisoned: {}", e))?;
+        let file = self.ioctl_file()?;
+        let file = Self::require_file(&file)?;
         unsafe {
             rtc_set_time(file.as_raw_fd(), &rt)?;
         }
-        drop(file);
         let mut clock = self
             .clock
             .lock()
-            .map_err(|e| anyhow::anyhow!("lock poisoned: {}", e))?;
+            .map_err(|e| anyhow::anyhow!("lock poisoned: {e}"))?;
         clock.drift = time.signed_duration_since(Utc::now());
         clock.pending_step = Some(time.signed_duration_since(old_time));
         Ok(())
@@ -183,21 +236,19 @@ impl Rtc for LinuxRtc {
         self.clock
             .lock()
             .map(|clock| clock.drift)
-            .map_err(|e| anyhow::anyhow!("lock poisoned: {}", e))
+            .map_err(|e| anyhow::anyhow!("lock poisoned: {e}"))
     }
 
     fn take_pending_step(&self) -> Result<Option<ChronoDuration>, Error> {
         self.clock
             .lock()
             .map(|mut clock| clock.pending_step.take())
-            .map_err(|e| anyhow::anyhow!("lock poisoned: {}", e))
+            .map_err(|e| anyhow::anyhow!("lock poisoned: {e}"))
     }
 
     fn wait_for_alarm_irq(&self, timeout: Option<Duration>) -> Result<Option<u32>, Error> {
-        let mut wait_file = self
-            .wait_file
-            .lock()
-            .map_err(|e| anyhow::anyhow!("lock poisoned: {}", e))?;
+        let mut wait_file = self.wait_file()?;
+        let wait_file = Self::require_file_mut(&mut wait_file)?;
         let mut poll_fds = [PollFd::new(wait_file.as_fd(), PollFlags::POLLIN)];
         let poll_timeout = match timeout {
             Some(duration) => PollTimeout::try_from(duration).unwrap_or(PollTimeout::MAX),
@@ -216,5 +267,37 @@ impl Rtc for LinuxRtc {
         let mut buf = [0u8; 4];
         wait_file.read_exact(&mut buf)?;
         Ok(Some(u32::from_ne_bytes(buf)))
+    }
+
+    fn release(&self) -> Result<(), Error> {
+        LinuxRtc::release(self)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::NamedTempFile;
+
+    #[test]
+    fn wait_fd_is_close_on_exec() {
+        use nix::fcntl::{FcntlArg, FdFlag, fcntl};
+
+        let temp = NamedTempFile::new().unwrap();
+        let rtc = LinuxRtc::new(temp.path()).unwrap();
+        let wait_file = rtc.wait_file().unwrap();
+        let file = LinuxRtc::require_file(&wait_file).unwrap();
+        let flags = FdFlag::from_bits_truncate(fcntl(file, FcntlArg::F_GETFD).unwrap());
+        assert!(flags.contains(FdFlag::FD_CLOEXEC));
+    }
+
+    #[test]
+    fn release_closes_handles_and_is_idempotent() {
+        let temp = NamedTempFile::new().unwrap();
+        let rtc = LinuxRtc::new(temp.path()).unwrap();
+        rtc.release().unwrap();
+        assert!(rtc.is_released());
+        assert!(rtc.read_time().is_err());
+        rtc.release().unwrap();
     }
 }

--- a/crates/core/src/device/rtc/manager.rs
+++ b/crates/core/src/device/rtc/manager.rs
@@ -110,6 +110,15 @@ pub trait Rtc: Send + Sync {
     ///
     /// Returns an error when waiting or reading the IRQ fails.
     fn wait_for_alarm_irq(&self, timeout: Option<Duration>) -> Result<Option<u32>, Error>;
+
+    /// Releases platform RTC resources held by this handle.
+    ///
+    /// Default implementation is a no-op. Linux closes exclusive `/dev/rtc0`
+    /// opens so a subsequent Cadmus process can reopen the device.
+    fn release(&self) -> Result<(), Error> {
+        let _ = self;
+        Ok(())
+    }
 }
 
 impl<T: Rtc + ?Sized> Rtc for std::sync::Arc<T> {
@@ -143,5 +152,9 @@ impl<T: Rtc + ?Sized> Rtc for std::sync::Arc<T> {
 
     fn wait_for_alarm_irq(&self, timeout: Option<Duration>) -> Result<Option<u32>, Error> {
         (**self).wait_for_alarm_irq(timeout)
+    }
+
+    fn release(&self) -> Result<(), Error> {
+        (**self).release()
     }
 }

--- a/crates/core/src/device/rtc/mod.rs
+++ b/crates/core/src/device/rtc/mod.rs
@@ -299,6 +299,31 @@ impl<R: Rtc> AlarmManager<R> {
         self.update_hardware_alarm_at(now)
     }
 
+    /// Stops the IRQ listener thread and joins it. Idempotent and safe if never started.
+    pub fn stop_irq_listener(&mut self) {
+        self.stop.store(true, Ordering::Relaxed);
+        if let Some(handle) = self.irq_thread.take() {
+            let _ = handle.join();
+        }
+    }
+
+    /// Clears every logical alarm and disables the hardware wake alarm.
+    pub fn clear_all_alarms(&mut self) -> Result<(), Error> {
+        let cleared: Vec<AlarmType> = self.scheduled_alarms.keys().copied().collect();
+        self.scheduled_alarms.clear();
+        self.rtc.disable_alarm()?;
+        if cleared.is_empty() {
+            tracing::debug!("Cleared RTC alarms on shutdown (none scheduled)");
+        } else {
+            tracing::info!(
+                count = cleared.len(),
+                alarm_types = ?cleared,
+                "Cleared all RTC alarms on shutdown"
+            );
+        }
+        Ok(())
+    }
+
     /// Returns `true` if an alarm of `alarm_type` is scheduled for a future time.
     pub fn is_alarm_scheduled(&self, alarm_type: AlarmType) -> bool {
         let now = self.authority_now();
@@ -507,6 +532,50 @@ pub fn set_time<R: Rtc>(
     alarms.sync()
 }
 
+/// Stops the IRQ listener and clears all logical and hardware RTC alarms.
+fn shutdown_alarm_manager<R: Rtc>(alarm_manager: &Option<Arc<Mutex<AlarmManager<R>>>>) {
+    let Some(alarm_manager) = alarm_manager else {
+        return;
+    };
+    let join_handle = {
+        let mut manager = alarm_manager
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        manager.stop.store(true, Ordering::Relaxed);
+        manager.irq_thread.take()
+    };
+    if let Some(handle) = join_handle {
+        let _ = handle.join();
+    }
+    let mut manager = alarm_manager
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    if let Err(error) = manager.clear_all_alarms() {
+        tracing::error!(error = %error, "Failed to clear RTC alarms on shutdown");
+    }
+}
+
+/// Stops the RTC IRQ listener, clears all logical alarms, and releases hardware RTC FDs.
+///
+/// Invoked from the application main loop after background tasks stop and before
+/// device `on_shutdown`. Failures are logged and do not abort shutdown.
+pub fn shutdown_rtc<D>(context: &crate::context::Context<D>)
+where
+    D: crate::device::Device,
+{
+    shutdown_alarm_manager(&context.alarm_manager);
+    match context.device.rtc() {
+        Ok(rtc) => {
+            if let Err(error) = rtc.release() {
+                tracing::error!(error = %error, "Failed to release RTC device on shutdown");
+            }
+        }
+        Err(error) => {
+            tracing::error!(error = %error, "Failed to access RTC device on shutdown");
+        }
+    }
+}
+
 impl<R: Rtc + 'static> AlarmManager<R> {
     /// Starts the owned IRQ listener thread once. Idempotent.
     ///
@@ -562,10 +631,7 @@ impl<R: Rtc + 'static> AlarmManager<R> {
 
 impl<R: Rtc> Drop for AlarmManager<R> {
     fn drop(&mut self) {
-        self.stop.store(true, Ordering::Relaxed);
-        if let Some(handle) = self.irq_thread.take() {
-            let _ = handle.join();
-        }
+        self.stop_irq_listener();
     }
 }
 
@@ -931,5 +997,85 @@ mod tests {
         rtc.simulate_alarm_fired();
         let data = handle.join().unwrap();
         assert_eq!(data, Some(0x20));
+    }
+
+    #[test]
+    fn clear_all_alarms_empties_schedule_and_disables_hardware() {
+        let (rtc, mut manager) = test_alarm_manager();
+        manager
+            .schedule_in(AlarmType::WakeDebounce, Duration::minutes(1))
+            .unwrap();
+        manager
+            .schedule_in(AlarmType::AutoPowerOff, Duration::hours(1))
+            .unwrap();
+        assert!(rtc.alarm_enabled());
+
+        manager.clear_all_alarms().unwrap();
+
+        assert!(manager.scheduled_alarms.is_empty());
+        assert!(!rtc.alarm_enabled());
+    }
+
+    #[test]
+    fn clear_all_alarms_is_idempotent_when_empty() {
+        let (rtc, mut manager) = test_alarm_manager();
+        manager.clear_all_alarms().unwrap();
+        manager.clear_all_alarms().unwrap();
+        assert!(manager.scheduled_alarms.is_empty());
+        assert!(!rtc.alarm_enabled());
+    }
+
+    #[test]
+    fn clear_all_alarms_clears_logical_schedule_when_disable_fails() {
+        let (rtc, mut manager) = test_alarm_manager();
+        manager
+            .schedule_in(AlarmType::WakeDebounce, Duration::minutes(1))
+            .unwrap();
+        manager
+            .schedule_in(AlarmType::AutoPowerOff, Duration::hours(1))
+            .unwrap();
+        rtc.set_fail_disable(true);
+
+        assert!(manager.clear_all_alarms().is_err());
+
+        assert!(manager.scheduled_alarms.is_empty());
+        assert!(!manager.has_alarm(AlarmType::WakeDebounce));
+        assert!(!manager.has_alarm(AlarmType::AutoPowerOff));
+        assert!(
+            rtc.alarm_enabled(),
+            "hardware alarm should stay armed when disable_alarm fails"
+        );
+    }
+
+    #[test]
+    fn shutdown_rtc_clears_logical_alarms_when_disable_fails() {
+        use crate::context::test_helpers::create_test_context;
+        use crate::device::DeviceHardware as _;
+
+        let context = create_test_context();
+        let rtc = context.device.rtc().unwrap();
+        {
+            let mut manager = context.alarm_manager.as_ref().unwrap().lock().unwrap();
+            manager
+                .schedule_in(AlarmType::WakeDebounce, Duration::minutes(1))
+                .unwrap();
+        }
+        rtc.set_fail_disable(true);
+
+        shutdown_rtc(&context);
+
+        let manager = context.alarm_manager.as_ref().unwrap().lock().unwrap();
+        assert!(!manager.has_alarm(AlarmType::WakeDebounce));
+        assert!(
+            rtc.alarm_enabled(),
+            "hardware alarm should stay armed when disable_alarm fails"
+        );
+    }
+
+    #[test]
+    fn stop_irq_listener_is_idempotent() {
+        let (_rtc, mut manager) = test_alarm_manager();
+        manager.stop_irq_listener();
+        manager.stop_irq_listener();
     }
 }

--- a/crates/core/src/device/rtc/test.rs
+++ b/crates/core/src/device/rtc/test.rs
@@ -2,6 +2,7 @@
 
 use anyhow::Error;
 use chrono::{DateTime, Duration as ChronoDuration, Utc};
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Condvar, Mutex};
 use std::time::Duration;
 
@@ -29,10 +30,22 @@ struct TestRtcState {
 }
 
 /// Assertable RTC test double for unit tests.
-#[derive(Clone)]
 pub struct TestRtc {
     state: Arc<Mutex<TestRtcState>>,
     cond: Arc<Condvar>,
+    fail_disable: Arc<AtomicBool>,
+    released: Arc<AtomicBool>,
+}
+
+impl Clone for TestRtc {
+    fn clone(&self) -> Self {
+        Self {
+            state: Arc::clone(&self.state),
+            cond: Arc::clone(&self.cond),
+            fail_disable: Arc::clone(&self.fail_disable),
+            released: Arc::clone(&self.released),
+        }
+    }
 }
 
 impl TestRtc {
@@ -48,7 +61,17 @@ impl TestRtc {
                 pending_step: None,
             })),
             cond: Arc::new(Condvar::new()),
+            fail_disable: Arc::new(AtomicBool::new(false)),
+            released: Arc::new(AtomicBool::new(false)),
         }
+    }
+
+    pub fn set_fail_disable(&self, fail: bool) {
+        self.fail_disable.store(fail, Ordering::Relaxed);
+    }
+
+    pub fn is_released(&self) -> bool {
+        self.released.load(Ordering::SeqCst)
     }
 
     pub fn scheduled_wake_time(&self) -> Option<DateTime<Utc>> {
@@ -110,6 +133,9 @@ impl Rtc for TestRtc {
     }
 
     fn disable_alarm(&self) -> Result<i32, Error> {
+        if self.fail_disable.load(Ordering::Relaxed) {
+            return Err(anyhow::anyhow!("simulated disable_alarm failure"));
+        }
         let mut state = self
             .state
             .lock()
@@ -184,5 +210,10 @@ impl Rtc for TestRtc {
                 }
             }
         }
+    }
+
+    fn release(&self) -> Result<(), Error> {
+        self.released.store(true, Ordering::SeqCst);
+        Ok(())
     }
 }


### PR DESCRIPTION
Soft suspend (#361, #835) added WakeDebounce and other RTC alarms that could survive process exit and wake the device after poweroff; unreleased /dev/rtc0 opens caused EBUSY on restart.

- Add shutdown_rtc() from app loop after background tasks stop
- Stop IRQ listener, clear logical alarms, release Linux RTC FDs
- Dup wait fd with CLOEXEC; log clear/release failures, keep exiting

Refs: #361

Change-Id: 1e1c25ee8b49c6483914865cce386c1e
Change-Id-Short: ylynxullrovq

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What

Adds RTC shutdown handling during application exit. The application stops the IRQ listener, clears alarms, releases RTC file descriptors, and logs cleanup failures without stopping shutdown.

## Why

This prevents stale RTC alarms and unreleased Linux RTC descriptors after power-off or quit shutdowns.

## How

- Calls `shutdown_rtc` after background tasks stop.
- Stops the IRQ listener and clears all alarms.
- Adds idempotent `Rtc::release` support.
- Closes Linux RTC descriptors and duplicates the wait descriptor with `CLOEXEC`.
- Adds tests for cleanup, release behavior, and simulated alarm-disable failures.

## Related

None found.

## Risk

**Risk:** High (4/5) — Changes native RTC and power-shutdown paths, although cleanup failures remain non-fatal.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->