### PR TITLE
dev(github): accept GH_TOKEN and repo scope

### DIFF
--- a/crates/core/i18n/en-GB/cadmus_core.ftl
+++ b/crates/core/i18n/en-GB/cadmus_core.ftl
@@ -225,3 +225,6 @@ calendar-weekday-thu = THU
 calendar-weekday-fri = FRI
 calendar-weekday-sat = SAT
 calendar-weekday-sun = SUN
+
+# OTA
+ota-downloading-stable-release = Downloading stable release… { $percent }%

--- a/crates/core/src/github/client.rs
+++ b/crates/core/src/github/client.rs
@@ -21,7 +21,24 @@ const GITHUB_OAUTH_CLIENT_ID: &str = env!("GH_OAUTH_CLIENT_ID");
 ///
 /// Current requirements:
 /// - `public_repo` — required to download Actions artifacts from public repositories
+///   (`repo` also satisfies this requirement)
 pub const REQUIRED_SCOPES: &[&str] = &["public_repo"];
+
+/// Returns whether `granted` satisfies a scope listed in [`REQUIRED_SCOPES`].
+///
+/// GitHub reports broader classic PAT scopes under different names — for
+/// example `repo` covers everything `public_repo` allows — so this helper
+/// accepts those supersets during verification.
+fn grants_required_scope(required: &str, granted: &[&str]) -> bool {
+    if granted.contains(&required) {
+        return true;
+    }
+
+    match required {
+        "public_repo" => granted.contains(&"repo"),
+        _ => false,
+    }
+}
 
 /// Thin HTTP wrapper around the GitHub REST API.
 ///
@@ -249,7 +266,7 @@ impl GithubClient {
 
         let missing: Vec<String> = REQUIRED_SCOPES
             .iter()
-            .filter(|&&required| !granted.contains(&required))
+            .filter(|&&required| !grants_required_scope(required, &granted))
             .map(|&s| s.to_owned())
             .collect();
 
@@ -349,5 +366,25 @@ impl GithubClient {
                 Err("Empty response from token endpoint".to_owned())
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn grants_required_scope_accepts_public_repo() {
+        assert!(grants_required_scope("public_repo", &["public_repo"]));
+    }
+
+    #[test]
+    fn grants_required_scope_accepts_repo_for_public_repo() {
+        assert!(grants_required_scope("public_repo", &["repo"]));
+    }
+
+    #[test]
+    fn grants_required_scope_rejects_missing_public_repo() {
+        assert!(!grants_required_scope("public_repo", &["gist"]));
     }
 }

--- a/crates/core/src/github/device_flow.rs
+++ b/crates/core/src/github/device_flow.rs
@@ -2,11 +2,162 @@ use secrecy::{ExposeSecret, SecretString};
 use std::fs::{self, File};
 use std::io::{Read, Write};
 
+/// Filename of the token written under [`crate::device::DevicePaths::install_dir()`].
 const TOKEN_FILENAME: &str = ".github_token";
+
+/// Debug-build environment variable read by [`token_from_env`].
+///
+/// Release builds never consult this value.
+#[cfg(debug_assertions)]
+const DEV_TOKEN_ENV: &str = "GH_TOKEN";
+
+/// Returns a GitHub token from the [`DEV_TOKEN_ENV`] environment variable.
+///
+/// Only available in debug builds (`debug_assertions`). Release builds always
+/// return `None` so PATs cannot be injected via the environment on device.
+#[cfg(debug_assertions)]
+pub fn token_from_env() -> Option<SecretString> {
+    token_from_env_var(std::env::var(DEV_TOKEN_ENV))
+}
+
+#[cfg(debug_assertions)]
+fn token_from_env_var(raw: Result<String, std::env::VarError>) -> Option<SecretString> {
+    let token = raw.ok()?;
+    let token = token.trim();
+    if token.is_empty() {
+        tracing::warn!(env = DEV_TOKEN_ENV, "Environment variable is set but empty");
+        return None;
+    }
+
+    tracing::info!(env = DEV_TOKEN_ENV, "Using GitHub token from environment");
+    Some(SecretString::from(token.to_owned()))
+}
+
+#[cfg(not(debug_assertions))]
+pub fn token_from_env() -> Option<SecretString> {
+    None
+}
+
+/// Origin of the token currently selected for GitHub OTA requests.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum AuthOrigin {
+    /// [`DEV_TOKEN_ENV`], captured by [`token_from_env`].
+    Environment,
+    /// Token from [`load_token`] / [`save_token`].
+    Saved,
+}
+
+/// Combined OTA GitHub credentials: a saved token plus an optional debug
+/// [`DEV_TOKEN_ENV`] override.
+pub(crate) struct ResolvedAuth {
+    /// Token persisted by [`save_token`] as [`TOKEN_FILENAME`] under
+    /// [`crate::device::DevicePaths::install_dir()`].
+    saved: Option<SecretString>,
+    /// Snapshot of [`DEV_TOKEN_ENV`] taken by [`token_from_env`] when this
+    /// session was loaded via [`Self::load`].
+    ///
+    /// Always `None` in release builds. Kept even after rejection so the
+    /// original env value is not re-read mid-session.
+    from_env: Option<SecretString>,
+    /// When `true`, [`effective`](Self::effective) skips `from_env` and uses
+    /// `saved` instead.
+    ///
+    /// Set by [`reject_effective`](Self::reject_effective) after GitHub
+    /// rejects the [`AuthOrigin::Environment`] token, so a later retry can
+    /// use the saved credential without deleting it. Starts `false`.
+    ignore_env: bool,
+}
+
+impl ResolvedAuth {
+    /// Loads the token saved under [`crate::device::DevicePaths::install_dir()`]
+    /// and, in debug builds, a [`DEV_TOKEN_ENV`] override via [`token_from_env`].
+    pub(crate) fn load(install_dir: &std::path::Path) -> Result<Self, String> {
+        Self::load_with(install_dir, token_from_env())
+    }
+
+    fn load_with(
+        install_dir: &std::path::Path,
+        from_env: Option<SecretString>,
+    ) -> Result<Self, String> {
+        let saved = match load_token(install_dir) {
+            Ok(token) => token,
+            Err(e) if from_env.is_some() => {
+                tracing::warn!(error = %e, "Failed to load saved GitHub token");
+                None
+            }
+            Err(e) => return Err(e),
+        };
+        Ok(Self::from_parts(saved, from_env))
+    }
+
+    pub(crate) fn empty() -> Self {
+        Self::from_parts(None, None)
+    }
+
+    fn from_parts(saved: Option<SecretString>, from_env: Option<SecretString>) -> Self {
+        Self {
+            saved,
+            from_env,
+            ignore_env: false,
+        }
+    }
+
+    /// Token that OTA requests should send, preferring [`DEV_TOKEN_ENV`] until
+    /// [`Self::reject_effective`] suppresses it for this session.
+    pub(crate) fn effective(&self) -> Option<SecretString> {
+        if self.ignore_env {
+            self.saved.clone()
+        } else {
+            self.from_env.clone().or_else(|| self.saved.clone())
+        }
+    }
+
+    /// Returns whether the effective token is from [`AuthOrigin::Environment`]
+    /// or [`AuthOrigin::Saved`].
+    pub(crate) fn origin(&self) -> Option<AuthOrigin> {
+        if !self.ignore_env && self.from_env.is_some() {
+            Some(AuthOrigin::Environment)
+        } else if self.saved.is_some() {
+            Some(AuthOrigin::Saved)
+        } else {
+            None
+        }
+    }
+
+    pub(crate) fn set_saved(&mut self, token: SecretString) {
+        self.saved = Some(token);
+    }
+
+    /// Marks the currently effective token as rejected.
+    ///
+    /// [`AuthOrigin::Environment`] tokens are ignored for the rest of this
+    /// session so a saved credential can still be used. [`AuthOrigin::Saved`]
+    /// tokens are cleared from memory; the caller must delete the on-disk file
+    /// with [`delete_token`] only when this returns [`AuthOrigin::Saved`].
+    pub(crate) fn reject_effective(&mut self) -> Option<AuthOrigin> {
+        let origin = self.origin()?;
+        match origin {
+            AuthOrigin::Environment => self.ignore_env = true,
+            AuthOrigin::Saved => self.saved = None,
+        }
+        Some(origin)
+    }
+}
+
+/// Loads a GitHub token for OTA authentication.
+///
+/// In debug builds, checks [`DEV_TOKEN_ENV`] first via [`token_from_env`] so
+/// local emulator runs can skip device flow when `GH_OAUTH_CLIENT_ID` was not
+/// baked in at compile time. Otherwise falls back to the token saved under
+/// [`crate::device::DevicePaths::install_dir()`].
+pub fn resolve_auth_token(install_dir: &std::path::Path) -> Result<Option<SecretString>, String> {
+    Ok(ResolvedAuth::load(install_dir)?.effective())
+}
 
 /// Persists a GitHub OAuth token to disk for reuse across app restarts.
 ///
-/// Writes to `<install-dir>/.github_token` with `0600` permissions.
+/// Writes [`TOKEN_FILENAME`] under [`crate::device::DevicePaths::install_dir()`]
+/// with `0600` permissions.
 ///
 /// # Errors
 ///
@@ -37,6 +188,7 @@ pub fn save_token(token: &SecretString, install_dir: &std::path::Path) -> Result
 
 /// Loads a previously saved GitHub OAuth token from disk.
 ///
+/// Reads [`TOKEN_FILENAME`] under [`crate::device::DevicePaths::install_dir()`].
 /// Returns `None` if no token file exists (first-time setup).
 ///
 /// # Errors
@@ -69,7 +221,8 @@ pub fn load_token(install_dir: &std::path::Path) -> Result<Option<SecretString>,
 
 /// Deletes the saved GitHub OAuth token from disk.
 ///
-/// Called when a token is found to be invalid or revoked, so the next
+/// Removes [`TOKEN_FILENAME`] under [`crate::device::DevicePaths::install_dir()`].
+/// Called when a saved token is found to be invalid or revoked, so the next
 /// authentication attempt starts fresh via device flow.
 ///
 /// Returns `Ok(())` if the file was deleted or did not exist.
@@ -88,4 +241,123 @@ pub fn delete_token(install_dir: &std::path::Path) -> Result<(), String> {
     fs::remove_file(&path).map_err(|e| format!("Failed to delete token file: {}", e))?;
     tracing::info!("GitHub token deleted");
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use secrecy::ExposeSecret;
+
+    #[test]
+    #[cfg(debug_assertions)]
+    fn token_from_env_var_returns_set_value() {
+        let token = token_from_env_var(Ok("env-token".to_owned())).expect("token");
+        assert_eq!(token.expose_secret(), "env-token");
+    }
+
+    #[test]
+    #[cfg(debug_assertions)]
+    fn token_from_env_var_rejects_empty_or_whitespace() {
+        assert!(token_from_env_var(Ok("   ".to_owned())).is_none());
+    }
+
+    #[test]
+    #[cfg(debug_assertions)]
+    fn token_from_env_var_returns_none_when_unset() {
+        assert!(token_from_env_var(Err(std::env::VarError::NotPresent)).is_none());
+    }
+
+    #[test]
+    fn resolve_auth_prefers_env_over_saved_file() {
+        let auth = ResolvedAuth::from_parts(
+            Some(SecretString::from("file-token".to_owned())),
+            Some(SecretString::from("env-token".to_owned())),
+        );
+
+        assert_eq!(auth.origin(), Some(AuthOrigin::Environment));
+        assert_eq!(
+            auth.effective().expect("token").expose_secret(),
+            "env-token"
+        );
+    }
+
+    #[test]
+    fn resolve_auth_falls_back_to_saved_file() {
+        let auth =
+            ResolvedAuth::from_parts(Some(SecretString::from("file-token".to_owned())), None);
+
+        assert_eq!(auth.origin(), Some(AuthOrigin::Saved));
+        assert_eq!(
+            auth.effective().expect("token").expose_secret(),
+            "file-token"
+        );
+    }
+
+    #[test]
+    fn reject_env_token_keeps_saved_credential() {
+        let mut auth = ResolvedAuth::from_parts(
+            Some(SecretString::from("file-token".to_owned())),
+            Some(SecretString::from("env-token".to_owned())),
+        );
+
+        assert_eq!(auth.reject_effective(), Some(AuthOrigin::Environment));
+        assert_eq!(auth.origin(), Some(AuthOrigin::Saved));
+        assert_eq!(
+            auth.effective().expect("token").expose_secret(),
+            "file-token"
+        );
+    }
+
+    #[test]
+    fn reject_env_token_without_saved_credential_leaves_none() {
+        let mut auth =
+            ResolvedAuth::from_parts(None, Some(SecretString::from("env-token".to_owned())));
+
+        assert_eq!(auth.reject_effective(), Some(AuthOrigin::Environment));
+        assert_eq!(auth.origin(), None);
+        assert!(auth.effective().is_none());
+    }
+
+    #[test]
+    fn reject_saved_token_clears_memory_only() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        save_token(&SecretString::from("file-token".to_owned()), tmp.path()).unwrap();
+
+        let mut auth =
+            ResolvedAuth::from_parts(Some(SecretString::from("file-token".to_owned())), None);
+
+        assert_eq!(auth.reject_effective(), Some(AuthOrigin::Saved));
+        assert!(auth.effective().is_none());
+        assert!(
+            load_token(tmp.path())
+                .expect("load")
+                .is_some_and(|token| token.expose_secret() == "file-token")
+        );
+    }
+
+    fn unreadable_token_dir() -> tempfile::TempDir {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        std::fs::create_dir(tmp.path().join(TOKEN_FILENAME)).expect("token path is a directory");
+        tmp
+    }
+
+    #[test]
+    fn load_with_env_token_ignores_saved_token_read_error() {
+        let tmp = unreadable_token_dir();
+        let auth =
+            ResolvedAuth::load_with(tmp.path(), Some(SecretString::from("env-token".to_owned())))
+                .expect("load");
+
+        assert_eq!(auth.origin(), Some(AuthOrigin::Environment));
+        assert_eq!(
+            auth.effective().expect("token").expose_secret(),
+            "env-token"
+        );
+    }
+
+    #[test]
+    fn load_without_env_token_preserves_saved_token_read_error() {
+        let tmp = unreadable_token_dir();
+        assert!(ResolvedAuth::load_with(tmp.path(), None).is_err());
+    }
 }

--- a/crates/core/src/github/mod.rs
+++ b/crates/core/src/github/mod.rs
@@ -2,7 +2,9 @@
 //!
 //! This module provides:
 //! - [`GithubClient`] — a thin blocking HTTP wrapper for the GitHub REST API
-//! - [`device_flow`] — token persistence helpers (`save_token`, `load_token`)
+//! - [`device_flow`] — token persistence helpers ([`device_flow::save_token`],
+//!   [`device_flow::load_token`], [`device_flow::resolve_auth_token`]) and
+//!   debug-build [`device_flow::token_from_env`] resolution
 //! - Shared types used by both the client and callers
 
 mod client;

--- a/crates/core/src/view/github.rs
+++ b/crates/core/src/view/github.rs
@@ -9,10 +9,11 @@ pub enum GithubEvent {
     DeviceAuthExpired,
     /// Device flow failed with an error message.
     DeviceAuthError(String),
-    /// A GitHub API call returned 401 or 403 — the saved token is invalid,
+    /// A GitHub API call returned 401 or 403 — the token in use is invalid,
     /// revoked, or missing required scopes.
     ///
-    /// `OtaView` handles this by deleting the stale token, clearing its
-    /// in-memory token, and re-triggering device flow for the pending download.
+    /// [`super::ota::OtaView`] drops the rejected token (environment tokens
+    /// are ignored for the rest of the session; saved tokens are deleted) and
+    /// either retries with a remaining credential or re-triggers device flow.
     TokenInvalid,
 }

--- a/crates/core/src/view/ota.rs
+++ b/crates/core/src/view/ota.rs
@@ -42,6 +42,10 @@ pub enum OtaEntryId {
     StableRelease,
 }
 
+fn stable_release_download_label(percent: u8) -> String {
+    fl!("ota-downloading-stable-release", percent = percent)
+}
+
 /// Attempts to show the OTA update view with validation checks.
 ///
 /// This function validates prerequisites before showing the OTA view:
@@ -101,6 +105,8 @@ enum PendingDownload {
     DefaultBranch,
     PrInputPending,
     Pr(u32),
+    StableReleaseCheck,
+    StableReleaseDownload,
 }
 
 /// UI view for downloading and installing OTA updates from GitHub.
@@ -128,7 +134,7 @@ pub struct OtaView {
     rect: Rectangle,
     children: Vec<Box<dyn View>>,
     view_id: ViewId,
-    github_token: Option<SecretString>,
+    auth: device_flow::ResolvedAuth,
     keyboard_index: Option<usize>,
     pending_download: Option<PendingDownload>,
     /// Index into `children` of the status `Label` shown during download.
@@ -156,11 +162,11 @@ impl OtaView {
         let view_id = ViewId::Ota(OtaViewId::Main);
         let (width, height) = context.device.dims();
 
-        let github_token = match device_flow::load_token(&context.device.install_dir()) {
-            Ok(token) => token,
+        let auth = match device_flow::ResolvedAuth::load(&context.device.install_dir()) {
+            Ok(auth) => auth,
             Err(e) => {
                 tracing::warn!(error = %e, "Failed to load saved GitHub token");
-                None
+                device_flow::ResolvedAuth::empty()
             }
         };
 
@@ -179,7 +185,7 @@ impl OtaView {
             rect: rect![0, 0, width as i32, height as i32],
             children,
             view_id,
-            github_token,
+            auth,
             keyboard_index: None,
             pending_download: None,
             status_label_index: None,
@@ -392,6 +398,31 @@ impl OtaView {
         }
     }
 
+    /// Returns the GitHub token used for OTA, including a debug-build
+    /// `GH_TOKEN` environment override when present and not suppressed.
+    fn effective_github_token(&self) -> Option<SecretString> {
+        self.auth.effective()
+    }
+
+    /// Restarts the in-flight download with the currently effective token.
+    fn resume_pending_download(&mut self, hub: &Hub, context: &AppContext) {
+        match self.pending_download.clone() {
+            Some(PendingDownload::DefaultBranch) => {
+                self.start_default_branch_download(hub, context);
+            }
+            Some(PendingDownload::Pr(pr_number)) => {
+                self.start_pr_download(pr_number, hub, context);
+            }
+            Some(PendingDownload::StableReleaseCheck) => {
+                self.on_select_stable_release(hub, context);
+            }
+            Some(PendingDownload::StableReleaseDownload) => {
+                self.start_stable_release_download(hub, context);
+            }
+            Some(PendingDownload::PrInputPending) | None => {}
+        }
+    }
+
     /// Checks that a GitHub token is available.
     ///
     /// Returns `true` if a token is present and the caller may proceed.
@@ -404,7 +435,7 @@ impl OtaView {
         rq: &mut RenderQueue,
         context: &mut AppContext,
     ) -> bool {
-        if self.github_token.is_some() {
+        if self.effective_github_token().is_some() {
             return true;
         }
 
@@ -425,7 +456,7 @@ impl OtaView {
     /// the view so re-authentication can proceed.
     #[cfg_attr(feature = "tracing", tracing::instrument(skip(self, hub, context)))]
     fn start_pr_download(&mut self, pr_number: u32, hub: &Hub, context: &AppContext) {
-        let Some(github_token) = self.github_token.clone() else {
+        let Some(github_token) = self.effective_github_token() else {
             tracing::error!(
                 "GitHub token is missing when starting download, this code path should be unreachable due to prior validation"
             );
@@ -560,7 +591,7 @@ impl OtaView {
     /// the view so re-authentication can proceed.
     #[cfg_attr(feature = "tracing", tracing::instrument(skip(self, hub, context)))]
     fn start_default_branch_download(&mut self, hub: &Hub, context: &AppContext) {
-        let Some(github_token) = self.github_token.clone() else {
+        let Some(github_token) = self.effective_github_token() else {
             tracing::error!(
                 "GitHub token is missing when starting download, this code path should be unreachable due to prior validation"
             );
@@ -701,7 +732,7 @@ impl OtaView {
     /// * `hub` - Event hub for sending notifications and status updates
     #[cfg_attr(feature = "tracing", tracing::instrument(skip(self, hub, context)))]
     fn start_stable_release_download(&mut self, hub: &Hub, context: &AppContext) {
-        let github_token = self.github_token.clone();
+        let github_token = self.effective_github_token();
         let hub2 = hub.clone();
         let parent_span = tracing::Span::current();
         let ota_view_id = self.view_id;
@@ -747,7 +778,7 @@ impl OtaView {
 
             hub2.send(
                 (Event::OtaDownloadProgress {
-                    label: "Downloading stable release… 0%".to_string(),
+                    label: stable_release_download_label(0),
                     percent: 0,
                 })
                 .into(),
@@ -759,7 +790,7 @@ impl OtaView {
                     let percent = (downloaded as f32 / total as f32 * 100.0) as u8;
                     hub2.send(
                         (Event::OtaDownloadProgress {
-                            label: format!("Downloading stable release… {}%", percent),
+                            label: stable_release_download_label(percent),
                             percent,
                         })
                         .into(),
@@ -854,12 +885,14 @@ impl OtaView {
     #[inline]
     #[cfg_attr(feature = "tracing", tracing::instrument(skip(self, hub, context)))]
     fn on_select_stable_release(&mut self, hub: &Hub, context: &AppContext) -> bool {
-        let github_token = self.github_token.clone();
+        self.pending_download = Some(PendingDownload::StableReleaseCheck);
+        let github_token = self.effective_github_token();
         let ota_view_id = self.view_id;
 
         let github = match GithubClient::new(github_token) {
             Ok(c) => c,
             Err(e) => {
+                self.pending_download = None;
                 tracing::error!(error = %e, "Failed to create GitHub client");
                 hub.send((Event::Close(ota_view_id)).into()).ok();
                 hub.send(
@@ -878,6 +911,7 @@ impl OtaView {
         let remote_version = match client.fetch_latest_release_version() {
             Ok(version) => version,
             Err(e) => {
+                self.pending_download = None;
                 tracing::error!(error = %e, "Failed to fetch or parse latest release version");
                 hub.send((Event::Close(ota_view_id)).into()).ok();
                 hub.send(
@@ -902,6 +936,7 @@ impl OtaView {
 
         match current_version.compare(&remote_version) {
             Ok(VersionComparison::Equal) => {
+                self.pending_download = None;
                 tracing::info!("Current version equals remote version - already latest");
                 hub.send((Event::Close(ota_view_id)).into()).ok();
                 hub.send(
@@ -913,6 +948,7 @@ impl OtaView {
                 .ok();
             }
             Ok(VersionComparison::Newer) => {
+                self.pending_download = None;
                 tracing::info!("Current version is newer than remote version");
                 hub.send((Event::Close(ota_view_id)).into()).ok();
                 hub.send(
@@ -928,6 +964,7 @@ impl OtaView {
                 hub.send((Event::StartStableReleaseDownload).into()).ok();
             }
             Ok(VersionComparison::Incomparable) => {
+                self.pending_download = None;
                 tracing::warn!("Cannot compare versions - divergent branches");
                 hub.send((Event::Close(ota_view_id)).into()).ok();
                 hub.send(
@@ -939,6 +976,7 @@ impl OtaView {
                 .ok();
             }
             Err(e) => {
+                self.pending_download = None;
                 tracing::error!(error = %e, "Version comparison error");
                 hub.send((Event::Close(ota_view_id)).into()).ok();
                 hub.send(
@@ -1014,7 +1052,7 @@ impl OtaView {
             tracing::error!(error = %e, "Failed to save GitHub token");
         }
 
-        self.github_token = Some(token.clone());
+        self.auth.set_saved(token.clone());
 
         match self.pending_download.take() {
             Some(PendingDownload::DefaultBranch) => {
@@ -1037,6 +1075,15 @@ impl OtaView {
                 rq.add(RenderData::new(self.id, self.rect, UpdateMode::Full));
                 self.start_pr_download(pr_number, hub, context);
             }
+            Some(PendingDownload::StableReleaseCheck) => {
+                self.on_select_stable_release(hub, context);
+            }
+            Some(PendingDownload::StableReleaseDownload) => {
+                self.build_progress_screen(&stable_release_download_label(0), context);
+                rq.add(RenderData::new(self.id, self.rect, UpdateMode::Full));
+                self.pending_download = Some(PendingDownload::StableReleaseDownload);
+                self.start_stable_release_download(hub, context);
+            }
             None => {}
         }
 
@@ -1050,13 +1097,24 @@ impl OtaView {
         rq: &mut RenderQueue,
         context: &mut AppContext,
     ) -> bool {
-        tracing::warn!("Saved GitHub token is invalid — clearing and re-authenticating");
-
-        if let Err(e) = device_flow::delete_token(&context.device.install_dir()) {
-            tracing::error!(error = %e, "Failed to delete stale token");
+        match self.auth.reject_effective() {
+            Some(device_flow::AuthOrigin::Environment) => {
+                tracing::warn!("GH_TOKEN rejected — ignoring it for this session");
+                if self.auth.effective().is_some() {
+                    self.resume_pending_download(hub, context);
+                    return true;
+                }
+            }
+            Some(device_flow::AuthOrigin::Saved) => {
+                tracing::warn!("Saved GitHub token is invalid — clearing and re-authenticating");
+                if let Err(e) = device_flow::delete_token(&context.device.install_dir()) {
+                    tracing::error!(error = %e, "Failed to delete stale token");
+                }
+            }
+            None => {
+                tracing::warn!("GitHub token rejected with no token loaded");
+            }
         }
-
-        self.github_token = None;
 
         let auth_view = DeviceAuthView::new(hub, context);
         self.children.push(Box::new(auth_view) as Box<dyn View>);
@@ -1140,7 +1198,8 @@ impl View for OtaView {
             Event::Github(GithubEvent::DeviceAuthExpired) => self.on_device_auth_expired(hub),
             Event::Github(GithubEvent::DeviceAuthError(msg)) => self.on_device_auth_error(msg, hub),
             Event::StartStableReleaseDownload => {
-                self.build_progress_screen("Downloading stable release… 0%", context);
+                self.pending_download = Some(PendingDownload::StableReleaseDownload);
+                self.build_progress_screen(&stable_release_download_label(0), context);
                 rq.add(RenderData::new(self.id, self.rect, UpdateMode::Full));
                 self.start_stable_release_download(hub, context);
                 true

--- a/docs/po/messages.pot
+++ b/docs/po/messages.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Cadmus Documentation\n"
-"POT-Creation-Date: 2026-08-22T10:32:43+02:00\n"
+"POT-Creation-Date: 2026-08-26T14:47:19Z\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"

--- a/docs/src/contributing/devenv-setup.md
+++ b/docs/src/contributing/devenv-setup.md
@@ -55,6 +55,22 @@ This guide covers setup on both Linux and macOS.
    cargo xtask run-emulator
    ```
 
+## Emulator GitHub Authentication
+
+Debug builds (`cargo xtask run-emulator`) can skip GitHub device flow by setting
+`GH_TOKEN` to a personal access token with `public_repo` (or the broader `repo`)
+scope:
+
+```bash
+export GH_TOKEN=ghp_…
+cargo xtask run-emulator
+```
+
+Cadmus reads `GH_TOKEN` first, trims whitespace, and ignores an empty value. If
+the environment token is missing or rejected, it falls back to the token saved
+under the emulator install directory (the same `.github_token` file device flow
+writes). Release builds never read `GH_TOKEN`.
+
 ## Available Commands
 
 Once inside the devenv shell, these commands are available:


### PR DESCRIPTION
Allow debug builds to authenticate OTA via GH_TOKEN, and treat classic PAT `repo` as satisfying required `public_repo` scope.

Change-Id: umrwuulnlynvwvyvsyuwpuonptlxpumk
Change-Id-Short: umrwuulnlynv

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What

Debug builds can use `GH_TOKEN` for GitHub OTA authentication. GitHub scope checks accept the broader `repo` scope as sufficient for `public_repo`.

## Why

This simplifies OTA authentication during development. It also preserves authentication when the saved token is unreadable or insufficient.

## How

- Resolve `GH_TOKEN` before the saved token in debug builds.
- Use the effective token for OTA validation, version checks, and downloads.
- Ignore rejected environment tokens for the session, while deleting rejected saved tokens.
- Track pending release checks and downloads so device authentication can resume correctly.
- Accept `repo` during scope checks and add token-resolution and scope tests.
- Document emulator authentication and token behavior.

## Related

None found.

## Risk

**Risk:** High (4/5) — Changes affect OTA authentication, credential handling, and resume behavior in device-related paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->