### PR TITLE
ci: split Kobo artifacts and add tracing build

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,3 @@
+self-hosted-runner:
+  labels:
+    - ubuntu-26.04

--- a/.github/actions/build-kobo/action.yml
+++ b/.github/actions/build-kobo/action.yml
@@ -19,6 +19,12 @@ inputs:
     description: "Build the test variant (installs to .adds/cadmus-tst)"
     required: false
     default: "false"
+  features:
+    description: >
+      Extra cargo features for the Cadmus build (e.g. test,tracing). When empty
+      and test is true, defaults to test.
+    required: false
+    default: ""
 
 runs:
   using: composite
@@ -79,8 +85,12 @@ runs:
         PKG_CONFIG_PATH_arm_unknown_linux_gnueabihf: ${{ github.workspace }}/target/cadmus-build-deps/arm-unknown-linux-gnueabihf/sqlite/lib/pkgconfig
         PKG_CONFIG_ALLOW_CROSS: 1
       run: |
-        if [ "${{ inputs.test }}" = "true" ]; then
-          cargo xtask build-kobo --features test
+        FEATURES="${{ inputs.features }}"
+        if [ -z "$FEATURES" ] && [ "${{ inputs.test }}" = "true" ]; then
+          FEATURES=test
+        fi
+        if [ -n "$FEATURES" ]; then
+          cargo xtask build-kobo --features "$FEATURES"
         else
           cargo xtask build-kobo
         fi

--- a/.github/workflows/build-release-candidate.yml
+++ b/.github/workflows/build-release-candidate.yml
@@ -72,11 +72,28 @@ jobs:
             dist/bin/*
             release-artifacts/*.tgz
 
-      - name: Upload artifacts
+      - name: Upload KoboRoot
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: cadmus-kobo-pr${{ inputs.pr_number }}-${{ steps.commit.outputs.short_sha }}
-          path: release-artifacts/*
+          path: release-artifacts/KoboRoot.tgz
+          if-no-files-found: error
+          retention-days: 14
+
+      - name: Upload KoboRoot with NickelMenu
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: cadmus-kobo-nm-pr${{ inputs.pr_number }}-${{ steps.commit.outputs.short_sha }}
+          path: release-artifacts/KoboRoot-nm.tgz
+          if-no-files-found: error
+          retention-days: 14
+
+      - name: Upload dist tarball
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: cadmus-kobo-dist-pr${{ inputs.pr_number }}-${{ steps.commit.outputs.short_sha }}
+          path: release-artifacts/cadmus-kobo.tar.gz
+          if-no-files-found: error
           retention-days: 14
 
       - name: Comment on PR or Issue

--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -475,11 +475,28 @@ jobs:
             dist/bin/*
             release-artifacts/*.tgz
 
-      - name: Upload artifacts
+      - name: Upload KoboRoot
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: cadmus-kobo-${{ steps.artifact.outputs.suffix }}
-          path: release-artifacts/*
+          path: release-artifacts/KoboRoot.tgz
+          if-no-files-found: error
+          retention-days: 7
+
+      - name: Upload KoboRoot with NickelMenu
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: cadmus-kobo-nm-${{ steps.artifact.outputs.suffix }}
+          path: release-artifacts/KoboRoot-nm.tgz
+          if-no-files-found: error
+          retention-days: 7
+
+      - name: Upload dist tarball
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: cadmus-kobo-dist-${{ steps.artifact.outputs.suffix }}
+          path: release-artifacts/cadmus-kobo.tar.gz
+          if-no-files-found: error
           retention-days: 7
 
   build-kobo-test:
@@ -525,11 +542,96 @@ jobs:
 
       - *generate-attestation
 
-      - name: Upload artifacts
+      - name: Upload KoboRoot
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: cadmus-kobo-test-${{ steps.artifact.outputs.suffix }}
-          path: release-artifacts/*
+          path: release-artifacts/KoboRoot-test.tgz
+          if-no-files-found: error
+          retention-days: 7
+
+      - name: Upload KoboRoot with NickelMenu
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: cadmus-kobo-nm-test-${{ steps.artifact.outputs.suffix }}
+          path: release-artifacts/KoboRoot-nm-test.tgz
+          if-no-files-found: error
+          retention-days: 7
+
+      - name: Upload dist tarball
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: cadmus-kobo-dist-test-${{ steps.artifact.outputs.suffix }}
+          path: release-artifacts/cadmus-kobo-test.tar.gz
+          if-no-files-found: error
+          retention-days: 7
+
+  build-kobo-test-tracing:
+    needs: [changes, cache-warmup, build-docs-epub]
+    if: github.event_name != 'pull_request' || needs.changes.outputs.cargo == 'true'
+    runs-on: ubuntu-26.04
+
+    permissions: *build-permissions
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+          persist-credentials: false
+
+      - *set-build-metadata
+
+      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
+        id: rust-toolchain
+        with:
+          targets: arm-unknown-linux-gnueabihf
+
+      - name: Restore shared cargo cache
+        uses: ./.github/actions/cargo-cache
+        with:
+          cachekey: ${{ steps.rust-toolchain.outputs.cachekey }}
+      - name: Download documentation EPUB
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: docs-epub
+          path: docs/book/epub
+
+      - name: Build Kobo test+tracing artifacts
+        uses: ./.github/actions/build-kobo
+        with:
+          gh-token: ${{ secrets.GITHUB_TOKEN }}
+          gh-oauth-client-id: ${{ secrets.GH_OAUTH_CLIENT_ID }}
+          test: "true"
+          features: "test,tracing"
+
+      - *get-commit
+      - *determine-suffix
+
+      - *generate-attestation
+
+      - name: Upload KoboRoot
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: cadmus-kobo-test-tracing-${{ steps.artifact.outputs.suffix }}
+          path: release-artifacts/KoboRoot-test.tgz
+          if-no-files-found: error
+          retention-days: 7
+
+      - name: Upload KoboRoot with NickelMenu
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: cadmus-kobo-nm-test-tracing-${{ steps.artifact.outputs.suffix }}
+          path: release-artifacts/KoboRoot-nm-test.tgz
+          if-no-files-found: error
+          retention-days: 7
+
+      - name: Upload dist tarball
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: cadmus-kobo-dist-test-tracing-${{ steps.artifact.outputs.suffix }}
+          path: release-artifacts/cadmus-kobo-test.tar.gz
+          if-no-files-found: error
           retention-days: 7
 
   required-cargo:
@@ -546,6 +648,7 @@ jobs:
       - test
       - build-kobo
       - build-kobo-test
+      - build-kobo-test-tracing
     if: ${{ always() && github.event_name == 'pull_request' && (cancelled() || contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')) }}
     runs-on: ubuntu-latest
     steps:

--- a/docs/po/messages.pot
+++ b/docs/po/messages.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Cadmus Documentation\n"
-"POT-Creation-Date: 2026-09-05T21:29:23+02:00\n"
+"POT-Creation-Date: 2026-09-12T15:21:16+02:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -383,7 +383,7 @@ msgid ""
 "Copy that renamed file to `/mnt/onboard/.kobo/KoboRoot.tgz` on the device."
 msgstr ""
 
-#: src/installation/index.md:32 src/installation/test-builds.md:13
+#: src/installation/index.md:32 src/installation/test-builds.md:15
 msgid "Eject the device and reboot."
 msgstr ""
 
@@ -476,44 +476,59 @@ msgid "Select the run for the change you want to test."
 msgstr ""
 
 #: src/installation/test-builds.md:7
-msgid ""
-"Download the `cadmus-kobo-test-<suffix>` file. ![Download from GitHub "
-"Actions](./screenshots/artifacts.png)"
+msgid "Download the package that matches your setup:"
+msgstr ""
+
+#: src/installation/test-builds.md:8
+msgid "`cadmus-kobo-test-<suffix>` — test build only"
 msgstr ""
 
 #: src/installation/test-builds.md:9
-msgid "Extract it and pick the [package](./index.md) that matches your setup."
+msgid ""
+"`cadmus-kobo-nm-test-<suffix>` — test build + NickelMenu ![Download from "
+"GitHub Actions](./screenshots/artifacts.png)"
 msgstr ""
 
-#: src/installation/test-builds.md:10
-msgid "Rename the selected file to `KoboRoot.tgz`."
+#: src/installation/test-builds.md:11 src/installation/manual-pr-install.md:17
+msgid "Extract the download if your browser saved it as a zip."
 msgstr ""
 
-#: src/installation/test-builds.md:11
+#: src/installation/test-builds.md:12
+msgid "Rename the package to `KoboRoot.tgz`."
+msgstr ""
+
+#: src/installation/test-builds.md:13
 msgid "Copy that renamed file to: `/mnt/onboard/.kobo/KoboRoot.tgz`"
 msgstr ""
 
-#: src/installation/test-builds.md:16
+#: src/installation/test-builds.md:18
 msgid ""
 "Test packages such as `KoboRoot-test.tgz` and `KoboRoot-nm-test.tgz` must be "
 "renamed to `KoboRoot.tgz` before you copy them to your Kobo."
 msgstr ""
 
-#: src/installation/test-builds.md:19
+#: src/installation/test-builds.md:22
+msgid ""
+"Runs also include `cadmus-kobo-test-tracing-<suffix>` (and a NickelMenu "
+"variant). That is a debug package with extra diagnostics. Install it the "
+"same way over USB. Wireless updates will not install it."
+msgstr ""
+
+#: src/installation/test-builds.md:26
 msgid "Updating an existing test build"
 msgstr ""
 
-#: src/installation/test-builds.md:21
+#: src/installation/test-builds.md:28
 msgid ""
 "Use the OTA feature to download updates from a PR number directly on your "
 "device. This lets you test changes without connecting to a computer."
 msgstr ""
 
-#: src/installation/test-builds.md:24
+#: src/installation/test-builds.md:31
 msgid "Switching builds"
 msgstr ""
 
-#: src/installation/test-builds.md:26
+#: src/installation/test-builds.md:33
 msgid ""
 "When both the main and test builds are installed, open the Exit menu and "
 "choose **Switch to Test** or **Switch to Main**. Cadmus hands off to the "
@@ -777,12 +792,30 @@ msgid "Press the cargo job ![cargo job](screenshots/pr-cargo-job.png)"
 msgstr ""
 
 #: src/installation/manual-pr-install.md:10
-msgid ""
-"Scroll down until you find the files ![Download from GitHub "
-"Actions](screenshots/artifacts.png)"
+msgid "Scroll to the files and download the package you want:"
+msgstr ""
+
+#: src/installation/manual-pr-install.md:11
+msgid "`cadmus-kobo-<suffix>` — Cadmus only"
+msgstr ""
+
+#: src/installation/manual-pr-install.md:12
+msgid "`cadmus-kobo-nm-<suffix>` — Cadmus + NickelMenu"
 msgstr ""
 
 #: src/installation/manual-pr-install.md:13
+msgid ""
+"`cadmus-kobo-test-tracing-<suffix>` — test build with extra diagnostics (USB "
+"only; see [Test builds](test-builds.md))"
+msgstr ""
+
+#: src/installation/manual-pr-install.md:15
+msgid ""
+"`cadmus-kobo-nm-test-tracing-<suffix>` — same, plus NickelMenu ![Download "
+"from GitHub Actions](screenshots/artifacts.png)"
+msgstr ""
+
+#: src/installation/manual-pr-install.md:19
 msgid "Afterward, follow the [installation](index.md) instructions accordingly."
 msgstr ""
 

--- a/docs/src/installation/manual-pr-install.md
+++ b/docs/src/installation/manual-pr-install.md
@@ -7,7 +7,13 @@ To manually install a PR build, follow these steps:
    ![pr checks](screenshots/pr-checks.png)
 3. Press the cargo job
    ![cargo job](screenshots/pr-cargo-job.png)
-4. Scroll down until you find the files
+4. Scroll to the files and download the package you want:
+   - `cadmus-kobo-<suffix>` — Cadmus only
+   - `cadmus-kobo-nm-<suffix>` — Cadmus + NickelMenu
+   - `cadmus-kobo-test-tracing-<suffix>` — test build with extra diagnostics
+     (USB only; see [Test builds](test-builds.md))
+   - `cadmus-kobo-nm-test-tracing-<suffix>` — same, plus NickelMenu
    ![Download from GitHub Actions](screenshots/artifacts.png)
+5. Extract the download if your browser saved it as a zip.
 
 Afterward, follow the [installation](index.md) instructions accordingly.

--- a/docs/src/installation/test-builds.md
+++ b/docs/src/installation/test-builds.md
@@ -4,10 +4,12 @@
 
 1. Open the [Cadmus GitHub Actions page](https://github.com/OGKevin/cadmus/actions/workflows/cargo.yml).
 2. Select the run for the change you want to test.
-3. Download the `cadmus-kobo-test-<suffix>` file.
+3. Download the package that matches your setup:
+   - `cadmus-kobo-test-<suffix>` — test build only
+   - `cadmus-kobo-nm-test-<suffix>` — test build + NickelMenu
    ![Download from GitHub Actions](./screenshots/artifacts.png)
-4. Extract it and pick the [package](./index.md) that matches your setup.
-5. Rename the selected file to `KoboRoot.tgz`.
+4. Extract the download if your browser saved it as a zip.
+5. Rename the package to `KoboRoot.tgz`.
 6. Copy that renamed file to:
    `/mnt/onboard/.kobo/KoboRoot.tgz`
 7. Eject the device and reboot.
@@ -15,6 +17,11 @@
 > [!NOTE]
 > Test packages such as `KoboRoot-test.tgz` and `KoboRoot-nm-test.tgz` must be
 > renamed to `KoboRoot.tgz` before you copy them to your Kobo.
+
+> [!NOTE]
+> Runs also include `cadmus-kobo-test-tracing-<suffix>` (and a NickelMenu
+> variant). That is a debug package with extra diagnostics. Install it the
+> same way over USB. Wireless updates will not install it.
 
 ## Updating an existing test build
 


### PR DESCRIPTION
OTA downloaded a 114MB zip for one KoboRoot file. Upload each package separately and ship a USB-only test+tracing job.

Closes: #564
Closes: CAD-101

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What

CI now publishes Kobo packages as separate artifacts. It also publishes USB-only Kobo test builds with tracing enabled.

## Why

Smaller artifacts can improve OTA speed for pull request builds. The tracing build supports testing when local builds are difficult.

## How

- Added a `features` input to the Kobo build action.
- Split release and test uploads into separate package artifacts.
- Added a required `build-kobo-test-tracing` job with `test,tracing` features.
- Updated installation documentation for package selection and tracing builds.

## Related

- [`#564`](https://github.com/OGKevin/cadmus/issues/564)
- [`#554`](https://github.com/OGKevin/cadmus/pull/554)
- [`#74`](https://github.com/OGKevin/cadmus/issues/74)
- [`#543`](https://github.com/OGKevin/cadmus/issues/543)

## Risk

**Risk:** High (4/5) — The changes affect Kobo package distribution and OTA or USB installation paths.

<sub>Generated by CodeRabbit.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->