### PR TITLE
refactor(ota): deploy KoboRoot via atomic rename

### DIFF
--- a/crates/core/i18n/en-GB/cadmus_core.ftl
+++ b/crates/core/i18n/en-GB/cadmus_core.ftl
@@ -44,6 +44,10 @@ top-menu-switch-to = Switch to { $build }
 top-menu-sync-time = Sync Time
 top-menu-wifi = WiFi
 
+# OTA
+
+ota-installing-and-rebooting = Installing and rebooting…
+
 # Settings - Button Scheme
 settings-button-scheme-natural = Natural
 settings-button-scheme-inverted = Inverted

--- a/crates/core/src/ota/client.rs
+++ b/crates/core/src/ota/client.rs
@@ -9,6 +9,9 @@ use percent_encoding::{NON_ALPHANUMERIC, utf8_percent_encode};
 use std::fs::File;
 use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
+
+#[cfg(test)]
+use std::cell::Cell;
 use zip::ZipArchive;
 
 #[cfg(all(not(test), not(feature = "emulator")))]
@@ -117,6 +120,43 @@ pub enum OtaError {
     /// Failed to parse version string
     #[error(transparent)]
     VersionParse(#[from] crate::version::VersionError),
+}
+
+/// Result of committing `KoboRoot.tgz` to the deploy path.
+///
+/// Rename publishes the bundle to Nickel. A later parent-directory sync
+/// failure does not undo that publication, so callers must treat
+/// [`DeployOutcome::CommittedNotDurable`] as a successful install and still
+/// schedule reboot.
+#[derive(Debug)]
+pub enum DeployOutcome {
+    /// The bundle is at this path and the parent directory was synced.
+    Durable(PathBuf),
+    /// The bundle was renamed into place, but the parent directory could not
+    /// be synced. The new file is visible to Nickel; durability is not
+    /// guaranteed across a crash before the next successful directory sync.
+    CommittedNotDurable {
+        /// Path of the published bundle.
+        path: PathBuf,
+        /// Error returned by the parent-directory sync.
+        error: OtaError,
+    },
+}
+
+impl DeployOutcome {
+    /// Returns the path where the bundle was published.
+    pub fn path(&self) -> &Path {
+        match self {
+            Self::Durable(path) | Self::CommittedNotDurable { path, .. } => path,
+        }
+    }
+
+    /// Consumes the outcome and returns the published path.
+    pub fn into_path(self) -> PathBuf {
+        match self {
+            Self::Durable(path) | Self::CommittedNotDurable { path, .. } => path,
+        }
+    }
 }
 
 impl From<ChunkedDownloadError> for OtaError {
@@ -578,52 +618,47 @@ impl OtaClient {
     ///
     /// # Returns
     ///
-    /// The path where the file was deployed, or an error if deployment fails.
+    /// The deploy outcome, or an error if the bundle was not published.
     ///
     /// # Errors
     ///
-    /// * `OtaError::Io` - Failed to read or write files
+    /// * `OtaError::Io` - Failed to read or write files before the bundle was renamed
     #[cfg_attr(feature = "tracing", tracing::instrument(skip(self)))]
-    pub fn deploy(&self, kobo_root_path: PathBuf) -> Result<PathBuf, OtaError> {
+    pub fn deploy(&self, kobo_root_path: PathBuf) -> Result<DeployOutcome, OtaError> {
         tracing::info!(path = ?kobo_root_path, "Deploying KoboRoot.tgz");
 
-        let deploy_path = self.deploy_path();
-        self.ensure_deploy_dir(&deploy_path)?;
-
         let mut src = File::open(&kobo_root_path)?;
-        let mut dst = File::create(&deploy_path)?;
-        let bytes_copied = std::io::copy(&mut src, &mut dst)?;
+        let outcome = self.write_staging_then_rename(|staging| {
+            let bytes_copied = std::io::copy(&mut src, staging)?;
+            tracing::debug!(
+                bytes = bytes_copied,
+                src = ?kobo_root_path,
+                "Streamed KoboRoot.tgz to staging path"
+            );
+            Ok(())
+        })?;
 
-        tracing::debug!(
-            bytes = bytes_copied,
-            src = ?kobo_root_path,
-            dst = ?deploy_path,
-            "Streamed KoboRoot.tgz to deploy path"
-        );
-
-        if kobo_root_path != deploy_path {
-            if let Err(e) = std::fs::remove_file(&kobo_root_path) {
-                tracing::error!(path = ?kobo_root_path, error = %e, "Failed to remove source file");
-            }
+        if kobo_root_path != outcome.path()
+            && let Err(e) = std::fs::remove_file(&kobo_root_path)
+        {
+            tracing::error!(path = ?kobo_root_path, error = %e, "Failed to remove source file");
         }
 
-        tracing::info!(path = ?deploy_path, "Update deployed successfully");
-        Ok(deploy_path)
+        tracing::info!(path = ?outcome.path(), "Update deployed successfully");
+        Ok(outcome)
     }
 
     /// Returns the platform-specific deployment path for KoboRoot.tgz.
     ///
     /// | Build context        | Path                                              |
     /// |----------------------|---------------------------------------------------|
-    /// | During `cargo test`  | `<temp_dir>/test-kobo-deployment/KoboRoot.tgz`    |
+    /// | During `cargo test`  | `{tmp_dir}/.kobo/KoboRoot.tgz`                    |
     /// | Emulator builds      | `/tmp/.kobo/KoboRoot.tgz`                         |
     /// | Kobo builds          | `{INTERNAL_CARD_ROOT}/.kobo/KoboRoot.tgz`         |
     fn deploy_path(&self) -> PathBuf {
         let path = cfg_select! {
             test => {
-                std::env::temp_dir()
-                    .join("test-kobo-deployment")
-                    .join("KoboRoot.tgz")
+                self.tmp_dir.join(".kobo").join("KoboRoot.tgz")
             }
             feature = "emulator" => { PathBuf::from("/tmp/.kobo/KoboRoot.tgz") }
             _ => { PathBuf::from(format!("{}/.kobo/KoboRoot.tgz", INTERNAL_CARD_ROOT)) }
@@ -631,6 +666,87 @@ impl OtaClient {
 
         tracing::debug!(path = ?path, "Deploy destination");
         path
+    }
+
+    fn staging_path(&self) -> PathBuf {
+        let deploy_path = self.deploy_path();
+        let deploy_name = deploy_path
+            .file_name()
+            .map(|name| name.to_string_lossy().into_owned())
+            .unwrap_or_else(|| "KoboRoot.tgz".to_owned());
+        let staging_name = format!("{deploy_name}.{}.partial", uuid::Uuid::now_v7());
+        deploy_path.with_file_name(staging_name)
+    }
+
+    fn write_staging_then_rename<F>(&self, write: F) -> Result<DeployOutcome, OtaError>
+    where
+        F: FnOnce(&mut File) -> Result<(), OtaError>,
+    {
+        let deploy_path = self.deploy_path();
+        let staging_path = self.staging_path();
+        self.ensure_deploy_dir(&deploy_path)?;
+
+        let result = (|| {
+            let mut staging = File::create(&staging_path)?;
+            write(&mut staging)?;
+            staging.sync_all()?;
+            std::fs::rename(&staging_path, &deploy_path)?;
+            match Self::sync_deploy_parent(&deploy_path) {
+                Ok(()) => Ok(DeployOutcome::Durable(deploy_path.clone())),
+                Err(error) => {
+                    tracing::warn!(
+                        path = ?deploy_path,
+                        error = %error,
+                        "Parent directory sync failed after committing bundle"
+                    );
+                    Ok(DeployOutcome::CommittedNotDurable {
+                        path: deploy_path.clone(),
+                        error,
+                    })
+                }
+            }
+        })();
+
+        if result.is_err()
+            && let Err(e) = std::fs::remove_file(&staging_path)
+            && staging_path.exists()
+        {
+            tracing::warn!(path = ?staging_path, error = %e, "Failed to remove staging file");
+        }
+
+        result
+    }
+
+    fn sync_deploy_parent(deploy_path: &Path) -> Result<(), OtaError> {
+        #[cfg(test)]
+        if FAIL_SYNC_DEPLOY_PARENT.with(|flag| flag.replace(false)) {
+            return Err(OtaError::Io(std::io::Error::other(
+                "injected sync_deploy_parent failure",
+            )));
+        }
+
+        let Some(parent) = deploy_path.parent() else {
+            return Ok(());
+        };
+
+        #[cfg(unix)]
+        {
+            use std::fs::OpenOptions;
+            use std::os::unix::fs::OpenOptionsExt;
+
+            OpenOptions::new()
+                .read(true)
+                .custom_flags(libc::O_DIRECTORY)
+                .open(parent)?
+                .sync_all()?;
+        }
+
+        #[cfg(not(unix))]
+        {
+            let _ = parent;
+        }
+
+        Ok(())
     }
 
     fn ensure_deploy_dir(&self, deploy_path: &Path) -> Result<(), OtaError> {
@@ -653,18 +769,17 @@ impl OtaClient {
         Ok(())
     }
 
-    fn deploy_bytes(&self, data: &[u8]) -> Result<PathBuf, OtaError> {
-        let deploy_path = self.deploy_path();
-        self.ensure_deploy_dir(&deploy_path)?;
+    fn deploy_bytes(&self, data: &[u8]) -> Result<DeployOutcome, OtaError> {
+        let byte_count = data.len();
+        let outcome = self.write_staging_then_rename(|staging| {
+            staging.write_all(data)?;
+            Ok(())
+        })?;
 
-        tracing::debug!(bytes = data.len(), path = ?deploy_path, "Writing file");
-        let mut file = File::create(&deploy_path)?;
-        file.write_all(data)?;
+        tracing::debug!(bytes = byte_count, path = ?outcome.path(), "Deployment complete");
+        tracing::info!(path = ?outcome.path(), "Update deployed successfully");
 
-        tracing::debug!(path = ?deploy_path, "Deployment complete");
-        tracing::info!(path = ?deploy_path, "Update deployed successfully");
-
-        Ok(deploy_path)
+        Ok(outcome)
     }
 
     /// Extracts KoboRoot.tgz from the artifact and deploys it for installation.
@@ -680,15 +795,15 @@ impl OtaClient {
     ///
     /// # Returns
     ///
-    /// The deployment path where KoboRoot.tgz was written.
+    /// The deploy outcome, or an error if the bundle was not published.
     ///
     /// # Errors
     ///
     /// * `OtaError::ZipError` - Failed to open or read ZIP archive
     /// * `OtaError::DeploymentError` - KoboRoot.tgz not found in archive
-    /// * `OtaError::Io` - Failed to write deployment file
+    /// * `OtaError::Io` - Failed to write deployment file before the bundle was renamed
     #[cfg_attr(feature = "tracing", tracing::instrument(skip(self)))]
-    pub fn extract_and_deploy(&self, zip_path: PathBuf) -> Result<PathBuf, OtaError> {
+    pub fn extract_and_deploy(&self, zip_path: PathBuf) -> Result<DeployOutcome, OtaError> {
         tracing::info!(path = ?zip_path, "Extracting and deploying update");
         tracing::debug!(path = ?zip_path, "Starting extraction");
 
@@ -738,12 +853,12 @@ impl OtaClient {
             "Extracted file"
         );
 
-        let deploy_path = self.deploy_bytes(&kobo_root_data)?;
+        let outcome = self.deploy_bytes(&kobo_root_data)?;
         if let Err(e) = std::fs::remove_file(&zip_path) {
             tracing::error!(path = ?zip_path, error = %e, "Failed to remove source file");
         }
 
-        Ok(deploy_path)
+        Ok(outcome)
     }
 
     /// Queries the GitHub API for the repository's default branch name.
@@ -897,6 +1012,11 @@ fn verify_scopes(github: &crate::github::GithubClient) -> Result<(), OtaError> {
     })
 }
 
+#[cfg(test)]
+thread_local! {
+    static FAIL_SYNC_DEPLOY_PARENT: Cell<bool> = const { Cell::new(false) };
+}
+
 /// Maps a failed `reqwest` response to the appropriate `OtaError`.
 ///
 /// A 401 Unauthorized response means the saved token has been revoked or
@@ -943,9 +1063,47 @@ mod tests {
         OtaClient::new(github, tmp_dir)
     }
 
+    fn ota_test_tempdir() -> tempfile::TempDir {
+        tempfile::Builder::new()
+            .prefix("cadmus-ota-")
+            .tempdir()
+            .expect("failed to create temp dir")
+    }
+
+    fn assert_no_partial_staging(deploy_path: &Path) {
+        let Some(parent) = deploy_path.parent() else {
+            return;
+        };
+        let leftovers: Vec<_> = std::fs::read_dir(parent)
+            .expect("read deploy directory")
+            .filter_map(Result::ok)
+            .filter(|entry| entry.file_name().to_string_lossy().ends_with(".partial"))
+            .map(|entry| entry.path())
+            .collect();
+        assert!(
+            leftovers.is_empty(),
+            "unexpected staging leftovers: {leftovers:?}"
+        );
+    }
+
+    struct FailSyncDeployParent;
+
+    impl FailSyncDeployParent {
+        fn arm() -> Self {
+            FAIL_SYNC_DEPLOY_PARENT.with(|flag| flag.set(true));
+            Self
+        }
+    }
+
+    impl Drop for FailSyncDeployParent {
+        fn drop(&mut self) {
+            FAIL_SYNC_DEPLOY_PARENT.with(|flag| flag.set(false));
+        }
+    }
+
     #[test]
     fn test_extract_and_deploy_success() {
-        let temp_dir = tempfile::tempdir().unwrap();
+        let temp_dir = ota_test_tempdir();
         let client = make_client(temp_dir.path().to_path_buf());
         let fixture_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
             .join("src/ota/tests/fixtures/test_artifact.zip");
@@ -960,7 +1118,7 @@ mod tests {
             result.err()
         );
 
-        let deploy_path = result.unwrap();
+        let deploy_path = result.unwrap().into_path();
         assert!(
             deploy_path.exists(),
             "Deployed file should exist at {:?}",
@@ -972,8 +1130,7 @@ mod tests {
             content.contains("Mock KoboRoot.tgz"),
             "Deployed file should contain mock content"
         );
-
-        std::fs::remove_file(&deploy_path).ok();
+        assert_no_partial_staging(&deploy_path);
         assert!(
             !artifact_path.exists(),
             "Downloaded artifact should be removed after successful deployment"
@@ -981,8 +1138,157 @@ mod tests {
     }
 
     #[test]
+    fn test_atomic_deploy_success() {
+        let temp_dir = ota_test_tempdir();
+        let client = make_client(temp_dir.path().to_path_buf());
+        let deploy_path = client.deploy_path();
+        let payload = b"new bundle content";
+
+        let result = client.write_staging_then_rename(|staging| {
+            staging.write_all(payload)?;
+            Ok(())
+        });
+
+        assert!(
+            result.is_ok(),
+            "Deployment should succeed: {:?}",
+            result.err()
+        );
+        let outcome = result.unwrap();
+        assert!(matches!(outcome, DeployOutcome::Durable(_)));
+        assert_eq!(outcome.path(), deploy_path.as_path());
+        assert_eq!(std::fs::read(&deploy_path).unwrap(), payload);
+        assert_no_partial_staging(&deploy_path);
+    }
+
+    #[test]
+    fn test_atomic_deploy_parent_sync_failure_is_committed_not_durable() {
+        let temp_dir = ota_test_tempdir();
+        let client = make_client(temp_dir.path().to_path_buf());
+        let deploy_path = client.deploy_path();
+        let existing = b"existing bundle content";
+        let payload = b"new bundle content";
+
+        client.ensure_deploy_dir(&deploy_path).unwrap();
+        std::fs::write(&deploy_path, existing).unwrap();
+
+        let _fail_sync = FailSyncDeployParent::arm();
+        let result = client.write_staging_then_rename(|staging| {
+            staging.write_all(payload)?;
+            Ok(())
+        });
+
+        match result {
+            Ok(DeployOutcome::CommittedNotDurable { path, error }) => {
+                assert_eq!(path, deploy_path);
+                assert_eq!(
+                    error.to_string(),
+                    "I/O error: injected sync_deploy_parent failure"
+                );
+            }
+            other => panic!("expected committed-not-durable outcome, got {other:?}"),
+        }
+        assert_eq!(std::fs::read(&deploy_path).unwrap(), payload);
+        assert_no_partial_staging(&deploy_path);
+    }
+
+    #[test]
+    fn test_deploy_parent_sync_failure_still_removes_source() {
+        let temp_dir = ota_test_tempdir();
+        let client = make_client(temp_dir.path().to_path_buf());
+        let deploy_path = client.deploy_path();
+        let source_path = temp_dir.path().join("source-KoboRoot.tgz");
+        let payload = b"source bundle content";
+
+        std::fs::write(&source_path, payload).unwrap();
+        let _fail_sync = FailSyncDeployParent::arm();
+
+        let outcome = client
+            .deploy(source_path.clone())
+            .expect("published bundle remains a successful deploy");
+
+        assert!(matches!(outcome, DeployOutcome::CommittedNotDurable { .. }));
+        assert_eq!(outcome.path(), deploy_path.as_path());
+        assert_eq!(std::fs::read(&deploy_path).unwrap(), payload);
+        assert!(
+            !source_path.exists(),
+            "source file should be removed after the bundle is committed"
+        );
+        assert_no_partial_staging(&deploy_path);
+    }
+
+    #[test]
+    fn test_atomic_deploy_failed_write_preserves_existing_bundle() {
+        let temp_dir = ota_test_tempdir();
+        let client = make_client(temp_dir.path().to_path_buf());
+        let deploy_path = client.deploy_path();
+        let existing = b"existing bundle content";
+
+        client.ensure_deploy_dir(&deploy_path).unwrap();
+        std::fs::write(&deploy_path, existing).unwrap();
+
+        let result = client.write_staging_then_rename(|staging| {
+            staging.write_all(b"partial data")?;
+            Err(OtaError::Io(std::io::Error::other("simulated failure")))
+        });
+
+        assert!(result.is_err(), "Deployment should fail");
+        assert_eq!(std::fs::read(&deploy_path).unwrap(), existing);
+        assert_no_partial_staging(&deploy_path);
+    }
+
+    #[test]
+    fn test_atomic_deploy_failed_write_without_existing_bundle() {
+        let temp_dir = ota_test_tempdir();
+        let client = make_client(temp_dir.path().to_path_buf());
+        let deploy_path = client.deploy_path();
+
+        let result = client.write_staging_then_rename(|_| {
+            Err(OtaError::Io(std::io::Error::other("simulated failure")))
+        });
+
+        assert!(result.is_err(), "Deployment should fail");
+        assert!(
+            !deploy_path.exists(),
+            "Final deploy path should not exist after failed deployment"
+        );
+        assert_no_partial_staging(&deploy_path);
+    }
+
+    #[test]
+    fn test_staging_path_uses_partial_suffix() {
+        let temp_dir = ota_test_tempdir();
+        let client = make_client(temp_dir.path().to_path_buf());
+        let deploy_path = client.deploy_path();
+        let staging_path = client.staging_path();
+        let staging_name = staging_path
+            .file_name()
+            .expect("staging file name")
+            .to_string_lossy();
+        let deploy_name = deploy_path
+            .file_name()
+            .expect("deploy file name")
+            .to_string_lossy();
+
+        assert_eq!(staging_path.parent(), deploy_path.parent());
+        assert!(
+            staging_name.starts_with(&format!("{deploy_name}.")),
+            "staging name {staging_name} should be derived from deploy name"
+        );
+        assert!(
+            staging_name.ends_with(".partial"),
+            "staging name {staging_name} should end with .partial"
+        );
+        assert_ne!(
+            client.staging_path(),
+            staging_path,
+            "each staging path should be unique"
+        );
+    }
+
+    #[test]
     fn test_extract_and_deploy_missing_koboroot() {
-        let temp_dir = tempfile::tempdir().unwrap();
+        let temp_dir = ota_test_tempdir();
         let client = make_client(temp_dir.path().to_path_buf());
         let fixture_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
             .join("src/ota/tests/fixtures/empty_artifact.zip");
@@ -1084,7 +1390,7 @@ mod tests {
     #[test]
     #[ignore]
     fn test_external_download_default_branch_and_deploy() {
-        let temp_dir = tempfile::tempdir().unwrap();
+        let temp_dir = ota_test_tempdir();
         let client = create_external_client(temp_dir.path().to_path_buf());
         let mut last_progress = None;
 
@@ -1117,7 +1423,7 @@ mod tests {
             deploy_result.err()
         );
 
-        let deploy_path = deploy_result.unwrap();
+        let deploy_path = deploy_result.unwrap().into_path();
         assert!(
             deploy_path.exists(),
             "Deployed file should exist at {:?}",
@@ -1130,7 +1436,7 @@ mod tests {
     #[test]
     #[ignore]
     fn test_external_download_stable_release_and_deploy() {
-        let temp_dir = tempfile::tempdir().unwrap();
+        let temp_dir = ota_test_tempdir();
         let client = create_external_client(temp_dir.path().to_path_buf());
         let download_result = client.download_stable_release_artifact(|_| {});
 
@@ -1159,7 +1465,7 @@ mod tests {
             deploy_result.err()
         );
 
-        let deploy_path = deploy_result.unwrap();
+        let deploy_path = deploy_result.unwrap().into_path();
         assert!(
             deploy_path.exists(),
             "Deployed file should exist at {:?}",

--- a/crates/core/src/ota/mod.rs
+++ b/crates/core/src/ota/mod.rs
@@ -12,4 +12,4 @@ mod client;
 
 pub use crate::github::OtaProgress;
 pub use cleanup::clean_bundled_files;
-pub use client::{ArtifactSource, OtaClient, OtaError};
+pub use client::{ArtifactSource, DeployOutcome, OtaClient, OtaError};

--- a/crates/core/src/view/ota.rs
+++ b/crates/core/src/view/ota.rs
@@ -18,13 +18,14 @@ use crate::geom::Rectangle;
 use crate::gesture::GestureEvent;
 use crate::github::GithubClient;
 use crate::github::device_flow;
-use crate::ota::{OtaClient, OtaError, OtaProgress, clean_bundled_files};
+use crate::ota::{DeployOutcome, OtaClient, OtaError, OtaProgress, clean_bundled_files};
 use crate::unit::scale_by_dpi;
 use crate::version::{VersionComparison, get_current_version};
 use crate::view::BIG_BAR_HEIGHT;
 use crate::view::filler::Filler;
 use crate::view::github::GithubEvent;
 use secrecy::SecretString;
+use std::path::Path;
 use std::thread;
 use tracing::{error, info};
 
@@ -533,20 +534,7 @@ impl OtaView {
                 Ok(zip_path) => {
                     info!(pr_number, "Download completed, starting extraction");
                     match client.extract_and_deploy(zip_path) {
-                        Ok(_) => {
-                            if let Err(e) = clean_bundled_files(&install_dir) {
-                                tracing::warn!(path = ?install_dir, error = %e, "Failed to clean bundled OTA files");
-                            }
-                            hub2.send(
-                                (Event::OtaDownloadProgress {
-                                    label: "Installing and rebooting…".to_string(),
-                                    percent: 100,
-                                })
-                                .into(),
-                            )
-                            .ok();
-                            send_reboot_after_delay(hub2.clone());
-                        }
+                        Ok(outcome) => finish_successful_deploy(&hub2, &install_dir, outcome),
                         Err(e) => {
                             error!(error = %e, "Deployment failed");
                             hub2.send((Event::Close(ota_view_id)).into()).ok();
@@ -668,20 +656,7 @@ impl OtaView {
                 Ok(zip_path) => {
                     info!("Main branch download completed, starting extraction");
                     match client.extract_and_deploy(zip_path) {
-                        Ok(_) => {
-                            if let Err(e) = clean_bundled_files(&install_dir) {
-                                tracing::warn!(path = ?install_dir, error = %e, "Failed to clean bundled OTA files");
-                            }
-                            hub2.send(
-                                (Event::OtaDownloadProgress {
-                                    label: "Installing and rebooting…".to_string(),
-                                    percent: 100,
-                                })
-                                .into(),
-                            )
-                            .ok();
-                            send_reboot_after_delay(hub2.clone());
-                        }
+                        Ok(outcome) => finish_successful_deploy(&hub2, &install_dir, outcome),
                         Err(e) => {
                             error!(error = %e, "Deployment failed");
                             hub2.send((Event::Close(ota_view_id)).into()).ok();
@@ -803,20 +778,7 @@ impl OtaView {
                 Ok(asset_path) => {
                     info!("Stable release download completed, deploying update");
                     match client.deploy(asset_path) {
-                        Ok(_) => {
-                            if let Err(e) = clean_bundled_files(&install_dir) {
-                                tracing::warn!(path = ?install_dir, error = %e, "Failed to clean bundled OTA files");
-                            }
-                            hub2.send(
-                                (Event::OtaDownloadProgress {
-                                    label: "Installing and rebooting…".to_string(),
-                                    percent: 100,
-                                })
-                                .into(),
-                            )
-                            .ok();
-                            send_reboot_after_delay(hub2.clone());
-                        }
+                        Ok(outcome) => finish_successful_deploy(&hub2, &install_dir, outcome),
                         Err(e) => {
                             error!(error = %e, "Deployment failed");
                             hub2.send((Event::Close(ota_view_id)).into()).ok();
@@ -851,6 +813,31 @@ impl OtaView {
             }
         });
     }
+}
+
+/// Completes a published OTA install, including the committed-but-not-durable
+/// case where parent-directory sync failed after rename.
+fn finish_successful_deploy(hub: &Hub, install_dir: &Path, outcome: DeployOutcome) {
+    if let DeployOutcome::CommittedNotDurable { path, error } = &outcome {
+        tracing::warn!(
+            path = ?path,
+            error = %error,
+            "OTA bundle committed but parent directory was not synced"
+        );
+    }
+
+    if let Err(e) = clean_bundled_files(install_dir) {
+        tracing::warn!(path = ?install_dir, error = %e, "Failed to clean bundled OTA files");
+    }
+    hub.send(
+        (Event::OtaDownloadProgress {
+            label: fl!("ota-installing-and-rebooting"),
+            percent: 100,
+        })
+        .into(),
+    )
+    .ok();
+    send_reboot_after_delay(hub.clone());
 }
 
 /// Spawns a thread that sleeps for 1 second then sends `Event::Select(EntryId::Reboot)`.


### PR DESCRIPTION
Write OTA bundles to a sibling `.partial` staging file, sync, then rename so Nickel never sees a truncated KoboRoot.tgz. Failed writes remove staging and leave any existing bundle intact.

- Add write_staging_then_rename() for deploy() and deploy_bytes()
- Cover staging cleanup and existing-bundle preservation in tests

Change-Id: a4479b09912aaed690f773a0ef31912a
Change-Id-Short: pvvsqozqqyxp
Ref: CAD-72
Ref: #475

This should make it safer to cancel OTA down the line. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What

OTA deployment now stages bundles in a sibling `.partial` file, synchronizes the file, and atomically renames it to `KoboRoot.tgz`. The deployment API reports whether the bundle is durable or committed but not directory-synced.

## Why

This reduces the risk of incomplete bundles during OTA cancellation or failed deployment. Cleanup and reboot still proceed when publication succeeds but the parent-directory sync fails.

## How

- Added `write_staging_then_rename()` for `deploy()` and `deploy_bytes()`.
- Added the public `DeployOutcome` type and propagated it through deployment and extraction flows.
- Preserved existing bundles and removed staging files after failed writes.
- Handled `CommittedNotDurable` results during post-deploy cleanup, warnings, progress display, and reboot scheduling.
- Added fault-injection tests for parent-directory sync failures and localized the installing-and-rebooting progress message with Fluent.

## Related

None found.

## Risk

**Risk:** High (4/5) — This changes the OTA installation path, filesystem durability handling, and device reboot behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->