### PR TITLE
feat(ota): cancel in-progress downloads

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -243,6 +243,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "backon"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cffb0e931875b666fc4fcb20fee52e9bbd1ef836fd9e9e04ec21555f9f85f7ef"
+dependencies = [
+ "fastrand",
+]
+
+[[package]]
 name = "backtrace"
 version = "0.3.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -404,6 +413,7 @@ version = "0.11.0"
 dependencies = [
  "anyhow",
  "arc-swap",
+ "backon",
  "bitflags",
  "blake3",
  "build-deps",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ members = [
 ]
 
 [workspace.dependencies]
+backon = { version = "1.6", default-features = false, features = ["std"] }
 cc = "1"
 io_tee = "0.1"
 rust-embed = "8"

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -37,6 +37,7 @@ nix = { version = "0.31.0", features = ["fs", "ioctl", "mount", "poll", "time"] 
 indexmap = { version = "2.13.0", features = ["serde"] }
 arc-swap = "1"
 anyhow = "1.0.100"
+backon = { workspace = true }
 thiserror = "2.0.17"
 secrecy = { version = "0.10", features = ["serde"] }
 walkdir = "2.5.0"

--- a/crates/core/i18n/en-GB/cadmus_core.ftl
+++ b/crates/core/i18n/en-GB/cadmus_core.ftl
@@ -46,7 +46,23 @@ top-menu-wifi = WiFi
 
 # OTA
 
+ota-already-latest = You already have the latest version
+ota-auth-error = GitHub authorization failed
+ota-auth-timed-out = GitHub authorization timed out. Please try again.
+ota-cannot-compare-versions = Cannot compare versions
+ota-check-updates-failed = Failed to check for updates
+ota-client-build-failed = Failed to create client
+ota-deployment-failed = Deployment failed
+ota-download-cancel = {cancel}
+ota-download-failed = Download failed
+ota-downloading-default-branch = Downloading main branch build… { $percent }%
+ota-downloading-pr = Downloading PR #{ $pr_number } build… { $percent }%
+ota-downloading-stable-release = Downloading stable release… { $percent }%
 ota-installing-and-rebooting = Installing and rebooting…
+ota-invalid-pr-number = Invalid PR number
+ota-pr-input-title = Download Build from PR
+ota-version-comparison-error = Version comparison failed
+ota-version-newer = Your version is newer than the latest release
 
 # Settings - Button Scheme
 settings-button-scheme-natural = Natural
@@ -229,6 +245,3 @@ calendar-weekday-thu = THU
 calendar-weekday-fri = FRI
 calendar-weekday-sat = SAT
 calendar-weekday-sun = SUN
-
-# OTA
-ota-downloading-stable-release = Downloading stable release… { $percent }%

--- a/crates/core/src/dictionary/monolingual/client.rs
+++ b/crates/core/src/dictionary/monolingual/client.rs
@@ -154,6 +154,7 @@ impl MonolingualClient {
                 &dest.to_path_buf(),
                 |u| self.http.get(u),
                 progress_callback,
+                None,
             )
             .map_err(|e| MonolingualError::Request(e.to_string()))
     }

--- a/crates/core/src/github/client.rs
+++ b/crates/core/src/github/client.rs
@@ -135,13 +135,20 @@ impl GithubClient {
         dest: &PathBuf,
         request_builder: B,
         progress_callback: &mut F,
+        should_cancel: Option<crate::http::CancelFunc<'_>>,
     ) -> Result<(), ChunkedDownloadError>
     where
         B: Fn(&str) -> RequestBuilder,
         F: FnMut(u64, u64),
     {
-        self.http
-            .download(url, total_size, dest, request_builder, progress_callback)
+        self.http.download(
+            url,
+            total_size,
+            dest,
+            request_builder,
+            progress_callback,
+            should_cancel,
+        )
     }
 
     fn with_auth(&self, builder: RequestBuilder) -> RequestBuilder {

--- a/crates/core/src/http.rs
+++ b/crates/core/src/http.rs
@@ -19,16 +19,135 @@
 //! }
 //! ```
 
+use backon::{BackoffBuilder, ExponentialBuilder};
 use reqwest::blocking::{Client as ReqwestClient, RequestBuilder};
 use rustls::RootCertStore;
 use std::io::Write;
 use std::path::PathBuf;
+use std::sync::atomic::{AtomicU8, Ordering};
 use std::time::Duration;
 use thiserror::Error;
 
 pub const CLIENT_TIMEOUT_SECS: u64 = 30;
 
 const USER_AGENT: &str = concat!("github.com/OGKevin/cadmus/", env!("GIT_VERSION"));
+
+const CANCEL_STATE_RUNNING: u8 = 0;
+const CANCEL_STATE_CANCELLED: u8 = 1;
+const CANCEL_STATE_COMMITTED: u8 = 2;
+
+/// Shared cancel/commit gate for long-running downloads and deploys.
+///
+/// Cancellation wins until [`Self::try_commit`] succeeds. After a successful
+/// commit transition, further cancel requests are ignored.
+#[derive(Debug, Default)]
+pub struct CancelFlag {
+    state: AtomicU8,
+}
+
+impl CancelFlag {
+    /// Creates a running cancel flag.
+    #[must_use]
+    pub const fn new() -> Self {
+        Self {
+            state: AtomicU8::new(CANCEL_STATE_RUNNING),
+        }
+    }
+
+    /// Requests cancellation. No-op if the operation already committed.
+    pub fn request_cancel(&self) {
+        let _ = self.state.compare_exchange(
+            CANCEL_STATE_RUNNING,
+            CANCEL_STATE_CANCELLED,
+            Ordering::AcqRel,
+            Ordering::Acquire,
+        );
+    }
+
+    /// Returns `true` when cancellation won before commit.
+    #[must_use]
+    pub fn is_cancelled(&self) -> bool {
+        self.state.load(Ordering::Acquire) == CANCEL_STATE_CANCELLED
+    }
+
+    /// Atomically commits if still running.
+    ///
+    /// Returns `true` when this call commits the operation. Returns `false`
+    /// when cancellation already won or another caller already committed.
+    #[must_use]
+    pub fn try_commit(&self) -> bool {
+        self.state
+            .compare_exchange(
+                CANCEL_STATE_RUNNING,
+                CANCEL_STATE_COMMITTED,
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            )
+            .is_ok()
+    }
+}
+
+/// Pollable cancel check for long-running downloads and deploys.
+///
+/// Prefer [`Self::from_flag`] with a shared [`CancelFlag`] so deploy can
+/// atomically choose between cancellation and publishing. [`Self::new`] wraps a
+/// plain predicate for tests and call sites that only need polling.
+#[derive(Clone, Copy)]
+pub enum CancelFunc<'a> {
+    /// Never cancels and always allows commit.
+    Never,
+    /// Poll-only cancel predicate without an atomic commit transition.
+    Check(&'a dyn Fn() -> bool),
+    /// Shared cancel/commit gate.
+    Flag(&'a CancelFlag),
+}
+
+impl std::fmt::Debug for CancelFunc<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("CancelFunc(..)")
+    }
+}
+
+impl<'a> CancelFunc<'a> {
+    /// Wraps a cancel predicate that returns `true` when work should stop.
+    #[must_use]
+    pub const fn new(check: &'a dyn Fn() -> bool) -> Self {
+        Self::Check(check)
+    }
+
+    /// Wraps a shared [`CancelFlag`] that supports atomic commit.
+    #[must_use]
+    pub const fn from_flag(flag: &'a CancelFlag) -> Self {
+        Self::Flag(flag)
+    }
+
+    /// A cancel check that never requests cancellation.
+    #[must_use]
+    pub const fn never() -> CancelFunc<'static> {
+        CancelFunc::Never
+    }
+
+    /// Returns `true` when the operation should abort.
+    #[must_use]
+    pub fn is_cancelled(self) -> bool {
+        match self {
+            Self::Never => false,
+            Self::Check(check) => check(),
+            Self::Flag(flag) => flag.is_cancelled(),
+        }
+    }
+
+    /// Atomically commits when backed by a [`CancelFlag`]; otherwise re-checks
+    /// cancellation. Returns `false` when cancellation already won.
+    #[must_use]
+    pub fn try_commit(self) -> bool {
+        match self {
+            Self::Never => true,
+            Self::Check(check) => !check(),
+            Self::Flag(flag) => flag.try_commit(),
+        }
+    }
+}
 
 #[derive(Error, Debug)]
 pub enum HttpError {
@@ -42,6 +161,7 @@ const INITIAL_CHUNK_SIZE: usize = 1024 * 1024;
 /// Target 80% of the HTTP timeout to leave headroom for throughput variance.
 const TARGET_CHUNK_SECS: f64 = CLIENT_TIMEOUT_SECS as f64 * 0.8;
 const MAX_RETRIES: usize = 3;
+const CANCEL_POLL_INTERVAL: Duration = Duration::from_millis(50);
 
 /// Error types that can occur during a chunked HTTP download.
 #[derive(Error, Debug)]
@@ -50,6 +170,8 @@ pub enum ChunkedDownloadError {
     Request(#[from] reqwest::Error),
     #[error("IO error: {0}")]
     Io(#[from] std::io::Error),
+    #[error("Download cancelled")]
+    Cancelled,
 }
 
 /// Pre-configured HTTP client for making network requests.
@@ -125,7 +247,8 @@ impl Client {
     ///
     /// Returns `ChunkedDownloadError::Io` if the destination file cannot be created
     /// or written. Returns `ChunkedDownloadError::Request` if all retry attempts for
-    /// any chunk fail.
+    /// any chunk fail. Returns `ChunkedDownloadError::Cancelled` when `should_cancel`
+    /// reports cancellation, including between retry attempts and during backoff.
     ///
     /// # Example
     ///
@@ -143,6 +266,7 @@ impl Client {
     ///     &dest,
     ///     |url| client.get(url),
     ///     &mut |downloaded, total| println!("{}/{}", downloaded, total),
+    ///     None,
     /// )?;
     /// # Ok(())
     /// # }
@@ -158,6 +282,7 @@ impl Client {
         dest: &PathBuf,
         request_builder: B,
         progress_callback: &mut F,
+        should_cancel: Option<CancelFunc<'_>>,
     ) -> Result<(), ChunkedDownloadError>
     where
         B: Fn(&str) -> RequestBuilder,
@@ -179,6 +304,12 @@ impl Client {
         );
 
         while downloaded < total_size {
+            if should_cancel.is_some_and(CancelFunc::is_cancelled) {
+                drop(file);
+                let _ = std::fs::remove_file(dest);
+                return Err(ChunkedDownloadError::Cancelled);
+            }
+
             let chunk_start = downloaded;
             let chunk_end = std::cmp::min(downloaded + chunk_size as u64 - 1, total_size - 1);
 
@@ -191,8 +322,21 @@ impl Client {
             );
 
             let start = std::time::Instant::now();
-            let chunk_data =
-                Self::download_chunk_with_retries(url, chunk_start, chunk_end, &request_builder)?;
+            let chunk_data = match Self::download_chunk_with_retries(
+                url,
+                chunk_start,
+                chunk_end,
+                &request_builder,
+                should_cancel,
+            ) {
+                Ok(data) => data,
+                Err(ChunkedDownloadError::Cancelled) => {
+                    drop(file);
+                    let _ = std::fs::remove_file(dest);
+                    return Err(ChunkedDownloadError::Cancelled);
+                }
+                Err(e) => return Err(e),
+            };
             let elapsed_secs = start.elapsed().as_secs_f64();
 
             file.write_all(&chunk_data)?;
@@ -230,50 +374,61 @@ impl Client {
     ///
     /// # Errors
     ///
-    /// Returns an error if all `MAX_RETRIES` attempts fail.
-    #[cfg_attr(feature = "tracing", tracing::instrument(skip(request_builder)))]
+    /// Returns an error if all retry attempts fail, or
+    /// [`ChunkedDownloadError::Cancelled`] if cancellation is requested before a
+    /// retry or during backoff.
+    #[cfg_attr(
+        feature = "tracing",
+        tracing::instrument(skip(request_builder, should_cancel))
+    )]
     fn download_chunk_with_retries<B>(
         url: &str,
         start: u64,
         end: u64,
         request_builder: &B,
+        should_cancel: Option<CancelFunc<'_>>,
     ) -> Result<Vec<u8>, ChunkedDownloadError>
     where
         B: Fn(&str) -> RequestBuilder,
     {
-        let mut last_error = None;
+        let mut backoff = ExponentialBuilder::default()
+            .with_min_delay(Duration::from_secs(1))
+            .with_factor(2.0)
+            .with_max_times(MAX_RETRIES.saturating_sub(1))
+            .build();
+        let mut attempt = 0_u32;
 
-        for attempt in 1..=MAX_RETRIES {
+        loop {
+            if should_cancel.is_some_and(CancelFunc::is_cancelled) {
+                return Err(ChunkedDownloadError::Cancelled);
+            }
+
+            attempt += 1;
             match Self::download_chunk(url, start, end, request_builder) {
                 Ok(data) => {
                     if attempt > 1 {
-                        tracing::debug!(
-                            attempt,
-                            max_retries = MAX_RETRIES,
-                            "Chunk download succeeded after retry"
-                        );
+                        tracing::debug!(attempt, "Chunk download succeeded after retry");
                     }
                     return Ok(data);
                 }
+                Err(ChunkedDownloadError::Cancelled) => {
+                    return Err(ChunkedDownloadError::Cancelled);
+                }
                 Err(e) => {
-                    tracing::warn!(
-                        attempt,
-                        max_retries = MAX_RETRIES,
-                        error = %e,
-                        "Chunk download failed"
-                    );
-                    last_error = Some(e);
-
-                    if attempt < MAX_RETRIES {
-                        let backoff_ms = 1000 * (2u64.pow(attempt as u32 - 1));
-                        tracing::debug!(backoff_ms, "Retrying after backoff");
-                        std::thread::sleep(Duration::from_millis(backoff_ms));
+                    tracing::warn!(attempt, error = %e, "Chunk download failed");
+                    match backoff.next() {
+                        Some(delay) => {
+                            tracing::debug!(
+                                backoff_ms = delay.as_millis(),
+                                "Retrying after backoff"
+                            );
+                            sleep_interruptible(delay, should_cancel)?;
+                        }
+                        None => return Err(e),
                     }
                 }
             }
         }
-
-        Err(last_error.expect("MAX_RETRIES >= 1, so last_error is always set"))
     }
 
     /// Downloads a specific byte range from a URL using the HTTP `Range` header.
@@ -315,4 +470,102 @@ fn build_root_store() -> RootCertStore {
     let mut store = RootCertStore::empty();
     store.extend(webpki_roots::TLS_SERVER_ROOTS.iter().cloned());
     store
+}
+
+fn sleep_interruptible(
+    duration: Duration,
+    should_cancel: Option<CancelFunc<'_>>,
+) -> Result<(), ChunkedDownloadError> {
+    let Some(should_cancel) = should_cancel else {
+        std::thread::sleep(duration);
+        return Ok(());
+    };
+
+    let deadline = std::time::Instant::now() + duration;
+    while std::time::Instant::now() < deadline {
+        if should_cancel.is_cancelled() {
+            return Err(ChunkedDownloadError::Cancelled);
+        }
+        let remaining = deadline.saturating_duration_since(std::time::Instant::now());
+        std::thread::sleep(remaining.min(CANCEL_POLL_INTERVAL));
+    }
+
+    if should_cancel.is_cancelled() {
+        return Err(ChunkedDownloadError::Cancelled);
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cancel_flag_cancel_wins_before_commit() {
+        let flag = CancelFlag::new();
+        flag.request_cancel();
+        assert!(flag.is_cancelled());
+        assert!(!flag.try_commit());
+    }
+
+    #[test]
+    fn cancel_flag_commit_wins_over_late_cancel() {
+        let flag = CancelFlag::new();
+        assert!(flag.try_commit());
+        flag.request_cancel();
+        assert!(!flag.is_cancelled());
+        assert!(!flag.try_commit());
+    }
+
+    #[test]
+    fn download_returns_cancelled_before_first_chunk() {
+        crate::crypto::init_crypto_provider();
+        let client = Client::new().expect("client");
+        let temp_dir = tempfile::Builder::new()
+            .prefix("cadmus-http-cancel-")
+            .tempdir()
+            .expect("tempdir");
+        let dest = temp_dir.path().join("partial.bin");
+
+        let cancel_check = || true;
+        let result = client.download(
+            "https://example.invalid/unused",
+            1024,
+            &dest,
+            |url| client.get(url),
+            &mut |_, _| {},
+            Some(CancelFunc::new(&cancel_check)),
+        );
+
+        assert!(matches!(result, Err(ChunkedDownloadError::Cancelled)));
+        assert!(!dest.exists(), "partial download file should be removed");
+    }
+
+    #[test]
+    fn download_returns_cancelled_during_chunk_retries() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        crate::crypto::init_crypto_provider();
+        let client = Client::new().expect("client");
+        let temp_dir = tempfile::Builder::new()
+            .prefix("cadmus-http-cancel-retry-")
+            .tempdir()
+            .expect("tempdir");
+        let dest = temp_dir.path().join("partial.bin");
+        let checks = AtomicUsize::new(0);
+        let cancel_check = || checks.fetch_add(1, Ordering::Relaxed) >= 2;
+
+        let result = client.download(
+            "http://127.0.0.1:1/unused",
+            1024,
+            &dest,
+            |url| client.get(url),
+            &mut |_, _| {},
+            Some(CancelFunc::new(&cancel_check)),
+        );
+
+        assert!(matches!(result, Err(ChunkedDownloadError::Cancelled)));
+        assert!(!dest.exists(), "partial download file should be removed");
+    }
 }

--- a/crates/core/src/ota/cleanup.rs
+++ b/crates/core/src/ota/cleanup.rs
@@ -70,9 +70,132 @@ fn remove_empty_dir_if_exists(path: &Path) -> io::Result<bool> {
     }
 }
 
+/// Removes partial OTA download files from a temp directory.
+pub fn cleanup_ota_artifacts(tmp_dir: &Path) {
+    let entries = match std::fs::read_dir(tmp_dir) {
+        Ok(entries) => entries,
+        Err(e) => {
+            tracing::warn!(path = ?tmp_dir, error = %e, "Failed to read OTA temp directory");
+            return;
+        }
+    };
+
+    for entry in entries {
+        let entry = match entry {
+            Ok(entry) => entry,
+            Err(e) => {
+                tracing::warn!(
+                    path = ?tmp_dir,
+                    error = %e,
+                    "Failed to read OTA temp directory entry"
+                );
+                continue;
+            }
+        };
+        let name = entry.file_name();
+        if name.to_string_lossy().starts_with("cadmus-ota-") {
+            let path = entry.path();
+            if let Err(e) = std::fs::remove_file(&path) {
+                tracing::warn!(path = ?path, error = %e, "Failed to remove OTA download artifact");
+            }
+        }
+    }
+}
+
+/// Removes leftover staging partials next to the deploy path and any partial OTA downloads.
+pub fn cleanup_ota_cancel(tmp_dir: &Path, deploy_path: &Path) {
+    cleanup_ota_artifacts(tmp_dir);
+    cleanup_staging_partials(deploy_path);
+}
+
+fn cleanup_staging_partials(deploy_path: &Path) {
+    let Some(parent) = deploy_path.parent() else {
+        return;
+    };
+    let Some(deploy_name) = deploy_path.file_name() else {
+        return;
+    };
+    let prefix = format!("{}.", deploy_name.to_string_lossy());
+
+    let entries = match std::fs::read_dir(parent) {
+        Ok(entries) => entries,
+        Err(e) => {
+            tracing::warn!(
+                path = ?parent,
+                error = %e,
+                "Failed to read OTA deploy directory for staging cleanup"
+            );
+            return;
+        }
+    };
+
+    for entry in entries {
+        let entry = match entry {
+            Ok(entry) => entry,
+            Err(e) => {
+                tracing::warn!(
+                    path = ?parent,
+                    error = %e,
+                    "Failed to read OTA deploy directory entry"
+                );
+                continue;
+            }
+        };
+        let name = entry.file_name();
+        let name = name.to_string_lossy();
+        if name.starts_with(&prefix) && name.ends_with(".partial") {
+            let path = entry.path();
+            if let Err(e) = std::fs::remove_file(&path) {
+                tracing::warn!(path = ?path, error = %e, "Failed to remove OTA staging partial");
+            }
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn cleanup_ota_artifacts_removes_cadmus_ota_prefix_files() {
+        let tmp = tempfile::Builder::new()
+            .prefix("cadmus-ota-cleanup-")
+            .tempdir()
+            .expect("tempdir");
+        let keep = tmp.path().join("other-file.txt");
+        let partial = tmp.path().join("cadmus-ota-123.zip");
+        std::fs::write(&keep, b"keep").unwrap();
+        std::fs::write(&partial, b"partial").unwrap();
+
+        cleanup_ota_artifacts(tmp.path());
+
+        assert!(!partial.exists());
+        assert!(keep.exists());
+    }
+
+    #[test]
+    fn cleanup_ota_cancel_removes_staging_partials_and_artifacts() {
+        let tmp = tempfile::Builder::new()
+            .prefix("cadmus-ota-cancel-")
+            .tempdir()
+            .expect("tempdir");
+        let keep = tmp.path().join("other-file.txt");
+        let partial = tmp.path().join("cadmus-ota-456.zip");
+        let deploy = tmp.path().join("KoboRoot.tgz");
+        let staging = tmp.path().join("KoboRoot.tgz.abc.partial");
+        let other_partial = tmp.path().join("other.tgz.xyz.partial");
+        std::fs::write(&keep, b"keep").unwrap();
+        std::fs::write(&partial, b"partial").unwrap();
+        std::fs::write(&staging, b"staging").unwrap();
+        std::fs::write(&other_partial, b"other").unwrap();
+
+        cleanup_ota_cancel(tmp.path(), &deploy);
+
+        assert!(!partial.exists());
+        assert!(!staging.exists());
+        assert!(other_partial.exists());
+        assert!(keep.exists());
+    }
 
     #[test]
     fn cleanup_removes_bundled_files_but_keeps_user_files() {

--- a/crates/core/src/ota/client.rs
+++ b/crates/core/src/ota/client.rs
@@ -3,7 +3,7 @@ use crate::github::types::{
     WorkflowRunsResponse,
 };
 use crate::github::{GithubClient, OtaProgress};
-use crate::http::ChunkedDownloadError;
+use crate::http::{CancelFunc, ChunkedDownloadError};
 use crate::version::GitVersion;
 use percent_encoding::{NON_ALPHANUMERIC, utf8_percent_encode};
 use std::fs::File;
@@ -120,6 +120,10 @@ pub enum OtaError {
     /// Failed to parse version string
     #[error(transparent)]
     VersionParse(#[from] crate::version::VersionError),
+
+    /// OTA download or deploy was cancelled by the user
+    #[error("OTA download cancelled")]
+    Cancelled,
 }
 
 /// Result of committing `KoboRoot.tgz` to the deploy path.
@@ -162,6 +166,7 @@ impl DeployOutcome {
 impl From<ChunkedDownloadError> for OtaError {
     fn from(e: ChunkedDownloadError) -> Self {
         match e {
+            ChunkedDownloadError::Cancelled => OtaError::Cancelled,
             ChunkedDownloadError::Request(r) if r.status().is_some() => api_error(r),
             ChunkedDownloadError::Request(r) => OtaError::Request(r),
             ChunkedDownloadError::Io(e) => OtaError::Io(e),
@@ -212,10 +217,15 @@ impl OtaClient {
         &self,
         pr_number: u32,
         mut progress_callback: F,
+        should_cancel: CancelFunc<'_>,
     ) -> Result<PathBuf, OtaError>
     where
         F: FnMut(OtaProgress),
     {
+        if should_cancel.is_cancelled() {
+            return Err(OtaError::Cancelled);
+        }
+
         check_disk_space(&self.tmp_dir)?;
         verify_scopes(&self.github)?;
 
@@ -335,7 +345,12 @@ impl OtaClient {
 
         let download_path = self.tmp_dir.join(format!("cadmus-ota-{}.zip", pr_number));
 
-        self.download_artifact_to_path(&artifact, &download_path, &mut progress_callback)?;
+        self.download_artifact_to_path(
+            &artifact,
+            &download_path,
+            &mut progress_callback,
+            should_cancel,
+        )?;
 
         progress_callback(OtaProgress::Complete {
             path: download_path.clone(),
@@ -374,10 +389,15 @@ impl OtaClient {
     pub fn download_default_branch_artifact<F>(
         &self,
         mut progress_callback: F,
+        should_cancel: CancelFunc<'_>,
     ) -> Result<PathBuf, OtaError>
     where
         F: FnMut(OtaProgress),
     {
+        if should_cancel.is_cancelled() {
+            return Err(OtaError::Cancelled);
+        }
+
         check_disk_space(&self.tmp_dir)?;
         verify_scopes(&self.github)?;
 
@@ -446,7 +466,12 @@ impl OtaClient {
 
         let download_path = self.tmp_dir.join(format!("cadmus-ota-{}.zip", short_sha));
 
-        self.download_artifact_to_path(&artifact, &download_path, &mut progress_callback)?;
+        self.download_artifact_to_path(
+            &artifact,
+            &download_path,
+            &mut progress_callback,
+            should_cancel,
+        )?;
 
         progress_callback(OtaProgress::Complete {
             path: download_path.clone(),
@@ -486,10 +511,15 @@ impl OtaClient {
     pub fn download_stable_release_artifact<F>(
         &self,
         mut progress_callback: F,
+        should_cancel: CancelFunc<'_>,
     ) -> Result<PathBuf, OtaError>
     where
         F: FnMut(OtaProgress),
     {
+        if should_cancel.is_cancelled() {
+            return Err(OtaError::Cancelled);
+        }
+
         check_disk_space(&self.tmp_dir)?;
 
         progress_callback(OtaProgress::FindingLatestBuild);
@@ -545,7 +575,7 @@ impl OtaClient {
 
         let download_path = self.tmp_dir.join("cadmus-ota-stable-release.tgz");
 
-        self.download_release_asset(asset, &download_path, &mut progress_callback)?;
+        self.download_release_asset(asset, &download_path, &mut progress_callback, should_cancel)?;
 
         progress_callback(OtaProgress::Complete {
             path: download_path.clone(),
@@ -624,12 +654,16 @@ impl OtaClient {
     ///
     /// * `OtaError::Io` - Failed to read or write files before the bundle was renamed
     #[cfg_attr(feature = "tracing", tracing::instrument(skip(self)))]
-    pub fn deploy(&self, kobo_root_path: PathBuf) -> Result<DeployOutcome, OtaError> {
+    pub fn deploy(
+        &self,
+        kobo_root_path: PathBuf,
+        should_cancel: CancelFunc<'_>,
+    ) -> Result<DeployOutcome, OtaError> {
         tracing::info!(path = ?kobo_root_path, "Deploying KoboRoot.tgz");
 
         let mut src = File::open(&kobo_root_path)?;
-        let outcome = self.write_staging_then_rename(|staging| {
-            let bytes_copied = std::io::copy(&mut src, staging)?;
+        let outcome = self.write_staging_then_rename(should_cancel, |staging, check| {
+            let bytes_copied = copy_with_cancel(&mut src, staging, check)?;
             tracing::debug!(
                 bytes = bytes_copied,
                 src = ?kobo_root_path,
@@ -655,7 +689,7 @@ impl OtaClient {
     /// | During `cargo test`  | `{tmp_dir}/.kobo/KoboRoot.tgz`                    |
     /// | Emulator builds      | `/tmp/.kobo/KoboRoot.tgz`                         |
     /// | Kobo builds          | `{INTERNAL_CARD_ROOT}/.kobo/KoboRoot.tgz`         |
-    fn deploy_path(&self) -> PathBuf {
+    pub(crate) fn deploy_path(&self) -> PathBuf {
         let path = cfg_select! {
             test => {
                 self.tmp_dir.join(".kobo").join("KoboRoot.tgz")
@@ -668,7 +702,7 @@ impl OtaClient {
         path
     }
 
-    fn staging_path(&self) -> PathBuf {
+    pub(crate) fn staging_path(&self) -> PathBuf {
         let deploy_path = self.deploy_path();
         let deploy_name = deploy_path
             .file_name()
@@ -678,9 +712,13 @@ impl OtaClient {
         deploy_path.with_file_name(staging_name)
     }
 
-    fn write_staging_then_rename<F>(&self, write: F) -> Result<DeployOutcome, OtaError>
+    fn write_staging_then_rename<F>(
+        &self,
+        should_cancel: CancelFunc<'_>,
+        write: F,
+    ) -> Result<DeployOutcome, OtaError>
     where
-        F: FnOnce(&mut File) -> Result<(), OtaError>,
+        F: FnOnce(&mut File, CancelFunc<'_>) -> Result<(), OtaError>,
     {
         let deploy_path = self.deploy_path();
         let staging_path = self.staging_path();
@@ -688,8 +726,14 @@ impl OtaClient {
 
         let result = (|| {
             let mut staging = File::create(&staging_path)?;
-            write(&mut staging)?;
+            write(&mut staging, should_cancel)?;
+            if should_cancel.is_cancelled() {
+                return Err(OtaError::Cancelled);
+            }
             staging.sync_all()?;
+            if !should_cancel.try_commit() {
+                return Err(OtaError::Cancelled);
+            }
             std::fs::rename(&staging_path, &deploy_path)?;
             match Self::sync_deploy_parent(&deploy_path) {
                 Ok(()) => Ok(DeployOutcome::Durable(deploy_path.clone())),
@@ -769,10 +813,19 @@ impl OtaClient {
         Ok(())
     }
 
-    fn deploy_bytes(&self, data: &[u8]) -> Result<DeployOutcome, OtaError> {
+    fn deploy_bytes(
+        &self,
+        data: &[u8],
+        should_cancel: CancelFunc<'_>,
+    ) -> Result<DeployOutcome, OtaError> {
         let byte_count = data.len();
-        let outcome = self.write_staging_then_rename(|staging| {
-            staging.write_all(data)?;
+        let outcome = self.write_staging_then_rename(should_cancel, |staging, check| {
+            for chunk in data.chunks(64 * 1024) {
+                if check.is_cancelled() {
+                    return Err(OtaError::Cancelled);
+                }
+                staging.write_all(chunk)?;
+            }
             Ok(())
         })?;
 
@@ -803,7 +856,15 @@ impl OtaClient {
     /// * `OtaError::DeploymentError` - KoboRoot.tgz not found in archive
     /// * `OtaError::Io` - Failed to write deployment file before the bundle was renamed
     #[cfg_attr(feature = "tracing", tracing::instrument(skip(self)))]
-    pub fn extract_and_deploy(&self, zip_path: PathBuf) -> Result<DeployOutcome, OtaError> {
+    pub fn extract_and_deploy(
+        &self,
+        zip_path: PathBuf,
+        should_cancel: CancelFunc<'_>,
+    ) -> Result<DeployOutcome, OtaError> {
+        if should_cancel.is_cancelled() {
+            return Err(OtaError::Cancelled);
+        }
+
         tracing::info!(path = ?zip_path, "Extracting and deploying update");
         tracing::debug!(path = ?zip_path, "Starting extraction");
 
@@ -823,6 +884,10 @@ impl OtaClient {
         tracing::debug!(target_file = kobo_root_name, "Looking for file");
 
         for i in 0..archive.len() {
+            if should_cancel.is_cancelled() {
+                return Err(OtaError::Cancelled);
+            }
+
             let mut entry = archive.by_index(i)?;
             let entry_name = entry.name().to_string();
 
@@ -830,7 +895,7 @@ impl OtaClient {
 
             if entry_name.eq(kobo_root_name) {
                 tracing::debug!(name = %entry_name, "Found target file");
-                entry.read_to_end(&mut kobo_root_data)?;
+                read_cancellable(&mut entry, &mut kobo_root_data, should_cancel)?;
                 found = true;
                 break;
             }
@@ -853,7 +918,7 @@ impl OtaClient {
             "Extracted file"
         );
 
-        let outcome = self.deploy_bytes(&kobo_root_data)?;
+        let outcome = self.deploy_bytes(&kobo_root_data, should_cancel)?;
         if let Err(e) = std::fs::remove_file(&zip_path) {
             tracing::error!(path = ?zip_path, error = %e, "Failed to remove source file");
         }
@@ -935,6 +1000,7 @@ impl OtaClient {
         artifact: &Artifact,
         download_path: &PathBuf,
         progress_callback: &mut F,
+        should_cancel: CancelFunc<'_>,
     ) -> Result<(), OtaError>
     where
         F: FnMut(OtaProgress),
@@ -952,6 +1018,7 @@ impl OtaClient {
             &mut |downloaded, total| {
                 progress_callback(OtaProgress::DownloadingArtifact { downloaded, total })
             },
+            Some(should_cancel),
         )?;
         Ok(())
     }
@@ -970,6 +1037,7 @@ impl OtaClient {
         asset: &ReleaseAsset,
         download_path: &PathBuf,
         progress_callback: &mut F,
+        should_cancel: CancelFunc<'_>,
     ) -> Result<(), OtaError>
     where
         F: FnMut(OtaProgress),
@@ -982,9 +1050,34 @@ impl OtaClient {
             &mut |downloaded, total| {
                 progress_callback(OtaProgress::DownloadingArtifact { downloaded, total })
             },
+            Some(should_cancel),
         )?;
         Ok(())
     }
+}
+
+fn copy_with_cancel(
+    src: &mut File,
+    dst: &mut File,
+    should_cancel: CancelFunc<'_>,
+) -> Result<u64, OtaError> {
+    let mut buf = [0u8; 64 * 1024];
+    let mut total = 0u64;
+
+    loop {
+        if should_cancel.is_cancelled() {
+            return Err(OtaError::Cancelled);
+        }
+
+        let read = src.read(&mut buf)?;
+        if read == 0 {
+            break;
+        }
+        dst.write_all(&buf[..read])?;
+        total += read as u64;
+    }
+
+    Ok(total)
 }
 
 fn is_ota_candidate_run(run: &WorkflowRun) -> bool {
@@ -1050,6 +1143,24 @@ fn check_disk_space(path: &Path) -> Result<(), OtaError> {
     Ok(())
 }
 
+fn read_cancellable(
+    reader: &mut impl Read,
+    buf: &mut Vec<u8>,
+    should_cancel: CancelFunc<'_>,
+) -> Result<(), OtaError> {
+    let mut chunk = [0_u8; 64 * 1024];
+    loop {
+        if should_cancel.is_cancelled() {
+            return Err(OtaError::Cancelled);
+        }
+        let n = reader.read(&mut chunk)?;
+        if n == 0 {
+            return Ok(());
+        }
+        buf.extend_from_slice(&chunk[..n]);
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1074,8 +1185,12 @@ mod tests {
         let Some(parent) = deploy_path.parent() else {
             return;
         };
-        let leftovers: Vec<_> = std::fs::read_dir(parent)
-            .expect("read deploy directory")
+        let entries = match std::fs::read_dir(parent) {
+            Ok(entries) => entries,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return,
+            Err(e) => panic!("read deploy directory: {e}"),
+        };
+        let leftovers: Vec<_> = entries
             .filter_map(Result::ok)
             .filter(|entry| entry.file_name().to_string_lossy().ends_with(".partial"))
             .map(|entry| entry.path())
@@ -1084,6 +1199,9 @@ mod tests {
             leftovers.is_empty(),
             "unexpected staging leftovers: {leftovers:?}"
         );
+    }
+    fn no_cancel() -> CancelFunc<'static> {
+        CancelFunc::never()
     }
 
     struct FailSyncDeployParent;
@@ -1110,7 +1228,7 @@ mod tests {
         let artifact_path = temp_dir.path().join("test_artifact.zip");
         std::fs::copy(&fixture_path, &artifact_path).unwrap();
 
-        let result = client.extract_and_deploy(artifact_path.clone());
+        let result = client.extract_and_deploy(artifact_path.clone(), no_cancel());
 
         assert!(
             result.is_ok(),
@@ -1144,7 +1262,7 @@ mod tests {
         let deploy_path = client.deploy_path();
         let payload = b"new bundle content";
 
-        let result = client.write_staging_then_rename(|staging| {
+        let result = client.write_staging_then_rename(no_cancel(), |staging, _| {
             staging.write_all(payload)?;
             Ok(())
         });
@@ -1173,7 +1291,7 @@ mod tests {
         std::fs::write(&deploy_path, existing).unwrap();
 
         let _fail_sync = FailSyncDeployParent::arm();
-        let result = client.write_staging_then_rename(|staging| {
+        let result = client.write_staging_then_rename(no_cancel(), |staging, _| {
             staging.write_all(payload)?;
             Ok(())
         });
@@ -1204,7 +1322,7 @@ mod tests {
         let _fail_sync = FailSyncDeployParent::arm();
 
         let outcome = client
-            .deploy(source_path.clone())
+            .deploy(source_path.clone(), no_cancel())
             .expect("published bundle remains a successful deploy");
 
         assert!(matches!(outcome, DeployOutcome::CommittedNotDurable { .. }));
@@ -1227,7 +1345,7 @@ mod tests {
         client.ensure_deploy_dir(&deploy_path).unwrap();
         std::fs::write(&deploy_path, existing).unwrap();
 
-        let result = client.write_staging_then_rename(|staging| {
+        let result = client.write_staging_then_rename(no_cancel(), |staging, _| {
             staging.write_all(b"partial data")?;
             Err(OtaError::Io(std::io::Error::other("simulated failure")))
         });
@@ -1243,7 +1361,7 @@ mod tests {
         let client = make_client(temp_dir.path().to_path_buf());
         let deploy_path = client.deploy_path();
 
-        let result = client.write_staging_then_rename(|_| {
+        let result = client.write_staging_then_rename(no_cancel(), |_, _| {
             Err(OtaError::Io(std::io::Error::other("simulated failure")))
         });
 
@@ -1253,6 +1371,189 @@ mod tests {
             "Final deploy path should not exist after failed deployment"
         );
         assert_no_partial_staging(&deploy_path);
+    }
+
+    #[test]
+    fn test_atomic_deploy_cancelled_before_rename() {
+        use crate::http::CancelFlag;
+
+        let temp_dir = ota_test_tempdir();
+        let client = make_client(temp_dir.path().to_path_buf());
+        let deploy_path = client.deploy_path();
+        let existing = b"existing bundle content";
+        let cancelled = CancelFlag::new();
+
+        client.ensure_deploy_dir(&deploy_path).unwrap();
+        std::fs::write(&deploy_path, existing).unwrap();
+        cancelled.request_cancel();
+
+        let result =
+            client.write_staging_then_rename(CancelFunc::from_flag(&cancelled), |staging, _| {
+                staging.write_all(b"partial data")?;
+                Ok(())
+            });
+
+        assert!(matches!(result, Err(OtaError::Cancelled)));
+        assert_eq!(std::fs::read(&deploy_path).unwrap(), existing);
+        assert_no_partial_staging(&deploy_path);
+    }
+
+    #[test]
+    fn test_atomic_deploy_commit_ignores_late_cancel() {
+        use crate::http::CancelFlag;
+
+        let temp_dir = ota_test_tempdir();
+        let client = make_client(temp_dir.path().to_path_buf());
+        let deploy_path = client.deploy_path();
+        let payload = b"committed bundle content";
+        let flag = CancelFlag::new();
+
+        let result =
+            client.write_staging_then_rename(CancelFunc::from_flag(&flag), |staging, _| {
+                staging.write_all(payload)?;
+                Ok(())
+            });
+
+        assert!(
+            result.is_ok(),
+            "committed deploy should succeed: {result:?}"
+        );
+        flag.request_cancel();
+        assert!(
+            !flag.is_cancelled(),
+            "cancel after commit must not flip cancelled state"
+        );
+        assert_eq!(std::fs::read(&deploy_path).unwrap(), payload);
+        assert_no_partial_staging(&deploy_path);
+    }
+
+    #[test]
+    fn test_atomic_deploy_cancelled_after_staging_sync() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        let temp_dir = ota_test_tempdir();
+        let client = make_client(temp_dir.path().to_path_buf());
+        let deploy_path = client.deploy_path();
+        let existing = b"existing bundle content";
+        let polls = AtomicUsize::new(0);
+
+        client.ensure_deploy_dir(&deploy_path).unwrap();
+        std::fs::write(&deploy_path, existing).unwrap();
+
+        let cancel_check = || polls.fetch_add(1, Ordering::Relaxed) >= 1;
+        let result =
+            client.write_staging_then_rename(CancelFunc::new(&cancel_check), |staging, _| {
+                staging.write_all(b"partial data")?;
+                Ok(())
+            });
+
+        assert!(matches!(result, Err(OtaError::Cancelled)));
+        assert_eq!(std::fs::read(&deploy_path).unwrap(), existing);
+        assert_no_partial_staging(&deploy_path);
+    }
+
+    #[test]
+    fn test_deploy_bytes_cancelled_mid_write() {
+        use std::sync::atomic::{AtomicBool, Ordering};
+
+        let temp_dir = ota_test_tempdir();
+        let client = make_client(temp_dir.path().to_path_buf());
+        let deploy_path = client.deploy_path();
+        let existing = b"existing bundle content";
+        let cancelled = AtomicBool::new(true);
+        let payload = vec![0u8; 128 * 1024];
+
+        client.ensure_deploy_dir(&deploy_path).unwrap();
+        std::fs::write(&deploy_path, existing).unwrap();
+
+        let cancel_check = || cancelled.load(Ordering::Relaxed);
+        let result = client.deploy_bytes(&payload, CancelFunc::new(&cancel_check));
+
+        assert!(matches!(result, Err(OtaError::Cancelled)));
+        assert_eq!(std::fs::read(&deploy_path).unwrap(), existing);
+        assert_no_partial_staging(&deploy_path);
+    }
+
+    #[test]
+    fn test_extract_and_deploy_cancelled_before_zip_walk() {
+        use std::sync::atomic::{AtomicBool, Ordering};
+
+        let temp_dir = ota_test_tempdir();
+        let client = make_client(temp_dir.path().to_path_buf());
+        let fixture_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("src/ota/tests/fixtures/test_artifact.zip");
+        let artifact_path = temp_dir.path().join("test_artifact.zip");
+        std::fs::copy(&fixture_path, &artifact_path).unwrap();
+
+        let cancelled = AtomicBool::new(true);
+        let cancel_check = || cancelled.load(Ordering::Relaxed);
+        let result =
+            client.extract_and_deploy(artifact_path.clone(), CancelFunc::new(&cancel_check));
+
+        assert!(matches!(result, Err(OtaError::Cancelled)));
+        assert!(
+            artifact_path.exists(),
+            "Source artifact should be retained when extraction is cancelled"
+        );
+        assert_no_partial_staging(&client.deploy_path());
+    }
+
+    #[test]
+    fn test_extract_and_deploy_cancelled_during_zip_walk() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        let temp_dir = ota_test_tempdir();
+        let client = make_client(temp_dir.path().to_path_buf());
+        let fixture_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("src/ota/tests/fixtures/test_artifact.zip");
+        let artifact_path = temp_dir.path().join("test_artifact.zip");
+        std::fs::copy(&fixture_path, &artifact_path).unwrap();
+
+        let checks = AtomicUsize::new(0);
+        let cancel_check = || checks.fetch_add(1, Ordering::Relaxed) >= 1;
+        let result =
+            client.extract_and_deploy(artifact_path.clone(), CancelFunc::new(&cancel_check));
+
+        assert!(matches!(result, Err(OtaError::Cancelled)));
+        assert!(
+            artifact_path.exists(),
+            "Source artifact should be retained when zip walk is cancelled"
+        );
+    }
+
+    #[test]
+    fn test_extract_and_deploy_cancelled_during_entry_read() {
+        use std::io::Write;
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        use zip::ZipWriter;
+        use zip::write::SimpleFileOptions;
+
+        let temp_dir = ota_test_tempdir();
+        let client = make_client(temp_dir.path().to_path_buf());
+        let artifact_path = temp_dir.path().join("large_artifact.zip");
+        let payload = vec![0u8; 128 * 1024];
+        {
+            let file = File::create(&artifact_path).unwrap();
+            let mut zip = ZipWriter::new(file);
+            let options = SimpleFileOptions::default();
+            zip.start_file("KoboRoot.tgz", options).unwrap();
+            zip.write_all(&payload).unwrap();
+            zip.start_file("KoboRoot-test.tgz", options).unwrap();
+            zip.write_all(&payload).unwrap();
+            zip.finish().unwrap();
+        }
+
+        let checks = AtomicUsize::new(0);
+        let cancel_check = || checks.fetch_add(1, Ordering::Relaxed) >= 3;
+        let result =
+            client.extract_and_deploy(artifact_path.clone(), CancelFunc::new(&cancel_check));
+
+        assert!(matches!(result, Err(OtaError::Cancelled)));
+        assert!(
+            artifact_path.exists(),
+            "Source artifact should be retained when entry extraction is cancelled"
+        );
+        assert_no_partial_staging(&client.deploy_path());
     }
 
     #[test]
@@ -1295,7 +1596,7 @@ mod tests {
         let artifact_path = temp_dir.path().join("empty_artifact.zip");
         std::fs::copy(&fixture_path, &artifact_path).unwrap();
 
-        let result = client.extract_and_deploy(artifact_path.clone());
+        let result = client.extract_and_deploy(artifact_path.clone(), no_cancel());
         assert!(result.is_err(), "Should fail when KoboRoot.tgz is missing");
 
         if let Err(OtaError::DeploymentError(msg)) = result {
@@ -1394,9 +1695,12 @@ mod tests {
         let client = create_external_client(temp_dir.path().to_path_buf());
         let mut last_progress = None;
 
-        let download_result = client.download_default_branch_artifact(|progress| {
-            last_progress = Some(format!("{:?}", progress));
-        });
+        let download_result = client.download_default_branch_artifact(
+            |progress| {
+                last_progress = Some(format!("{:?}", progress));
+            },
+            no_cancel(),
+        );
 
         assert!(
             download_result.is_ok(),
@@ -1415,7 +1719,7 @@ mod tests {
             "Downloaded ZIP should not be empty"
         );
 
-        let deploy_result = client.extract_and_deploy(zip_path.clone());
+        let deploy_result = client.extract_and_deploy(zip_path.clone(), no_cancel());
 
         assert!(
             deploy_result.is_ok(),
@@ -1438,7 +1742,7 @@ mod tests {
     fn test_external_download_stable_release_and_deploy() {
         let temp_dir = ota_test_tempdir();
         let client = create_external_client(temp_dir.path().to_path_buf());
-        let download_result = client.download_stable_release_artifact(|_| {});
+        let download_result = client.download_stable_release_artifact(|_| {}, no_cancel());
 
         assert!(
             download_result.is_ok(),
@@ -1457,7 +1761,7 @@ mod tests {
             "Downloaded asset should not be empty"
         );
 
-        let deploy_result = client.deploy(asset_path.clone());
+        let deploy_result = client.deploy(asset_path.clone(), no_cancel());
 
         assert!(
             deploy_result.is_ok(),

--- a/crates/core/src/ota/mod.rs
+++ b/crates/core/src/ota/mod.rs
@@ -11,5 +11,6 @@ mod cleanup;
 mod client;
 
 pub use crate::github::OtaProgress;
-pub use cleanup::clean_bundled_files;
+pub use crate::http::{CancelFlag, CancelFunc};
+pub use cleanup::{clean_bundled_files, cleanup_ota_artifacts, cleanup_ota_cancel};
 pub use client::{ArtifactSource, DeployOutcome, OtaClient, OtaError};

--- a/crates/core/src/view/mod.rs
+++ b/crates/core/src/view/mod.rs
@@ -557,6 +557,8 @@ pub enum Event {
     OtaDownloadProgress {
         label: String,
         percent: u8,
+        /// When false, the update is committed and cancel must be hidden.
+        cancelable: bool,
     },
     /// Signal to start downloading the stable release after version check.
     ///

--- a/crates/core/src/view/ota.rs
+++ b/crates/core/src/view/ota.rs
@@ -1,3 +1,4 @@
+use super::button::Button;
 use super::device_auth::DeviceAuthView;
 use super::dialog::Dialog;
 use super::input_field::InputField;
@@ -11,6 +12,7 @@ use super::{
 };
 use crate::color::WHITE;
 use crate::device::AppContext;
+use crate::device::wifi::WifiSession;
 use crate::device::{DeviceIdentity as _, DevicePaths as _};
 use crate::fl;
 use crate::font::{NORMAL_STYLE, font_from_style};
@@ -18,14 +20,18 @@ use crate::geom::Rectangle;
 use crate::gesture::GestureEvent;
 use crate::github::GithubClient;
 use crate::github::device_flow;
-use crate::ota::{DeployOutcome, OtaClient, OtaError, OtaProgress, clean_bundled_files};
+use crate::ota::{
+    CancelFlag, CancelFunc, DeployOutcome, OtaClient, OtaError, OtaProgress, clean_bundled_files,
+    cleanup_ota_cancel,
+};
 use crate::unit::scale_by_dpi;
 use crate::version::{VersionComparison, get_current_version};
 use crate::view::BIG_BAR_HEIGHT;
 use crate::view::filler::Filler;
 use crate::view::github::GithubEvent;
 use secrecy::SecretString;
-use std::path::Path;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
 use std::thread;
 use tracing::{error, info};
 
@@ -41,10 +47,6 @@ pub enum OtaViewId {
 pub enum OtaEntryId {
     DefaultBranch,
     StableRelease,
-}
-
-fn stable_release_download_label(percent: u8) -> String {
-    fl!("ota-downloading-stable-release", percent = percent)
 }
 
 /// Attempts to show the OTA update view with validation checks.
@@ -110,6 +112,30 @@ enum PendingDownload {
     StableReleaseDownload,
 }
 
+#[derive(Clone, Copy)]
+enum OtaDownloadKind {
+    /// GitHub Actions artifact from a pull request build.
+    Pr(u32),
+    /// Latest artifact from the repository default branch.
+    DefaultBranch,
+    /// Latest stable release asset.
+    StableRelease,
+}
+
+impl OtaDownloadKind {
+    fn progress_label(self, percent: u8) -> String {
+        match self {
+            Self::Pr(pr_number) => fl!(
+                "ota-downloading-pr",
+                pr_number = pr_number,
+                percent = percent
+            ),
+            Self::DefaultBranch => fl!("ota-downloading-default-branch", percent = percent),
+            Self::StableRelease => fl!("ota-downloading-stable-release", percent = percent),
+        }
+    }
+}
+
 /// UI view for downloading and installing OTA updates from GitHub.
 ///
 /// Manages two screens:
@@ -118,9 +144,10 @@ enum PendingDownload {
 /// 2. PR input screen - prompts for PR number input (only for PR Build)
 ///
 /// Once a download starts, the view transitions to a full-screen progress
-/// screen showing a status label and a [`ProgressBar`]. On successful
-/// deployment the label updates to "Rebooting…" and the app reboots
-/// automatically via [`Event::Select`] with [`EntryId::Reboot`].
+/// screen showing a status label, a [`ProgressBar`], and a Cancel button.
+/// Downloads run in a background thread via [`run_ota_download`]. On successful
+/// deployment the label updates to "Installing and rebooting…" and the app
+/// reboots automatically via [`Event::Select`] with [`EntryId::Reboot`].
 ///
 /// When a GitHub token is required but not present, the view pushes a
 /// [`DeviceAuthView`] child to guide the user through device flow
@@ -142,6 +169,11 @@ pub struct OtaView {
     status_label_index: Option<usize>,
     /// Index into `children` of the `ProgressBar` shown during download.
     progress_bar_index: Option<usize>,
+    /// Index into `children` of the Cancel button shown during download.
+    cancel_button_index: Option<usize>,
+    cancelled: Arc<CancelFlag>,
+    download_in_progress: bool,
+    download_committed: bool,
 }
 
 impl OtaView {
@@ -191,6 +223,10 @@ impl OtaView {
             pending_download: None,
             status_label_index: None,
             progress_bar_index: None,
+            cancel_button_index: None,
+            cancelled: Arc::new(CancelFlag::new()),
+            download_in_progress: false,
+            download_committed: false,
         }
     }
 
@@ -253,11 +289,7 @@ impl OtaView {
             rect.max.x - padding,
             rect.min.y + padding + 3 * x_height
         ];
-        let title = Label::new(
-            title_rect,
-            "Download Build from PR".to_string(),
-            Align::Center,
-        );
+        let title = Label::new(title_rect, fl!("ota-pr-input-title"), Align::Center);
         self.children.push(Box::new(title));
 
         let input_rect = rect![
@@ -283,9 +315,10 @@ impl OtaView {
     /// 1. A white full-screen [`Filler`] background
     /// 2. A centered [`Label`] with the given status text
     /// 3. A centered [`ProgressBar`] below the label
+    /// 4. A Cancel [`Button`] below the progress bar
     ///
-    /// The indices of the label and progress bar are stored so they can be
-    /// updated incrementally as progress events arrive.
+    /// The indices of the label, progress bar, and cancel button are stored so
+    /// they can be updated incrementally as progress events arrive.
     fn build_progress_screen(&mut self, status: &str, context: &mut AppContext) {
         let dpi = context.device.dpi();
         let (width, height) = context.device.dims();
@@ -293,7 +326,9 @@ impl OtaView {
         self.children.clear();
         self.status_label_index = None;
         self.progress_bar_index = None;
+        self.cancel_button_index = None;
         self.keyboard_index = None;
+        self.download_committed = false;
 
         self.children.push(Box::new(Filler::new(
             rect![0, 0, width as i32, height as i32],
@@ -330,7 +365,62 @@ impl OtaView {
         self.children.push(Box::new(ProgressBar::new(bar_rect, 0)));
         self.progress_bar_index = Some(self.children.len() - 1);
 
+        let button_width = scale_by_dpi(200.0, dpi) as i32;
+        let button_height = scale_by_dpi(40.0, dpi) as i32;
+        let button_x = (width as i32 - button_width) / 2;
+        let button_y = center_y + gap / 2 + bar_height + gap;
+        let cancel_rect = rect![
+            button_x,
+            button_y,
+            button_x + button_width,
+            button_y + button_height
+        ];
+        self.children.push(Box::new(Button::new(
+            cancel_rect,
+            Event::Close(self.view_id),
+            fl!("ota-download-cancel"),
+        )));
+        self.cancel_button_index = Some(self.children.len() - 1);
+
         self.rect = rect![0, 0, width as i32, height as i32];
+    }
+
+    /// Resets cancel state and marks a new download as in progress.
+    fn begin_download(&mut self) {
+        self.cancelled = Arc::new(CancelFlag::new());
+        self.download_in_progress = true;
+        self.download_committed = false;
+    }
+
+    /// Signals the background download thread to stop and clean up.
+    fn cancel_download(&self) {
+        self.cancelled.request_cancel();
+    }
+
+    /// Removes the Cancel button after the update is committed to disk.
+    fn hide_cancel_button(&mut self, rq: &mut RenderQueue) {
+        if let Some(idx) = self.cancel_button_index.take()
+            && let Some(child) = self.children.get(idx)
+        {
+            let button_rect = *child.rect();
+            self.children.remove(idx);
+            self.shift_child_indices_after_remove(idx);
+            rq.add(RenderData::expose(button_rect, UpdateMode::Gui));
+        }
+    }
+
+    fn shift_child_indices_after_remove(&mut self, removed: usize) {
+        for index in [
+            &mut self.status_label_index,
+            &mut self.progress_bar_index,
+            &mut self.cancel_button_index,
+        ] {
+            if let Some(i) = index
+                && *i > removed
+            {
+                *i -= 1;
+            }
+        }
     }
 
     /// Toggles keyboard visibility based on focus state.
@@ -364,13 +454,12 @@ impl OtaView {
     ) {
         if let Ok(pr_number) = text.trim().parse::<u32>() {
             self.pending_download = Some(PendingDownload::Pr(pr_number));
-            self.build_progress_screen(&format!("Downloading PR #{} build…", pr_number), context);
+            self.build_progress_screen(&OtaDownloadKind::Pr(pr_number).progress_label(0), context);
             rq.add(RenderData::new(self.id, self.rect, UpdateMode::Full));
             self.start_pr_download(pr_number, hub, context);
         } else {
             hub.send(
-                (Event::Notification(NotificationEvent::Show("Invalid PR number".to_string())))
-                    .into(),
+                (Event::Notification(NotificationEvent::Show(fl!("ota-invalid-pr-number")))).into(),
             )
             .ok();
         }
@@ -395,7 +484,11 @@ impl OtaView {
             && !context.kb_rect.includes(tap_position)
             && !context.kb_rect.is_empty()
         {
-            hub.send((Event::Close(self.view_id)).into()).ok();
+            if self.download_in_progress && !self.download_committed {
+                self.cancel_download();
+            } else {
+                hub.send((Event::Close(self.view_id)).into()).ok();
+            }
         }
     }
 
@@ -424,6 +517,17 @@ impl OtaView {
         }
     }
 
+    /// Consumes a close request during an in-flight download by cancelling instead
+    /// of closing immediately; the background thread closes the view after cleanup.
+    fn on_close_during_download(&mut self) -> bool {
+        if self.download_in_progress && !self.download_committed {
+            self.cancel_download();
+            true
+        } else {
+            false
+        }
+    }
+
     /// Checks that a GitHub token is available.
     ///
     /// Returns `true` if a token is present and the caller may proceed.
@@ -448,13 +552,10 @@ impl OtaView {
         false
     }
 
-    /// Initiates the PR artifact download in a background thread.
+    /// Starts a PR artifact download via [`run_ota_download`].
     ///
-    /// Sends [`Event::OtaDownloadProgress`] during the download. On success,
-    /// updates the status label to "Rebooting…" and sends
-    /// [`Event::Select`] with [`EntryId::Reboot`] to trigger an automatic reboot.
-    /// On a 401 response, sends [`Event::Github`] with [`GithubEvent::TokenInvalid`] without closing
-    /// the view so re-authentication can proceed.
+    /// Requires a GitHub token; callers must validate with
+    /// [`Self::require_github_token`] first.
     #[cfg_attr(feature = "tracing", tracing::instrument(skip(self, hub, context)))]
     fn start_pr_download(&mut self, pr_number: u32, hub: &Hub, context: &AppContext) {
         let Some(github_token) = self.effective_github_token() else {
@@ -464,119 +565,23 @@ impl OtaView {
             return;
         };
 
-        let hub2 = hub.clone();
-        let parent_span = tracing::Span::current();
-        let ota_view_id = self.view_id;
-        let tmp_dir = context.device.tmp_dir();
-        let install_dir = context.device.install_dir();
-        let wifi_session = context.wifi_session.clone();
-
-        thread::spawn(move || {
-            let _span =
-                tracing::info_span!(parent: &parent_span, "pr_download_async", pr_number).entered();
-            let _wifi = match wifi_session.acquire("ota-download") {
-                Ok(lease) => lease,
-                Err(e) => {
-                    error!(error = %e, "Failed to acquire WiFi lease for OTA download");
-                    hub2.send((Event::Close(ota_view_id)).into()).ok();
-                    hub2.send(
-                        (Event::Notification(NotificationEvent::Show(fl!(
-                            "notification-not-online"
-                        ))))
-                        .into(),
-                    )
-                    .ok();
-                    return;
-                }
-            };
-            let github = match GithubClient::new(Some(github_token)) {
-                Ok(c) => c,
-                Err(e) => {
-                    error!(error = %e, "Failed to create GitHub client");
-                    hub2.send((Event::Close(ota_view_id)).into()).ok();
-                    hub2.send(
-                        (Event::Notification(NotificationEvent::Show(format!(
-                            "Failed to create client: {}",
-                            e
-                        ))))
-                        .into(),
-                    )
-                    .ok();
-                    return;
-                }
-            };
-            let client = OtaClient::new(github, tmp_dir);
-
-            hub2.send(
-                (Event::OtaDownloadProgress {
-                    label: format!("Downloading PR #{} build… 0%", pr_number),
-                    percent: 0,
-                })
-                .into(),
-            )
-            .ok();
-
-            let download_result = client.download_pr_artifact(pr_number, |ota_progress| {
-                if let OtaProgress::DownloadingArtifact { downloaded, total } = ota_progress {
-                    let percent = (downloaded as f32 / total as f32 * 100.0) as u8;
-                    hub2.send(
-                        (Event::OtaDownloadProgress {
-                            label: format!("Downloading PR #{} build… {}%", pr_number, percent),
-                            percent,
-                        })
-                        .into(),
-                    )
-                    .ok();
-                }
-            });
-
-            match download_result {
-                Ok(zip_path) => {
-                    info!(pr_number, "Download completed, starting extraction");
-                    match client.extract_and_deploy(zip_path) {
-                        Ok(outcome) => finish_successful_deploy(&hub2, &install_dir, outcome),
-                        Err(e) => {
-                            error!(error = %e, "Deployment failed");
-                            hub2.send((Event::Close(ota_view_id)).into()).ok();
-                            hub2.send(
-                                (Event::Notification(NotificationEvent::Show(format!(
-                                    "Deployment failed: {}",
-                                    e
-                                ))))
-                                .into(),
-                            )
-                            .ok();
-                        }
-                    }
-                }
-                Err(OtaError::Unauthorized) | Err(OtaError::InsufficientScopes(_)) => {
-                    tracing::warn!(pr_number, "GitHub token rejected — triggering re-auth");
-                    hub2.send((Event::Github(GithubEvent::TokenInvalid)).into())
-                        .ok();
-                }
-                Err(e) => {
-                    error!(error = %e, "PR download failed");
-                    hub2.send((Event::Close(ota_view_id)).into()).ok();
-                    hub2.send(
-                        (Event::Notification(NotificationEvent::Show(format!(
-                            "Download failed: {}",
-                            e
-                        ))))
-                        .into(),
-                    )
-                    .ok();
-                }
-            }
+        self.begin_download();
+        run_ota_download(OtaDownloadContext {
+            kind: OtaDownloadKind::Pr(pr_number),
+            hub: hub.clone(),
+            ota_view_id: self.view_id,
+            tmp_dir: context.device.tmp_dir(),
+            install_dir: context.device.install_dir(),
+            github_token: Some(github_token),
+            cancelled: Arc::clone(&self.cancelled),
+            wifi_session: context.wifi_session.clone(),
         });
     }
 
-    /// Initiates the default branch download in a background thread.
+    /// Starts a default-branch artifact download via [`run_ota_download`].
     ///
-    /// Sends [`Event::OtaDownloadProgress`] during the download. On success,
-    /// updates the status label to "Rebooting…" and sends
-    /// [`Event::Select`] with [`EntryId::Reboot`] to trigger an automatic reboot.
-    /// On a 401 response, sends [`Event::Github`] with [`GithubEvent::TokenInvalid`] without closing
-    /// the view so re-authentication can proceed.
+    /// Requires a GitHub token; callers must validate with
+    /// [`Self::require_github_token`] first.
     #[cfg_attr(feature = "tracing", tracing::instrument(skip(self, hub, context)))]
     fn start_default_branch_download(&mut self, hub: &Hub, context: &AppContext) {
         let Some(github_token) = self.effective_github_token() else {
@@ -586,233 +591,54 @@ impl OtaView {
             return;
         };
 
-        let hub2 = hub.clone();
-        let parent_span = tracing::Span::current();
-        let ota_view_id = self.view_id;
-        let tmp_dir = context.device.tmp_dir();
-        let install_dir = context.device.install_dir();
-        let wifi_session = context.wifi_session.clone();
-
-        thread::spawn(move || {
-            let _span = tracing::info_span!(parent: &parent_span, "default_branch_download_async")
-                .entered();
-            let _wifi = match wifi_session.acquire("ota-download") {
-                Ok(lease) => lease,
-                Err(e) => {
-                    error!(error = %e, "Failed to acquire WiFi lease for OTA download");
-                    hub2.send((Event::Close(ota_view_id)).into()).ok();
-                    hub2.send(
-                        (Event::Notification(NotificationEvent::Show(fl!(
-                            "notification-not-online"
-                        ))))
-                        .into(),
-                    )
-                    .ok();
-                    return;
-                }
-            };
-            let github = match GithubClient::new(Some(github_token)) {
-                Ok(c) => c,
-                Err(e) => {
-                    error!(error = %e, "Failed to create GitHub client");
-                    hub2.send((Event::Close(ota_view_id)).into()).ok();
-                    hub2.send(
-                        (Event::Notification(NotificationEvent::Show(format!(
-                            "Failed to create client: {}",
-                            e
-                        ))))
-                        .into(),
-                    )
-                    .ok();
-                    return;
-                }
-            };
-            let client = OtaClient::new(github, tmp_dir);
-
-            hub2.send(
-                (Event::OtaDownloadProgress {
-                    label: "Downloading main branch build… 0%".to_string(),
-                    percent: 0,
-                })
-                .into(),
-            )
-            .ok();
-
-            let download_result = client.download_default_branch_artifact(|ota_progress| {
-                if let OtaProgress::DownloadingArtifact { downloaded, total } = ota_progress {
-                    let percent = (downloaded as f32 / total as f32 * 100.0) as u8;
-                    hub2.send(
-                        (Event::OtaDownloadProgress {
-                            label: format!("Downloading main branch build… {}%", percent),
-                            percent,
-                        })
-                        .into(),
-                    )
-                    .ok();
-                }
-            });
-
-            match download_result {
-                Ok(zip_path) => {
-                    info!("Main branch download completed, starting extraction");
-                    match client.extract_and_deploy(zip_path) {
-                        Ok(outcome) => finish_successful_deploy(&hub2, &install_dir, outcome),
-                        Err(e) => {
-                            error!(error = %e, "Deployment failed");
-                            hub2.send((Event::Close(ota_view_id)).into()).ok();
-                            hub2.send(
-                                (Event::Notification(NotificationEvent::Show(format!(
-                                    "Deployment failed: {}",
-                                    e
-                                ))))
-                                .into(),
-                            )
-                            .ok();
-                        }
-                    }
-                }
-                Err(OtaError::Unauthorized) | Err(OtaError::InsufficientScopes(_)) => {
-                    tracing::warn!("GitHub token rejected — triggering re-auth");
-                    hub2.send((Event::Github(GithubEvent::TokenInvalid)).into())
-                        .ok();
-                }
-                Err(e) => {
-                    error!(error = %e, "Main branch download failed");
-                    hub2.send((Event::Close(ota_view_id)).into()).ok();
-                    hub2.send(
-                        (Event::Notification(NotificationEvent::Show(format!(
-                            "Download failed: {}",
-                            e
-                        ))))
-                        .into(),
-                    )
-                    .ok();
-                }
-            }
+        self.begin_download();
+        run_ota_download(OtaDownloadContext {
+            kind: OtaDownloadKind::DefaultBranch,
+            hub: hub.clone(),
+            ota_view_id: self.view_id,
+            tmp_dir: context.device.tmp_dir(),
+            install_dir: context.device.install_dir(),
+            github_token: Some(github_token),
+            cancelled: Arc::clone(&self.cancelled),
+            wifi_session: context.wifi_session.clone(),
         });
     }
 
-    /// Initiates the stable release download in a background thread.
+    /// Starts a stable release download via [`run_ota_download`].
     ///
-    /// Sends [`Event::OtaDownloadProgress`] during the download. On success,
-    /// updates the status label to "Rebooting…" and sends
-    /// [`Event::Select`] with [`EntryId::Reboot`] to trigger an automatic reboot.
-    /// On a 401 response, sends [`Event::Github`] with [`GithubEvent::TokenInvalid`] without closing
-    /// the view so re-authentication can proceed.
-    ///
-    /// GitHub authentication is not required for this operation.
-    ///
-    /// # Arguments
-    ///
-    /// * `hub` - Event hub for sending notifications and status updates
+    /// GitHub authentication is optional for this path.
     #[cfg_attr(feature = "tracing", tracing::instrument(skip(self, hub, context)))]
     fn start_stable_release_download(&mut self, hub: &Hub, context: &AppContext) {
-        let github_token = self.effective_github_token();
-        let hub2 = hub.clone();
-        let parent_span = tracing::Span::current();
-        let ota_view_id = self.view_id;
-        let tmp_dir = context.device.tmp_dir();
-        let install_dir = context.device.install_dir();
-        let wifi_session = context.wifi_session.clone();
-
-        thread::spawn(move || {
-            let _span = tracing::info_span!(parent: &parent_span, "stable_release_download_async")
-                .entered();
-            let _wifi = match wifi_session.acquire("ota-download") {
-                Ok(lease) => lease,
-                Err(e) => {
-                    error!(error = %e, "Failed to acquire WiFi lease for OTA download");
-                    hub2.send((Event::Close(ota_view_id)).into()).ok();
-                    hub2.send(
-                        (Event::Notification(NotificationEvent::Show(fl!(
-                            "notification-not-online"
-                        ))))
-                        .into(),
-                    )
-                    .ok();
-                    return;
-                }
-            };
-            let github = match GithubClient::new(github_token) {
-                Ok(c) => c,
-                Err(e) => {
-                    error!(error = %e, "Failed to create GitHub client");
-                    hub2.send((Event::Close(ota_view_id)).into()).ok();
-                    hub2.send(
-                        (Event::Notification(NotificationEvent::Show(format!(
-                            "Failed to create client: {}",
-                            e
-                        ))))
-                        .into(),
-                    )
-                    .ok();
-                    return;
-                }
-            };
-            let client = OtaClient::new(github, tmp_dir);
-
-            hub2.send(
-                (Event::OtaDownloadProgress {
-                    label: stable_release_download_label(0),
-                    percent: 0,
-                })
-                .into(),
-            )
-            .ok();
-
-            let download_result = client.download_stable_release_artifact(|ota_progress| {
-                if let OtaProgress::DownloadingArtifact { downloaded, total } = ota_progress {
-                    let percent = (downloaded as f32 / total as f32 * 100.0) as u8;
-                    hub2.send(
-                        (Event::OtaDownloadProgress {
-                            label: stable_release_download_label(percent),
-                            percent,
-                        })
-                        .into(),
-                    )
-                    .ok();
-                }
-            });
-
-            match download_result {
-                Ok(asset_path) => {
-                    info!("Stable release download completed, deploying update");
-                    match client.deploy(asset_path) {
-                        Ok(outcome) => finish_successful_deploy(&hub2, &install_dir, outcome),
-                        Err(e) => {
-                            error!(error = %e, "Deployment failed");
-                            hub2.send((Event::Close(ota_view_id)).into()).ok();
-                            hub2.send(
-                                (Event::Notification(NotificationEvent::Show(format!(
-                                    "Deployment failed: {}",
-                                    e
-                                ))))
-                                .into(),
-                            )
-                            .ok();
-                        }
-                    }
-                }
-                Err(OtaError::Unauthorized) | Err(OtaError::InsufficientScopes(_)) => {
-                    tracing::warn!("GitHub token rejected on stable release — triggering re-auth");
-                    hub2.send((Event::Github(GithubEvent::TokenInvalid)).into())
-                        .ok();
-                }
-                Err(e) => {
-                    error!(error = %e, "Stable release download failed");
-                    hub2.send((Event::Close(ota_view_id)).into()).ok();
-                    hub2.send(
-                        (Event::Notification(NotificationEvent::Show(format!(
-                            "Download failed: {}",
-                            e
-                        ))))
-                        .into(),
-                    )
-                    .ok();
-                }
-            }
+        self.begin_download();
+        run_ota_download(OtaDownloadContext {
+            kind: OtaDownloadKind::StableRelease,
+            hub: hub.clone(),
+            ota_view_id: self.view_id,
+            tmp_dir: context.device.tmp_dir(),
+            install_dir: context.device.install_dir(),
+            github_token: self.effective_github_token(),
+            cancelled: Arc::clone(&self.cancelled),
+            wifi_session: context.wifi_session.clone(),
         });
     }
+}
+
+/// Parameters for a background OTA download started by [`run_ota_download`].
+struct OtaDownloadContext {
+    kind: OtaDownloadKind,
+    hub: Hub,
+    ota_view_id: ViewId,
+    tmp_dir: PathBuf,
+    install_dir: PathBuf,
+    github_token: Option<SecretString>,
+    cancelled: Arc<CancelFlag>,
+    wifi_session: Arc<WifiSession>,
+}
+
+/// Cleans up partial OTA files and closes the view after user cancellation.
+fn finish_ota_cancelled(hub: &Hub, ota_view_id: ViewId, tmp_dir: &Path, deploy_path: &Path) {
+    cleanup_ota_cancel(tmp_dir, deploy_path);
+    hub.send((Event::Close(ota_view_id)).into()).ok();
 }
 
 /// Completes a published OTA install, including the committed-but-not-durable
@@ -829,15 +655,205 @@ fn finish_successful_deploy(hub: &Hub, install_dir: &Path, outcome: DeployOutcom
     if let Err(e) = clean_bundled_files(install_dir) {
         tracing::warn!(path = ?install_dir, error = %e, "Failed to clean bundled OTA files");
     }
+    send_ota_progress(hub, fl!("ota-installing-and-rebooting"), 100, false);
+    send_reboot_after_delay(hub.clone());
+}
+
+/// Sends an [`Event::OtaDownloadProgress`] update to the UI thread.
+fn send_ota_progress(hub: &Hub, label: String, percent: u8, cancelable: bool) {
     hub.send(
         (Event::OtaDownloadProgress {
-            label: fl!("ota-installing-and-rebooting"),
-            percent: 100,
+            label,
+            percent,
+            cancelable,
         })
         .into(),
     )
     .ok();
-    send_reboot_after_delay(hub.clone());
+}
+
+/// Runs an OTA download and deployment in a background thread.
+///
+/// Sends [`Event::OtaDownloadProgress`] during the download and deployment.
+/// Progress events set `cancelable: true` until `KoboRoot.tgz` is committed;
+/// the UI hides the Cancel button when `cancelable` becomes `false`.
+///
+/// On success, sends a final progress update ("Installing and rebooting…") and
+/// schedules an automatic reboot via [`send_reboot_after_delay`].
+///
+/// On user cancellation, deletes partial download and staging files via
+/// [`finish_ota_cancelled`] and closes the view without rebooting.
+///
+/// On a 401 or insufficient-scopes response, sends [`Event::Github`] with
+/// [`GithubEvent::TokenInvalid`] without closing the view so re-authentication
+/// can proceed.
+///
+/// Acquires a WiFi lease for the duration of the download; the lease is
+/// released when the thread exits.
+fn run_ota_download(ctx: OtaDownloadContext) {
+    let OtaDownloadContext {
+        kind,
+        hub,
+        ota_view_id,
+        tmp_dir,
+        install_dir,
+        github_token,
+        cancelled,
+        wifi_session,
+    } = ctx;
+
+    let hub2 = hub.clone();
+    let parent_span = tracing::Span::current();
+    thread::spawn(move || {
+        let _span = match kind {
+            OtaDownloadKind::Pr(pr_number) => tracing::info_span!(
+                parent: &parent_span,
+                "pr_download_async",
+                pr_number
+            )
+            .entered(),
+            OtaDownloadKind::DefaultBranch => tracing::info_span!(
+                parent: &parent_span,
+                "default_branch_download_async"
+            )
+            .entered(),
+            OtaDownloadKind::StableRelease => tracing::info_span!(
+                parent: &parent_span,
+                "stable_release_download_async"
+            )
+            .entered(),
+        };
+        let should_cancel = CancelFunc::from_flag(&cancelled);
+
+        let _wifi = match wifi_session.acquire("ota-download") {
+            Ok(lease) => lease,
+            Err(e) => {
+                error!(error = %e, "Failed to acquire WiFi lease for OTA download");
+                hub2.send((Event::Close(ota_view_id)).into()).ok();
+                hub2.send(
+                    (Event::Notification(NotificationEvent::Show(fl!("notification-not-online"))))
+                        .into(),
+                )
+                .ok();
+                return;
+            }
+        };
+
+        let github = match GithubClient::new(github_token) {
+            Ok(c) => c,
+            Err(e) => {
+                error!(error = %e, "Failed to create GitHub client");
+                hub2.send((Event::Close(ota_view_id)).into()).ok();
+                hub2.send(
+                    (Event::Notification(NotificationEvent::Show(fl!("ota-client-build-failed"))))
+                        .into(),
+                )
+                .ok();
+                return;
+            }
+        };
+
+        let client = OtaClient::new(github, tmp_dir.clone());
+        let deploy_path = client.deploy_path();
+
+        let initial_label = kind.progress_label(0);
+        send_ota_progress(&hub2, initial_label, 0, true);
+
+        let download_result = match kind {
+            OtaDownloadKind::Pr(pr_number) => client.download_pr_artifact(
+                pr_number,
+                |ota_progress| {
+                    if let OtaProgress::DownloadingArtifact { downloaded, total } = ota_progress {
+                        let percent = (downloaded as f32 / total as f32 * 100.0) as u8;
+                        send_ota_progress(
+                            &hub2,
+                            OtaDownloadKind::Pr(pr_number).progress_label(percent),
+                            percent,
+                            true,
+                        );
+                    }
+                },
+                should_cancel,
+            ),
+            OtaDownloadKind::DefaultBranch => client.download_default_branch_artifact(
+                |ota_progress| {
+                    if let OtaProgress::DownloadingArtifact { downloaded, total } = ota_progress {
+                        let percent = (downloaded as f32 / total as f32 * 100.0) as u8;
+                        send_ota_progress(
+                            &hub2,
+                            OtaDownloadKind::DefaultBranch.progress_label(percent),
+                            percent,
+                            true,
+                        );
+                    }
+                },
+                should_cancel,
+            ),
+            OtaDownloadKind::StableRelease => client.download_stable_release_artifact(
+                |ota_progress| {
+                    if let OtaProgress::DownloadingArtifact { downloaded, total } = ota_progress {
+                        let percent = (downloaded as f32 / total as f32 * 100.0) as u8;
+                        send_ota_progress(
+                            &hub2,
+                            OtaDownloadKind::StableRelease.progress_label(percent),
+                            percent,
+                            true,
+                        );
+                    }
+                },
+                should_cancel,
+            ),
+        };
+
+        if matches!(download_result, Err(OtaError::Cancelled)) {
+            finish_ota_cancelled(&hub2, ota_view_id, &tmp_dir, &deploy_path);
+            return;
+        }
+
+        match download_result {
+            Ok(artifact_path) => {
+                info!("Download completed, starting deployment");
+                let deploy_result = match kind {
+                    OtaDownloadKind::StableRelease => client.deploy(artifact_path, should_cancel),
+                    _ => client.extract_and_deploy(artifact_path, should_cancel),
+                };
+
+                if matches!(deploy_result, Err(OtaError::Cancelled)) {
+                    finish_ota_cancelled(&hub2, ota_view_id, &tmp_dir, &deploy_path);
+                    return;
+                }
+
+                match deploy_result {
+                    Ok(outcome) => finish_successful_deploy(&hub2, &install_dir, outcome),
+                    Err(e) => {
+                        error!(error = %e, "Deployment failed");
+                        hub2.send((Event::Close(ota_view_id)).into()).ok();
+                        hub2.send(
+                            (Event::Notification(NotificationEvent::Show(fl!(
+                                "ota-deployment-failed"
+                            ))))
+                            .into(),
+                        )
+                        .ok();
+                    }
+                }
+            }
+            Err(OtaError::Unauthorized) | Err(OtaError::InsufficientScopes(_)) => {
+                tracing::warn!("GitHub token rejected — triggering re-auth");
+                hub2.send((Event::Github(GithubEvent::TokenInvalid)).into())
+                    .ok();
+            }
+            Err(e) => {
+                error!(error = %e, "OTA download failed");
+                hub2.send((Event::Close(ota_view_id)).into()).ok();
+                hub2.send(
+                    (Event::Notification(NotificationEvent::Show(fl!("ota-download-failed"))))
+                        .into(),
+                )
+                .ok();
+            }
+        }
+    });
 }
 
 /// Spawns a thread that sleeps for 1 second then sends `Event::Select(EntryId::Reboot)`.
@@ -863,7 +879,7 @@ impl OtaView {
             return true;
         }
         self.pending_download = Some(PendingDownload::DefaultBranch);
-        self.build_progress_screen("Downloading main branch build… 0%", context);
+        self.build_progress_screen(&OtaDownloadKind::DefaultBranch.progress_label(0), context);
         rq.add(RenderData::new(self.id, self.rect, UpdateMode::Full));
         self.start_default_branch_download(hub, context);
         true
@@ -883,11 +899,8 @@ impl OtaView {
                 tracing::error!(error = %e, "Failed to create GitHub client");
                 hub.send((Event::Close(ota_view_id)).into()).ok();
                 hub.send(
-                    (Event::Notification(NotificationEvent::Show(format!(
-                        "Failed to create client: {}",
-                        e
-                    ))))
-                    .into(),
+                    (Event::Notification(NotificationEvent::Show(fl!("ota-client-build-failed"))))
+                        .into(),
                 )
                 .ok();
                 return true;
@@ -902,11 +915,8 @@ impl OtaView {
                 tracing::error!(error = %e, "Failed to fetch or parse latest release version");
                 hub.send((Event::Close(ota_view_id)).into()).ok();
                 hub.send(
-                    (Event::Notification(NotificationEvent::Show(format!(
-                        "Failed to check for updates: {}",
-                        e
-                    ))))
-                    .into(),
+                    (Event::Notification(NotificationEvent::Show(fl!("ota-check-updates-failed"))))
+                        .into(),
                 )
                 .ok();
                 return true;
@@ -927,10 +937,8 @@ impl OtaView {
                 tracing::info!("Current version equals remote version - already latest");
                 hub.send((Event::Close(ota_view_id)).into()).ok();
                 hub.send(
-                    (Event::Notification(NotificationEvent::Show(
-                        "You already have the latest version".to_string(),
-                    )))
-                    .into(),
+                    (Event::Notification(NotificationEvent::Show(fl!("ota-already-latest"))))
+                        .into(),
                 )
                 .ok();
             }
@@ -939,10 +947,7 @@ impl OtaView {
                 tracing::info!("Current version is newer than remote version");
                 hub.send((Event::Close(ota_view_id)).into()).ok();
                 hub.send(
-                    (Event::Notification(NotificationEvent::Show(
-                        "Your version is newer than the latest release".to_string(),
-                    )))
-                    .into(),
+                    (Event::Notification(NotificationEvent::Show(fl!("ota-version-newer")))).into(),
                 )
                 .ok();
             }
@@ -955,9 +960,9 @@ impl OtaView {
                 tracing::warn!("Cannot compare versions - divergent branches");
                 hub.send((Event::Close(ota_view_id)).into()).ok();
                 hub.send(
-                    (Event::Notification(NotificationEvent::Show(
-                        "Cannot compare versions - divergent branches".to_string(),
-                    )))
+                    (Event::Notification(NotificationEvent::Show(fl!(
+                        "ota-cannot-compare-versions"
+                    ))))
                     .into(),
                 )
                 .ok();
@@ -967,9 +972,8 @@ impl OtaView {
                 tracing::error!(error = %e, "Version comparison error");
                 hub.send((Event::Close(ota_view_id)).into()).ok();
                 hub.send(
-                    (Event::Notification(NotificationEvent::Show(format!(
-                        "Version comparison error: {}",
-                        e
+                    (Event::Notification(NotificationEvent::Show(fl!(
+                        "ota-version-comparison-error"
                     ))))
                     .into(),
                 )
@@ -998,8 +1002,23 @@ impl OtaView {
         true
     }
 
+    /// Updates the progress label and bar from an [`Event::OtaDownloadProgress`].
+    ///
+    /// Hides the Cancel button when `cancelable` is `false`, indicating the
+    /// update has been committed to disk.
     #[inline]
-    fn on_download_progress(&mut self, label: &str, percent: u8, rq: &mut RenderQueue) -> bool {
+    fn on_download_progress(
+        &mut self,
+        label: &str,
+        percent: u8,
+        cancelable: bool,
+        rq: &mut RenderQueue,
+    ) -> bool {
+        if !cancelable {
+            self.download_committed = true;
+            self.hide_cancel_button(rq);
+        }
+
         if let Some(idx) = self.status_label_index {
             if let Some(child) = self.children.get_mut(idx) {
                 if let Some(lbl) = child.downcast_mut::<Label>() {
@@ -1009,9 +1028,12 @@ impl OtaView {
         }
 
         if percent == 100 {
-            if let Some(idx) = self.progress_bar_index.take() {
-                let bar_rect = *self.children[idx].rect();
+            if let Some(idx) = self.progress_bar_index.take()
+                && let Some(child) = self.children.get(idx)
+            {
+                let bar_rect = *child.rect();
                 self.children.remove(idx);
+                self.shift_child_indices_after_remove(idx);
                 rq.add(RenderData::expose(bar_rect, UpdateMode::Gui));
             }
         } else if let Some(idx) = self.progress_bar_index {
@@ -1043,7 +1065,10 @@ impl OtaView {
 
         match self.pending_download.take() {
             Some(PendingDownload::DefaultBranch) => {
-                self.build_progress_screen("Downloading main branch build… 0%", context);
+                self.build_progress_screen(
+                    &OtaDownloadKind::DefaultBranch.progress_label(0),
+                    context,
+                );
                 rq.add(RenderData::new(self.id, self.rect, UpdateMode::Full));
                 self.start_default_branch_download(hub, context);
             }
@@ -1056,7 +1081,7 @@ impl OtaView {
             }
             Some(PendingDownload::Pr(pr_number)) => {
                 self.build_progress_screen(
-                    &format!("Downloading PR #{} build… 0%", pr_number),
+                    &OtaDownloadKind::Pr(pr_number).progress_label(0),
                     context,
                 );
                 rq.add(RenderData::new(self.id, self.rect, UpdateMode::Full));
@@ -1066,7 +1091,10 @@ impl OtaView {
                 self.on_select_stable_release(hub, context);
             }
             Some(PendingDownload::StableReleaseDownload) => {
-                self.build_progress_screen(&stable_release_download_label(0), context);
+                self.build_progress_screen(
+                    &OtaDownloadKind::StableRelease.progress_label(0),
+                    context,
+                );
                 rq.add(RenderData::new(self.id, self.rect, UpdateMode::Full));
                 self.pending_download = Some(PendingDownload::StableReleaseDownload);
                 self.start_stable_release_download(hub, context);
@@ -1103,6 +1131,9 @@ impl OtaView {
             }
         }
 
+        self.download_in_progress = false;
+        self.download_committed = false;
+
         let auth_view = DeviceAuthView::new(hub, context);
         self.children.push(Box::new(auth_view) as Box<dyn View>);
         rq.add(RenderData::new(self.id, self.rect, UpdateMode::Gui));
@@ -1113,13 +1144,8 @@ impl OtaView {
     fn on_device_auth_expired(&mut self, hub: &Hub) -> bool {
         tracing::warn!("Device flow code expired");
         self.pending_download = None;
-        hub.send(
-            (Event::Notification(NotificationEvent::Show(
-                "GitHub authorization timed out. Please try again.".to_string(),
-            )))
-            .into(),
-        )
-        .ok();
+        hub.send((Event::Notification(NotificationEvent::Show(fl!("ota-auth-timed-out")))).into())
+            .ok();
         hub.send((Event::Close(self.view_id)).into()).ok();
         true
     }
@@ -1128,14 +1154,8 @@ impl OtaView {
     fn on_device_auth_error(&mut self, msg: &str, hub: &Hub) -> bool {
         tracing::error!(error = %msg, "Device flow error");
         self.pending_download = None;
-        hub.send(
-            (Event::Notification(NotificationEvent::Show(format!(
-                "GitHub auth error: {}",
-                msg
-            ))))
-            .into(),
-        )
-        .ok();
+        hub.send((Event::Notification(NotificationEvent::Show(fl!("ota-auth-error")))).into())
+            .ok();
         hub.send((Event::Close(self.view_id)).into()).ok();
         true
     }
@@ -1175,9 +1195,12 @@ impl View for OtaView {
                 self.handle_outside_tap(*center, context, hub);
                 true
             }
-            Event::OtaDownloadProgress { label, percent } => {
-                self.on_download_progress(label, *percent, rq)
-            }
+            Event::Close(id) if *id == self.view_id => self.on_close_during_download(),
+            Event::OtaDownloadProgress {
+                label,
+                percent,
+                cancelable,
+            } => self.on_download_progress(label, *percent, *cancelable, rq),
             Event::Github(GithubEvent::DeviceAuthComplete(token)) => {
                 self.on_device_auth_complete(token, hub, rq, context)
             }
@@ -1186,7 +1209,10 @@ impl View for OtaView {
             Event::Github(GithubEvent::DeviceAuthError(msg)) => self.on_device_auth_error(msg, hub),
             Event::StartStableReleaseDownload => {
                 self.pending_download = Some(PendingDownload::StableReleaseDownload);
-                self.build_progress_screen(&stable_release_download_label(0), context);
+                self.build_progress_screen(
+                    &OtaDownloadKind::StableRelease.progress_label(0),
+                    context,
+                );
                 rq.add(RenderData::new(self.id, self.rect, UpdateMode::Full));
                 self.start_stable_release_download(hub, context);
                 true
@@ -1359,6 +1385,164 @@ mod tests {
     /// to the hub. We drain the hub and dispatch each event through the
     /// view tree — just like the main loop does — and assert that the
     /// parent never inserts a keyboard child.
+    #[test]
+    fn test_progress_screen_shows_cancel_button() {
+        let mut context = create_test_context();
+        let mut ota = create_ota_view(&mut context);
+
+        let label = OtaDownloadKind::DefaultBranch.progress_label(0);
+        ota.build_progress_screen(&label, &mut context);
+
+        let cancel_idx = ota
+            .cancel_button_index
+            .expect("progress screen must include a cancel button");
+        assert!(
+            ota.children[cancel_idx].downcast_ref::<Button>().is_some(),
+            "cancel child must be a Button"
+        );
+    }
+
+    #[test]
+    fn test_shift_child_indices_after_remove_updates_cancel_button_index() {
+        let mut context = create_test_context();
+        let mut ota = create_ota_view(&mut context);
+
+        let label = OtaDownloadKind::DefaultBranch.progress_label(0);
+        ota.build_progress_screen(&label, &mut context);
+
+        assert_eq!(ota.progress_bar_index, Some(2));
+        assert_eq!(ota.cancel_button_index, Some(3));
+
+        ota.progress_bar_index = None;
+        ota.shift_child_indices_after_remove(2);
+
+        assert_eq!(ota.cancel_button_index, Some(2));
+        assert_eq!(ota.status_label_index, Some(1));
+    }
+
+    #[test]
+    fn test_close_during_download_sets_cancel_flag() {
+        let mut context = create_test_context();
+        let mut ota = create_ota_view(&mut context);
+        let (hub, _rx) = channel();
+        let mut bus: Bus = VecDeque::new();
+        let mut rq = RenderQueue::new();
+
+        ota.begin_download();
+        assert!(!ota.cancelled.is_cancelled());
+
+        let handled = ota.handle_event(
+            &Event::Close(ota.view_id),
+            &hub,
+            &mut bus,
+            &mut rq,
+            &mut context,
+        );
+
+        assert!(handled);
+        assert!(ota.cancelled.is_cancelled());
+        assert!(ota.download_in_progress);
+    }
+
+    #[test]
+    fn test_close_after_commit_does_not_cancel() {
+        let mut context = create_test_context();
+        let mut ota = create_ota_view(&mut context);
+        let (hub, _rx) = channel();
+        let mut bus: Bus = VecDeque::new();
+        let mut rq = RenderQueue::new();
+
+        ota.begin_download();
+        ota.download_committed = true;
+
+        let handled = ota.handle_event(
+            &Event::Close(ota.view_id),
+            &hub,
+            &mut bus,
+            &mut rq,
+            &mut context,
+        );
+
+        assert!(!handled);
+        assert!(!ota.cancelled.is_cancelled());
+    }
+
+    #[test]
+    fn test_progress_non_cancelable_hides_cancel_and_marks_committed() {
+        let mut context = create_test_context();
+        let mut ota = create_ota_view(&mut context);
+        let mut rq = RenderQueue::new();
+
+        let label = OtaDownloadKind::DefaultBranch.progress_label(50);
+        ota.build_progress_screen(&label, &mut context);
+        ota.begin_download();
+        let cancel_idx = ota.cancel_button_index.expect("cancel button");
+
+        let handled = ota.on_download_progress("Installing…", 90, false, &mut rq);
+
+        assert!(handled);
+        assert!(ota.download_committed);
+        assert!(ota.cancel_button_index.is_none());
+        assert!(
+            ota.children
+                .get(cancel_idx)
+                .and_then(|c| c.downcast_ref::<Button>())
+                .is_none(),
+            "cancel button child must be removed"
+        );
+    }
+
+    #[test]
+    fn test_progress_100_removes_bar_and_shifts_cancel_index() {
+        let mut context = create_test_context();
+        let mut ota = create_ota_view(&mut context);
+        let mut rq = RenderQueue::new();
+
+        let label = OtaDownloadKind::DefaultBranch.progress_label(0);
+        ota.build_progress_screen(&label, &mut context);
+        assert_eq!(ota.progress_bar_index, Some(2));
+        assert_eq!(ota.cancel_button_index, Some(3));
+
+        let handled = ota.on_download_progress("Done", 100, true, &mut rq);
+
+        assert!(handled);
+        assert!(ota.progress_bar_index.is_none());
+        assert_eq!(ota.cancel_button_index, Some(2));
+        assert!(
+            ota.children[2].downcast_ref::<Button>().is_some(),
+            "cancel button must remain addressable after progress bar removal"
+        );
+    }
+
+    #[test]
+    fn test_progress_100_then_hide_cancel_does_not_panic() {
+        let mut context = create_test_context();
+        let mut ota = create_ota_view(&mut context);
+        let mut rq = RenderQueue::new();
+
+        let label = OtaDownloadKind::DefaultBranch.progress_label(0);
+        ota.build_progress_screen(&label, &mut context);
+        ota.on_download_progress("Done", 100, true, &mut rq);
+        ota.on_download_progress("Installing…", 100, false, &mut rq);
+
+        assert!(ota.download_committed);
+        assert!(ota.cancel_button_index.is_none());
+        assert!(ota.progress_bar_index.is_none());
+    }
+
+    #[test]
+    fn test_effective_github_token_prefers_stored_token() {
+        use secrecy::ExposeSecret;
+
+        let mut context = create_test_context();
+        let mut ota = create_ota_view(&mut context);
+        ota.auth
+            .set_saved(SecretString::from("stored-token".to_owned()));
+
+        let token = ota.effective_github_token().expect("token");
+        assert_eq!(token.expose_secret(), "stored-token");
+    }
+
     #[test]
     fn test_parent_keyboard_not_shown_when_ota_focuses_input() {
         crate::crypto::init_crypto_provider();

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -12488,20 +12488,6 @@
         }
       }
     },
-    "node_modules/vite-tsconfig-paths/node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "extraneous": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
-      }
-    },
     "node_modules/vite/node_modules/lightningcss": {
       "version": "1.33.0",
       "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.33.0.tgz",


### PR DESCRIPTION
Let users abort OTA before the atomic rename commits KoboRoot.tgz, cleaning partial downloads and staging files instead of rebooting.

- CancelFunc shared across HTTP, GitHub, and OTA download/deploy
- Progress UI Cancel button; hide after commit
- Debug GH_TOKEN auth; treat repo as satisfying public_repo

Change-Id: b2aa5195af34d0a76b6521cb81937a05
Change-Id-Short: oxppuyqupkwv

Closes: #475 
Closes: CAD-72

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What

Users can cancel OTA downloads and deployment before `KoboRoot.tgz` is committed. The UI shows a Cancel button and removes it after commit.

## Why

This prevents incomplete OTA artifacts and staging files from remaining after cancellation. It addresses [`#475`](https://github.com/OGKevin/cadmus/issues/475) and CAD-72.

## How

- Added cooperative cancellation across HTTP, GitHub, and OTA flows.
- Added cleanup for partial downloads and deployment staging files.
- Added cancellable extraction, atomic rename handling, and deployment outcomes.
- Added localized OTA progress and error messages.
- Updated GitHub authentication and repository scope handling.

## Related

- [`#475`](https://github.com/OGKevin/cadmus/issues/475)
- CAD-72

## Risk

**Risk:** High (4/5) — OTA download, deployment, cleanup, atomic rename, and reboot paths changed.

<sub>Generated by CodeRabbit.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->